### PR TITLE
fix(spells): correct True Strike action cost from 2 to 1

### DIFF
--- a/packs/spells/core/radiant/true-strike.json
+++ b/packs/spells/core/radiant/true-strike.json
@@ -10,7 +10,7 @@
 			"acquireTargetsFromTemplate": false,
 			"cost": {
 				"details": "",
-				"quantity": 2,
+				"quantity": 1,
 				"type": "action",
 				"isReaction": false
 			},


### PR DESCRIPTION
## Summary
- Fixed True Strike cantrip action cost from 2 to 1 to match the spell description

## Test plan
- [ ] Verify True Strike cantrip shows 1 action cost in the character sheet
- [ ] Confirm the spell description still shows "1 Action"