### PR TITLE
Editable movement speed on NPC, and monsters

### DIFF
--- a/src/documents/actor/minion.ts
+++ b/src/documents/actor/minion.ts
@@ -1,6 +1,7 @@
 import type { NimbleMinionData } from '../../models/actor/MinionDataModel.js';
-import { NimbleBaseActor } from './base.svelte.js';
+import CharacterMovementConfigDialog from '../../view/dialogs/CharacterMovementConfigDialog.svelte';
 import NPCMetaConfigDialog from '../../view/dialogs/NPCMetaConfigDialog.svelte';
+import { NimbleBaseActor } from './base.svelte.js';
 
 export class NimbleMinion extends NimbleBaseActor {
 	declare system: NimbleMinionData;
@@ -36,5 +37,18 @@ export class NimbleMinion extends NimbleBaseActor {
 		);
 
 		this.#dialogs.metaConfig.render(true);
+	}
+
+	async configureMovement() {
+		const { default: GenericDialog } = await import('../dialogs/GenericDialog.svelte.js');
+
+		this.#dialogs.configureMovement ??= new GenericDialog(
+			`${this.name}: Configure Movement Speeds`,
+			CharacterMovementConfigDialog,
+			{ document: this },
+			{ icon: 'fa-solid fa-person-running', width: 600 },
+		);
+
+		await this.#dialogs.configureMovement.render(true);
 	}
 }

--- a/src/documents/actor/npc.ts
+++ b/src/documents/actor/npc.ts
@@ -1,38 +1,52 @@
 import type { NimbleNPCData } from '../../models/actor/NPCDataModel.js';
+import CharacterMovementConfigDialog from '../../view/dialogs/CharacterMovementConfigDialog.svelte';
 import NPCMetaConfigDialog from '../../view/dialogs/NPCMetaConfigDialog.svelte';
 import { NimbleBaseActor } from './base.svelte.js';
 
 export class NimbleNPC extends NimbleBaseActor {
-	declare system: NimbleNPCData;
+		declare system: NimbleNPCData;
 
-	#dialogs: Record<string, any>;
+		#dialogs: Record<string, any>;
 
-	constructor(data, context) {
-		super(data, context);
+		constructor(data, context) {
+			super(data, context);
 
-		this.#dialogs = {};
+			this.#dialogs = {};
+		}
+
+		/** ------------------------------------------------------ */
+		/**                 Data Prep Functions                    */
+		/** ------------------------------------------------------ */
+		override prepareBaseData() {
+			super.prepareBaseData();
+		}
+
+		override prepareDerivedData() {
+			super.prepareDerivedData();
+		}
+
+		async editMetadata() {
+			const { default: GenericDialog } = await import('../dialogs/GenericDialog.svelte.js');
+
+			this.#dialogs.metaConfig ??= new GenericDialog(
+				`${this.name}: Configuration`,
+				NPCMetaConfigDialog,
+				{ actor: this },
+			);
+
+			this.#dialogs.metaConfig.render(true);
+		}
+
+		async configureMovement() {
+			const { default: GenericDialog } = await import('../dialogs/GenericDialog.svelte.js');
+
+			this.#dialogs.configureMovement ??= new GenericDialog(
+				`${this.name}: Configure Movement Speeds`,
+				CharacterMovementConfigDialog,
+				{ document: this },
+				{ icon: 'fa-solid fa-person-running', width: 600 },
+			);
+
+			await this.#dialogs.configureMovement.render(true);
+		}
 	}
-
-	/** ------------------------------------------------------ */
-	/**                 Data Prep Functions                    */
-	/** ------------------------------------------------------ */
-	override prepareBaseData() {
-		super.prepareBaseData();
-	}
-
-	override prepareDerivedData() {
-		super.prepareDerivedData();
-	}
-
-	async editMetadata() {
-		const { default: GenericDialog } = await import('../dialogs/GenericDialog.svelte.js');
-
-		this.#dialogs.metaConfig ??= new GenericDialog(
-			`${this.name}: Configuration`,
-			NPCMetaConfigDialog,
-			{ actor: this },
-		);
-
-		this.#dialogs.metaConfig.render(true);
-	}
-}

--- a/src/documents/actor/soloMonster.ts
+++ b/src/documents/actor/soloMonster.ts
@@ -1,6 +1,7 @@
 import type { NimbleSoloMonsterData } from '../../models/actor/SoloMonsterDataModel.js';
-import { NimbleBaseActor } from './base.svelte.js';
+import CharacterMovementConfigDialog from '../../view/dialogs/CharacterMovementConfigDialog.svelte';
 import NPCMetaConfigDialog from '../../view/dialogs/NPCMetaConfigDialog.svelte';
+import { NimbleBaseActor } from './base.svelte.js';
 
 export class NimbleSoloMonster extends NimbleBaseActor {
 	declare system: NimbleSoloMonsterData;
@@ -38,7 +39,7 @@ export class NimbleSoloMonster extends NimbleBaseActor {
 			system: {
 				actorName: this.name,
 				description: this.system.bloodiedEffect.description,
-				image: "icons/svg/blood.svg",
+				image: 'icons/svg/blood.svg',
 				name: 'Bloodied',
 				permissions: this.permission,
 			},
@@ -66,7 +67,7 @@ export class NimbleSoloMonster extends NimbleBaseActor {
 			system: {
 				actorName: this.name,
 				description: this.system.lastStandEffect.description,
-				image: "icons/svg/skull.svg",
+				image: 'icons/svg/skull.svg',
 				name: 'Last Stand',
 				permissions: this.permission,
 			},
@@ -89,5 +90,18 @@ export class NimbleSoloMonster extends NimbleBaseActor {
 		);
 
 		this.#dialogs.metaConfig.render(true);
+	}
+
+	async configureMovement() {
+		const { default: GenericDialog } = await import('../dialogs/GenericDialog.svelte.js');
+
+		this.#dialogs.configureMovement ??= new GenericDialog(
+			`${this.name}: Configure Movement Speeds`,
+			CharacterMovementConfigDialog,
+			{ document: this },
+			{ icon: 'fa-solid fa-person-running', width: 600 },
+		);
+
+		await this.#dialogs.configureMovement.render(true);
 	}
 }

--- a/src/models/actor/MinionDataModel.ts
+++ b/src/models/actor/MinionDataModel.ts
@@ -31,6 +31,43 @@ const MinionSchema = () => ({
 			initial: 'medium',
 			options: ['tiny', 'small', 'medium', 'large', 'huge', 'gargantuan'],
 		}),
+		movement: new fields.SchemaField({
+			burrow: new fields.NumberField({
+				required: true,
+				nullable: false,
+				initial: 0,
+				integer: true,
+				min: 0,
+			}),
+			climb: new fields.NumberField({
+				required: true,
+				nullable: false,
+				initial: 0,
+				integer: true,
+				min: 0,
+			}),
+			fly: new fields.NumberField({
+				required: true,
+				nullable: false,
+				initial: 0,
+				integer: true,
+				min: 0,
+			}),
+			swim: new fields.NumberField({
+				required: true,
+				nullable: false,
+				initial: 0,
+				integer: true,
+				min: 0,
+			}),
+			walk: new fields.NumberField({
+				required: true,
+				nullable: false,
+				initial: 6,
+				integer: true,
+				min: 0,
+			}),
+		}),
 	}),
 	description: new fields.HTMLField({ required: true, nullable: false, initial: '' }),
 	details: new fields.SchemaField({

--- a/src/models/actor/NPCDataModel.ts
+++ b/src/models/actor/NPCDataModel.ts
@@ -25,6 +25,43 @@ const NPCSchema = () => ({
 			temp: new fields.NumberField({ required: true, initial: 0, nullable: false }),
 			value: new fields.NumberField({ required: true, initial: 10, nullable: false }),
 		}),
+		movement: new fields.SchemaField({
+			burrow: new fields.NumberField({
+				required: true,
+				nullable: false,
+				initial: 0,
+				integer: true,
+				min: 0,
+			}),
+			climb: new fields.NumberField({
+				required: true,
+				nullable: false,
+				initial: 0,
+				integer: true,
+				min: 0,
+			}),
+			fly: new fields.NumberField({
+				required: true,
+				nullable: false,
+				initial: 0,
+				integer: true,
+				min: 0,
+			}),
+			swim: new fields.NumberField({
+				required: true,
+				nullable: false,
+				initial: 0,
+				integer: true,
+				min: 0,
+			}),
+			walk: new fields.NumberField({
+				required: true,
+				nullable: false,
+				initial: 6,
+				integer: true,
+				min: 0,
+			}),
+		}),
 		sizeCategory: new fields.StringField({
 			required: true,
 			nullable: false,

--- a/src/models/actor/SoloMonsterDataModel.ts
+++ b/src/models/actor/SoloMonsterDataModel.ts
@@ -31,6 +31,43 @@ const soloMonsterSchema = () => ({
 			initial: 'medium',
 			options: ['tiny', 'small', 'medium', 'large', 'huge', 'gargantuan'],
 		}),
+		movement: new fields.SchemaField({
+			burrow: new fields.NumberField({
+				required: true,
+				nullable: false,
+				initial: 0,
+				integer: true,
+				min: 0,
+			}),
+			climb: new fields.NumberField({
+				required: true,
+				nullable: false,
+				initial: 0,
+				integer: true,
+				min: 0,
+			}),
+			fly: new fields.NumberField({
+				required: true,
+				nullable: false,
+				initial: 0,
+				integer: true,
+				min: 0,
+			}),
+			swim: new fields.NumberField({
+				required: true,
+				nullable: false,
+				initial: 0,
+				integer: true,
+				min: 0,
+			}),
+			walk: new fields.NumberField({
+				required: true,
+				nullable: false,
+				initial: 6,
+				integer: true,
+				min: 0,
+			}),
+		}),
 	}),
 	description: new fields.HTMLField({ required: true, nullable: false, initial: '' }),
 	details: new fields.SchemaField({

--- a/src/view/dialogs/NPCMetaConfigDialog.svelte
+++ b/src/view/dialogs/NPCMetaConfigDialog.svelte
@@ -1,5 +1,7 @@
-<script>
+<script lang="ts">
+import localize from '../../utils/localize.js';
 import TagGroup from '../components/TagGroup.svelte';
+import MovementSpeed from '../sheets/components/MovementSpeed.svelte';
 
 function prepareSizeCategoryOptions() {
 	return Object.entries(sizeCategories).map(([key, value]) => ({
@@ -63,6 +65,8 @@ let { actor } = $props();
             </h3>
         </label>
     {/if}
+
+	<MovementSpeed {actor} showDefaultSpeed={true} />
 </section>
 
 <style>

--- a/src/view/sheets/components/MovementSpeed.svelte
+++ b/src/view/sheets/components/MovementSpeed.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+	import localize from '../../../utils/localize.js';
+
+	const { movementTypes } = CONFIG.NIMBLE;
+
+	let { actor, showDefaultSpeed = false } = $props();
+
+	// Check if movement is the default (walk=6, all others=0)
+	let isDefaultMovement = $derived.by(() => {
+		const movement = actor.reactive.system.attributes.movement;
+		const isDefault = movement.walk === 6
+			&& movement.burrow === 0
+			&& movement.climb === 0
+			&& movement.fly === 0
+			&& movement.swim === 0;
+		return isDefault;
+	});
+
+	// Show movement if: not hiding defaults, OR if we are hiding defaults but this isn't default
+	let shouldShowMovement = $derived(showDefaultSpeed || !isDefaultMovement);
+
+	let movementModes = $derived.by(() => {
+		const movement = actor.reactive.system.attributes.movement;
+
+		return Object.entries(movement)
+			.reduce((modes: string[], [key, value]): string[] => {
+				if (value) {
+					const movementType = localize(movementTypes[key] ?? key);
+					modes.push(`${movementType}: ${value} spaces`);
+				}
+
+				return modes;
+			}, [])
+			.sort((a, b) => a.localeCompare(b));
+	});
+</script>
+
+{#if shouldShowMovement}
+
+	{#each [{ heading: "Movement", configMethod: actor.configureMovement.bind(actor), content: movementModes, prompt: "configureMovement" }] as { heading, configMethod, content, prompt }}
+		{@const tooltip = localize(`NIMBLE.prompts.${prompt}`)}
+
+		<section>
+			<header class="nimble-section-header">
+				<h3 class="nimble-heading" data-heading-variant="section">
+					{heading}
+				</h3>
+
+				<button
+					class="nimble-button"
+					data-button-variant="icon"
+					type="button"
+					aria-label={tooltip}
+					data-tooltip={tooltip}
+					onclick={configMethod}
+				>
+					<i class="fa-solid fa-edit"></i>
+				</button>
+			</header>
+
+			<ul class="nimble-proficiency-list">
+				{#each content as label}
+					<li class="nimble-proficiency-list__item">
+						{label}
+					</li>
+				{:else}
+					<li class="nimble-proficiency-list__item">None</li>
+				{/each}
+			</ul>
+		</section>
+	{/each}
+{/if}
+
+<style>
+	.nimble-proficiency-list {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.25rem 1ch;
+        margin: 0;
+        padding: 0;
+        list-style: none;
+        font-size: var(--nimble-sm-text);
+        font-weight: 500;
+    }
+</style>

--- a/src/view/sheets/pages/NPCCoreTab.svelte
+++ b/src/view/sheets/pages/NPCCoreTab.svelte
@@ -1,12 +1,12 @@
-<script>
+<script lang="ts">
+import { FALSE, TRUE } from 'sass';
 import { getContext, onDestroy } from 'svelte';
-
+import sortItems from '../../../utils/sortItems.js';
 import ArmorClass from '../components/ArmorClass.svelte';
 import Editor from '../components/Editor.svelte';
 import MonsterFeature from '../components/MonsterFeature.svelte';
+import MovementSpeed from '../components/MovementSpeed.svelte';
 import SavingThrows from '../components/SavingThrows.svelte';
-import sortItems from '../../../utils/sortItems.js';
-import { FALSE, TRUE } from 'sass';
 
 async function configureItem(event, id) {
 	event.stopPropagation();
@@ -213,9 +213,7 @@ onDestroy(() => {
             </button>
         </section>
     </section>
-	<header class="nimble-sheet__static nimble-sheet__static--features">
-
-	</header>
+	{#if Object.entries(categorizedItems).length > 0}
 	<section class="nimble-sheet__body nimble-sheet__body--player-character">
 		{#each Object.entries(categorizedItems).sort(sortItemCategories) as [categoryName, itemCategory]}
 			{@const allCollapsed = items.every(item => item.flags.nimble?.collapsed)}
@@ -377,6 +375,10 @@ onDestroy(() => {
 			</section>
 		{/each}
 	</section>
+	{/if}
+	<section class="nimble-monster-sheet-section">
+		<MovementSpeed {actor} showDefaultSpeed={false} />
+	</section>
 </section>
 
 <style lang="scss">
@@ -429,7 +431,7 @@ onDestroy(() => {
     }
 
     .nimble-monster-sheet-section {
-        padding: 0 0.5rem 0.5rem 0;
+        padding: 0.5rem;
 
         &--defenses {
             display: grid;

--- a/src/view/sheets/pages/PlayerCharacterCoreTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterCoreTab.svelte
@@ -1,71 +1,53 @@
 <script lang="ts">
-    // Types
-    import type { NimbleCharacter } from "../../../documents/actor/character.js";
+// Types
 
-    // Helper Functions
-    import { getContext } from "svelte";
-    import localize from "../../../utils/localize.js";
-    import replaceHyphenWithMinusSign from "../../dataPreparationHelpers/replaceHyphenWithMinusSign.js";
+// Helper Functions
+import { getContext } from 'svelte';
+import type { NimbleCharacter } from '../../../documents/actor/character.js';
+import localize from '../../../utils/localize.js';
+import replaceHyphenWithMinusSign from '../../dataPreparationHelpers/replaceHyphenWithMinusSign.js';
 
-    // Components
-    import AbilityScores from "../components/AbilityScores.svelte";
-    import ArmorClass from "../components/ArmorClass.svelte";
-    import SavingThrows from "../components/SavingThrows.svelte";
-    import Skills from "../components/Skills.svelte";
+// Components
+import AbilityScores from '../components/AbilityScores.svelte';
+import ArmorClass from '../components/ArmorClass.svelte';
+import MovementSpeed from '../components/MovementSpeed.svelte';
+import SavingThrows from '../components/SavingThrows.svelte';
+import Skills from '../components/Skills.svelte';
 
-    function getArmorProficiencies(proficiencies: Set<string>) {
-        return [...proficiencies]
-            .map((key): string => armorTypesPlural[key] ?? key)
-            .sort((a, b) => a.localeCompare(b));
-    }
+function getArmorProficiencies(proficiencies: Set<string>) {
+	return [...proficiencies]
+		.map((key): string => armorTypesPlural[key] ?? key)
+		.sort((a, b) => a.localeCompare(b));
+}
 
-    function getLanguageProficiencies(proficiencies: Set<string>) {
-        return [...proficiencies]
-            .map((key): string => languages[key] ?? key)
-            .sort((a, b) => a.localeCompare(b));
-    }
+function getLanguageProficiencies(proficiencies: Set<string>) {
+	return [...proficiencies]
+		.map((key): string => languages[key] ?? key)
+		.sort((a, b) => a.localeCompare(b));
+}
 
-    function getMovementLabels(movementModes: Record<string, number>) {
-        return Object.entries(movementModes)
-            .reduce((modes: string[], [key, value]): string[] => {
-                if (value) {
-                    const movementType = localize(movementTypes[key] ?? key);
-                    modes.push(`${movementType}: ${value} spaces`);
-                }
+function getWeaponProficiencies(proficiencies: Set<string>) {
+	return [...proficiencies];
+}
 
-                return modes;
-            }, [])
-            .sort((a, b) => a.localeCompare(b));
-    }
+const { armorTypesPlural, languages, movementTypes } = CONFIG.NIMBLE;
 
-    function getWeaponProficiencies(proficiencies: Set<string>) {
-        return [...proficiencies];
-    }
+let actor: NimbleCharacter = getContext('actor');
+let skills = $derived(actor.reactive.system.skills);
+let abilities = $derived(actor.reactive.system.abilities);
+let characterSavingThrows = $derived(actor.reactive.system.savingThrows);
+let initiative = $derived(actor.reactive.system.attributes.initiative.mod);
 
-    const { armorTypesPlural, languages, movementTypes } = CONFIG.NIMBLE;
+// Proficiencies
+let armorProficiencies = $derived(getArmorProficiencies(actor.reactive.system.proficiencies.armor));
 
-    let actor: NimbleCharacter = getContext("actor");
-    let skills = $derived(actor.reactive.system.skills);
-    let abilities = $derived(actor.reactive.system.abilities);
-    let characterSavingThrows = $derived(actor.reactive.system.savingThrows);
-    let initiative = $derived(actor.reactive.system.attributes.initiative.mod);
+let languageProficiencies = $derived(
+	getLanguageProficiencies(actor.reactive.system.proficiencies.languages),
+);
 
-    let movementModes = $derived(
-        getMovementLabels(actor.reactive.system.attributes.movement),
-    );
-
-    // Proficiencies
-    let armorProficiencies = $derived(
-        getArmorProficiencies(actor.reactive.system.proficiencies.armor),
-    );
-
-    let languageProficiencies = $derived(
-        getLanguageProficiencies(actor.reactive.system.proficiencies.languages),
-    );
-
-    let weaponProficiencies = $derived(
-        getWeaponProficiencies(actor.reactive.system.proficiencies.weapons),
-    );
+let weaponProficiencies = $derived(
+	getWeaponProficiencies(actor.reactive.system.proficiencies.weapons),
+);
 </script>
 
 <section class="nimble-sheet__body nimble-sheet__body--player-character">
@@ -117,7 +99,9 @@
 
     <Skills {skills} />
 
-    {#each [{ heading: "Movement", configMethod: actor.configureMovement.bind(actor), content: movementModes, prompt: "configureMovement" }, { heading: "Language Proficiencies", configMethod: actor.configureLanguageProficiencies.bind(actor), content: languageProficiencies, prompt: "configureLanguageProficiencies" }, { heading: "Armor Proficiencies", configMethod: actor.configureArmorProficiencies.bind(actor), content: armorProficiencies, prompt: "configureArmorProficiencies" }, { heading: "Weapon Proficiencies", configMethod: actor.configureWeaponProficiencies.bind(actor), content: weaponProficiencies.filter((weapon) => weapon.trim().length > 0), prompt: "configureWeaponProficiencies" }] as { heading, configMethod, content, prompt }}
+	<MovementSpeed {actor} showDefaultSpeed={true} />
+
+    {#each [{ heading: "Language Proficiencies", configMethod: actor.configureLanguageProficiencies.bind(actor), content: languageProficiencies, prompt: "configureLanguageProficiencies" }, { heading: "Armor Proficiencies", configMethod: actor.configureArmorProficiencies.bind(actor), content: armorProficiencies, prompt: "configureArmorProficiencies" }, { heading: "Weapon Proficiencies", configMethod: actor.configureWeaponProficiencies.bind(actor), content: weaponProficiencies.filter((weapon) => weapon.trim().length > 0), prompt: "configureWeaponProficiencies" }] as { heading, configMethod, content, prompt }}
         {@const tooltip = localize(`NIMBLE.prompts.${prompt}`)}
 
         <section>


### PR DESCRIPTION
### Clicking on edit next to metadata will bring up configuration.

<img width="659" height="470" alt="Screenshot 2025-10-25 at 9 13 10 PM" src="https://github.com/user-attachments/assets/fbaf4a55-ed8f-405b-89a7-e290faaa23e2" />

### Clicking on Configure Movement next to Movement will bring up movement configuration dialog. The NPC movement speed not displayed when set to default.

<img width="922" height="594" alt="Screenshot 2025-10-25 at 9 13 20 PM" src="https://github.com/user-attachments/assets/0a78823c-9db5-4223-b95f-a7bb230a26ed" />

### NPC movement speed displayed when modified away from default.

<img width="944" height="560" alt="Screenshot 2025-10-25 at 9 13 59 PM" src="https://github.com/user-attachments/assets/6f9d4381-9c08-48d4-8dae-42d7f25f871c" />

### Solo monster movement speed not displayed when set to default.

<img width="935" height="518" alt="Screenshot 2025-10-25 at 9 14 24 PM" src="https://github.com/user-attachments/assets/185c36d3-8a39-4a9b-97f1-f2417931dc80" />

### Minion movement speed displayed when modified away from default.

<img width="923" height="590" alt="Screenshot 2025-10-25 at 9 13 29 PM" src="https://github.com/user-attachments/assets/8f6394f3-820f-4b72-a0f4-c8afbc34c3b8" />
