### PR TITLE
feat(rules): add initiative roll mode rule for advantage/disadvantage

### DIFF
--- a/packs/ancestries/core/common/elf.json
+++ b/packs/ancestries/core/common/elf.json
@@ -23,9 +23,14 @@
 				"type": "speedBonus",
 				"value": "1",
 				"label": "Lithe"
+			}, {
+				"type": "initiativeRollMode",
+				"value": 1,
+				"mode": "adjust",
+				"label": "Lithe (Advantage on Initiative)"
 			}
 		],
-		"description": "<p>Elves epitomize swiftness and grace. Their tall, slender forms belie their innate speed, grace, and wit. Formidable in both diplomacy and combat, elves strike swiftly, often preventing the worst by acting first.</p><hr><p><strong>Lithe</strong></p><p>Advantage on Initiative [M]</p><p>+1 Speed [M]</p><p>You know Elvish if your INT is not negative [M]</p>",
+		"description": "<p>Elves epitomize swiftness and grace. Their tall, slender forms belie their innate speed, grace, and wit. Formidable in both diplomacy and combat, elves strike swiftly, often preventing the worst by acting first.</p><hr><p><strong>Lithe</strong></p><p>Advantage on Initiative</p><p>+1 Speed [M]</p><p>You know Elvish if your INT is not negative</p>",
 		"exotic": false,
 		"size": [
 			"medium"

--- a/packs/ancestries/core/common/elf.json
+++ b/packs/ancestries/core/common/elf.json
@@ -23,7 +23,8 @@
 				"type": "speedBonus",
 				"value": "1",
 				"label": "Lithe"
-			}, {
+			},
+			{
 				"type": "initiativeRollMode",
 				"value": 1,
 				"mode": "adjust",

--- a/packs/classFeatures/core/berserker/savage-arsenal/eager-for-battle.json
+++ b/packs/classFeatures/core/berserker/savage-arsenal/eager-for-battle.json
@@ -7,7 +7,14 @@
 		"group": "savage-arsenal",
 		"macro": "",
 		"identifier": "",
-		"rules": [],
+		"rules": [
+			{
+				"type": "initiativeRollMode",
+				"value": 1,
+				"mode": "adjust",
+				"label": "Eager for Battle (Advantage on Initiative)"
+			}
+		],
 		"activation": {
 			"acquireTargetsFromTemplate": false,
 			"cost": {

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -474,6 +474,7 @@
 			"hitDiceAdvantage": "Hit Dice Advantage",
 			"incrementHitDice": "Increment Hit Dice",
 			"initiativeBonus": "Initiative Bonus",
+			"initiativeRollMode": "Initiative Roll Mode",
 			"maxHitDice": "Hit Dice",
 			"maxHpBonus": "Hit Points",
 			"maximizeHitDice": "Maximize Hit Dice",

--- a/src/config/registerRulesConfig.ts
+++ b/src/config/registerRulesConfig.ts
@@ -5,6 +5,7 @@ import { GrantProficiencyRule } from '../models/rules/grantProficiencies.ts';
 import { HitDiceAdvantageRule } from '../models/rules/hitDiceAdvantage.js';
 import { IncrementHitDiceRule } from '../models/rules/incrementHitDice.js';
 import { InitiativeBonusRule } from '../models/rules/initiativeBonus.js';
+import { InitiativeRollModeRule } from '../models/rules/initiativeRollMode.js';
 import { MaxHitDiceRule } from '../models/rules/maxHitDice.js';
 import { MaxHpBonusRule } from '../models/rules/maxHpBonus.js';
 import { MaximizeHitDiceRule } from '../models/rules/maximizeHitDice.js';
@@ -24,6 +25,7 @@ export default function registerRulesConfig() {
 		hitDiceAdvantage: 'NIMBLE.ruleTypes.hitDiceAdvantage',
 		incrementHitDice: 'NIMBLE.ruleTypes.incrementHitDice',
 		initiativeBonus: 'NIMBLE.ruleTypes.initiativeBonus',
+		initiativeRollMode: 'NIMBLE.ruleTypes.initiativeRollMode',
 		maxHitDice: 'NIMBLE.ruleTypes.maxHitDice',
 		maxHpBonus: 'NIMBLE.ruleTypes.maxHpBonus',
 		maximizeHitDice: 'NIMBLE.ruleTypes.maximizeHitDice',
@@ -43,6 +45,7 @@ export default function registerRulesConfig() {
 		hitDiceAdvantage: HitDiceAdvantageRule,
 		incrementHitDice: IncrementHitDiceRule,
 		initiativeBonus: InitiativeBonusRule,
+		initiativeRollMode: InitiativeRollModeRule,
 		maxHitDice: MaxHitDiceRule,
 		maxHpBonus: MaxHpBonusRule,
 		maximizeHitDice: MaximizeHitDiceRule,

--- a/src/models/actor/CharacterDataModel.ts
+++ b/src/models/actor/CharacterDataModel.ts
@@ -167,6 +167,12 @@ const characterSchema = () => ({
 				initial: '',
 				nullable: false,
 			}),
+			defaultRollMode: new fields.NumberField({
+				required: true,
+				initial: 0,
+				nullable: false,
+				integer: true,
+			}),
 		}),
 		movement: new fields.SchemaField({
 			burrow: new fields.NumberField({
@@ -528,6 +534,7 @@ class NimbleCharacterData extends foundry.abstract.TypeDataModel<
 		hitDice: Record<string, HitDiceData>;
 		initiative: {
 			bonuses: string;
+			defaultRollMode: number;
 			mod: number;
 		};
 		movement: {

--- a/src/models/rules/initiativeRollMode.ts
+++ b/src/models/rules/initiativeRollMode.ts
@@ -1,0 +1,67 @@
+import { NimbleBaseRule } from './base.js';
+
+function schema() {
+	const { fields } = foundry.data;
+
+	return {
+		value: new fields.NumberField({ required: true, nullable: false, initial: 1 }),
+		mode: new fields.StringField({ required: true, nullable: false, initial: 'set' }),
+		type: new fields.StringField({
+			required: true,
+			nullable: false,
+			initial: 'initiativeRollMode',
+		}),
+	};
+}
+
+declare namespace InitiativeRollModeRule {
+	type Schema = NimbleBaseRule.Schema & ReturnType<typeof schema>;
+}
+
+class InitiativeRollModeRule extends NimbleBaseRule<InitiativeRollModeRule.Schema> {
+	declare value: number;
+	declare mode: string;
+
+	static override defineSchema(): InitiativeRollModeRule.Schema {
+		return {
+			...NimbleBaseRule.defineSchema(),
+			...schema(),
+		};
+	}
+
+	override tooltipInfo(): string {
+		return super.tooltipInfo(
+			new Map([
+				['value', 'number'],
+				['mode', '"set" | "adjust"'],
+			]),
+		);
+	}
+
+	override afterPrepareData(): void {
+		const { item } = this;
+		if (!item.isEmbedded) return;
+
+		const { actor } = item;
+
+		interface ActorAttributes {
+			attributes: {
+				initiative: { defaultRollMode?: number };
+			};
+		}
+		const actorSystem = actor.system as object as ActorAttributes;
+		const currentRollMode = actorSystem.attributes.initiative.defaultRollMode ?? 0;
+
+		let newRollMode: number;
+		if (this.mode === 'set') {
+			newRollMode = this.value;
+		} else {
+			// 'adjust' mode - add to current
+			newRollMode = currentRollMode + this.value;
+		}
+
+		foundry.utils.setProperty(actor.system, 'attributes.initiative.defaultRollMode', newRollMode);
+	}
+}
+
+export { InitiativeRollModeRule };


### PR DESCRIPTION
## Summary
- Implements `initiativeRollMode` rule type that allows ancestries, boons, class features, and other items to grant advantage or disadvantage on initiative rolls
- Applies the rule to items with "Advantage on Initiative":
  - **Elf ancestry** (Lithe feature)
  - **Eager for Battle** (Berserker Savage Arsenal feature)

## Changes
- **New rule type**: `InitiativeRollModeRule` in `src/models/rules/initiativeRollMode.ts`
- **Character data model**: Added `defaultRollMode` field to initiative attributes
- **Initiative formula**: Updated `_getInitiativeFormula()` to use the new roll mode system
- **Elf ancestry**: Added `initiativeRollMode` rule with advantage (value: 1)
- **Eager for Battle**: Added `initiativeRollMode` rule with advantage (value: 1)
- **Localization**: Added translation key for the new rule type

## Test plan
- [ ] Create an Elf character and verify initiative rolls use 2d20kh (advantage)
- [ ] Give a Berserker the Eager for Battle feature and verify initiative rolls use 2d20kh
- [ ] Create a non-Elf character without advantage features and verify initiative rolls use 1d20 (normal)
- [ ] Verify stacking works (e.g., Elf with Eager for Battle should roll 3d20kh)