### PR TITLE
fix: correct damage types for creature attacks

### DIFF
--- a/packs/legendaryMonsters/core/thorn-quickblade.json
+++ b/packs/legendaryMonsters/core/thorn-quickblade.json
@@ -327,7 +327,7 @@
 						{
 							"id": "Vmm3IICgQYD0xGC3",
 							"type": "damage",
-							"damageType": "acid",
+							"damageType": "piercing",
 							"formula": "2d4+3",
 							"parentContext": null,
 							"parentNode": null,

--- a/packs/monsters/core/horrors/spiny-fiend.json
+++ b/packs/monsters/core/horrors/spiny-fiend.json
@@ -282,7 +282,7 @@
 						{
 							"id": "3LCSykvkYyEpMtVF",
 							"type": "damage",
-							"damageType": "acid",
+							"damageType": "piercing",
 							"formula": "1d6+6",
 							"parentContext": null,
 							"parentNode": null,

--- a/packs/monsters/core/underground/great-worm.json
+++ b/packs/monsters/core/underground/great-worm.json
@@ -218,7 +218,7 @@
 									{
 										"id": "ogrGMAxnbWUF6fBB",
 										"type": "damage",
-										"damageType": "acid",
+										"damageType": "bludgeoning",
 										"formula": "50",
 										"parentContext": "failedSave",
 										"parentNode": "WWKE5zboJ97IA44J"

--- a/packs/monsters/core/underground/nestweaver.json
+++ b/packs/monsters/core/underground/nestweaver.json
@@ -299,7 +299,7 @@
 						{
 							"id": "cREA7LLMJ7O9va97",
 							"type": "damage",
-							"damageType": "acid",
+							"damageType": "poison",
 							"formula": "3d8+6",
 							"parentContext": null,
 							"parentNode": null,


### PR DESCRIPTION
## Summary
- Fixed several creature attacks that were incorrectly using "acid" as a placeholder damage type
- Thorn Quickblade rapier: acid → piercing
- Spiny Fiend spine: acid → piercing
- Great Worm crush: acid → bludgeoning
- Nestweaver bite: acid → poison

## Test plan
- [ ] Load Thorn Quickblade and use Heart Piercer attack - verify chat shows "piercing" damage
- [ ] Load Spiny Fiend and use Shoot Spine attack - verify chat shows "piercing" damage
- [ ] Load Great Worm and use Crush attack - verify chat shows "bludgeoning" damage
- [ ] Load Nestweaver and use Bite attack - verify chat shows "poison" damage