### PR TITLE
Proper case on size and remove stray closing brace

### DIFF
--- a/src/view/sheets/NPCSheet.svelte
+++ b/src/view/sheets/NPCSheet.svelte
@@ -12,16 +12,6 @@ function getHitPointPercentage(currentHP, maxHP) {
 	return Math.clamp(0, Math.round((currentHP / maxHP) * 100), 100);
 }
 
-const sizeLabels = {
-	tiny: 'Tiny',
-	small: 'Small',
-	medium: 'Medium',
-	large: 'Large',
-	huge: 'Huge',
-	gargantuan: 'Gargantuan',
-};
-
-
 function updateCurrentHP(newValue) {
 	actor.update({ 'system.attributes.hp.value': newValue });
 }


### PR DESCRIPTION
Remove the extra closing brace on the end of the monster level description.

Fixes issues https://github.com/Nimble-Co/FoundryVTT-Nimble/issues/84 and https://github.com/Nimble-Co/FoundryVTT-Nimble/issues/95