### PR TITLE
Tc/chore/unused vars error on linter

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -22,7 +22,10 @@
 			"complexity": {
 				"noForEach": "off"
 			},
-			"correctness": { "noInvalidUseBeforeDeclaration": "off" },
+			"correctness": {
+				"noInvalidUseBeforeDeclaration": "off",
+				"noUnusedVariables": "error"
+			},
 			"performance": {
 				"noDelete": "off"
 			},

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,7 +19,7 @@ export default [
 			...tseslint.configs.recommended.rules,
 			'no-unused-vars': 'off',
 			'@typescript-eslint/no-unused-vars': [
-				'warn',
+				'error',
 				{
 					argsIgnorePattern: '^_',
 					varsIgnorePattern: '^_',
@@ -61,7 +61,7 @@ export default [
 			// Add your custom rules here
 			'no-unused-vars': 'off', // Turn off for Svelte files as it has false positives with reactive statements
 			'@typescript-eslint/no-unused-vars': [
-				'warn',
+				'error',
 				{
 					argsIgnorePattern: '^_',
 					varsIgnorePattern: '^_',


### PR DESCRIPTION
Linter will have an error on any unused vars in the linter unless they are explicitly prefixed with an underscore.