### PR TITLE
feat(sheets): support separate token and actor images

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -327,6 +327,7 @@
 			"changeItemImage": "Change Item Image",
 			"changeSpellImage": "Change Spell Image",
 			"changeSubclassImage": "Change Subclass Image",
+			"changeTokenImage": "Change Token Image",
 			"configureAbilityScores": "Configure Ability Scores",
 			"configureArmorProficiencies": "Configure Armor Proficiencies",
 			"configureLanguageProficiencies": "Configure Language Proficiencies",

--- a/public/lang/es.json
+++ b/public/lang/es.json
@@ -392,6 +392,7 @@
 			"changeItemImage": "Change Item Image",
 			"changeSpellImage": "Change Spell Image",
 			"changeSubclassImage": "Change Subclass Image",
+			"changeTokenImage": "Change Token Image",
 			"configureAbilityScores": "Configure Ability Scores",
 			"configureArmorProficiencies": "Configure Armor Proficiencies",
 			"configureLanguageProficiencies": "Configure Language Proficiencies",

--- a/src/documents/actor/base.svelte.ts
+++ b/src/documents/actor/base.svelte.ts
@@ -605,11 +605,18 @@ class NimbleBaseActor<ActorType extends SystemActorTypes = SystemActorTypes> ext
 			foundry.utils.setProperty(changesObj, 'system.attributes.hp.temp', 0);
 		}
 
-		// If Image is changed, change prototype token as well
+		// If Image is changed, change prototype token as well (unless separate images are enabled)
 		const img = foundry.utils.getProperty(changesObj, 'img');
 		if (img) {
-			// we don't update the token image if the tokenizer module is installed & active
-			if (game.modules.get('tokenizer')?.active === false) {
+			const useSeparateTokenImage =
+				(this.getFlag('nimble', 'useSeparateTokenImage' as never) as boolean) ?? false;
+			const tokenizerActive =
+				game.modules.get('tokenizer')?.active || game.modules.get('vtta-tokenizer')?.active;
+
+			// Don't update the token image if:
+			// - The tokenizer module is installed & active, OR
+			// - The user has enabled separate token images
+			if (!tokenizerActive && !useSeparateTokenImage) {
 				foundry.utils.setProperty(changes, 'prototypeToken.texture.src', img);
 			}
 		}

--- a/src/scss/components/_image.scss
+++ b/src/scss/components/_image.scss
@@ -44,7 +44,11 @@
     &--actor,
     &--actor:focus,
     &--actor:hover {
+      display: flex;
+      align-items: center;
+      justify-content: center;
       flex-grow: 1;
+      min-height: 0;
       border-radius: 0;
     }
 
@@ -78,6 +82,21 @@
       scale: var(--nimble-actor-image-scale, 100%);
       object-position: top center;
       height: 100%;
+      transition: clip-path 0.2s ease-in-out, top 0.2s ease-in-out, left 0.2s ease-in-out;
+    }
+
+    &--token-view {
+      // Reset offsets and scale for token view - show the token image as-is
+      top: 0 !important;
+      left: 0 !important;
+      scale: 100% !important;
+      width: auto;
+      max-width: 100%;
+      max-height: 100%;
+      margin: auto;
+      object-position: center;
+      object-fit: contain;
+      aspect-ratio: unset;
     }
 
     &[src$=".svg" i] {
@@ -88,5 +107,33 @@
     &--actor.nimble-icon__image[src$=".svg" i] {
       padding-block-end: 1rem;
     }
+  }
+}
+
+.system-nimble .nimble-image-view-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  width: 100%;
+  padding: 0.25rem 0.5rem;
+  margin: 0;
+  background-color: var(--nimble-button-background-color, rgba(0, 0, 0, 0.1));
+  border: 1px solid var(--nimble-border-color, hsl(41, 18%, 54%));
+  border-top: 0;
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+  color: var(--nimble-text-color);
+  font-size: var(--nimble-sm-text, 0.75rem);
+  cursor: pointer;
+  transition: background-color 0.15s ease-in-out;
+
+  &:hover,
+  &:focus {
+    background-color: var(--nimble-button-hover-background-color, rgba(0, 0, 0, 0.2));
+  }
+
+  i {
+    font-size: 0.875em;
   }
 }

--- a/src/view/handlers/updateDocumentImage.ts
+++ b/src/view/handlers/updateDocumentImage.ts
@@ -1,11 +1,20 @@
 declare const Tokenizer: { tokenizeActor?(actor: Actor): void } | undefined;
 
+export type ImageType = 'actor' | 'token';
+
+export interface UpdateDocumentImageOptions {
+	shiftKey?: boolean;
+	imageType?: ImageType;
+}
+
 export default async function updateDocumentImage(
 	document: Actor | Item,
-	options = { shiftKey: false },
+	options: UpdateDocumentImageOptions = {},
 ) {
+	const { shiftKey = false, imageType = 'actor' } = options;
+
 	// Add support for tokenizer
-	if (game.modules.get('vtta-tokenizer')?.active && !options.shiftKey) {
+	if (game.modules.get('vtta-tokenizer')?.active && !shiftKey) {
 		if (['character', 'soloMonster', 'npc', 'minion'].includes(document.type)) {
 			// eslint-disable-next-line no-undef
 			Tokenizer?.tokenizeActor?.(document as Actor);
@@ -13,11 +22,21 @@ export default async function updateDocumentImage(
 		}
 	}
 
+	// Determine current image and update path based on image type
+	const isTokenImage = imageType === 'token' && 'prototypeToken' in document;
+	const currentImage = isTokenImage
+		? (document as Actor).prototypeToken?.texture?.src
+		: document.img;
+
 	const filePicker = new FilePicker({
 		type: 'image',
-		current: document.img ?? undefined,
+		current: currentImage ?? undefined,
 		callback: async (path) => {
-			await document.update({ img: path });
+			if (isTokenImage) {
+				await document.update({ 'prototypeToken.texture.src': path } as Record<string, unknown>);
+			} else {
+				await document.update({ img: path });
+			}
 		},
 	});
 

--- a/src/view/sheets/NPCSheet.svelte
+++ b/src/view/sheets/NPCSheet.svelte
@@ -11,6 +11,15 @@
 		return Math.clamp(0, Math.round((currentHP / maxHP) * 100), 100);
 	}
 
+	function handleImageToggleClick() {
+		// If clicking while in token mode and tokenizer is active, trigger tokenizer
+		if (showTokenImage && game.modules.get('vtta-tokenizer')?.active) {
+			updateDocumentImage(actor, { imageType: 'token' });
+		} else {
+			showTokenImage = !showTokenImage;
+		}
+	}
+
 	function updateCurrentHP(newValue) {
 		actor.update({ 'system.attributes.hp.value': newValue });
 	}
@@ -88,6 +97,14 @@
 	let actorImageYOffset = $derived(flags?.actorImageYOffset ?? 0);
 	let actorImageScale = $derived(flags?.actorImageScale ?? 100);
 
+	// Token image
+	let tokenImageSrc = $derived(actor.reactive.prototypeToken?.texture?.src ?? '');
+	let showTokenImage = $state(false);
+	let currentImageSrc = $derived(
+		showTokenImage ? tokenImageSrc || actor.reactive.img : actor.reactive.img,
+	);
+	let currentImageType = $derived(showTokenImage ? 'token' : 'actor');
+
 	setContext('actor', actor);
 </script>
 
@@ -95,14 +112,18 @@
 	<section class="nimble-icon nimble-icon--actor">
 		<button
 			class="nimble-icon__button nimble-icon__button--actor"
-			data-tooltip="NIMBLE.prompts.changeActorImage"
+			data-tooltip={showTokenImage
+				? 'NIMBLE.prompts.changeTokenImage'
+				: 'NIMBLE.prompts.changeActorImage'}
 			type="button"
-			aria-label="Change Actor Image"
-			onclick={(event) => updateDocumentImage(actor, { shiftKey: event.shiftKey })}
+			aria-label={showTokenImage ? 'Change Token Image' : 'Change Actor Image'}
+			onclick={(event) =>
+				updateDocumentImage(actor, { shiftKey: event.shiftKey, imageType: currentImageType })}
 		>
 			<img
 				class="nimble-icon__image nimble-icon__image--actor"
-				src={actor.reactive.img}
+				class:nimble-icon__image--token-view={showTokenImage}
+				src={currentImageSrc}
 				alt={actor.reactive.name}
 				style="
                     --nimble-actor-image-x-offset: {actorImageXOffset}px;
@@ -110,6 +131,20 @@
                     --nimble-actor-image-scale: {actorImageScale}%;
                 "
 			/>
+		</button>
+
+		<button
+			class="nimble-image-view-toggle"
+			type="button"
+			aria-label={showTokenImage ? 'Show Actor Image' : 'Show Token Image'}
+			data-tooltip={showTokenImage ? 'Show Actor Image' : 'Show Token Image'}
+			onclick={() => {
+				handleImageToggleClick();
+				game.tooltip.deactivate();
+			}}
+		>
+			<i class="fa-solid {showTokenImage ? 'fa-user' : 'fa-circle-user'}"></i>
+			<span>{showTokenImage ? 'Token' : 'Avatar'}</span>
 		</button>
 	</section>
 

--- a/src/view/sheets/PlayerCharacterSheet.svelte
+++ b/src/view/sheets/PlayerCharacterSheet.svelte
@@ -139,6 +139,14 @@
 	let actorImageYOffset = $derived(flags?.actorImageYOffset ?? 0);
 	let actorImageScale = $derived(flags?.actorImageScale ?? 100);
 
+	// Token image
+	let tokenImageSrc = $derived(actor.reactive.prototypeToken?.texture?.src ?? '');
+	let showTokenImage = $state(false);
+	let currentImageSrc = $derived(
+		showTokenImage ? tokenImageSrc || actor.reactive.img : actor.reactive.img,
+	);
+	let currentImageType = $derived(showTokenImage ? 'token' : 'actor');
+
 	let metaData = $derived.by(() => {
 		const c = actor.reactive.items.find((i) => i.type === 'class') ?? null;
 		const sub = actor.reactive.items.find((i) => i.type === 'subclass') ?? null;
@@ -251,14 +259,20 @@
 
 		<button
 			class="nimble-icon__button nimble-icon__button--actor"
-			aria-label={localize('NIMBLE.prompts.changeActorImage')}
-			data-tooltip="NIMBLE.prompts.changeActorImage"
-			onclick={(event) => updateDocumentImage(actor, { shiftKey: event.shiftKey })}
+			aria-label={showTokenImage
+				? localize('NIMBLE.prompts.changeTokenImage')
+				: localize('NIMBLE.prompts.changeActorImage')}
+			data-tooltip={showTokenImage
+				? 'NIMBLE.prompts.changeTokenImage'
+				: 'NIMBLE.prompts.changeActorImage'}
+			onclick={(event) =>
+				updateDocumentImage(actor, { shiftKey: event.shiftKey, imageType: currentImageType })}
 			type="button"
 		>
 			<img
 				class="nimble-icon__image nimble-icon__image--actor"
-				src={actor.reactive.img}
+				class:nimble-icon__image--token-view={showTokenImage}
+				src={currentImageSrc}
 				alt={actor.reactive.name}
 				style="
                     --nimble-actor-image-x-offset: {actorImageXOffset}px;
@@ -373,6 +387,20 @@
 <currentTab.component />
 
 <section class="nimble-sheet__sidebar">
+	<button
+		class="nimble-button"
+		data-button-variant="overhang"
+		aria-label={showTokenImage ? 'Show Actor Image' : 'Show Token Image'}
+		data-tooltip={showTokenImage ? 'Show Actor Image' : 'Show Token Image'}
+		onclick={() => {
+			showTokenImage = !showTokenImage;
+			game.tooltip.deactivate();
+		}}
+		type="button"
+	>
+		<i class="fa-solid {showTokenImage ? 'fa-user' : 'fa-circle-user'}"></i>
+	</button>
+
 	<button
 		class="nimble-button"
 		data-button-variant="overhang"

--- a/src/view/sheets/pages/NPCSettingsTab.svelte
+++ b/src/view/sheets/pages/NPCSettingsTab.svelte
@@ -6,6 +6,7 @@
 	let actorImageXOffset = $derived(flags?.actorImageXOffset ?? 0);
 	let actorImageYOffset = $derived(flags?.actorImageYOffset ?? 0);
 	let actorImageScale = $derived(flags?.actorImageScale ?? 100);
+	let useSeparateTokenImage = $derived(flags?.useSeparateTokenImage ?? false);
 </script>
 
 <section class="nimble-sheet__body">
@@ -51,6 +52,16 @@
 				/>
 			</label>
 		</div>
+
+		<label class="nimble-field">
+			<input
+				type="checkbox"
+				checked={useSeparateTokenImage}
+				onchange={({ target }) => actor.setFlag('nimble', 'useSeparateTokenImage', target.checked)}
+			/>
+
+			<span class="nimble-field__label"> Use Separate Token Image </span>
+		</label>
 	</section>
 </section>
 

--- a/src/view/sheets/pages/PlayerCharacterSettingsTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterSettingsTab.svelte
@@ -17,6 +17,7 @@
 	let actorImageXOffset = $derived(flags?.actorImageXOffset ?? 0);
 	let actorImageYOffset = $derived(flags?.actorImageYOffset ?? 0);
 	let actorImageScale = $derived(flags?.actorImageScale ?? 100);
+	let useSeparateTokenImage = $derived(flags?.useSeparateTokenImage ?? false);
 
 	let bonusInventorySlots = $derived(actor.reactive?.system?.inventory?.bonusSlots ?? 0);
 
@@ -70,6 +71,16 @@
 				/>
 			</label>
 		</div>
+
+		<label class="nimble-field">
+			<input
+				type="checkbox"
+				checked={useSeparateTokenImage}
+				onchange={({ target }) => actor.setFlag('nimble', 'useSeparateTokenImage', target.checked)}
+			/>
+
+			<span class="nimble-field__label"> Use Separate Token Image </span>
+		</label>
 	</section>
 
 	<section>


### PR DESCRIPTION
Add ability to toggle between actor portrait and token image on character and NPC sheets. Includes a new setting to prevent actor image changes from automatically updating the token image, and integration with tokenizer.