### PR TITLE
feat: add MaxManaBonusRule and initiative mana recovery

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -473,6 +473,7 @@
 			"initiativeBonus": "Initiative Bonus",
 			"maxHitDice": "Hit Dice",
 			"maxHpBonus": "Hit Points",
+			"maxManaBonus": "Mana",
 			"maximizeHitDice": "Maximize Hit Dice",
 			"maxWounds": "Wounds",
 			"note": "Note",

--- a/public/lang/es.json
+++ b/public/lang/es.json
@@ -513,6 +513,7 @@
 			"initiativeBonus": "Initiative Bonus",
 			"maxHitDice": "Hit Dice",
 			"maxHpBonus": "Hit Points",
+			"maxManaBonus": "Mana",
 			"maxWounds": "Wounds",
 			"maximizeHitDice": "Maximize Hit Dice",
 			"note": "Note",

--- a/public/lang/fr.json
+++ b/public/lang/fr.json
@@ -492,6 +492,7 @@
 			"initiativeBonus": "Bonus d'Initiative",
 			"maxHitDice": "Dés de Vie Maximum",
 			"maxHpBonus": "Points de Vie Bonus Maximum",
+			"maxManaBonus": "Mana",
 			"maxWounds": "Blessures Maximum",
 			"maximizeHitDice": "Maximiser les Dés de Vie",
 			"note": "Note",

--- a/src/config/registerRulesConfig.ts
+++ b/src/config/registerRulesConfig.ts
@@ -7,6 +7,7 @@ import { IncrementHitDiceRule } from '../models/rules/incrementHitDice.js';
 import { InitiativeBonusRule } from '../models/rules/initiativeBonus.js';
 import { MaxHitDiceRule } from '../models/rules/maxHitDice.js';
 import { MaxHpBonusRule } from '../models/rules/maxHpBonus.js';
+import { MaxManaBonusRule } from '../models/rules/maxManaBonus.js';
 import { MaximizeHitDiceRule } from '../models/rules/maximizeHitDice.js';
 import { MaxWoundsRule } from '../models/rules/maxWounds.js';
 import { NoteRule } from '../models/rules/note.js';
@@ -25,6 +26,7 @@ export default function registerRulesConfig() {
 		initiativeBonus: 'NIMBLE.ruleTypes.initiativeBonus',
 		maxHitDice: 'NIMBLE.ruleTypes.maxHitDice',
 		maxHpBonus: 'NIMBLE.ruleTypes.maxHpBonus',
+		maxManaBonus: 'NIMBLE.ruleTypes.maxManaBonus',
 		maximizeHitDice: 'NIMBLE.ruleTypes.maximizeHitDice',
 		maxWounds: 'NIMBLE.ruleTypes.maxWounds',
 		note: 'NIMBLE.ruleTypes.note',
@@ -43,6 +45,7 @@ export default function registerRulesConfig() {
 		initiativeBonus: InitiativeBonusRule,
 		maxHitDice: MaxHitDiceRule,
 		maxHpBonus: MaxHpBonusRule,
+		maxManaBonus: MaxManaBonusRule,
 		maximizeHitDice: MaximizeHitDiceRule,
 		maxWounds: MaxWoundsRule,
 		note: NoteRule,

--- a/src/documents/actor/character.ts
+++ b/src/documents/actor/character.ts
@@ -358,6 +358,9 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 			maxMana += resolvedValue;
 		});
 
+		// Add mana bonus from rules (e.g., maxManaBonus rule)
+		maxMana += actorData.resources.mana.bonus ?? 0;
+
 		return maxMana;
 	}
 

--- a/src/documents/combat/combat.svelte.ts
+++ b/src/documents/combat/combat.svelte.ts
@@ -1,4 +1,6 @@
 import { createSubscriber } from 'svelte/reactivity';
+import type { NimbleRollData } from '#types/rollData.d.ts';
+import { hasInitiativeManaRecovery, getInitiativeManaAmount } from '../../utils/manaRecovery.js';
 import type { NimbleCombatant } from '../combatant/combatant.svelte.js';
 
 /** Combatant system data with actions */
@@ -9,6 +11,22 @@ interface CombatantSystemWithActions {
 			max: number;
 		};
 	};
+}
+
+/** Actor with mana resources */
+interface ActorWithMana {
+	system: {
+		resources?: {
+			mana?: {
+				current: number;
+				combatMana: number;
+				max: number;
+			};
+		};
+	};
+	items: Iterable<{ type: string; system?: { mana?: { formula?: string; recovery?: string } } }>;
+	getRollData(): NimbleRollData;
+	update(data: Record<string, unknown>): Promise<unknown>;
 }
 
 class NimbleCombat extends Combat {
@@ -158,6 +176,29 @@ class NimbleCombat extends Combat {
 				if (total >= 20) combatantUpdates[actionPath] = 3;
 				else if (total >= 10) combatantUpdates[actionPath] = 2;
 				else combatantUpdates[actionPath] = 1;
+
+				// Grant mana on initiative for classes with initiative recovery
+				const actor = combatant.actor as ActorWithMana | null;
+				if (actor) {
+					const classes = [...actor.items].filter((i) => i.type === 'class');
+					if (hasInitiativeManaRecovery(classes)) {
+						const manaAmount = getInitiativeManaAmount(actor, classes);
+						if (manaAmount > 0) {
+							const currentMana = actor.system.resources?.mana?.current ?? 0;
+							const maxMana = actor.system.resources?.mana?.max ?? 0;
+							const currentCombatMana = actor.system.resources?.mana?.combatMana ?? 0;
+							const newMana = Math.min(currentMana + manaAmount, maxMana);
+							const actualGain = newMana - currentMana;
+
+							if (actualGain > 0) {
+								await actor.update({
+									'system.resources.mana.current': newMana,
+									'system.resources.mana.combatMana': currentCombatMana + actualGain,
+								});
+							}
+						}
+					}
+				}
 			}
 
 			updates.push(combatantUpdates);

--- a/src/models/actor/CharacterDataModel.ts
+++ b/src/models/actor/CharacterDataModel.ts
@@ -336,6 +336,16 @@ const characterSchema = () => ({
 				initial: 0,
 				nullable: false,
 			}),
+			bonus: new fields.NumberField({
+				required: true,
+				initial: 0,
+				nullable: false,
+			}),
+			combatMana: new fields.NumberField({
+				required: true,
+				initial: 0,
+				nullable: false,
+			}),
 		}),
 	}),
 	levelUpHistory: new fields.ArrayField(
@@ -575,6 +585,8 @@ class NimbleCharacterData extends foundry.abstract.TypeDataModel<
 		mana: {
 			current: number;
 			baseMax: number;
+			bonus: number;
+			combatMana: number;
 			value: number;
 			max: number;
 		};

--- a/src/models/rules/maxManaBonus.ts
+++ b/src/models/rules/maxManaBonus.ts
@@ -1,0 +1,122 @@
+import getDeterministicBonus from '../../dice/getDeterministicBonus.js';
+import { NimbleBaseRule } from './base.js';
+
+/** Actor system data with mana attributes */
+interface ActorSystemWithMana {
+	resources: {
+		mana: {
+			bonus: number;
+		};
+	};
+}
+
+/** Class item system data */
+interface ClassItemSystem {
+	classLevel: number;
+}
+
+function schema() {
+	const { fields } = foundry.data;
+
+	return {
+		value: new fields.NumberField({ required: true, nullable: false, initial: 0 }),
+		perLevel: new fields.BooleanField({ required: true, nullable: false, initial: false }),
+		type: new fields.StringField({ required: true, nullable: false, initial: 'maxManaBonus' }),
+	};
+}
+
+declare namespace MaxManaBonusRule {
+	type Schema = NimbleBaseRule.Schema & ReturnType<typeof schema>;
+}
+
+class MaxManaBonusRule extends NimbleBaseRule<MaxManaBonusRule.Schema> {
+	declare value: number;
+	declare perLevel: boolean;
+
+	static override defineSchema(): MaxManaBonusRule.Schema {
+		return {
+			...NimbleBaseRule.defineSchema(),
+			...schema(),
+		};
+	}
+
+	override tooltipInfo(): string {
+		return super.tooltipInfo(
+			new Map([
+				['value', 'number'],
+				['perLevel', 'boolean'],
+			]),
+		);
+	}
+
+	override async preCreate(): Promise<void> {
+		if (this.invalid) return;
+
+		const { actor } = this;
+		if (!actor) return;
+
+		// Update actor bonus mana
+		const formula = this.perLevel ? `${this.value} * @level` : this.value;
+
+		const addedMana = getDeterministicBonus(formula, actor.getRollData());
+		if (addedMana === null) return;
+
+		const actorSystem = actor.system as unknown as ActorSystemWithMana;
+		const { bonus } = actorSystem.resources.mana;
+		await actor.update({ system: { resources: { mana: { bonus: bonus + addedMana } } } } as Record<
+			string,
+			unknown
+		>);
+	}
+
+	async preUpdate(changes: Record<string, unknown>): Promise<void> {
+		if (this.invalid) return;
+
+		const { actor, item } = this;
+		if (!actor || !item) return;
+		if (item.type !== 'class') return;
+
+		if (!this.perLevel) return;
+
+		// Return if update doesn't pertain to level
+		const keys = Object.keys(foundry.utils.flattenObject(changes));
+		const itemSystem = item.system as unknown as ClassItemSystem;
+		if (
+			!keys.includes('system.classLevel') ||
+			changes['system.classLevel'] === itemSystem.classLevel
+		)
+			return;
+
+		const formula = this.value;
+		const addedMana = getDeterministicBonus(formula, actor.getRollData());
+		if (addedMana === null) return;
+
+		const actorSystem = actor.system as unknown as ActorSystemWithMana;
+		const { bonus } = actorSystem.resources.mana;
+		await actor.update({ system: { resources: { mana: { bonus: bonus + addedMana } } } } as Record<
+			string,
+			unknown
+		>);
+	}
+
+	async afterDelete(): Promise<void> {
+		if (this.invalid) return;
+
+		const { actor, item } = this;
+		if (!actor || !item) return;
+
+		const formula = this.perLevel ? `${this.value} * @level` : this.value;
+
+		const addedMana = getDeterministicBonus(formula, actor.getRollData());
+		if (addedMana === null) return;
+
+		const actorSystem = actor.system as unknown as ActorSystemWithMana;
+		const { bonus } = actorSystem.resources.mana;
+		await actor.update({ system: { resources: { mana: { bonus: bonus - addedMana } } } } as Record<
+			string,
+			unknown
+		>);
+	}
+}
+
+export { MaxManaBonusRule };


### PR DESCRIPTION
## Summary
- Add **MaxManaBonusRule** - a new rule type that adds to max mana (follows MaxHpBonusRule pattern)
- Implement **Initiative Mana Recovery** - grants mana when rolling initiative for classes with `recovery: 'initiative'`, cleared when combat ends
- Update rest logic to exclude initiative-only recovery from rest restoration

## Test plan
- [ ] Create an item with a `maxManaBonus` rule, assign to character, and verify max mana increases
- [ ] Remove item and verify max mana decreases
- [ ] Create a class with `mana.recovery: 'initiative'` and a mana formula
- [ ] Add character with this class to combat, roll initiative, and verify mana is granted
- [ ] End combat and verify combat-granted mana is cleared
- [ ] With initiative-only class, take a rest and verify mana is NOT restored