### PR TITLE
fixes and feat: light-dark mode combat UI, roll init from pc sheet

### DIFF
--- a/src/documents/sheets/FeatureSheet.svelte.ts
+++ b/src/documents/sheets/FeatureSheet.svelte.ts
@@ -31,7 +31,7 @@ export default class FeatureSheet extends SvelteApplicationMixin(
 			resizable: true,
 		},
 		position: {
-			width: 288,
+			width: 400,
 			height: 'auto',
 		},
 		actions: {},

--- a/src/nimble.ts
+++ b/src/nimble.ts
@@ -29,3 +29,13 @@ Hooks.on('createActiveEffect', handleAutomaticConditionApplication.postCreate);
 Hooks.on('deleteActiveEffect', handleAutomaticConditionApplication.postDelete);
 
 Hooks.on('hotbarDrop', hotbarDrop);
+
+// Refresh tokens when combat ends to remove turn indicators
+Hooks.on('deleteCombat', () => {
+	if (!canvas.ready) return;
+
+	// Refresh all tokens on the canvas to clear turn indicators
+	for (const token of canvas.tokens.placeables) {
+		token.renderFlags.set({ refreshTurnMarker: true });
+	}
+});

--- a/src/scss/base/_theme.scss
+++ b/src/scss/base/_theme.scss
@@ -1,6 +1,10 @@
 //** FOUNDRY DARK THEME **/
 
 .theme-dark {
+  /** COMBAT TRACKER **/
+  --nimble-combat-tracker-text-color: hsl(38, 38%, 94%);
+  --nimble-combat-tracker-background: hsla(0, 0%, 0%, 0.85);
+
   /** TEXT COLORS **/
   --nimble-dark-text-color: hsl(36, 53%, 80%);
   --nimble-dark-text-hover-color: hsl(36, 58%, 90%);

--- a/src/scss/base/_variables.scss
+++ b/src/scss/base/_variables.scss
@@ -89,6 +89,10 @@
 
     --nimble-defeated-combatant-name-color: hsl(1, 75%, 60%);
 
+    /** COMBAT TRACKER **/
+    --nimble-combat-tracker-text-color: var(--nimble-dark-text-color);
+    --nimble-combat-tracker-background: hsla(0, 0%, 100%, 0.85);
+
     --nimble-checkbox-checked-color: var(--nimble-hp-bar-background);
     --nimble-checkbox-checkmark-color: var(--nimble-light-text-color);
 

--- a/src/scss/components/_combat-tracker.scss
+++ b/src/scss/components/_combat-tracker.scss
@@ -1,10 +1,14 @@
 .nimble-combat-tracker {
+  --nimble-combat-tracker-hover-color: hsl(0, 66%, 53%);
+  --nimble-combat-tracker-border-color: hsl(41, 18%, 54%);
+
   display: flex;
   flex-direction: column;
   height: 100dvh;
   width: 6.5rem;
-  color: var(--color-text-light-highlight);
-  background: url("/ui/denim075.png") repeat;
+  color: var(--nimble-combat-tracker-text-color);
+  background: var(--nimble-combat-tracker-background);
+  backdrop-filter: blur(4px);
   box-shadow: 0 0 20px var(--color-shadow-dark);
   border-inline-end: 1px solid var(--color-dark-4);
   overflow-y: clip;
@@ -39,6 +43,12 @@
     background: transparent;
     border: 0;
     transition: var(--nimble-standard-transition);
+
+    &:hover,
+    &:focus {
+      color: var(--nimble-combat-tracker-hover-color);
+      text-shadow: 0 0 8px var(--nimble-combat-tracker-hover-color);
+    }
   }
 
   &__header {
@@ -60,6 +70,7 @@
     font-family: var(--font-h3);
     font-size: var(--nimble-md-text);
     font-weight: 600;
+    color: var(--nimble-combat-tracker-text-color);
     border: 0;
   }
 
@@ -71,10 +82,17 @@
     font-weight: 600;
     color: inherit;
     background: transparent;
-    border: 1px solid hsl(41, 18%, 54%);
+    border: 1px solid var(--nimble-combat-tracker-border-color);
     border-radius: 4px;
     box-shadow: var(--nimble-box-shadow);
     transition: var(--nimble-standard-transition);
+
+    &:hover,
+    &:focus {
+      color: var(--nimble-combat-tracker-hover-color);
+      border-color: var(--nimble-combat-tracker-hover-color);
+      box-shadow: 0 0 8px var(--nimble-combat-tracker-hover-color);
+    }
   }
 }
 
@@ -101,6 +119,8 @@
 
     &:focus,
     &:hover {
+      color: var(--nimble-combat-tracker-hover-color);
+      text-shadow: 0 0 8px var(--nimble-combat-tracker-hover-color);
       box-shadow: none;
       transform: scale(1.2);
     }
@@ -137,11 +157,16 @@
   line-height: 1;
   color: inherit;
   background: transparent;
-  border: 1px solid hsl(41, 18%, 54%);
+  border: 1px solid var(--nimble-combat-tracker-border-color);
   border-radius: 4px;
   box-shadow: var(--nimble-box-shadow);
   overflow: hidden;
   transition: var(--nimble-standard-transition);
+
+  &:hover {
+    border-color: var(--nimble-combat-tracker-hover-color);
+    box-shadow: 0 0 6px var(--nimble-combat-tracker-hover-color);
+  }
 
   &--active {
     border-color: var(--color-border-highlight);
@@ -158,7 +183,7 @@
     font-size: var(--nimble-sm-text);
     font-weight: 500;
     line-height: 1;
-    text-shadow: 1px 1px 4px var(--color-shadow-dark);
+    color: var(--nimble-combat-tracker-text-color);
     border: 0;
     white-space: nowrap;
     text-overflow: ellipsis;
@@ -225,14 +250,15 @@
   }
 
   &__initiative-button {
-    --nimble-icon-color: var(--nimble-medium-text-color);
+    --nimble-icon-color: var(--nimble-combat-tracker-text-color);
 
     width: 100%;
     transition: var(--nimble-standard-transition);
 
     &:hover {
-      --nimble-icon-color: var(--nimble-light-text-color);
+      --nimble-icon-color: var(--nimble-combat-tracker-hover-color);
       box-shadow: none;
+      text-shadow: 0 0 8px var(--nimble-combat-tracker-hover-color);
     }
   }
 
@@ -306,6 +332,12 @@
     border: 0;
     border-radius: 4px;
     transition: var(--nimble-standard-transition);
+
+    &:hover,
+    &:focus {
+      color: var(--nimble-combat-tracker-hover-color);
+      text-shadow: 0 0 6px var(--nimble-combat-tracker-hover-color);
+    }
 
     &--active {
       --nimble-combatant-controls-overlay-display: block;

--- a/src/view/ui/CombatTracker.svelte
+++ b/src/view/ui/CombatTracker.svelte
@@ -114,10 +114,12 @@
 			in:slide={{ axis: 'y', delay: 200 }}
 			out:fade={{ delay: 0 }}
 		>
-			{#if currentCombat?.reactive?.round === 0}
+			{#if currentCombat?.reactive?.round === 0 && game.user!.isGM}
 				<button class="nimble-combat-tracker__start-button" onclick={startCombat}>
 					Start Combat
 				</button>
+			{:else if currentCombat?.reactive?.round === 0}
+				<h2 class="nimble-combat-tracker__heading">Combat Not Started</h2>
 			{:else}
 				<h2 class="nimble-combat-tracker__heading">
 					Round {currentCombat?.reactive?.round}
@@ -145,7 +147,7 @@
 			{/each}
 		</ol>
 
-		{#if currentCombat?.reactive?.combatants.some((combatant) => combatant.initiative === null)}
+		{#if game.user!.isGM && currentCombat?.reactive?.combatants.some((combatant) => combatant.initiative === null)}
 			<footer class="nimble-combat-tracker__footer">
 				<div class="nimble-combat-tracker__footer-roll-container">
 					<button


### PR DESCRIPTION
Feature to enhance light/dark mode for combat UI.
Feature for rolling initiative from PC sheet.
Fix for removing the combat token turn indicator when ending combat.
Fix to only allow GM to start combat or roll initiative for all.