### PR TITLE
feat(objects): add dedicated price property to items

### DIFF
--- a/packs/items/core/armors/adventurers-garb.json
+++ b/packs/items/core/armors/adventurers-garb.json
@@ -72,6 +72,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 10,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/armors/chain-shirt.json
+++ b/packs/items/core/armors/chain-shirt.json
@@ -72,6 +72,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 60,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/armors/cheap-hides.json
+++ b/packs/items/core/armors/cheap-hides.json
@@ -72,6 +72,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 5,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/armors/cloth-epic-enchantment.json
+++ b/packs/items/core/armors/cloth-epic-enchantment.json
@@ -72,6 +72,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 10000,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/armors/cloth-major-enchantment.json
+++ b/packs/items/core/armors/cloth-major-enchantment.json
@@ -72,6 +72,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 1000,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/armors/cloth-minor-enchantment.json
+++ b/packs/items/core/armors/cloth-minor-enchantment.json
@@ -72,6 +72,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 100,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/armors/dragon-shield.json
+++ b/packs/items/core/armors/dragon-shield.json
@@ -72,6 +72,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 9000,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/armors/dragonscale.json
+++ b/packs/items/core/armors/dragonscale.json
@@ -72,6 +72,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 3000,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/armors/full-plate.json
+++ b/packs/items/core/armors/full-plate.json
@@ -72,6 +72,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 2000,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/armors/half-plate.json
+++ b/packs/items/core/armors/half-plate.json
@@ -72,6 +72,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 200,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/armors/hard-leather.json
+++ b/packs/items/core/armors/hard-leather.json
@@ -72,6 +72,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 300,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/armors/iron-shield.json
+++ b/packs/items/core/armors/iron-shield.json
@@ -72,6 +72,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 80,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/armors/mithril-plate.json
+++ b/packs/items/core/armors/mithril-plate.json
@@ -72,6 +72,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 5000,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/armors/ox-hide.json
+++ b/packs/items/core/armors/ox-hide.json
@@ -72,6 +72,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 45,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/armors/rusty-mail.json
+++ b/packs/items/core/armors/rusty-mail.json
@@ -72,6 +72,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 15,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/armors/rusty-plate.json
+++ b/packs/items/core/armors/rusty-plate.json
@@ -72,6 +72,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 25,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/armors/scale-mail.json
+++ b/packs/items/core/armors/scale-mail.json
@@ -72,6 +72,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 700,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/armors/tower-shield.json
+++ b/packs/items/core/armors/tower-shield.json
@@ -72,6 +72,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 1500,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/armors/traveling-robes-and-sandals.json
+++ b/packs/items/core/armors/traveling-robes-and-sandals.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 0,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/armors/wooden-buckler.json
+++ b/packs/items/core/armors/wooden-buckler.json
@@ -72,6 +72,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 5,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/armors/wyrmhide.json
+++ b/packs/items/core/armors/wyrmhide.json
@@ -72,6 +72,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 2000,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/consumables/greater-healing-potion.json
+++ b/packs/items/core/consumables/greater-healing-potion.json
@@ -69,6 +69,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 150,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/consumables/healing-potion.json
+++ b/packs/items/core/consumables/healing-potion.json
@@ -69,6 +69,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 50,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/consumables/supreme-healing-potion.json
+++ b/packs/items/core/consumables/supreme-healing-potion.json
@@ -69,6 +69,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 450,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/consumables/vial-of-pitch.json
+++ b/packs/items/core/consumables/vial-of-pitch.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 2,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/misc/bell.json
+++ b/packs/items/core/misc/bell.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 2,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/misc/blanket.json
+++ b/packs/items/core/misc/blanket.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 1,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/misc/bucket.json
+++ b/packs/items/core/misc/bucket.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 1,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/misc/camping-supplies.json
+++ b/packs/items/core/misc/camping-supplies.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 5,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/misc/chain-10-ft.json
+++ b/packs/items/core/misc/chain-10-ft.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 50,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/misc/chalk.json
+++ b/packs/items/core/misc/chalk.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 1,
+			"denomination": "sp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/misc/crowbar.json
+++ b/packs/items/core/misc/crowbar.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 2,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/misc/dice.json
+++ b/packs/items/core/misc/dice.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 5,
+			"denomination": "sp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/misc/grappling-hook.json
+++ b/packs/items/core/misc/grappling-hook.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 4,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/misc/hunting-trap.json
+++ b/packs/items/core/misc/hunting-trap.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 10,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/misc/instrument.json
+++ b/packs/items/core/misc/instrument.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 25,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/misc/lantern-and-oil.json
+++ b/packs/items/core/misc/lantern-and-oil.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 10,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/misc/large-sack.json
+++ b/packs/items/core/misc/large-sack.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 5,
+			"denomination": "sp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/misc/lock-pick.json
+++ b/packs/items/core/misc/lock-pick.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 5,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/misc/magnifying-glass.json
+++ b/packs/items/core/misc/magnifying-glass.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 5,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/misc/manacles.json
+++ b/packs/items/core/misc/manacles.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 3,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/misc/mirror.json
+++ b/packs/items/core/misc/mirror.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 4,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/misc/padlock-and-key.json
+++ b/packs/items/core/misc/padlock-and-key.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 3,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/misc/pitons.json
+++ b/packs/items/core/misc/pitons.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 5,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/misc/pulley.json
+++ b/packs/items/core/misc/pulley.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 3,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/misc/quiver-and-ammo.json
+++ b/packs/items/core/misc/quiver-and-ammo.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 10,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/misc/rope-50ft.json
+++ b/packs/items/core/misc/rope-50ft.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 10,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/misc/saw.json
+++ b/packs/items/core/misc/saw.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 4,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/misc/shiny-object.json
+++ b/packs/items/core/misc/shiny-object.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 1,
+			"denomination": "sp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/misc/shovel.json
+++ b/packs/items/core/misc/shovel.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 3,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/misc/soap.json
+++ b/packs/items/core/misc/soap.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 1,
+			"denomination": "sp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/misc/strange-plant.json
+++ b/packs/items/core/misc/strange-plant.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 5,
+			"denomination": "sp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/misc/telescope.json
+++ b/packs/items/core/misc/telescope.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 10,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/misc/torch-stack-of-2.json
+++ b/packs/items/core/misc/torch-stack-of-2.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 5,
+			"denomination": "sp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/weapons/battleaxe.json
+++ b/packs/items/core/weapons/battleaxe.json
@@ -104,6 +104,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 30,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/weapons/clubmace.json
+++ b/packs/items/core/weapons/clubmace.json
@@ -102,6 +102,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 2,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/weapons/crossbow.json
+++ b/packs/items/core/weapons/crossbow.json
@@ -105,6 +105,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 60,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/weapons/dagger.json
+++ b/packs/items/core/weapons/dagger.json
@@ -105,6 +105,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 3,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/weapons/glaive.json
+++ b/packs/items/core/weapons/glaive.json
@@ -104,6 +104,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 60,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/weapons/greataxe.json
+++ b/packs/items/core/weapons/greataxe.json
@@ -103,6 +103,10 @@
 				"overridesTwoHanded": true
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 100,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/weapons/greatmaul.json
+++ b/packs/items/core/weapons/greatmaul.json
@@ -103,6 +103,10 @@
 				"overridesTwoHanded": true
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 80,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/weapons/greatsword.json
+++ b/packs/items/core/weapons/greatsword.json
@@ -103,6 +103,10 @@
 				"overridesTwoHanded": true
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 120,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/weapons/hand-axe.json
+++ b/packs/items/core/weapons/hand-axe.json
@@ -104,6 +104,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 8,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/weapons/handheld-ballista.json
+++ b/packs/items/core/weapons/handheld-ballista.json
@@ -105,6 +105,10 @@
 				"overridesTwoHanded": true
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 120,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/weapons/javelins.json
+++ b/packs/items/core/weapons/javelins.json
@@ -103,6 +103,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 20,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/weapons/longbow.json
+++ b/packs/items/core/weapons/longbow.json
@@ -104,6 +104,10 @@
 				"overridesTwoHanded": true
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 30,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/weapons/longsword.json
+++ b/packs/items/core/weapons/longsword.json
@@ -104,6 +104,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 60,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/weapons/pole-hammer.json
+++ b/packs/items/core/weapons/pole-hammer.json
@@ -105,6 +105,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 60,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/weapons/rapier.json
+++ b/packs/items/core/weapons/rapier.json
@@ -102,6 +102,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 60,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/weapons/short-sword.json
+++ b/packs/items/core/weapons/short-sword.json
@@ -104,6 +104,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 10,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/weapons/shortbow.json
+++ b/packs/items/core/weapons/shortbow.json
@@ -104,6 +104,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 25,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/weapons/sickle.json
+++ b/packs/items/core/weapons/sickle.json
@@ -114,6 +114,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 10,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/weapons/sling.json
+++ b/packs/items/core/weapons/sling.json
@@ -115,6 +115,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 4,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/weapons/spear.json
+++ b/packs/items/core/weapons/spear.json
@@ -104,6 +104,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 60,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/weapons/staff.json
+++ b/packs/items/core/weapons/staff.json
@@ -104,6 +104,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 8,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/items/core/weapons/throwing-hammers.json
+++ b/packs/items/core/weapons/throwing-hammers.json
@@ -103,6 +103,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 25,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/coreRules/ball-of-spiders.json
+++ b/packs/magicItems/core/coreRules/ball-of-spiders.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 250,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/coreRules/bloodstained-quill.json
+++ b/packs/magicItems/core/coreRules/bloodstained-quill.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 250,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/coreRules/button-of-protection.json
+++ b/packs/magicItems/core/coreRules/button-of-protection.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 2500,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/coreRules/eyes-of-the-street.json
+++ b/packs/magicItems/core/coreRules/eyes-of-the-street.json
@@ -59,6 +59,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 250,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/coreRules/gnatbane-weapon.json
+++ b/packs/magicItems/core/coreRules/gnatbane-weapon.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 250,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/coreRules/grim-coronet.json
+++ b/packs/magicItems/core/coreRules/grim-coronet.json
@@ -59,6 +59,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 2500,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/coreRules/handwraps-of-force.json
+++ b/packs/magicItems/core/coreRules/handwraps-of-force.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 2500,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/coreRules/harbinger-and-sovereign-abyssals-claim.json
+++ b/packs/magicItems/core/coreRules/harbinger-and-sovereign-abyssals-claim.json
@@ -85,6 +85,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 1000000,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/coreRules/key-of-doors.json
+++ b/packs/magicItems/core/coreRules/key-of-doors.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 25000,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/coreRules/mindlink-daggers.json
+++ b/packs/magicItems/core/coreRules/mindlink-daggers.json
@@ -85,6 +85,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 2500,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/coreRules/phoenix-helm.json
+++ b/packs/magicItems/core/coreRules/phoenix-helm.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 1000000,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/coreRules/resolute-fangs-golden-bastion.json
+++ b/packs/magicItems/core/coreRules/resolute-fangs-golden-bastion.json
@@ -72,6 +72,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 1000000,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/coreRules/skitter-shoes.json
+++ b/packs/magicItems/core/coreRules/skitter-shoes.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 2500,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/coreRules/trinket-of-ill-omen.json
+++ b/packs/magicItems/core/coreRules/trinket-of-ill-omen.json
@@ -69,6 +69,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 2500,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/coreRules/vindication.json
+++ b/packs/magicItems/core/coreRules/vindication.json
@@ -82,6 +82,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 1000000,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/coreRules/weapon-of-animosity-legendary.json
+++ b/packs/magicItems/core/coreRules/weapon-of-animosity-legendary.json
@@ -92,6 +92,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 1000000,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/coreRules/weapon-of-animosity-rare.json
+++ b/packs/magicItems/core/coreRules/weapon-of-animosity-rare.json
@@ -92,6 +92,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 2500,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/coreRules/weapon-of-animosity-uncommon.json
+++ b/packs/magicItems/core/coreRules/weapon-of-animosity-uncommon.json
@@ -92,6 +92,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 250,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/coreRules/weapon-of-animosity-very-rare.json
+++ b/packs/magicItems/core/coreRules/weapon-of-animosity-very-rare.json
@@ -92,6 +92,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 25000,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/coreRules/weapon-of-many-hands-legendary.json
+++ b/packs/magicItems/core/coreRules/weapon-of-many-hands-legendary.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 1000000,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/coreRules/weapon-of-many-hands-rare.json
+++ b/packs/magicItems/core/coreRules/weapon-of-many-hands-rare.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 2500,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/coreRules/weapon-of-many-hands-uncommon.json
+++ b/packs/magicItems/core/coreRules/weapon-of-many-hands-uncommon.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 250,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/coreRules/weapon-of-many-hands-very-rare.json
+++ b/packs/magicItems/core/coreRules/weapon-of-many-hands-very-rare.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 25000,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/coreRules/weapon-of-slaying-legendary.json
+++ b/packs/magicItems/core/coreRules/weapon-of-slaying-legendary.json
@@ -90,6 +90,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 1000000,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/coreRules/weapon-of-slaying-rare.json
+++ b/packs/magicItems/core/coreRules/weapon-of-slaying-rare.json
@@ -90,6 +90,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 2500,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/coreRules/weapon-of-slaying-uncommon.json
+++ b/packs/magicItems/core/coreRules/weapon-of-slaying-uncommon.json
@@ -90,6 +90,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 250,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/coreRules/weapon-of-slaying-very-rare.json
+++ b/packs/magicItems/core/coreRules/weapon-of-slaying-very-rare.json
@@ -90,6 +90,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 25000,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/coreRules/weapon-of-wounding.json
+++ b/packs/magicItems/core/coreRules/weapon-of-wounding.json
@@ -81,6 +81,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 250,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/gmGuide/gem-of-escape.json
+++ b/packs/magicItems/core/gmGuide/gem-of-escape.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 2500,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/gmGuide/glacier-in-a-bottle.json
+++ b/packs/magicItems/core/gmGuide/glacier-in-a-bottle.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 2500,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/gmGuide/hear-ring.json
+++ b/packs/magicItems/core/gmGuide/hear-ring.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 250,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/gmGuide/lumina-living-sunbeam.json
+++ b/packs/magicItems/core/gmGuide/lumina-living-sunbeam.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 2500,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/gmGuide/pocket-cauldron.json
+++ b/packs/magicItems/core/gmGuide/pocket-cauldron.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 2500,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/gmGuide/the-grimoire-of-truths.json
+++ b/packs/magicItems/core/gmGuide/the-grimoire-of-truths.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 25000,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/spellScrollTemplates/spell-scroll-cantrip.json
+++ b/packs/magicItems/core/spellScrollTemplates/spell-scroll-cantrip.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 10,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/spellScrollTemplates/spell-scroll-tier-1.json
+++ b/packs/magicItems/core/spellScrollTemplates/spell-scroll-tier-1.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 35,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/spellScrollTemplates/spell-scroll-tier-2.json
+++ b/packs/magicItems/core/spellScrollTemplates/spell-scroll-tier-2.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 100,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/spellScrollTemplates/spell-scroll-tier-3.json
+++ b/packs/magicItems/core/spellScrollTemplates/spell-scroll-tier-3.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 300,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/spellScrollTemplates/spell-scroll-tier-4.json
+++ b/packs/magicItems/core/spellScrollTemplates/spell-scroll-tier-4.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 1000,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/spellScrollTemplates/spell-scroll-tier-5.json
+++ b/packs/magicItems/core/spellScrollTemplates/spell-scroll-tier-5.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 3000,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/spellScrollTemplates/spell-scroll-tier-6.json
+++ b/packs/magicItems/core/spellScrollTemplates/spell-scroll-tier-6.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 10000,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/spellScrollTemplates/spell-scroll-tier-7.json
+++ b/packs/magicItems/core/spellScrollTemplates/spell-scroll-tier-7.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 25000,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/spellScrollTemplates/spell-scroll-tier-8.json
+++ b/packs/magicItems/core/spellScrollTemplates/spell-scroll-tier-8.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 75000,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/spellScrollTemplates/spell-scroll-tier-9.json
+++ b/packs/magicItems/core/spellScrollTemplates/spell-scroll-tier-9.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 200000,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/wandTemplates/wand-cantrip.json
+++ b/packs/magicItems/core/wandTemplates/wand-cantrip.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 50,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/wandTemplates/wand-tier-1.json
+++ b/packs/magicItems/core/wandTemplates/wand-tier-1.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 175,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/wandTemplates/wand-tier-2.json
+++ b/packs/magicItems/core/wandTemplates/wand-tier-2.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 500,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/wandTemplates/wand-tier-3.json
+++ b/packs/magicItems/core/wandTemplates/wand-tier-3.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 1500,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/wandTemplates/wand-tier-4.json
+++ b/packs/magicItems/core/wandTemplates/wand-tier-4.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 5000,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/wandTemplates/wand-tier-5.json
+++ b/packs/magicItems/core/wandTemplates/wand-tier-5.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 15000,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/wandTemplates/wand-tier-6.json
+++ b/packs/magicItems/core/wandTemplates/wand-tier-6.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 50000,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/wandTemplates/wand-tier-7.json
+++ b/packs/magicItems/core/wandTemplates/wand-tier-7.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 125000,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/wandTemplates/wand-tier-8.json
+++ b/packs/magicItems/core/wandTemplates/wand-tier-8.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 375000,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/wandTemplates/wand-tier-9.json
+++ b/packs/magicItems/core/wandTemplates/wand-tier-9.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 1000000,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/wands/elderwyrms-majesty.json
+++ b/packs/magicItems/core/wands/elderwyrms-majesty.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 1000000,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/wands/heartwood-splinter-of-the-tree-of-life.json
+++ b/packs/magicItems/core/wands/heartwood-splinter-of-the-tree-of-life.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 1000000,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/wands/wand-of-barrier-of-wind.json
+++ b/packs/magicItems/core/wands/wand-of-barrier-of-wind.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 500,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/wands/wand-of-dread-visage.json
+++ b/packs/magicItems/core/wands/wand-of-dread-visage.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 500,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/wands/wand-of-firestep.json
+++ b/packs/magicItems/core/wands/wand-of-firestep.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 50,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/wands/wand-of-fly.json
+++ b/packs/magicItems/core/wands/wand-of-fly.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 1500,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/wands/wand-of-glacier-strike.json
+++ b/packs/magicItems/core/wands/wand-of-glacier-strike.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 375000,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/wands/wand-of-ride-the-lightning.json
+++ b/packs/magicItems/core/wands/wand-of-ride-the-lightning.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 50000,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/packs/magicItems/core/wands/wand-of-sacrifice.json
+++ b/packs/magicItems/core/wands/wand-of-sacrifice.json
@@ -60,6 +60,10 @@
 				"overridesTwoHanded": false
 			},
 			"thrownRange": 4
+		},
+		"price": {
+			"value": 50000,
+			"denomination": "gp"
 		}
 	},
 	"effects": [],

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -365,6 +365,9 @@
 			"consumable": "Consumables",
 			"misc": "Miscellaneous"
 		},
+		"objectSheet": {
+			"price": "Price"
+		},
 		"prompts": {
 			"changeActorImage": "Change Actor Image",
 			"changeBoonImage": "Change Boon Image",

--- a/src/migration/migrations/Migration002ItemPrices.ts
+++ b/src/migration/migrations/Migration002ItemPrices.ts
@@ -1,0 +1,60 @@
+import { MigrationBase } from '../MigrationBase.js';
+
+/**
+ * Extract price from item description HTML.
+ * Looks for patterns like "Cost:</strong> 60 gp" or "Cost: 5 sp"
+ */
+function extractPriceFromDescription(description: string | undefined): {
+	value: number;
+	denomination: 'cp' | 'sp' | 'gp';
+} | null {
+	if (!description) return null;
+
+	// Strip HTML tags for easier matching
+	const textOnly = description.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ');
+
+	// Match patterns like "Cost: 60 gp" or "Cost: 5 sp"
+	const costMatch = textOnly.match(/Cost:?\s*(\d+(?:,\d{3})*(?:\.\d+)?)\s*(gp|sp|cp)/i);
+	if (costMatch) {
+		const value = parseFloat(costMatch[1].replace(/,/g, ''));
+		const denomination = costMatch[2].toLowerCase() as 'cp' | 'sp' | 'gp';
+		return { value, denomination };
+	}
+
+	return null;
+}
+
+/**
+ * Migration to add price field to object items.
+ *
+ * For items of type 'object' that don't have a price field:
+ * 1. Attempts to extract price from the description
+ * 2. Falls back to default of 0 gp if no price found
+ */
+class Migration002ItemPrices extends MigrationBase {
+	static override readonly version = 2;
+
+	override readonly version = Migration002ItemPrices.version;
+
+	override async updateItem(source: any): Promise<void> {
+		// Only process object type items
+		if (source.type !== 'object') return;
+
+		// Skip if price already exists
+		if (source.system?.price !== undefined) return;
+
+		// Try to extract price from description
+		const extractedPrice = extractPriceFromDescription(source.system?.description?.public);
+
+		// Set the price field
+		source.system.price = extractedPrice ?? { value: 0, denomination: 'gp' };
+
+		if (extractedPrice) {
+			console.log(
+				`Nimble Migration | ${source.name}: extracted price ${extractedPrice.value} ${extractedPrice.denomination}`,
+			);
+		}
+	}
+}
+
+export { Migration002ItemPrices };

--- a/src/migration/migrations/index.ts
+++ b/src/migration/migrations/index.ts
@@ -1,1 +1,2 @@
 export { Migration001AttackSequenceItems } from './Migration001AttackSequenceItems.js';
+export { Migration002ItemPrices } from './Migration002ItemPrices.js';

--- a/src/models/item/ObjectDataModel.ts
+++ b/src/models/item/ObjectDataModel.ts
@@ -11,6 +11,20 @@ const schema = () => ({
 	}),
 	identified: new fields.BooleanField({ required: true, nullable: false, initial: true }),
 	objectType: new fields.StringField({ required: true, initial: '', nullable: false }),
+	price: new fields.SchemaField({
+		value: new fields.NumberField({
+			required: true,
+			initial: 0,
+			nullable: false,
+			min: 0,
+		}),
+		denomination: new fields.StringField({
+			required: true,
+			initial: 'gp',
+			nullable: false,
+			choices: ['cp', 'sp', 'gp'],
+		}),
+	}),
 	quantity: new fields.NumberField({
 		required: true,
 		initial: 1,
@@ -108,6 +122,10 @@ class NimbleObjectData extends NimbleBaseItemData<
 	};
 	declare identified: boolean;
 	declare objectType: string;
+	declare price: {
+		value: number;
+		denomination: 'cp' | 'sp' | 'gp';
+	};
 	declare quantity: number;
 	declare unidentifiedName: string;
 	declare objectSizeType: 'slots' | 'stackable' | 'smallSized';

--- a/src/view/sheets/ObjectSheet.svelte
+++ b/src/view/sheets/ObjectSheet.svelte
@@ -138,6 +138,41 @@
 
 		<div>
 			<header class="nimble-section-header">
+				<h3 class="nimble-heading" data-heading-variant="section">
+					{localize('NIMBLE.objectSheet.price')}
+				</h3>
+			</header>
+
+			<div class="nimble-price-field">
+				<input
+					class="nimble-price-field__value"
+					type="number"
+					min="0"
+					step="1"
+					value={item.reactive.system.price?.value ?? 0}
+					onchange={({ target }) =>
+						item.update({
+							'system.price.value': Number(target.value),
+						})}
+				/>
+
+				<select
+					class="nimble-price-field__denomination"
+					value={item.reactive.system.price?.denomination ?? 'gp'}
+					onchange={({ target }) =>
+						item.update({
+							'system.price.denomination': target.value,
+						})}
+				>
+					<option value="cp">{localize('NIMBLE.currencyAbbreviations.cp')}</option>
+					<option value="sp">{localize('NIMBLE.currencyAbbreviations.sp')}</option>
+					<option value="gp">{localize('NIMBLE.currencyAbbreviations.gp')}</option>
+				</select>
+			</div>
+		</div>
+
+		<div>
+			<header class="nimble-section-header">
 				<h3 class="nimble-heading" data-heading-variant="section">General Configuration</h3>
 			</header>
 
@@ -324,3 +359,20 @@
 <PrimaryNavigation bind:currentTab {navigation} />
 
 {@render currentTab.component()}
+
+<style lang="scss">
+	.nimble-price-field {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+
+		&__value {
+			flex: 1;
+		}
+
+		&__denomination {
+			flex: 0 0 auto;
+			width: auto;
+		}
+	}
+</style>


### PR DESCRIPTION
## Summary
- Add a `price` field to `ObjectDataModel` with `value` (number) and `denomination` (cp/sp/gp)
- Add price editing UI in the Object sheet Config tab
- Populate prices for all 139 compendium items:
  - **Basic items**: Extracted from existing description text (weapons, armor, equipment)
  - **Magic items**: Based on rarity (Uncommon=250gp, Rare=2,500gp, Very Rare=25,000gp, Legendary=1,000,000gp)
  - **Spell scrolls**: Tier-based pricing (Cantrip=10gp up to Tier 9=200,000gp)
  - **Wands**: Tier-based pricing (Cantrip=50gp up to Tier 9=1,000,000gp)

External modules (shop/storefront modules) can now access item prices via `item.system.price.value` and `item.system.price.denomination`.

## Test plan
- [ ] Create a new object item and verify the Price section appears in the Config tab
- [ ] Set a price value and denomination, save, and verify the values persist
- [ ] Verify compendium items have correct prices populated
- [ ] Verify external modules can access `item.system.price.value` and `item.system.price.denomination`