### PR TITLE
fixing Might typo on half-giant and orcs ancestries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5648,9 +5648,9 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "6.3.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
-      "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
+      "version": "6.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.6.tgz",
+      "integrity": "sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/packs/ancestries/exotic/half-giant.json
+++ b/packs/ancestries/exotic/half-giant.json
@@ -16,7 +16,7 @@
 				"priority": 1,
 				"value": "2",
 				"skills": [
-					"Might"
+					"might"
 				]
 			}
 		],

--- a/packs/ancestries/exotic/orc.json
+++ b/packs/ancestries/exotic/orc.json
@@ -16,7 +16,7 @@
 				"priority": 1,
 				"value": "",
 				"skills": [
-					"Might"
+					"might"
 				]
 			}
 		],


### PR DESCRIPTION
The problem was a typo on the skill naming. It was "Might" but it should be "might".

<img width="1005" height="1104" alt="Screenshot 2025-09-20 195934" src="https://github.com/user-attachments/assets/75fb4260-d343-49f5-978e-7b39d54d921d" />
<img width="1726" height="1117" alt="Screenshot 2025-09-20 195949" src="https://github.com/user-attachments/assets/b1518244-661b-4f24-8b99-f44eb0db5d8c" />
<img width="557" height="944" alt="Screenshot 2025-09-20 200012" src="https://github.com/user-attachments/assets/437f1c5e-3300-4322-80e7-50b7b03d9dc1" />
<img width="2523" height="1118" alt="Screenshot 2025-09-20 200036" src="https://github.com/user-attachments/assets/0667c7d6-d8d7-42c1-920b-096a611c5177" />
