### PR TITLE
fix: correct armor proficiency path mapping

### DIFF
--- a/packs/classFeatures/core/commander/commander-subclasses/champion-of-the-bulwark/armor-master.json
+++ b/packs/classFeatures/core/commander/commander-subclasses/champion-of-the-bulwark/armor-master.json
@@ -14,7 +14,7 @@
 				"label": "Armor master",
 				"predicate": {},
 				"priority": 1,
-				"proficiencyType": "armors",
+				"proficiencyType": "armor",
 				"values": [
 					"plate"
 				]

--- a/src/models/rules/grantProficiencies.ts
+++ b/src/models/rules/grantProficiencies.ts
@@ -69,7 +69,10 @@ class GrantProficiencyRule extends NimbleBaseRule<GrantProficiencyRule.Schema> {
 
 		if (!values.length) return;
 		if (values.includes('all')) {
-			values = Object.keys(CONFIG.NIMBLE[PROFICIENCY_TYPE_MAPPING[proficiencyType] ?? []]);
+			const configKey = PROFICIENCY_TYPE_MAPPING[proficiencyType];
+			if (configKey) {
+				values = Object.keys(CONFIG.NIMBLE[configKey]);
+			}
 		}
 
 		foundry.utils.setProperty(

--- a/src/models/rules/grantProficiencies.ts
+++ b/src/models/rules/grantProficiencies.ts
@@ -2,7 +2,7 @@ import type { NimbleCharacter } from '../../documents/actor/character.ts';
 import { NimbleBaseRule } from './base.ts';
 
 const PROFICIENCY_TYPE_MAPPING = {
-	armors: 'armorTypes',
+	armor: 'armorTypes',
 	languages: 'languages',
 	weapons: null,
 };


### PR DESCRIPTION
## Summary
- Fixed mismatch between `PROFICIENCY_TYPE_MAPPING` key (`armors`) and schema-defined proficiencyType (`armor`)
- Updated armor-master.json to use the correct singular form

## Test plan
- [ ] Apply armor proficiency via grantProficiency rule and verify it appears on the character sheet
- [ ] Test the Armor Master feature (Champion of the Bulwark) grants plate armor proficiency correctly