### PR TITLE
feat(ancestry): add speed bonus rule for ancestry speed adjustments

### DIFF
--- a/packs/ancestries/core/common/dwarf.json
+++ b/packs/ancestries/core/common/dwarf.json
@@ -34,6 +34,11 @@
 						"min": 0
 					}
 				}
+			},
+			{
+				"type": "speedBonus",
+				"value": "-1",
+				"label": "Stout"
 			}
 		],
 		"description": "<p>Dwarf, in the old language, means “stone.” You are resilient, solid, stout. Even when driven to exhaustion, you will not falter. Forgoing speed, you are gifted with physical vitality and a belly that can handle the finest (and worst) consumables this world has to offer.</p><hr><p><strong>Stout</strong></p><p>+2 max Hit Dice [M]</p><p>+1 max Wounds [A]</p><p>-1 Speed [M]</p><p>You know Dwarvish if your INT is not negative [M]</p>",

--- a/packs/ancestries/core/common/elf.json
+++ b/packs/ancestries/core/common/elf.json
@@ -18,6 +18,11 @@
 						"min": 0
 					}
 				}
+			},
+			{
+				"type": "speedBonus",
+				"value": "1",
+				"label": "Lithe"
 			}
 		],
 		"description": "<p>Elves epitomize swiftness and grace. Their tall, slender forms belie their innate speed, grace, and wit. Formidable in both diplomacy and combat, elves strike swiftly, often preventing the worst by acting first.</p><hr><p><strong>Lithe</strong></p><p>Advantage on Initiative [M]</p><p>+1 Speed [M]</p><p>You know Elvish if your INT is not negative [M]</p>",

--- a/packs/ancestries/core/common/gnome.json
+++ b/packs/ancestries/core/common/gnome.json
@@ -18,6 +18,11 @@
 						"min": 0
 					}
 				}
+			},
+			{
+				"type": "speedBonus",
+				"value": "-1",
+				"label": "Optimistic"
 			}
 		],
 		"description": "<p>Eccentric, curious, and perpetually optimistic, gnomes are cheerful—especially when compared to their typically grumpier and larger kin, the dwarves. Known for their tinkering, spreading cheer, and playful antics, gnomes pursue their passions with a scatterbrained enthusiasm.</p><hr><p><strong>Optimistic</strong></p><p>Allow an ally within Reach 6 to reroll any single die. Resets when healed to your max HP. </p><p>-1 Speed [M]</p><p>You know Dwarvish if your INT is not negative (but you call it Gnomish, of course) [M]</p>",

--- a/packs/ancestries/core/exotic/birdfolk.json
+++ b/packs/ancestries/core/exotic/birdfolk.json
@@ -5,7 +5,14 @@
 	"system": {
 		"macro": "",
 		"identifier": "",
-		"rules": [],
+		"rules": [
+			{
+				"type": "speedBonus",
+				"value": "@attributes.movement.walk",
+				"movementType": "fly",
+				"label": "Hollow Bones"
+			}
+		],
 		"description": "<p>Birdfolk find sanctuary not in stone or chains, but within the boundless expanse of the sky. However, the gift of flight comes at a cost—hollow bones, and commensurate frailty.</p><hr><p><strong>Hollow Bones</strong></p><p>You have a fly Speed as long as you are wearing armor no heavier than Leather. </p><p>Crits against you are Vicious (the attacker rolls 1 additional die). </p><p>Forced movement moves you twice as far.</p>",
 		"exotic": true,
 		"size": [

--- a/packs/ancestries/core/exotic/turtlefolk.json
+++ b/packs/ancestries/core/exotic/turtlefolk.json
@@ -11,11 +11,16 @@
 				"disabled": false,
 				"id": "ODF6VnVsmfBrfFtp",
 				"identifier": "",
-				"label": "Slow but Steady",
+				"label": "Slow & Steady",
 				"predicate": {},
 				"priority": 1,
 				"formula": "+4",
 				"mode": "add"
+			},
+			{
+				"type": "speedBonus",
+				"value": "-2",
+				"label": "Slow & Steady"
 			}
 		],
 		"description": "<p>Turtlefolk take their time in everything they do; they are patient, sturdy, and slow to anger. They rely on their thick shells for protection, making them difficult to harm, but their cautious movements come at the cost of speed.</p><hr><p><strong>Slow & Steady</strong></p><p>+4 Armor [A]</p><p>–2 speed [M]</p>",

--- a/packs/boons/core/epic/epic-speed.json
+++ b/packs/boons/core/epic/epic-speed.json
@@ -16,6 +16,11 @@
 				"predicate": {},
 				"priority": 1,
 				"value": "4"
+			},
+			{
+				"type": "speedBonus",
+				"value": "4",
+				"label": "Epic Speed"
 			}
 		],
 		"description": "<p><span class=\"dig-1hicw9p1_4-2-0 dig-1hicw9p0_4-2-0 dig-ekabin0_4-2-0 dig-Theme-vis2023 dig-Theme-vis2023--dark dig-Mode--dark In-Theme-Provider\" style=\"display: contents;\">+4 Speed [M]<br>+4 Initiative [A]</span></p>",

--- a/packs/boons/core/minor/intrepid.json
+++ b/packs/boons/core/minor/intrepid.json
@@ -5,7 +5,13 @@
 	"system": {
 		"macro": "",
 		"identifier": "",
-		"rules": [],
+		"rules": [
+			{
+				"type": "speedBonus",
+				"value": "1",
+				"label": "Intrepid"
+			}
+		],
 		"description": "<p>+1 Speed. [M]</p>",
 		"boonType": "minor"
 	},

--- a/packs/classFeatures/core/hunter/hunter-progression/explorer-of-the-wilds.json
+++ b/packs/classFeatures/core/hunter/hunter-progression/explorer-of-the-wilds.json
@@ -6,7 +6,19 @@
 	"system": {
 		"macro": "",
 		"identifier": "",
-		"rules": [],
+		"rules": [
+			{
+				"type": "speedBonus",
+				"value": "2",
+				"label": "Explorer of the Wilds"
+			},
+			{
+				"type": "speedBonus",
+				"value": "@attributes.movement.walk",
+				"movementType": "climb",
+				"label": "Explorer of the Wilds"
+			}
+		],
 		"activation": {
 			"acquireTargetsFromTemplate": false,
 			"cost": {

--- a/packs/classFeatures/core/oathsworn/sacred-decree/unstoppable-protector.json
+++ b/packs/classFeatures/core/oathsworn/sacred-decree/unstoppable-protector.json
@@ -6,7 +6,13 @@
 	"system": {
 		"macro": "",
 		"identifier": "",
-		"rules": [],
+		"rules": [
+			{
+				"type": "speedBonus",
+				"value": "1",
+				"label": "Unstoppable Protector"
+			}
+		],
 		"activation": {
 			"acquireTargetsFromTemplate": false,
 			"cost": {

--- a/packs/classFeatures/core/stormshifter/chimeric-boon/fleet-footed.json
+++ b/packs/classFeatures/core/stormshifter/chimeric-boon/fleet-footed.json
@@ -6,7 +6,13 @@
 	"system": {
 		"macro": "",
 		"identifier": "",
-		"rules": [],
+		"rules": [
+			{
+				"type": "speedBonus",
+				"value": "2",
+				"label": "Fleet Footed"
+			}
+		],
 		"activation": {
 			"acquireTargetsFromTemplate": false,
 			"cost": {

--- a/packs/classFeatures/core/stormshifter/chimeric-boon/winged.json
+++ b/packs/classFeatures/core/stormshifter/chimeric-boon/winged.json
@@ -6,7 +6,14 @@
 	"system": {
 		"macro": "",
 		"identifier": "",
-		"rules": [],
+		"rules": [
+			{
+				"type": "speedBonus",
+				"value": "@attributes.movement.walk",
+				"movementType": "fly",
+				"label": "Winged"
+			}
+		],
 		"activation": {
 			"acquireTargetsFromTemplate": false,
 			"cost": {

--- a/packs/classFeatures/core/the-cheat/the-cheat-subclasses/tools-of-the-silent-blade/professional-skulker.json
+++ b/packs/classFeatures/core/the-cheat/the-cheat-subclasses/tools-of-the-silent-blade/professional-skulker.json
@@ -6,7 +6,14 @@
 	"system": {
 		"macro": "",
 		"identifier": "",
-		"rules": [],
+		"rules": [
+			{
+				"type": "speedBonus",
+				"value": "@attributes.movement.walk",
+				"movementType": "climb",
+				"label": "Professional Skulker"
+			}
+		],
 		"activation": {
 			"acquireTargetsFromTemplate": false,
 			"cost": {

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -478,7 +478,8 @@
 			"note": "Note",
 			"savingThrowBonus": "Save Bonus",
 			"savingThrowRollMode": "Save Roll Mode",
-			"skillBonus": "Skill Bonus"
+			"skillBonus": "Skill Bonus",
+			"speedBonus": "Speed Bonus"
 		},
 		"creatureFeatures": {
 			"noFeatures": "No features yet.",

--- a/src/config.ts
+++ b/src/config.ts
@@ -354,6 +354,14 @@ const movementTypes = {
 	walk: 'NIMBLE.movementTypes.walk',
 };
 
+const movementTypeIcons = {
+	burrow: 'fa-solid fa-circle-down',
+	climb: 'fa-solid fa-mountain',
+	fly: 'fa-solid fa-feather',
+	swim: 'fa-solid fa-water',
+	walk: 'fa-solid fa-person-walking',
+};
+
 const npcArmorEffects = {
 	none: 'NIMBLE.armorEffects.none',
 	medium: 'NIMBLE.armorEffects.medium',
@@ -775,6 +783,7 @@ const NIMBLE = {
 	manaRecoveryTypes,
 	monsterFeatureTypes,
 	movementTypes,
+	movementTypeIcons,
 	npcArmorEffects,
 	npcArmorIcons,
 	npcArmorTypeAbbreviations,

--- a/src/config/registerRulesConfig.ts
+++ b/src/config/registerRulesConfig.ts
@@ -13,6 +13,7 @@ import { NoteRule } from '../models/rules/note.js';
 import { SavingThrowBonusRule } from '../models/rules/savingThrowBonus.js';
 import { SavingThrowRollModeRule } from '../models/rules/savingThrowRollMode.js';
 import { SkillBonusRule } from '../models/rules/skillBonus.js';
+import { SpeedBonusRule } from '../models/rules/speedBonus.js';
 
 export default function registerRulesConfig() {
 	const ruleTypes = {
@@ -31,6 +32,7 @@ export default function registerRulesConfig() {
 		savingThrowBonus: 'NIMBLE.ruleTypes.savingThrowBonus',
 		savingThrowRollMode: 'NIMBLE.ruleTypes.savingThrowRollMode',
 		skillBonus: 'NIMBLE.ruleTypes.skillBonus',
+		speedBonus: 'NIMBLE.ruleTypes.speedBonus',
 	};
 
 	const ruleDataModels = {
@@ -49,6 +51,7 @@ export default function registerRulesConfig() {
 		savingThrowBonus: SavingThrowBonusRule,
 		savingThrowRollMode: SavingThrowRollModeRule,
 		skillBonus: SkillBonusRule,
+		speedBonus: SpeedBonusRule,
 	} as const;
 
 	return { ruleDataModels, ruleTypes };

--- a/src/models/rules/speedBonus.test.ts
+++ b/src/models/rules/speedBonus.test.ts
@@ -1,0 +1,370 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SpeedBonusRule } from './speedBonus.js';
+
+/**
+ * Creates a mock actor with movement attributes
+ */
+function createMockActor(
+	movement: Record<string, number> = { walk: 6, fly: 0, climb: 0, swim: 0, burrow: 0 },
+) {
+	return {
+		system: {
+			attributes: {
+				movement: { ...movement },
+			},
+		},
+		getRollData: vi.fn(() => ({
+			attributes: {
+				movement: { ...movement },
+			},
+		})),
+	};
+}
+
+/**
+ * Creates a mock item that contains the rule
+ */
+function createMockItem(actor: ReturnType<typeof createMockActor>) {
+	return {
+		isEmbedded: true,
+		actor,
+		name: 'Test Item',
+		uuid: 'test-item-uuid',
+	};
+}
+
+/**
+ * Creates a SpeedBonusRule instance with the given configuration
+ */
+function createSpeedBonusRule(
+	config: {
+		value: string;
+		movementType?: string;
+		disabled?: boolean;
+		label?: string;
+	},
+	actor: ReturnType<typeof createMockActor>,
+) {
+	const item = createMockItem(actor);
+
+	const sourceData = {
+		value: config.value,
+		movementType: config.movementType,
+		disabled: config.disabled ?? false,
+		label: config.label ?? 'Test Rule',
+		id: 'test-rule-id',
+		identifier: '',
+		priority: 1,
+		predicate: {},
+		type: 'speedBonus',
+	};
+
+	// Create the rule with a mock parent
+	const rule = new SpeedBonusRule(sourceData as any, { parent: item as any, strict: false });
+
+	// Manually set properties since the mock DataModel doesn't do this automatically
+	(rule as any).value = config.value;
+	(rule as any).movementType = config.movementType ?? 'walk';
+	(rule as any).disabled = config.disabled ?? false;
+	(rule as any).label = config.label ?? 'Test Rule';
+
+	// Override the _source to control hasExplicitMovementType() behavior
+	if (config.movementType !== undefined) {
+		(rule as any)._source = { movementType: config.movementType };
+	} else {
+		(rule as any)._source = {};
+	}
+
+	// Override the item getter to return our mock
+	Object.defineProperty(rule, 'item', {
+		get: () => item,
+		configurable: true,
+	});
+
+	return rule;
+}
+
+describe('SpeedBonusRule', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe('prePrepareData (numeric bonuses)', () => {
+		it('should apply positive numeric bonus to walk speed', () => {
+			const actor = createMockActor({ walk: 6, fly: 0, climb: 0, swim: 0, burrow: 0 });
+			const rule = createSpeedBonusRule({ value: '1' }, actor);
+
+			rule.prePrepareData();
+
+			expect(actor.system.attributes.movement.walk).toBe(7);
+		});
+
+		it('should apply negative numeric bonus to walk speed', () => {
+			const actor = createMockActor({ walk: 6, fly: 0, climb: 0, swim: 0, burrow: 0 });
+			const rule = createSpeedBonusRule({ value: '-1' }, actor);
+
+			rule.prePrepareData();
+
+			expect(actor.system.attributes.movement.walk).toBe(5);
+		});
+
+		it('should not reduce walk speed below 0', () => {
+			const actor = createMockActor({ walk: 2, fly: 0, climb: 0, swim: 0, burrow: 0 });
+			const rule = createSpeedBonusRule({ value: '-5' }, actor);
+
+			rule.prePrepareData();
+
+			expect(actor.system.attributes.movement.walk).toBe(0);
+		});
+
+		it('should apply bonus to specific movement type when movementType is set', () => {
+			const actor = createMockActor({ walk: 6, fly: 0, climb: 0, swim: 0, burrow: 0 });
+			const rule = createSpeedBonusRule({ value: '3', movementType: 'climb' }, actor);
+
+			rule.prePrepareData();
+
+			expect(actor.system.attributes.movement.climb).toBe(3);
+			expect(actor.system.attributes.movement.walk).toBe(6); // Unchanged
+		});
+
+		it('should stack multiple numeric bonuses to walk', () => {
+			const actor = createMockActor({ walk: 6, fly: 0, climb: 0, swim: 0, burrow: 0 });
+
+			// Apply first bonus: Elf +1
+			const elfRule = createSpeedBonusRule({ value: '1', label: 'Lithe' }, actor);
+			elfRule.prePrepareData();
+			expect(actor.system.attributes.movement.walk).toBe(7);
+
+			// Apply second bonus: Epic Speed +4
+			const epicRule = createSpeedBonusRule({ value: '4', label: 'Epic Speed' }, actor);
+			epicRule.prePrepareData();
+			expect(actor.system.attributes.movement.walk).toBe(11);
+		});
+
+		it('should not process formula values in prePrepareData', () => {
+			const actor = createMockActor({ walk: 6, fly: 0, climb: 0, swim: 0, burrow: 0 });
+			const rule = createSpeedBonusRule(
+				{ value: '@attributes.movement.walk', movementType: 'climb' },
+				actor,
+			);
+
+			rule.prePrepareData();
+
+			// Formula values should be skipped in prePrepareData
+			expect(actor.system.attributes.movement.climb).toBe(0);
+		});
+
+		it('should use default walk speed of 6 when not set', () => {
+			const actor = createMockActor({} as any);
+			actor.system.attributes.movement = {} as any;
+			const rule = createSpeedBonusRule({ value: '2' }, actor);
+
+			rule.prePrepareData();
+
+			expect(actor.system.attributes.movement.walk).toBe(8); // 6 default + 2
+		});
+	});
+
+	describe('afterPrepareData (formula-based bonuses)', () => {
+		it('should process formula values in afterPrepareData', () => {
+			const actor = createMockActor({ walk: 8, fly: 0, climb: 0, swim: 0, burrow: 0 });
+			// Update getRollData to return the current walk value
+			actor.getRollData = vi.fn(() => ({
+				attributes: {
+					movement: actor.system.attributes.movement,
+				},
+			}));
+			const rule = createSpeedBonusRule(
+				{ value: '@attributes.movement.walk', movementType: 'climb' },
+				actor,
+			);
+
+			rule.afterPrepareData();
+
+			// Climb should equal walk (8)
+			expect(actor.system.attributes.movement.climb).toBe(8);
+		});
+
+		it('should not process numeric values in afterPrepareData', () => {
+			const actor = createMockActor({ walk: 6, fly: 0, climb: 0, swim: 0, burrow: 0 });
+			const rule = createSpeedBonusRule({ value: '2' }, actor);
+
+			rule.afterPrepareData();
+
+			// Numeric values should be skipped in afterPrepareData (already processed in prePrepareData)
+			expect(actor.system.attributes.movement.walk).toBe(6);
+		});
+
+		it('should apply generic formula bonus to walk only', () => {
+			const actor = createMockActor({ walk: 6, fly: 0, climb: 0, swim: 0, burrow: 0 });
+			actor.getRollData = vi.fn(() => ({
+				level: 5,
+			}));
+			// Generic formula bonus (no explicit movementType)
+			const rule = createSpeedBonusRule({ value: '@level' }, actor);
+			// Remove movementType from _source to make it generic
+			(rule as any)._source = {};
+
+			rule.afterPrepareData();
+
+			// Formula @level = 5 should be added to walk
+			expect(actor.system.attributes.movement.walk).toBe(11);
+		});
+	});
+
+	describe('two-phase processing', () => {
+		it('should ensure climb speed equals fully modified walk speed', () => {
+			// Scenario: Elf (+1) with Explorer of the Wilds (+2 walk, climb = walk) and Epic Speed (+4)
+			// Expected: walk = 6 + 1 + 2 + 4 = 13, climb = 13
+			const actor = createMockActor({ walk: 6, fly: 0, climb: 0, swim: 0, burrow: 0 });
+
+			// Phase 1: Apply numeric bonuses
+			const elfRule = createSpeedBonusRule({ value: '1', label: 'Elf Lithe' }, actor);
+			elfRule.prePrepareData();
+			expect(actor.system.attributes.movement.walk).toBe(7);
+
+			const explorerWalkRule = createSpeedBonusRule(
+				{ value: '2', label: 'Explorer of the Wilds' },
+				actor,
+			);
+			explorerWalkRule.prePrepareData();
+			expect(actor.system.attributes.movement.walk).toBe(9);
+
+			const epicSpeedRule = createSpeedBonusRule({ value: '4', label: 'Epic Speed' }, actor);
+			epicSpeedRule.prePrepareData();
+			expect(actor.system.attributes.movement.walk).toBe(13);
+
+			// Phase 2: Apply formula bonuses (climb = walk)
+			// Update getRollData to return current movement values
+			actor.getRollData = vi.fn(() => ({
+				attributes: {
+					movement: actor.system.attributes.movement,
+				},
+			}));
+
+			const explorerClimbRule = createSpeedBonusRule(
+				{
+					value: '@attributes.movement.walk',
+					movementType: 'climb',
+					label: 'Explorer of the Wilds',
+				},
+				actor,
+			);
+			explorerClimbRule.afterPrepareData();
+
+			// Climb should now equal the fully modified walk speed
+			expect(actor.system.attributes.movement.climb).toBe(13);
+		});
+	});
+
+	describe('movement type handling', () => {
+		it('should apply fly speed bonus', () => {
+			const actor = createMockActor({ walk: 6, fly: 0, climb: 0, swim: 0, burrow: 0 });
+			const rule = createSpeedBonusRule({ value: '6', movementType: 'fly' }, actor);
+
+			rule.prePrepareData();
+
+			expect(actor.system.attributes.movement.fly).toBe(6);
+		});
+
+		it('should apply swim speed bonus', () => {
+			const actor = createMockActor({ walk: 6, fly: 0, climb: 0, swim: 0, burrow: 0 });
+			const rule = createSpeedBonusRule({ value: '4', movementType: 'swim' }, actor);
+
+			rule.prePrepareData();
+
+			expect(actor.system.attributes.movement.swim).toBe(4);
+		});
+
+		it('should apply burrow speed bonus', () => {
+			const actor = createMockActor({ walk: 6, fly: 0, climb: 0, swim: 0, burrow: 0 });
+			const rule = createSpeedBonusRule({ value: '3', movementType: 'burrow' }, actor);
+
+			rule.prePrepareData();
+
+			expect(actor.system.attributes.movement.burrow).toBe(3);
+		});
+
+		it('should add to existing movement speed', () => {
+			const actor = createMockActor({ walk: 6, fly: 4, climb: 0, swim: 0, burrow: 0 });
+			const rule = createSpeedBonusRule({ value: '2', movementType: 'fly' }, actor);
+
+			rule.prePrepareData();
+
+			expect(actor.system.attributes.movement.fly).toBe(6); // 4 + 2
+		});
+	});
+
+	describe('edge cases', () => {
+		it('should handle non-embedded items gracefully', () => {
+			const actor = createMockActor({ walk: 6, fly: 0, climb: 0, swim: 0, burrow: 0 });
+			const item = {
+				isEmbedded: false, // Not embedded
+				actor,
+				name: 'Test Item',
+				uuid: 'test-item-uuid',
+			};
+
+			const rule = new SpeedBonusRule(
+				{
+					value: '2',
+					movementType: 'walk',
+					disabled: false,
+					label: 'Test Rule',
+					id: 'test-rule-id',
+					identifier: '',
+					priority: 1,
+					predicate: {},
+					type: 'speedBonus',
+				} as any,
+				{ parent: item as any, strict: false },
+			);
+
+			// Manually set properties
+			(rule as any).value = '2';
+			(rule as any).movementType = 'walk';
+			(rule as any)._source = {};
+
+			// Override the item getter
+			Object.defineProperty(rule, 'item', {
+				get: () => item,
+				configurable: true,
+			});
+
+			rule.prePrepareData();
+
+			// Should not modify anything since item is not embedded
+			expect(actor.system.attributes.movement.walk).toBe(6);
+		});
+
+		it('should handle zero bonus value', () => {
+			const actor = createMockActor({ walk: 6, fly: 0, climb: 0, swim: 0, burrow: 0 });
+			const rule = createSpeedBonusRule({ value: '0' }, actor);
+
+			rule.prePrepareData();
+
+			expect(actor.system.attributes.movement.walk).toBe(6);
+		});
+
+		it('should handle whitespace in numeric values', () => {
+			const actor = createMockActor({ walk: 6, fly: 0, climb: 0, swim: 0, burrow: 0 });
+			const rule = createSpeedBonusRule({ value: '  2  ' }, actor);
+
+			rule.prePrepareData();
+
+			expect(actor.system.attributes.movement.walk).toBe(8);
+		});
+	});
+
+	describe('schema', () => {
+		it('should define the correct schema fields', () => {
+			const schema = SpeedBonusRule.defineSchema();
+
+			expect(schema).toHaveProperty('value');
+			expect(schema).toHaveProperty('type');
+			expect(schema).toHaveProperty('movementType');
+			expect(schema).toHaveProperty('disabled');
+			expect(schema).toHaveProperty('label');
+		});
+	});
+});

--- a/src/models/rules/speedBonus.ts
+++ b/src/models/rules/speedBonus.ts
@@ -2,6 +2,8 @@ import { NimbleBaseRule } from './base.js';
 
 type MovementType = 'walk' | 'fly' | 'climb' | 'swim' | 'burrow';
 
+const DEFAULT_WALK_SPEED = 6;
+
 function schema() {
 	const { fields } = foundry.data;
 
@@ -76,13 +78,13 @@ class SpeedBonusRule extends NimbleBaseRule<SpeedBonusRule.Schema> {
 		if (this.hasExplicitMovementType()) {
 			// Apply bonus to specific movement type only
 			const movementType = this.movementType;
-			const defaultValue = movementType === 'walk' ? 6 : 0;
+			const defaultValue = movementType === 'walk' ? DEFAULT_WALK_SPEED : 0;
 			const originalValue = actorSystem.system.attributes.movement[movementType] ?? defaultValue;
 			const modifiedValue = Math.max(0, originalValue + value);
 			foundry.utils.setProperty(actor.system, `attributes.movement.${movementType}`, modifiedValue);
 		} else {
 			// Generic speed bonus: apply to walk only
-			const walkValue = actorSystem.system.attributes.movement.walk ?? 6;
+			const walkValue = actorSystem.system.attributes.movement.walk ?? DEFAULT_WALK_SPEED;
 			foundry.utils.setProperty(
 				actor.system,
 				'attributes.movement.walk',
@@ -108,14 +110,14 @@ class SpeedBonusRule extends NimbleBaseRule<SpeedBonusRule.Schema> {
 		if (this.hasExplicitMovementType()) {
 			// Apply to specific movement type (e.g., "gain climb speed equal to walk")
 			const movementType = this.movementType;
-			const defaultValue = movementType === 'walk' ? 6 : 0;
+			const defaultValue = movementType === 'walk' ? DEFAULT_WALK_SPEED : 0;
 			const originalValue = actorSystem.system.attributes.movement[movementType] ?? defaultValue;
 			const modifiedValue = Math.max(0, originalValue + value);
 			foundry.utils.setProperty(actor.system, `attributes.movement.${movementType}`, modifiedValue);
 		} else {
 			// Generic formula bonus: apply to walk only
 			// (other movement types granted via formula already inherit walk's bonuses)
-			const walkValue = actorSystem.system.attributes.movement.walk ?? 6;
+			const walkValue = actorSystem.system.attributes.movement.walk ?? DEFAULT_WALK_SPEED;
 			foundry.utils.setProperty(
 				actor.system,
 				'attributes.movement.walk',

--- a/src/models/rules/speedBonus.ts
+++ b/src/models/rules/speedBonus.ts
@@ -1,0 +1,50 @@
+import { NimbleBaseRule } from './base.js';
+
+function schema() {
+	const { fields } = foundry.data;
+
+	return {
+		value: new fields.StringField({ required: true, nullable: false, initial: '' }),
+		type: new fields.StringField({ required: true, nullable: false, initial: 'speedBonus' }),
+	};
+}
+
+declare namespace SpeedBonusRule {
+	type Schema = NimbleBaseRule.Schema & ReturnType<typeof schema>;
+}
+
+class SpeedBonusRule extends NimbleBaseRule<SpeedBonusRule.Schema> {
+	declare value: string;
+
+	static override defineSchema(): SpeedBonusRule.Schema {
+		return {
+			...NimbleBaseRule.defineSchema(),
+			...schema(),
+		};
+	}
+
+	override tooltipInfo(): string {
+		return super.tooltipInfo(new Map([['value', 'string']]));
+	}
+
+	override afterPrepareData(): void {
+		const { item } = this;
+		if (!item.isEmbedded) return;
+
+		const { actor } = item;
+		const value = this.resolveFormula(this.value) ?? 0;
+
+		interface ActorAttributes {
+			attributes: {
+				movement: { walk?: number };
+			};
+		}
+		const actorSystem = actor.system as object as ActorAttributes;
+		const originalValue = actorSystem.attributes.movement.walk ?? 6;
+		const modifiedValue = Math.max(0, originalValue + value);
+
+		foundry.utils.setProperty(actor.system, 'attributes.movement.walk', modifiedValue);
+	}
+}
+
+export { SpeedBonusRule };

--- a/src/scss/base/_theme.scss
+++ b/src/scss/base/_theme.scss
@@ -54,4 +54,10 @@
 
   --nimble-rule-background-color: hsl(210, 30%, 25%);
   --nimble-rule-border-color: hsl(210, 30%, 40%);
+
+  /** ROLL RESULT COLORS **/
+  --nimble-roll-success-color: hsl(120, 45%, 55%);
+  --nimble-roll-success-background-color: hsl(120, 30%, 25%);
+  --nimble-roll-failure-color: hsl(0, 65%, 60%);
+  --nimble-roll-failure-background-color: hsl(0, 40%, 25%);
 }

--- a/src/view/dialogs/CharacterMovementConfigDialog.svelte
+++ b/src/view/dialogs/CharacterMovementConfigDialog.svelte
@@ -26,11 +26,25 @@
 				if (rule.disabled) continue;
 
 				const value = getDeterministicBonus(rule.value, rollData) ?? 0;
-				const movementType = rule.movementType ?? 'walk';
+				if (value === 0) continue;
 
-				if (value !== 0) {
+				// Check if movementType was explicitly set in source data
+				const hasExplicitMovementType = rule._source?.movementType !== undefined;
+
+				if (hasExplicitMovementType) {
+					// Specific movement type bonus (e.g., "gain climb = walk")
+					const movementType = rule.movementType;
 					bonusesByType[movementType] ??= [];
 					bonusesByType[movementType].push({
+						itemName: item.name,
+						label: rule.label,
+						value,
+					});
+				} else {
+					// Generic speed bonus: only applies to walk
+					// (other movement types granted via formula inherit walk's bonuses)
+					bonusesByType['walk'] ??= [];
+					bonusesByType['walk'].push({
 						itemName: item.name,
 						label: rule.label,
 						value,

--- a/src/view/dialogs/CharacterMovementConfigDialog.svelte
+++ b/src/view/dialogs/CharacterMovementConfigDialog.svelte
@@ -166,11 +166,11 @@
 		border: 1px solid var(--nimble-card-border-color);
 
 		&--has-bonus {
-			border-color: hsl(200, 50%, 50%);
+			border-color: var(--nimble-accent-color);
 			background: linear-gradient(
 				to bottom,
 				var(--nimble-box-background-color),
-				hsl(200, 30%, 95%)
+				color-mix(in srgb, var(--nimble-accent-color) 10%, var(--nimble-box-background-color))
 			);
 		}
 
@@ -233,14 +233,14 @@
 			align-items: center;
 			justify-content: space-between;
 			padding: 0.25rem 0.375rem;
-			background: hsl(200, 50%, 45%);
+			background: var(--nimble-accent-color);
 			border-radius: 4px;
 		}
 
 		&__total-label {
 			font-size: var(--nimble-xs-text);
 			font-weight: 500;
-			color: hsl(200, 30%, 95%);
+			color: var(--nimble-light-text-color, #fff);
 			text-transform: uppercase;
 			letter-spacing: 0.025em;
 		}
@@ -248,7 +248,7 @@
 		&__total-value {
 			font-size: var(--nimble-sm-text);
 			font-weight: 700;
-			color: #fff;
+			color: var(--nimble-light-text-color, #fff);
 		}
 
 		&__bonus-list {
@@ -282,10 +282,10 @@
 
 		&__bonus-value {
 			font-weight: 600;
-			color: hsl(139, 50%, 40%);
+			color: var(--nimble-roll-success-color);
 
 			&--negative {
-				color: hsl(0, 50%, 50%);
+				color: var(--nimble-roll-failure-color);
 			}
 		}
 	}

--- a/src/view/dialogs/CharacterMovementConfigDialog.svelte
+++ b/src/view/dialogs/CharacterMovementConfigDialog.svelte
@@ -1,59 +1,335 @@
 <script>
+	import localize from '../../utils/localize.js';
+	import getDeterministicBonus from '../../dice/getDeterministicBonus.js';
+
 	let { document } = $props();
 
-	const { movementTypes } = CONFIG.NIMBLE;
+	const { movementTypes, movementTypeIcons } = CONFIG.NIMBLE;
+	const movementKeys = ['walk', 'fly', 'climb', 'swim', 'burrow'];
+
+	// Get base movement values from source (before rule modifications)
+	let baseMovement = $derived(document._source?.system?.attributes?.movement ?? {});
+
+	// Get current (derived) movement values with bonuses applied
+	let currentMovement = $derived(document.reactive?.system?.attributes?.movement ?? {});
+
+	// Collect speed bonuses from rules
+	let speedBonuses = $derived.by(() => {
+		const bonuses = [];
+		const rollData = document.getRollData?.() ?? {};
+
+		for (const item of document.items ?? []) {
+			if (!item.rules) continue;
+
+			for (const rule of item.rules.values()) {
+				if (rule.type !== 'speedBonus') continue;
+				if (rule.disabled) continue;
+
+				const value = getDeterministicBonus(rule.value, rollData) ?? 0;
+
+				if (value !== 0) {
+					bonuses.push({
+						name: item.name,
+						value,
+					});
+				}
+			}
+		}
+
+		return bonuses;
+	});
+
+	let totalSpeedBonus = $derived(speedBonuses.reduce((acc, b) => acc + b.value, 0));
+
+	function updateMovement(key, value) {
+		document.update({
+			[`system.attributes.movement.${key}`]: Number.parseInt(value, 10) || 0,
+		});
+	}
+
+	function formatBonus(value) {
+		return value >= 0 ? `+${value}` : `${value}`;
+	}
 </script>
 
-<section class="nimble-sheet__body nimble-sheet__body--movement-config">
-	<table class="nimble-movement-config-table">
-		<thead>
-			<tr>
-				{#each Object.keys(document.reactive?.system?.attributes?.movement) as key}
-					{@const movementType = movementTypes[key] ?? key}
+<section class="nimble-sheet__body nimble-movement-config">
+	<!-- Movement Types Grid -->
+	<div class="movement-grid">
+		{#each movementKeys as key}
+			{@const icon = movementTypeIcons[key]}
+			{@const label = localize(movementTypes[key])}
+			{@const baseValue = baseMovement[key] ?? 0}
+			{@const currentValue = currentMovement[key] ?? 0}
+			{@const hasBonus = key === 'walk' && totalSpeedBonus !== 0}
 
-					<th>{movementType}</th>
-				{/each}
-			</tr>
-		</thead>
+			<div class="movement-card" class:movement-card--has-bonus={hasBonus}>
+				<div class="movement-card__header">
+					<i class="movement-card__icon {icon}"></i>
+					<span class="movement-card__label">{label}</span>
+				</div>
 
-		<tbody>
-			<tr>
-				{#each Object.entries(document.reactive?.system?.attributes?.movement) as [key, distance]}
-					<td>
+				<div class="movement-card__body">
+					<div class="movement-card__input-wrapper">
 						<input
-							class="nimble-movement-config__field"
+							class="movement-card__input"
 							type="number"
-							value={distance}
-							onchange={({ target }) =>
-								document.update({
-									[`system.attributes.movement.${key}`]: target.value,
-								})}
+							min="0"
+							value={baseValue}
+							onchange={({ target }) => updateMovement(key, target.value)}
 						/>
-					</td>
-				{/each}
-			</tr>
-		</tbody>
-	</table>
+						<span class="movement-card__unit">spaces</span>
+					</div>
 
-	<aside>Note: All measurements are given in grid spaces.</aside>
+					{#if hasBonus}
+						<div class="movement-card__total">
+							<span class="movement-card__total-label">Total</span>
+							<span class="movement-card__total-value">{currentValue}</span>
+						</div>
+					{/if}
+				</div>
+			</div>
+		{/each}
+	</div>
+
+	<!-- Speed Bonuses from Rules -->
+	{#if speedBonuses.length > 0}
+		<div class="speed-bonuses">
+			<div class="speed-bonuses__header">
+				<i class="fa-solid fa-bolt"></i>
+				<span>Speed Bonuses</span>
+			</div>
+
+			<div class="speed-bonuses__list">
+				{#each speedBonuses as bonus}
+					<div class="speed-bonus-item">
+						<span class="speed-bonus-item__name">{bonus.name}</span>
+						<span
+							class="speed-bonus-item__value"
+							class:speed-bonus-item__value--negative={bonus.value < 0}
+						>
+							{formatBonus(bonus.value)}
+						</span>
+					</div>
+				{/each}
+			</div>
+
+			<div class="speed-bonuses__total">
+				<span class="speed-bonuses__total-label">Total Bonus</span>
+				<span
+					class="speed-bonuses__total-value"
+					class:speed-bonuses__total-value--negative={totalSpeedBonus < 0}
+				>
+					{formatBonus(totalSpeedBonus)}
+				</span>
+			</div>
+		</div>
+	{/if}
+
+	<aside class="movement-note">
+		<i class="fa-solid fa-circle-info"></i>
+		<span>All measurements are in grid spaces.</span>
+	</aside>
 </section>
 
 <style lang="scss">
-	.nimble-movement-config-table {
-		text-align: center;
-		vertical-align: middle;
+	.nimble-movement-config {
+		--nimble-sheet-body-padding-block-start: 0.5rem;
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
 
-		thead {
-			text-align: center;
+	.movement-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(7rem, 1fr));
+		gap: 0.5rem;
+	}
+
+	.movement-card {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+		padding: 0.625rem;
+		background: var(--nimble-box-background-color);
+		border-radius: 6px;
+		border: 1px solid var(--nimble-card-border-color);
+
+		&--has-bonus {
+			border-color: hsl(200, 50%, 50%);
+			background: linear-gradient(
+				to bottom,
+				var(--nimble-box-background-color),
+				hsl(200, 30%, 95%)
+			);
 		}
 
-		td {
+		&__header {
+			display: flex;
+			align-items: center;
+			gap: 0.375rem;
+			padding-bottom: 0.375rem;
+			border-bottom: 1px solid var(--nimble-card-border-color);
+		}
+
+		&__icon {
+			font-size: 0.875rem;
+			color: var(--nimble-accent-color);
+		}
+
+		&__label {
+			font-size: var(--nimble-sm-text);
+			font-weight: 600;
+			color: var(--nimble-dark-text-color);
+		}
+
+		&__body {
+			display: flex;
+			flex-direction: column;
+			gap: 0.375rem;
+		}
+
+		&__input-wrapper {
+			display: flex;
+			align-items: center;
+			gap: 0.25rem;
+		}
+
+		&__input {
+			width: 3.5rem;
+			padding: 0.375rem;
 			font-size: var(--nimble-md-text);
+			font-weight: 600;
+			text-align: center;
+			border: 1px solid var(--nimble-card-border-color);
+			border-radius: 4px;
+			background: var(--nimble-input-background-color);
+			color: var(--nimble-dark-text-color);
+
+			&:focus {
+				outline: 2px solid var(--nimble-accent-color);
+				outline-offset: -1px;
+				border-color: var(--nimble-accent-color);
+			}
+		}
+
+		&__unit {
+			font-size: var(--nimble-xs-text);
+			color: var(--nimble-medium-text-color);
+		}
+
+		&__total {
+			display: flex;
+			align-items: center;
+			justify-content: space-between;
+			padding: 0.25rem 0.375rem;
+			background: hsl(200, 50%, 45%);
+			border-radius: 4px;
+		}
+
+		&__total-label {
+			font-size: var(--nimble-xs-text);
+			font-weight: 500;
+			color: hsl(200, 30%, 95%);
+			text-transform: uppercase;
+			letter-spacing: 0.025em;
+		}
+
+		&__total-value {
+			font-size: var(--nimble-sm-text);
+			font-weight: 700;
+			color: #fff;
 		}
 	}
 
-	aside {
+	.speed-bonuses {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+		padding: 0.75rem;
+		background: var(--nimble-box-background-color);
+		border-radius: 6px;
+		border: 1px solid var(--nimble-card-border-color);
+
+		&__header {
+			display: flex;
+			align-items: center;
+			gap: 0.375rem;
+			font-size: var(--nimble-sm-text);
+			font-weight: 600;
+			color: var(--nimble-dark-text-color);
+
+			i {
+				color: hsl(45, 70%, 50%);
+			}
+		}
+
+		&__list {
+			display: flex;
+			flex-direction: column;
+			gap: 0.25rem;
+		}
+
+		&__total {
+			display: flex;
+			justify-content: space-between;
+			align-items: center;
+			padding-top: 0.5rem;
+			margin-top: 0.25rem;
+			border-top: 1px solid var(--nimble-card-border-color);
+		}
+
+		&__total-label {
+			font-size: var(--nimble-xs-text);
+			font-weight: 600;
+			color: var(--nimble-medium-text-color);
+			text-transform: uppercase;
+			letter-spacing: 0.025em;
+		}
+
+		&__total-value {
+			font-size: var(--nimble-md-text);
+			font-weight: 700;
+			color: hsl(139, 50%, 40%);
+
+			&--negative {
+				color: hsl(0, 50%, 50%);
+			}
+		}
+	}
+
+	.speed-bonus-item {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		padding: 0.25rem 0.375rem;
+		background: var(--nimble-input-background-color);
+		border-radius: 4px;
+
+		&__name {
+			font-size: var(--nimble-sm-text);
+			color: var(--nimble-dark-text-color);
+		}
+
+		&__value {
+			font-size: var(--nimble-sm-text);
+			font-weight: 600;
+			color: hsl(139, 50%, 40%);
+
+			&--negative {
+				color: hsl(0, 50%, 50%);
+			}
+		}
+	}
+
+	.movement-note {
+		display: flex;
+		align-items: center;
+		gap: 0.375rem;
 		font-size: var(--nimble-sm-text);
-		font-weight: 500;
+		color: var(--nimble-medium-text-color);
+
+		i {
+			color: var(--nimble-accent-color);
+		}
 	}
 </style>

--- a/src/view/dialogs/CharacterMovementConfigDialog.svelte
+++ b/src/view/dialogs/CharacterMovementConfigDialog.svelte
@@ -154,6 +154,7 @@
 		display: grid;
 		grid-template-columns: repeat(auto-fill, minmax(7rem, 1fr));
 		gap: 0.5rem;
+		align-items: stretch;
 	}
 
 	.movement-card {
@@ -164,6 +165,7 @@
 		background: var(--nimble-box-background-color);
 		border-radius: 6px;
 		border: 1px solid var(--nimble-card-border-color);
+		height: 100%;
 
 		&--has-bonus {
 			border-color: var(--nimble-accent-color);
@@ -197,6 +199,7 @@
 			display: flex;
 			flex-direction: column;
 			gap: 0.375rem;
+			flex: 1;
 		}
 
 		&__input-wrapper {
@@ -235,12 +238,13 @@
 			padding: 0.25rem 0.375rem;
 			background: var(--nimble-accent-color);
 			border-radius: 4px;
+			margin-top: auto;
 		}
 
 		&__total-label {
 			font-size: var(--nimble-xs-text);
 			font-weight: 500;
-			color: var(--nimble-light-text-color, #fff);
+			color: white;
 			text-transform: uppercase;
 			letter-spacing: 0.025em;
 		}
@@ -248,7 +252,7 @@
 		&__total-value {
 			font-size: var(--nimble-sm-text);
 			font-weight: 700;
-			color: var(--nimble-light-text-color, #fff);
+			color: white;
 		}
 
 		&__bonus-list {

--- a/src/view/sheets/components/MovementSpeed.svelte
+++ b/src/view/sheets/components/MovementSpeed.svelte
@@ -2,15 +2,17 @@
 	import { getContext } from 'svelte';
 	import localize from '../../../utils/localize.js';
 
-	const { movementTypes } = CONFIG.NIMBLE;
+	const { movementTypes, movementTypeIcons } = CONFIG.NIMBLE;
 
 	let { actor, showDefaultSpeed = false } = $props();
 	const editingEnabledStore = getContext('editingEnabled');
 	let editingEnabled = $derived($editingEnabledStore ?? true);
 
+	// Access the full reactive movement object to ensure proper reactivity tracking
+	let movement = $derived(actor.reactive.system.attributes.movement);
+
 	// Check if movement is the default (walk=6, all others=0)
 	let isDefaultMovement = $derived.by(() => {
-		const movement = actor.reactive.system.attributes.movement;
 		const isDefault =
 			movement.walk === 6 &&
 			movement.burrow === 0 &&
@@ -23,67 +25,101 @@
 	// Show movement if: not hiding defaults, OR if we are hiding defaults but this isn't default
 	let shouldShowMovement = $derived(showDefaultSpeed || !isDefaultMovement);
 
-	let movementModes = $derived.by(() => {
-		const movement = actor.reactive.system.attributes.movement;
+	// Get walk speed for primary display
+	let walkSpeed = $derived(movement.walk);
 
-		return Object.entries(movement)
-			.reduce((modes: string[], [key, value]): string[] => {
-				if (value) {
-					const movementType = localize(movementTypes[key] ?? key);
-					modes.push(`${movementType}: ${value} spaces`);
-				}
+	// Get alternate movement types (non-walk) that have non-zero values
+	let alternateMovements = $derived.by(() => {
+		const alternateTypes = ['fly', 'climb', 'swim', 'burrow'];
 
-				return modes;
-			}, [])
-			.sort((a, b) => a.localeCompare(b));
+		return alternateTypes
+			.filter((type) => movement[type] > 0)
+			.map((type) => ({
+				type,
+				value: movement[type],
+				icon: movementTypeIcons[type],
+				label: localize(movementTypes[type]),
+			}));
 	});
+
+	const configTooltip = localize('NIMBLE.prompts.configureMovement');
 </script>
 
 {#if shouldShowMovement}
-	{#each [{ heading: 'Movement', configMethod: actor.configureMovement.bind(actor), content: movementModes, prompt: 'configureMovement' }] as { heading, configMethod, content, prompt }}
-		{@const tooltip = localize(`NIMBLE.prompts.${prompt}`)}
+	<section class="nimble-movement" style="grid-area: speed;">
+		<div class="nimble-movement__primary">
+			<span class="nimble-heading" data-heading-variant="section">Speed</span>
+			<span class="nimble-movement__value">{walkSpeed}</span>
+		</div>
 
-		<section>
-			<header class="nimble-section-header">
-				<h3 class="nimble-heading" data-heading-variant="section">
-					{heading}
-				</h3>
-
-				<button
-					class="nimble-button"
-					data-button-variant="icon"
-					type="button"
-					aria-label={tooltip}
-					data-tooltip={tooltip}
-					onclick={configMethod}
-					disabled={!editingEnabled}
-				>
-					<i class="fa-solid fa-edit"></i>
-				</button>
-			</header>
-
-			<ul class="nimble-proficiency-list">
-				{#each content as label}
-					<li class="nimble-proficiency-list__item">
-						{label}
-					</li>
-				{:else}
-					<li class="nimble-proficiency-list__item">None</li>
+		{#if alternateMovements.length > 0}
+			<div class="nimble-movement__secondary">
+				{#each alternateMovements as { type, value, icon, label }}
+					<span
+						class="nimble-movement__icon"
+						data-tooltip="{label} {value}"
+						data-tooltip-direction="UP"
+					>
+						<i class={icon}></i>
+						<span class="nimble-movement__icon-value">{value}</span>
+					</span>
 				{/each}
-			</ul>
-		</section>
-	{/each}
+			</div>
+		{/if}
+
+		<button
+			class="nimble-button"
+			data-button-variant="icon"
+			type="button"
+			aria-label={configTooltip}
+			data-tooltip={configTooltip}
+			onclick={() => actor.configureMovement()}
+			disabled={!editingEnabled}
+		>
+			<i class="fa-solid fa-edit"></i>
+		</button>
+	</section>
 {/if}
 
 <style>
-	.nimble-proficiency-list {
+	.nimble-movement {
 		display: flex;
-		flex-wrap: wrap;
-		gap: 0.25rem 1ch;
-		margin: 0;
-		padding: 0;
-		list-style: none;
+		align-items: center;
+		gap: 0.75rem;
+	}
+
+	.nimble-movement__primary {
+		display: flex;
+		align-items: baseline;
+		gap: 0.5rem;
+	}
+
+	.nimble-movement__value {
 		font-size: var(--nimble-sm-text);
-		font-weight: 500;
+		font-weight: 600;
+		color: var(--nimble-dark-text-color);
+	}
+
+	.nimble-movement__secondary {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+	}
+
+	.nimble-movement__icon {
+		display: flex;
+		align-items: center;
+		gap: 0.25rem;
+		color: var(--nimble-dark-text-color);
+		font-size: var(--nimble-sm-text);
+		cursor: default;
+	}
+
+	.nimble-movement__icon i {
+		font-size: 0.75rem;
+	}
+
+	.nimble-movement__icon-value {
+		font-weight: 600;
 	}
 </style>

--- a/src/view/sheets/components/MovementSpeed.svelte
+++ b/src/view/sheets/components/MovementSpeed.svelte
@@ -35,7 +35,6 @@
 		return alternateTypes
 			.filter((type) => movement[type] > 0)
 			.map((type) => ({
-				type,
 				value: movement[type],
 				icon: movementTypeIcons[type],
 				label: localize(movementTypes[type]),
@@ -54,7 +53,7 @@
 
 		{#if alternateMovements.length > 0}
 			<div class="nimble-movement__secondary">
-				{#each alternateMovements as { type, value, icon, label }}
+				{#each alternateMovements as { value, icon, label }}
 					<span
 						class="nimble-movement__icon"
 						data-tooltip="{label} {value}"

--- a/src/view/sheets/pages/NPCCoreTab.svelte
+++ b/src/view/sheets/pages/NPCCoreTab.svelte
@@ -444,6 +444,8 @@
 	<section class="nimble-monster-sheet-section nimble-monster-sheet-section--defenses">
 		<SavingThrows characterSavingThrows={actor.reactive.system.savingThrows} />
 
+		<MovementSpeed {actor} showDefaultSpeed={false} />
+
 		<section class="nimble-other-attribute-wrapper" style="grid-area: armor;">
 			<header class="nimble-section-header" data-header-alignment="center">
 				<h3 class="nimble-heading" data-heading-variant="section">
@@ -631,10 +633,6 @@
 				<p>{creatureFeatures.noFeatures}</p>
 			</section>
 		{/if}
-
-		<section class="nimble-monster-sheet-section">
-			<MovementSpeed {actor} showDefaultSpeed={false} />
-		</section>
 	</section>
 </section>
 
@@ -1427,7 +1425,7 @@
 		padding: 0.25rem 0.5rem 0.25rem;
 
 		&:first-of-type {
-			padding: 0.75rem 0.5rem 0.75rem !important;
+			padding: 0.25rem 0.5rem 0.75rem !important;
 		}
 		&:not(:last-of-type) {
 			padding: 0 0.5rem 0.75rem;
@@ -1439,7 +1437,10 @@
 		&--defenses {
 			display: grid;
 			grid-template-columns: 1fr 4.2rem;
-			grid-template-areas: 'savingThrows armor';
+			grid-template-areas:
+				'savingThrows armor'
+				'speed armor';
+			row-gap: 0.25rem;
 		}
 	}
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -10,12 +10,16 @@ import {
 	foundryApiMocks,
 	globalFoundryMocks,
 	MockRollConstructor,
+	uiMock,
 } from './mocks/foundry.js';
 
 // Mock Foundry global object required setup before importing config
 // CRITICAL: These document classes must be mocked BEFORE any code tries to extend them
 // They are global Foundry classes, not part of the foundry object
 Object.assign(globalThis, globalFoundryMocks);
+
+// Mock the ui global for notifications
+(globalThis as object as { ui: typeof uiMock }).ui = uiMock;
 
 // Mock foundry object for utilities and APIs
 // foundryApiMocks already includes a trackable Roll mock


### PR DESCRIPTION
## Summary
- Add a new `speedBonus` rule type that modifies character movement speeds
- Support multiple movement types: walk, fly, climb, swim, burrow
- Use two-phase processing to ensure correct bonus application:
  - `prePrepareData`: apply numeric bonuses to walk first
  - `afterPrepareData`: evaluate formula-based rules (e.g., climb = walk)
- Generic speed bonuses (no explicit movementType) apply to walk speed only
- Abilities that grant movement types via formula automatically inherit walk's bonuses
- Apply ancestry speed adjustments automatically:
  - Elf: +1 speed (7 total)
  - Dwarf: -1 speed (5 total)
  - Gnome: -1 speed (5 total)
  - Turtlefolk: -2 speed (4 total)
  - Birdfolk: gain fly speed (equal to walk speed)
- Redesign MovementSpeed component with compact "Speed #" display and icons for alternate movement types
- Update CharacterMovementConfigDialog to show bonuses per movement type with source labels
- Add speed bonuses to class features:
  - Explorer of the Wilds (Hunter): +2 walk, gain climb speed
  - Professional Skulker (The Cheat): gain climb speed
  - Unstoppable Protector (Oathsworn): +1 speed
  - Fleet Footed (Stormshifter): +2 speed
  - Winged (Stormshifter): gain fly speed
- Add speed bonuses to boons:
  - Intrepid: +1 speed
  - Epic Speed: +4 speed

## Test plan
- [x] Create an Elf character and verify speed shows as 7
- [x] Create a Dwarf character and verify speed shows as 5
- [x] Create a Gnome character and verify speed shows as 5
- [x] Create a Turtlefolk character and verify speed shows as 4
- [x] Create a Birdfolk character and verify fly speed appears equal to walk speed
- [x] Create an Elf Hunter with Explorer of the Wilds and Epic Speed, verify:
  - Walk speed: 13 (6 base + 1 Elf + 2 Explorer + 4 Epic)
  - Climb speed: 13 (equals walk speed)
- [x] Add Winged chimeric boon and verify fly speed equals walk speed
- [x] Open Configure Movement dialog and verify bonuses show with source labels
- [x] Verify speed displays correctly on NPC/Solo monster sheets (only if non-default)