### PR TITLE
tokenizer fixes

### DIFF
--- a/src/documents/actor/base.svelte.ts
+++ b/src/documents/actor/base.svelte.ts
@@ -498,10 +498,14 @@ class NimbleBaseActor extends Actor {
 
 		switch (type) {
 			case 'abilityCheck':
-				title = `${this.name}: Configure ${CONFIG.NIMBLE.abilityScores[data?.abilityKey ?? '']} Ability Check`;
+				title = `${this.name}: Configure ${
+					CONFIG.NIMBLE.abilityScores[data?.abilityKey ?? '']
+				} Ability Check`;
 				break;
 			case 'savingThrow':
-				title = `${this.name}: Configure ${CONFIG.NIMBLE.savingThrows[data?.saveKey ?? '']} Saving Throw`;
+				title = `${this.name}: Configure ${
+					CONFIG.NIMBLE.savingThrows[data?.saveKey ?? '']
+				} Saving Throw`;
 				break;
 			case 'skillCheck':
 				title = `${this.name}: Configure ${CONFIG.NIMBLE.skills[data?.skillKey ?? '']} Skill Check`;
@@ -571,7 +575,10 @@ class NimbleBaseActor extends Actor {
 		// If Image is changed, change prototype token as well
 		const img = foundry.utils.getProperty(changes, 'img');
 		if (img) {
-			foundry.utils.setProperty(changes, 'prototypeToken.texture.src', img);
+			// we don't update the token image if the tokenizer module is installed & active
+			if (game.modules.get('tokenizer')?.active === false) {
+				foundry.utils.setProperty(changes, 'prototypeToken.texture.src', img);
+			}
 		}
 
 		return super._preUpdate(changes, options, user);

--- a/src/view/handlers/updateDocumentImage.ts
+++ b/src/view/handlers/updateDocumentImage.ts
@@ -1,7 +1,7 @@
 export default async function updateDocumentImage(document, options = { shiftKey: false }) {
 	// Add support for tokenizer
 	if (game.modules.get('vtta-tokenizer')?.active && !options.shiftKey) {
-		if (['character', 'soloMonster'].includes(document.type)) {
+		if (['character', 'soloMonster', 'npc', 'minion'].includes(document.type)) {
 			// eslint-disable-next-line no-undef
 			Tokenizer?.tokenizeActor(document);
 			return null;


### PR DESCRIPTION
Fixes for:

- opening tokenizer dialog for every actor type
- don't overwrite the token image if the tokenizer module is active