### PR TITLE
fix(tooltips): invalidate cache when items are modified

### DIFF
--- a/src/view/sheets/pages/PlayerCharacterFeaturesTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterFeaturesTab.svelte
@@ -131,17 +131,17 @@
 		// Track changes in regular items
 		items.forEach((item) => {
 			// Access reactive properties to track changes
-			item.reactive.name;
-			item.reactive.img;
-			item.reactive.system;
+			void item.reactive.name;
+			void item.reactive.img;
+			void item.reactive.system;
 			// Clear the cache entry so it will be regenerated on next hover
 			tooltipCache.delete(item.reactive._id);
 		});
 		// Track changes in subclasses
 		subclasses.forEach((subclass) => {
-			subclass.reactive.name;
-			subclass.reactive.img;
-			subclass.reactive.system;
+			void subclass.reactive.name;
+			void subclass.reactive.img;
+			void subclass.reactive.system;
 			tooltipCache.delete(subclass.reactive._id);
 		});
 	});

--- a/src/view/sheets/pages/PlayerCharacterInventoryTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterInventoryTab.svelte
@@ -56,9 +56,9 @@
 	$effect(() => {
 		items.forEach((item) => {
 			// Access reactive properties to track changes
-			item.reactive.name;
-			item.reactive.img;
-			item.reactive.system;
+			void item.reactive.name;
+			void item.reactive.img;
+			void item.reactive.system;
 			// Clear the cache entry so it will be regenerated on next hover
 			tooltipCache.delete(item.reactive._id);
 		});

--- a/src/view/sheets/pages/PlayerCharacterSpellsTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterSpellsTab.svelte
@@ -168,9 +168,9 @@
 	$effect(() => {
 		spells.forEach((spell) => {
 			// Access reactive properties to track changes
-			spell.reactive.name;
-			spell.reactive.img;
-			spell.reactive.system;
+			void spell.reactive.name;
+			void spell.reactive.img;
+			void spell.reactive.system;
 			// Clear the cache entry so it will be regenerated on next hover
 			tooltipCache.delete(spell.reactive._id);
 		});


### PR DESCRIPTION
## Summary
- Fix tooltip reactivity bug where item tooltips don't update when renamed or modified
- Tooltips now properly invalidate their cache when item properties change (name, image, system data)
- Remove duplicate item name display in features tab

## Test plan
- [ ] Rename an item in the inventory tab and verify the tooltip updates on hover
- [ ] Rename a spell in the spells tab and verify the tooltip updates on hover
- [ ] Rename a feature in the features tab and verify the tooltip updates on hover
- [ ] Verify features tab no longer shows duplicate item names