### PR TITLE
fix(grantItem): add quantity support to item grant rules

### DIFF
--- a/packs/classes/core/commander.json
+++ b/packs/classes/core/commander.json
@@ -28,6 +28,7 @@
 				"priority": 1,
 				"allowDuplicate": true,
 				"inMemoryOnly": false,
+				"quantity": 4,
 				"uuid": "Compendium.nimble.nimble-items.Item.YbHHJEDlYHoEvyje"
 			},
 			{

--- a/packs/classes/core/the-cheat.json
+++ b/packs/classes/core/the-cheat.json
@@ -16,18 +16,7 @@
 				"priority": 1,
 				"allowDuplicate": true,
 				"inMemoryOnly": false,
-				"uuid": "Compendium.nimble.nimble-items.Item.O1sCIVQKfAqSlDT5"
-			},
-			{
-				"type": "grantItem",
-				"disabled": false,
-				"id": "snAchOLX0tw5RXZZ",
-				"identifier": "",
-				"label": "Starting Gear - Dagger",
-				"predicate": {},
-				"priority": 1,
-				"allowDuplicate": true,
-				"inMemoryOnly": false,
+				"quantity": 2,
 				"uuid": "Compendium.nimble.nimble-items.Item.O1sCIVQKfAqSlDT5"
 			},
 			{

--- a/src/models/rules/grantItem.ts
+++ b/src/models/rules/grantItem.ts
@@ -7,6 +7,7 @@ function schema() {
 	return {
 		allowDuplicate: new fields.BooleanField({ required: true, nullable: false, initial: true }),
 		inMemoryOnly: new fields.BooleanField({ required: true, nullable: false, initial: false }),
+		quantity: new fields.NumberField({ required: false, nullable: true, initial: null, min: 1 }),
 		uuid: new fields.StringField({ required: true, nullable: false, initial: '' }),
 		type: new fields.StringField({ required: true, nullable: false, initial: 'grantItem' }),
 	};
@@ -20,6 +21,8 @@ class ItemGrantRule extends NimbleBaseRule<ItemGrantRule.Schema> {
 	declare allowDuplicate: boolean;
 
 	declare inMemoryOnly: boolean;
+
+	declare quantity: number | null;
 
 	declare uuid: string;
 
@@ -38,6 +41,7 @@ class ItemGrantRule extends NimbleBaseRule<ItemGrantRule.Schema> {
 			new Map([
 				['allowDuplicate', 'boolean'],
 				['inMemoryOnly', 'boolean'],
+				['quantity', 'number'],
 				['uuid', 'string'],
 			]),
 		);
@@ -93,6 +97,17 @@ class ItemGrantRule extends NimbleBaseRule<ItemGrantRule.Schema> {
 		// TODO: Effects
 
 		grantedSource._stats.compendiumSource = uuid;
+
+		// Apply quantity override if specified
+		if (this.quantity !== null) {
+			interface SystemWithQuantity {
+				quantity?: number;
+			}
+			const system = grantedSource.system as SystemWithQuantity;
+			if ('quantity' in system) {
+				system.quantity = this.quantity;
+			}
+		}
 
 		// TODO: Apply Alteration
 

--- a/src/view/dialogs/components/characterCreator/StartingEquipmentSelection.svelte
+++ b/src/view/dialogs/components/characterCreator/StartingEquipmentSelection.svelte
@@ -85,8 +85,8 @@
 					<ul class="equipment-list">
 						{#each equipmentRules as rule}
 							<li>
-								{rule.label ||
-									game.i18n.localize(startingEquipment.unknownItem)}{#if rule.quantity > 1}
+								{rule.label || game.i18n.localize(startingEquipment.unknownItem)}
+								{#if rule.quantity > 1}
 									({rule.quantity}){/if}
 							</li>
 						{/each}

--- a/src/view/dialogs/components/characterCreator/StartingEquipmentSelection.svelte
+++ b/src/view/dialogs/components/characterCreator/StartingEquipmentSelection.svelte
@@ -84,7 +84,11 @@
 				{#if equipmentRules.length > 0}
 					<ul class="equipment-list">
 						{#each equipmentRules as rule}
-							<li>{rule.label || game.i18n.localize(startingEquipment.unknownItem)}</li>
+							<li>
+								{rule.label ||
+									game.i18n.localize(startingEquipment.unknownItem)}{#if rule.quantity > 1}
+									({rule.quantity}){/if}
+							</li>
 						{/each}
 					</ul>
 				{:else}


### PR DESCRIPTION
## Summary
- Add optional `quantity` field to `ItemGrantRule` to allow specifying how many of an item to grant
- Display quantity in parentheses in character creation starting equipment list (e.g., "Starting Gear - Javelin (4)")
- Update Commander class to grant 4 javelins instead of 1
- Consolidate The Cheat's two separate dagger grants into one with quantity 2

Fixes issue where Commander creation was only giving 1 javelin instead of 4.

## Test plan
- [x] Create a new Commander character and verify they receive 4 javelins
- [x] Create a new The Cheat character and verify they receive 2 daggers
- [x] Verify the character creation dialog shows "Starting Gear - Javelin (4)" for Commander
- [x] Verify the character creation dialog shows "Starting Gear - Dagger (2)" for The Cheat