### PR TITLE
fix: handle unknown compendium types in preparePackIndexes

### DIFF
--- a/src/utils/preparePackIndexes.ts
+++ b/src/utils/preparePackIndexes.ts
@@ -49,10 +49,13 @@ export function preparePackIndexes() {
 		const indexType = indexTypes[0];
 		if (!indexType) return;
 
-		const { applyFunc } = PACK_DATA_CONFIG[indexType];
+		const packConfig = PACK_DATA_CONFIG[indexType as keyof typeof PACK_DATA_CONFIG];
+		if (!packConfig) return;
+
+		const { applyFunc } = packConfig;
 		if (!applyFunc) return;
 
-		applyFunc(pack);
+		applyFunc(pack, {});
 	});
 }
 


### PR DESCRIPTION
## Summary
- Fixes custom Actor compendiums breaking translations to effects on tokens
- Adds guard clause to skip unknown compendium types (like "actor") that aren't in `PACK_DATA_CONFIG`
- Previously, destructuring from `undefined` caused a TypeError that crashed the setup hook

## Test plan
- [x] Add a custom Actor compendium to a world
- [x] Place an actor in the compendium
- [x] Verify effect translations on tokens still work correctly
- [x] Verify no console errors appear related to preparePackIndexes