### PR TITLE
revert: remove non-functional edit toggle feature from PR #266

### DIFF
--- a/src/view/sheets/PlayerCharacterSheet.svelte
+++ b/src/view/sheets/PlayerCharacterSheet.svelte
@@ -1,6 +1,5 @@
 <script>
 	import { setContext } from 'svelte';
-	import { readable } from 'svelte/store';
 	import localize from '../../utils/localize.js';
 	import PrimaryNavigation from '../components/PrimaryNavigation.svelte';
 	import updateDocumentImage from '../handlers/updateDocumentImage.js';
@@ -97,10 +96,6 @@
 		await actor.editCurrentHitDice();
 	}
 
-	async function toggleEditingEnabled() {
-		await actor.setFlag('nimble', 'editingEnabled', !editingEnabled);
-	}
-
 	let { actor, sheet } = $props();
 
 	const navigation = $state([
@@ -169,11 +164,6 @@
 	let actorImageXOffset = $derived(flags?.actorImageXOffset ?? 0);
 	let actorImageYOffset = $derived(flags?.actorImageYOffset ?? 0);
 	let actorImageScale = $derived(flags?.actorImageScale ?? 100);
-	let editingEnabled = $derived(flags?.editingEnabled ?? true);
-	const editingEnabledStore = readable(editingEnabled, (set) => {
-		$effect(() => set(editingEnabled));
-		return () => {};
-	});
 
 	let metaData = $derived.by(() => {
 		const c = actor.reactive.items.find((i) => i.type === 'class') ?? null;
@@ -260,26 +250,9 @@
 	setContext('actor', actor);
 	setContext('document', actor);
 	setContext('application', sheet);
-	setContext('editingEnabled', editingEnabledStore);
 </script>
 
 <header class="nimble-sheet__header">
-	<button
-		class="nimble-edit-toggle"
-		class:nimble-edit-toggle--enabled={editingEnabled}
-		type="button"
-		aria-pressed={editingEnabled}
-		aria-label={editingEnabled ? 'Disable editing' : 'Enable editing'}
-		data-tooltip={editingEnabled ? 'Editing Enabled' : 'Editing Locked'}
-		onclick={toggleEditingEnabled}
-	>
-		<span class="nimble-edit-toggle__track">
-			<span class="nimble-edit-toggle__thumb">
-				<i class="fa-solid {editingEnabled ? 'fa-pen' : 'fa-lock'}"></i>
-			</span>
-		</span>
-	</button>
-
 	<div class="nimble-icon nimble-icon--actor">
 		<ul
 			class="nimble-wounds-list"
@@ -308,7 +281,6 @@
 			data-tooltip="NIMBLE.prompts.changeActorImage"
 			onclick={(event) => updateDocumentImage(actor, { shiftKey: event.shiftKey })}
 			type="button"
-			disabled={!editingEnabled}
 		>
 			<img
 				class="nimble-icon__image nimble-icon__image--actor"
@@ -351,7 +323,6 @@
 				aria-label="Configure Hit Points"
 				data-tooltip="Configure Hit Points"
 				onclick={() => actor.configureHitPoints()}
-				disabled={!editingEnabled}
 			>
 				<i class="fa-solid fa-edit"></i>
 			</button>
@@ -365,7 +336,7 @@
 			{updateCurrentHP}
 			{updateMaxHP}
 			{updateTempHP}
-			disableMaxHPEdit={!editingEnabled}
+			disableMaxHPEdit={true}
 		/>
 
 		<h3 class="nimble-heading nimble-heading--hit-dice">
@@ -378,7 +349,6 @@
 				aria-label={CONFIG.NIMBLE.hitDice.configureHitDice}
 				data-tooltip={CONFIG.NIMBLE.hitDice.configureHitDice}
 				onclick={() => actor.configureHitDice()}
-				disabled={!editingEnabled}
 			>
 				<i class="fa-solid fa-edit"></i>
 			</button>
@@ -391,7 +361,6 @@
 			{updateCurrentHitDice}
 			{editCurrentHitDice}
 			{rollHitDice}
-			disableControls={!editingEnabled}
 		/>
 
 		{#if hasMana}
@@ -418,7 +387,6 @@
 			autocomplete="off"
 			spellcheck="false"
 			onchange={({ target }) => actor.update({ name: target.value })}
-			disabled={!editingEnabled}
 		/>
 
 		{#if metaData}
@@ -432,7 +400,6 @@
 					aria-label="Edit"
 					data-tooltip="Edit"
 					onclick={() => actor.editMetadata()}
-					disabled={!editingEnabled}
 				>
 					<i class="fa-solid fa-edit"></i>
 				</button>
@@ -494,75 +461,6 @@
 </section>
 
 <style lang="scss">
-	.nimble-sheet__header {
-		position: relative;
-	}
-
-	.nimble-edit-toggle {
-		position: absolute;
-		top: 0.5rem;
-		left: 0.5rem;
-		z-index: 50;
-		display: inline-flex;
-		align-items: center;
-		justify-content: center;
-		border: 1px solid hsl(41, 18%, 54%);
-		border-radius: 999px;
-		background: hsl(215, 30%, 10%);
-		padding: 0.125rem;
-		box-shadow: var(--nimble-card-box-shadow);
-		cursor: pointer;
-		transition:
-			transform 0.15s ease,
-			box-shadow 0.15s ease;
-
-		&:hover {
-			transform: translateY(-1px);
-			box-shadow:
-				var(--nimble-card-box-shadow),
-				0 0 6px rgba(255, 255, 255, 0.2);
-		}
-
-		&:disabled {
-			opacity: 0.6;
-			cursor: default;
-		}
-	}
-
-	.nimble-edit-toggle__track {
-		position: relative;
-		width: 2.1rem;
-		height: 1rem;
-		border-radius: 999px;
-		background: linear-gradient(to right, hsl(45, 35%, 30%) 0%, hsl(45, 35%, 18%) 100%);
-		border: 1px solid hsl(41, 18%, 54%);
-		display: flex;
-		align-items: center;
-	}
-
-	.nimble-edit-toggle__thumb {
-		position: absolute;
-		left: 0.1rem;
-		width: 0.85rem;
-		height: 0.85rem;
-		border-radius: 50%;
-		background: hsl(45, 70%, 72%);
-		display: inline-flex;
-		align-items: center;
-		justify-content: center;
-		color: hsl(215, 30%, 12%);
-		font-size: 0.45rem;
-		transform: translateX(0);
-		transition:
-			transform 0.2s ease-in-out,
-			background-color 0.2s ease-in-out;
-		box-shadow: 0 0 4px rgba(0, 0, 0, 0.45);
-	}
-
-	.nimble-edit-toggle--enabled .nimble-edit-toggle__thumb {
-		transform: translateX(1.05rem);
-	}
-
 	.nimble-player-character-header {
 		display: flex;
 		flex-direction: column;

--- a/src/view/sheets/components/AbilityScores.svelte
+++ b/src/view/sheets/components/AbilityScores.svelte
@@ -7,8 +7,6 @@
 
 	const { abilityScores, abilityScoreAbbreviations, sectionHeaders } = CONFIG.NIMBLE;
 	const actor = getContext('actor');
-	const editingEnabledStore = getContext('editingEnabled');
-	let editingEnabled = $derived($editingEnabledStore ?? true);
 </script>
 
 {#snippet abilityScoreSnippet(abilityScore, abilityKey)}
@@ -45,7 +43,6 @@
 			data-tooltip="NIMBLE.prompts.configureAbilityScores"
 			aria-label={localize('NIMBLE.prompts.configureAbilityScores')}
 			onclick={() => actor.configureAbilityScores()}
-			disabled={!editingEnabled}
 		>
 			<i class="fa-solid fa-edit"></i>
 		</button>

--- a/src/view/sheets/components/Editor.svelte
+++ b/src/view/sheets/components/Editor.svelte
@@ -12,7 +12,6 @@
 		content: string;
 		field: string;
 		document: foundry.abstract.Document.Any;
-		editable?: boolean;
 		editorOptions?: EditorOptions;
 		enrichOptions?: EnrichOptions;
 	}
@@ -21,7 +20,6 @@
 		content,
 		field,
 		document,
-		editable = true,
 		editorOptions = {} as EditorOptions,
 		enrichOptions = {} as EnrichOptions,
 	}: Props = $props();
@@ -33,8 +31,8 @@
 			collaborate: false,
 			compact: false,
 			documentUUID: document.uuid,
-			editable,
-			toggled: editable,
+			editable: true,
+			toggled: true,
 			value: content,
 		},
 		editorOptions,

--- a/src/view/sheets/components/HitDiceBar.svelte
+++ b/src/view/sheets/components/HitDiceBar.svelte
@@ -41,7 +41,6 @@
 	let isUpdating = $state(false);
 
 	async function handleUpdateCurrentHitDice(newValue: number) {
-		if (disableControls) return;
 		isUpdating = true;
 		try {
 			await updateCurrentHitDice?.(newValue);
@@ -56,7 +55,7 @@
 	}
 
 	async function handleEditCurrentHitDice() {
-		if (isUpdating || disableControls) return;
+		if (isUpdating) return;
 		await editCurrentHitDice?.();
 	}
 
@@ -76,11 +75,9 @@
 		{#if hasMultipleDieSizes}
 			<span
 				class="nimble-hit-dice-bar__values nimble-hit-dice-bar__values--clickable"
-				class:nimble-hit-dice-bar__values--disabled={disableControls}
 				onclick={handleEditCurrentHitDice}
 				data-tooltip={CONFIG.NIMBLE.hitDice.editCurrentHitDice}
 				aria-label={CONFIG.NIMBLE.hitDice.editCurrentHitDice}
-				aria-disabled={disableControls}
 				role="button"
 				tabindex="0"
 				onkeydown={(e) => e.key === 'Enter' && handleEditCurrentHitDice()}
@@ -200,15 +197,6 @@
 					text-shadow:
 						0 0 4px hsl(41, 18%, 54%),
 						0 0 8px rgba(255, 255, 255, 0.4);
-				}
-			}
-
-			&--disabled {
-				cursor: default;
-				opacity: 0.6;
-
-				&:hover {
-					text-shadow: none;
 				}
 			}
 		}

--- a/src/view/sheets/components/MovementSpeed.svelte
+++ b/src/view/sheets/components/MovementSpeed.svelte
@@ -1,12 +1,9 @@
 <script lang="ts">
-	import { getContext } from 'svelte';
 	import localize from '../../../utils/localize.js';
 
 	const { movementTypes } = CONFIG.NIMBLE;
 
 	let { actor, showDefaultSpeed = false } = $props();
-	const editingEnabledStore = getContext('editingEnabled');
-	let editingEnabled = $derived($editingEnabledStore ?? true);
 
 	// Check if movement is the default (walk=6, all others=0)
 	let isDefaultMovement = $derived.by(() => {
@@ -56,7 +53,6 @@
 					aria-label={tooltip}
 					data-tooltip={tooltip}
 					onclick={configMethod}
-					disabled={!editingEnabled}
 				>
 					<i class="fa-solid fa-edit"></i>
 				</button>

--- a/src/view/sheets/components/SavingThrows.svelte
+++ b/src/view/sheets/components/SavingThrows.svelte
@@ -15,8 +15,6 @@
 
 	const { saves, savingThrows, savingThrowAbbreviations } = CONFIG.NIMBLE;
 	const actor = getContext('actor');
-	const editingEnabledStore = getContext('editingEnabled');
-	let editingEnabled = $derived($editingEnabledStore ?? true);
 </script>
 
 {#snippet savingThrowSnippet(saveKey, save)}
@@ -66,7 +64,6 @@
 			data-tooltip="NIMBLE.prompts.configureSavingThrows"
 			aria-label={localize('NIMBLE.prompts.configureSavingThrows')}
 			onclick={() => actor.configureSavingThrows()}
-			disabled={!editingEnabled}
 		>
 			<i class="fa-solid fa-edit"></i>
 		</button>

--- a/src/view/sheets/components/Skills.svelte
+++ b/src/view/sheets/components/Skills.svelte
@@ -20,8 +20,6 @@
 	const { abilityScoreAbbreviations, defaultSkillAbilities, skills: skillNames } = CONFIG.NIMBLE;
 
 	const actor = getContext('actor');
-	const editingEnabledStore = getContext('editingEnabled');
-	let editingEnabled = $derived($editingEnabledStore ?? true);
 
 	let flags = $derived(actor.reactive.flags.nimble);
 	let compactSkillsView = $derived(flags?.compactSkillsView ?? true);
@@ -78,7 +76,6 @@
 			aria-label={localize('NIMBLE.prompts.configureSkills')}
 			data-tooltip={localize('NIMBLE.prompts.configureSkills')}
 			onclick={() => actor.configureSkills()}
-			disabled={!editingEnabled}
 		>
 			<i class="fa-solid fa-edit"></i>
 		</button>

--- a/src/view/sheets/pages/PlayerCharacterBioTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterBioTab.svelte
@@ -4,8 +4,6 @@
 	import Editor from '../components/Editor.svelte';
 
 	let actor = getContext('actor');
-	const editingEnabledStore = getContext('editingEnabled');
-	let editingEnabled = $derived($editingEnabledStore ?? true);
 	let details = $derived(actor.reactive.system.details);
 	let age = $derived(details?.age ?? '');
 	let gender = $derived(details?.gender ?? '');
@@ -24,7 +22,6 @@
 				type="text"
 				value={age}
 				onchange={({ target }) => actor.update({ 'system.details.age': target.value })}
-				disabled={!editingEnabled}
 			/>
 		</label>
 
@@ -37,7 +34,6 @@
 				type="text"
 				value={height}
 				onchange={({ target }) => actor.update({ 'system.details.height': target.value })}
-				disabled={!editingEnabled}
 			/>
 		</label>
 
@@ -50,7 +46,6 @@
 				type="text"
 				value={weight}
 				onchange={({ target }) => actor.update({ 'system.details.weight': target.value })}
-				disabled={!editingEnabled}
 			/>
 		</label>
 
@@ -63,7 +58,6 @@
 				type="text"
 				value={gender}
 				onchange={({ target }) => actor.update({ 'system.details.gender': target.value })}
-				disabled={!editingEnabled}
 			/>
 		</label>
 
@@ -77,7 +71,6 @@
 					field="system.details.notes"
 					content={actor.reactive.system.details.notes}
 					document={actor}
-					editable={editingEnabled}
 				/>
 			</div>
 		{/key}

--- a/src/view/sheets/pages/PlayerCharacterCoreTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterCoreTab.svelte
@@ -59,8 +59,6 @@
 	const { armorTypesPlural, languages } = CONFIG.NIMBLE;
 
 	let actor: NimbleCharacter = getContext('actor');
-	const editingEnabledStore = getContext('editingEnabled');
-	let editingEnabled = $derived($editingEnabledStore ?? true);
 	let skills = $derived(actor.reactive.system.skills);
 	let abilities = $derived(actor.reactive.system.abilities);
 	let characterSavingThrows = $derived(actor.reactive.system.savingThrows);
@@ -135,7 +133,6 @@
 					aria-label={tooltip}
 					data-tooltip={tooltip}
 					onclick={configMethod}
-					disabled={!editingEnabled}
 				>
 					<i class="fa-solid fa-edit"></i>
 				</button>

--- a/src/view/sheets/pages/PlayerCharacterFeaturesTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterFeaturesTab.svelte
@@ -117,8 +117,6 @@
 
 	let actor = getContext('actor');
 	let sheet = getContext('application');
-	const editingEnabledStore = getContext('editingEnabled');
-	let editingEnabled = $derived($editingEnabledStore ?? true);
 
 	let searchTerm = $state('');
 	let items = $derived(filterItems(actor.reactive, validTypes, searchTerm));
@@ -207,7 +205,6 @@
 								type="button"
 								aria-label="Delete {item.reactive.name}"
 								onclick={(event) => deleteItem(event, item._id)}
-								disabled={!editingEnabled}
 							>
 								<i class="fa-solid fa-trash"></i>
 							</button>
@@ -262,7 +259,6 @@
 										type="button"
 										aria-label="Delete {subclass.reactive.name}"
 										onclick={(event) => deleteItem(event, subclass._id)}
-										disabled={!editingEnabled}
 									>
 										<i class="fa-solid fa-trash"></i>
 									</button>

--- a/src/view/sheets/pages/PlayerCharacterInventoryTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterInventoryTab.svelte
@@ -46,8 +46,6 @@
 
 	let actor = getContext('actor');
 	let sheet = getContext('application');
-	const editingEnabledStore = getContext('editingEnabled');
-	let editingEnabled = $derived($editingEnabledStore ?? true);
 	let searchTerm = $state('');
 
 	const tooltipCache = new Map();
@@ -262,7 +260,6 @@
 								type="button"
 								aria-label="Delete {item.name}"
 								onclick={(event) => deleteItem(event, item._id)}
-								disabled={!editingEnabled}
 							>
 								<i class="fa-solid fa-trash"></i>
 							</button>

--- a/src/view/sheets/pages/PlayerCharacterSettingsTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterSettingsTab.svelte
@@ -8,8 +8,6 @@
 	}
 
 	let actor = getContext('actor');
-	const editingEnabledStore = getContext('editingEnabled');
-	let editingEnabled = $derived($editingEnabledStore ?? true);
 	let flags = $derived(actor.reactive.flags.nimble);
 
 	let automaticallyExecuteAvailableMacros = $derived(
@@ -45,7 +43,6 @@
 					type="number"
 					value={actorImageXOffset}
 					onchange={({ target }) => actor.setFlag('nimble', 'actorImageXOffset', target.value)}
-					disabled={!editingEnabled}
 				/>
 			</label>
 
@@ -58,7 +55,6 @@
 					type="number"
 					value={actorImageYOffset}
 					onchange={({ target }) => actor.setFlag('nimble', 'actorImageYOffset', target.value)}
-					disabled={!editingEnabled}
 				/>
 			</label>
 
@@ -71,7 +67,6 @@
 					type="number"
 					value={actorImageScale}
 					onchange={({ target }) => actor.setFlag('nimble', 'actorImageScale', target.value)}
-					disabled={!editingEnabled}
 				/>
 			</label>
 		</div>
@@ -88,7 +83,6 @@
 				checked={automaticallyExecuteAvailableMacros}
 				onchange={({ target }) =>
 					actor.setFlag('nimble', 'automaticallyExecuteAvailableMacros', target.checked)}
-				disabled={!editingEnabled}
 			/>
 
 			<span class="nimble-field__label"> Execute Item Macros on Item Activation </span>
@@ -100,7 +94,6 @@
 				checked={showEmbeddedDocumentImages}
 				onchange={({ target }) =>
 					actor.setFlag('nimble', 'showEmbeddedDocumentImages', target.checked)}
-				disabled={!editingEnabled}
 			/>
 
 			<span class="nimble-field__label"> Show Embedded Document Images </span>
@@ -117,7 +110,6 @@
 				type="checkbox"
 				checked={trackInventorySlots}
 				onchange={({ target }) => actor.setFlag('nimble', 'trackInventorySlots', target.checked)}
-				disabled={!editingEnabled}
 			/>
 
 			<span class="nimble-field__label"> Track Inventory Slots </span>
@@ -129,7 +121,6 @@
 					type="checkbox"
 					checked={includeCurrencyBulk}
 					onchange={({ target }) => actor.setFlag('nimble', 'includeCurrencyBulk', target.checked)}
-					disabled={!editingEnabled}
 				/>
 
 				<span class="nimble-field__label"> Automatically Include Currency Bulk </span>
@@ -143,7 +134,6 @@
 						type="button"
 						aria-label="Decrement Bonus Inventory Slots"
 						onclick={() => updateBonusInventorySlots(bonusInventorySlots - 1)}
-						disabled={!editingEnabled}
 					>
 						<i class="fa-solid fa-minus"></i>
 					</button>
@@ -158,7 +148,6 @@
 						type="button"
 						aria-label="Increment Bonus Inventory Slots"
 						onclick={() => updateBonusInventorySlots(bonusInventorySlots + 1)}
-						disabled={!editingEnabled}
 					>
 						<i class="fa-solid fa-plus"></i>
 					</button>
@@ -179,7 +168,6 @@
 				type="checkbox"
 				checked={compactSkillsView}
 				onchange={({ target }) => actor.setFlag('nimble', 'compactSkillsView', target.checked)}
-				disabled={!editingEnabled}
 			/>
 
 			<span class="nimble-field__label"> Use Two-Column Skills View </span>
@@ -190,7 +178,6 @@
 				type="checkbox"
 				checked={showPassiveSkillScores}
 				onchange={({ target }) => actor.setFlag('nimble', 'showPassiveSkillScores', target.checked)}
-				disabled={!editingEnabled}
 			/>
 
 			<span class="nimble-field__label"> Show Passive Skill Scores </span>


### PR DESCRIPTION
The edit toggle (lock/unlock) feature was not working as intended - the toggle button was not clickable. This reverts all editingEnabled state management and disabled attributes across the character sheet.