### PR TITLE
fix: allow observers to switch tabs on other players' sheets

### DIFF
--- a/src/view/components/PrimaryNavigationItem.svelte
+++ b/src/view/components/PrimaryNavigationItem.svelte
@@ -13,7 +13,7 @@
 		aria-label={localize(tab.tooltip)}
 		data-tooltip={localize(tab.tooltip)}
 		data-tooltip-direction="UP"
-		onclick={() => (currentTab = tab)}
+		onpointerup={(e) => e.button === 0 && (currentTab = tab)}
 	>
 		<i class={tab.icon}></i>
 		{localize(tab.label ?? '')}


### PR DESCRIPTION
## Summary
Fixes issue where tab navigation didn't work in character sheets for:
- Observers viewing other players' sheets
- Any user clicking tabs inside `<nav>` elements

Foundry's ApplicationV2 intercepts mouse events (`onclick`) on nav elements and for observers. Pointer events are not intercepted, so using `onpointerup` ensures tab switching works for all users.

## Test plan
- [ ] As an owner, open your own character sheet and verify tabs work
- [ ] As an observer, open another player's character sheet and verify tabs work
- [ ] Test same behavior with NPC sheets