### PR TITLE
Limit skill points to a max of 12 on level up

### DIFF
--- a/src/view/dialogs/components/levelUpHelper/SkillPointAssignment.svelte
+++ b/src/view/dialogs/components/levelUpHelper/SkillPointAssignment.svelte
@@ -46,7 +46,7 @@ function canSubtract(skill, skillKey) {
 function getSubtractTooltip(skill, skillKey) {
 	if (skill.points + skillPointChanges[skillKey] < 1) return 'Skill points can’t go below 0.';
 	if (skillPointChanges[skillKey] === -1) return 'Already marked to transfer 1 point.';
-	if (Object.values(skillPointChanges).some((value) => value === 1)) return '';
+	if (skillPointAdded) return '';
 	if (skillPointRemoved) return 'Only one transfer per level-up.';
 
 	return '';


### PR DESCRIPTION
Added style to show buttons visually as disabled. Included tooltip that will describe the reason why they are disabled. You cannot add more than 12 to a skill.

<img width="635" height="674" alt="Screenshot 2025-10-26 at 1 20 35 AM" src="https://github.com/user-attachments/assets/6aa74b50-3a08-4963-b4b7-591da1417f07" />
<img width="630" height="664" alt="Screenshot 2025-10-26 at 1 09 34 AM" src="https://github.com/user-attachments/assets/bf31c864-ea6a-4d65-8f49-ea51f3ea54df" />
<img width="634" height="672" alt="Screenshot 2025-10-26 at 1 00 06 AM" src="https://github.com/user-attachments/assets/2674525b-f9c6-4c63-bb54-37adf5f9709d" />
