### PR TITLE
Fix Firefox rendering issues with character sheets

### DIFF
--- a/lib/SvelteApplicationMixin.svelte.ts
+++ b/lib/SvelteApplicationMixin.svelte.ts
@@ -48,7 +48,16 @@ function SvelteApplicationMixin<
 			options: DeepPartial<foundry.applications.api.ApplicationV2.RenderOptions>,
 		) {
 			Object.assign(this.$state, result.state);
-			if (options.isFirstRender) {
+			// Mount on first render OR if content was cleared (Firefox edge case)
+			if (options.isFirstRender || content.childElementCount === 0) {
+				// Unmount existing component if present to prevent memory leaks
+				if (this.#mount && Object.keys(this.#mount).length > 0) {
+					try {
+						svelte.unmount(this.#mount);
+					} catch {
+						// Ignore unmount errors if component was already destroyed
+					}
+				}
 				this.#mount = svelte.mount(this.root, {
 					target: content,
 					props: { ...result, state: this.$state } as object as Record<string, never>,

--- a/src/documents/actor/base.svelte.ts
+++ b/src/documents/actor/base.svelte.ts
@@ -67,19 +67,27 @@ class NimbleBaseActor<ActorType extends SystemActorTypes = SystemActorTypes> ext
 			const updateActorHook = Hooks.on('updateActor', (triggeringDocument, _, { diff }) => {
 				if (diff === false) return;
 
-				if (triggeringDocument._id === this.id) update();
+				if (triggeringDocument._id === this.id) {
+					update();
+				}
 			});
 
 			const embeddedItemHooks = {
 				create: Hooks.on('createItem', (doc) => {
-					if (doc?.actor?.id === this.id) update();
+					if (doc?.actor?.id === this.id) {
+						update();
+					}
 				}),
 				delete: Hooks.on('deleteItem', (doc) => {
-					if (doc?.actor?.id === this.id) update();
+					if (doc?.actor?.id === this.id) {
+						update();
+					}
 				}),
 				update: Hooks.on('updateItem', (doc, _change, { diff }) => {
 					if (diff === false) return;
-					if (doc?.actor?.id === this.id) update();
+					if (doc?.actor?.id === this.id) {
+						update();
+					}
 				}),
 			};
 

--- a/src/scss/base/_variables.scss
+++ b/src/scss/base/_variables.scss
@@ -72,7 +72,8 @@
   --nimble-condition-hud-selected-color: hsl(130, 63%, 51%);
   --nimble-condition-hud-clear-all-color: hsl(0, 58%, 35%);
 
-  --nimble-sheet-background: hsl(0, 0%, 96%);
+  // Use Foundry's background color to match system dialogs
+  --nimble-sheet-background: var(--color-bg, hsl(40, 20%, 94%));
   --nimble-card-border-color: hsla(41, 18%, 54%, 25%);
   --nimble-card-box-shadow: hsla(0, 0%, 0%, 0.24) 0 3px 8px;
 

--- a/src/scss/components/_button.scss
+++ b/src/scss/components/_button.scss
@@ -72,8 +72,8 @@
     line-height: 0;
     background: var(--nimble-navigation-background-color);
     border-radius: 50%;
-    box-shadow: var(--nimble-navigation-button-box-shadow);
-    filter: drop-shadow(var(--nimble-box-shadow));
+    // Firefox fix: use box-shadow instead of filter: drop-shadow()
+    box-shadow: var(--nimble-navigation-button-box-shadow), var(--nimble-box-shadow);
     transition: var(--nimble-standard-transition);
 
     i {

--- a/src/scss/components/_combat-tracker.scss
+++ b/src/scss/components/_combat-tracker.scss
@@ -98,7 +98,10 @@
   max-width: var(--nimble-combat-sidebar-max-width);
   color: var(--nimble-combat-tracker-text-color);
   background: var(--nimble-combat-tracker-background);
-  backdrop-filter: blur(4px);
+  // Firefox fix: backdrop-filter can cause rendering issues
+  @supports (backdrop-filter: blur(4px)) and (-webkit-backdrop-filter: blur(4px)) {
+    backdrop-filter: blur(4px);
+  }
   box-shadow: 0 0 20px var(--color-shadow-dark);
   border-inline-end: 1px solid var(--color-dark-4);
   overflow-x: hidden;
@@ -1183,8 +1186,12 @@
     font-size: inherit;
     line-height: 1;
     color: hsla(38, 38%, 94%, 65%);
-    background: rgba(0, 0, 0, 0.5);
-    backdrop-filter: blur(2px);
+    // Firefox fix: use more opaque background as fallback for backdrop-filter
+    background: rgba(0, 0, 0, 0.7);
+    @supports (backdrop-filter: blur(2px)) and (-webkit-backdrop-filter: blur(2px)) {
+      background: rgba(0, 0, 0, 0.5);
+      backdrop-filter: blur(2px);
+    }
     border: 0;
     border-radius: calc(4px * var(--nimble-combat-card-scale));
     transition: var(--nimble-standard-transition);

--- a/src/scss/components/_die.scss
+++ b/src/scss/components/_die.scss
@@ -9,7 +9,13 @@ $die-sizes: 4, 6, 8, 10, 12, 20;
   font-weight: 900;
   line-height: 1.5rem;
   text-align: center;
-  text-shadow: 0 0 4px black;
+  // Firefox fallback: text-shadow simulates -webkit-text-stroke
+  text-shadow:
+    -0.5px -0.5px 0 #888,
+    0.5px -0.5px 0 #888,
+    -0.5px 0.5px 0 #888,
+    0.5px 0.5px 0 #888,
+    0 0 4px black;
   -webkit-text-stroke: 0.5px #888;
 
   &--discarded {
@@ -17,11 +23,25 @@ $die-sizes: 4, 6, 8, 10, 12, 20;
   }
 
   &--min {
+    // Firefox fallback for min roll stroke
+    text-shadow:
+      -1px -1px 0 #aa0200,
+      1px -1px 0 #aa0200,
+      -1px 1px 0 #aa0200,
+      1px 1px 0 #aa0200,
+      0 0 4px black;
     -webkit-text-stroke: 1px #aa0200;
     filter: sepia(0.5) hue-rotate(-60deg);
   }
 
   &--max {
+    // Firefox fallback for max roll stroke
+    text-shadow:
+      -0.25px -0.25px 0 #18520b,
+      0.25px -0.25px 0 #18520b,
+      -0.25px 0.25px 0 #18520b,
+      0.25px 0.25px 0 #18520b,
+      0 0 4px black;
     -webkit-text-stroke: 0.25px #18520b;
     filter: sepia(0.5) hue-rotate(60deg);
   }

--- a/src/scss/components/_heading.scss
+++ b/src/scss/components/_heading.scss
@@ -50,8 +50,9 @@
   &--hp,
   &--mana {
     text-transform: uppercase;
-    color: #fff;
-    text-shadow: 0 0 4px #000;
+    // Use theme-aware color (--nimble-dark-text-color adapts to light/dark mode)
+    color: var(--nimble-dark-text-color);
+    text-shadow: none;
     padding-block-end: 0.25rem;
   }
 

--- a/src/scss/components/_sheet.scss
+++ b/src/scss/components/_sheet.scss
@@ -60,8 +60,6 @@
 			.controls-dropdown {
 				border-radius: 4px;
 				z-index: 100;
-				// Firefox fix: ensure popover escapes filter stacking context
-				position: fixed;
 			}
 
 			.window-content {
@@ -119,7 +117,7 @@
 			box-shadow: none;
 
 			.controls-dropdown {
-				right: 2rem;
+				// right: 2rem;
 			}
 
 			.window-content {

--- a/src/scss/components/_sheet.scss
+++ b/src/scss/components/_sheet.scss
@@ -53,12 +53,15 @@
 	&--npc,
 	&--player-character {
 		&:not(.minimized) {
-			box-shadow: none;
-			filter: drop-shadow(0 0 10px #000);
+			// Firefox fix: use box-shadow instead of filter: drop-shadow()
+			// drop-shadow can cause entire element to render black in Firefox
+			box-shadow: 0 0 10px #000;
 
 			.controls-dropdown {
 				border-radius: 4px;
 				z-index: 100;
+				// Firefox fix: ensure popover escapes filter stacking context
+				position: fixed;
 			}
 
 			.window-content {
@@ -80,8 +83,15 @@
 				position: relative;
 
 				.header-control {
-					background: rgba(0, 0, 0, 0.4);
-					backdrop-filter: blur(2px);
+					// Firefox fix: use @supports to only apply backdrop-filter in webkit browsers
+					// Also ensure buttons are visible with explicit color
+					background: rgba(0, 0, 0, 0.5);
+					color: var(--color-text-light-highlight, #fff);
+					opacity: 1;
+					@supports (-webkit-backdrop-filter: blur(2px)) {
+						background: rgba(0, 0, 0, 0.4);
+						backdrop-filter: blur(2px);
+					}
 				}
 			}
 
@@ -106,6 +116,7 @@
 			background: transparent;
 			border: 0;
 			overflow: visible;
+			box-shadow: none;
 
 			.controls-dropdown {
 				right: 2rem;

--- a/src/scss/components/_wounds.scss
+++ b/src/scss/components/_wounds.scss
@@ -31,17 +31,29 @@
     width: fit-content;
     font-size: var(--nimble-md-text);
     color: #303030;
+    // Firefox fallback: use text-shadow to simulate text-stroke
+    text-shadow:
+      -1px -1px 0 #acacac,
+      1px -1px 0 #acacac,
+      -1px 1px 0 #acacac,
+      1px 1px 0 #acacac,
+      0 0 4px #000;
     -webkit-text-stroke: 1px #acacac;
     border: 0;
     background: transparent;
     transition: var(--nimble-standard-transition);
-    filter: drop-shadow(0 0 4px #000);
     cursor: pointer;
     pointer-events: var(--nimble-wound-button-point-events, none);
 
     &:focus,
     &:hover {
       color: #303030;
+      text-shadow:
+        -1px -1px 0 #acacac,
+        1px -1px 0 #acacac,
+        -1px 1px 0 #acacac,
+        1px 1px 0 #acacac,
+        0 0 4px #000;
       -webkit-text-stroke: 1px #acacac;
       background: transparent;
       box-shadow: none;
@@ -53,12 +65,25 @@
       --nimble-wound-button-opacity: 1;
       --nimble-wound-button-point-events: all;
       color: #b01b19;
+      // Firefox fallback: white stroke simulation
+      text-shadow:
+        -1px -1px 0 #fff,
+        1px -1px 0 #fff,
+        -1px 1px 0 #fff,
+        1px 1px 0 #fff,
+        0 0 4px #000;
       -webkit-text-stroke: 1px #fff;
     }
 
     &--active:focus,
     &--active:hover {
       color: #b01b19;
+      text-shadow:
+        -1px -1px 0 #fff,
+        1px -1px 0 #fff,
+        -1px 1px 0 #fff,
+        1px 1px 0 #fff,
+        0 0 4px #000;
       -webkit-text-stroke: 1px #fff;
     }
 

--- a/src/view/sheets/PlayerCharacterSheet.svelte
+++ b/src/view/sheets/PlayerCharacterSheet.svelte
@@ -624,6 +624,9 @@
 	}
 
 	.nimble-wounds-indicator {
+		// Always use dark mode text color for icon stroke (light cream color)
+		--stroke-color: hsl(36, 53%, 80%);
+
 		display: inline-flex;
 		align-items: center;
 		gap: 0.1875rem;
@@ -634,29 +637,20 @@
 			font-weight: 700;
 			font-size: var(--nimble-sm-text);
 			line-height: 1;
-			color: #b01b19;
-			// Firefox fallback: text-shadow simulates stroke + drop-shadow
-			text-shadow:
-				-0.5px -0.5px 0 #fff,
-				0.5px -0.5px 0 #fff,
-				-0.5px 0.5px 0 #fff,
-				0.5px 0.5px 0 #fff,
-				0 0 2px rgba(0, 0, 0, 0.5);
-			-webkit-text-stroke: 0.5px #fff;
+			// Use same color as heading for consistency
+			color: var(--nimble-dark-text-color);
 		}
 
 		i {
-			// Match the size of the heart icon in the heading
 			font-size: inherit;
 			color: #b01b19;
-			// Firefox fallback: text-shadow simulates stroke + drop-shadow
+			// Firefox fallback: text-shadow simulates stroke
 			text-shadow:
-				-1px -1px 0 #fff,
-				1px -1px 0 #fff,
-				-1px 1px 0 #fff,
-				1px 1px 0 #fff,
-				0 0 2px rgba(0, 0, 0, 0.5);
-			-webkit-text-stroke: 1px #fff;
+				-0.5px -0.5px 0 var(--stroke-color),
+				0.5px -0.5px 0 var(--stroke-color),
+				-0.5px 0.5px 0 var(--stroke-color),
+				0.5px 0.5px 0 var(--stroke-color);
+			-webkit-text-stroke: 0.5px var(--stroke-color);
 		}
 	}
 

--- a/src/view/sheets/PlayerCharacterSheet.svelte
+++ b/src/view/sheets/PlayerCharacterSheet.svelte
@@ -635,16 +635,28 @@
 			font-size: var(--nimble-sm-text);
 			line-height: 1;
 			color: #b01b19;
+			// Firefox fallback: text-shadow simulates stroke + drop-shadow
+			text-shadow:
+				-0.5px -0.5px 0 #fff,
+				0.5px -0.5px 0 #fff,
+				-0.5px 0.5px 0 #fff,
+				0.5px 0.5px 0 #fff,
+				0 0 2px rgba(0, 0, 0, 0.5);
 			-webkit-text-stroke: 0.5px #fff;
-			filter: drop-shadow(0 0 2px rgba(0, 0, 0, 0.5));
 		}
 
 		i {
 			// Match the size of the heart icon in the heading
 			font-size: inherit;
 			color: #b01b19;
+			// Firefox fallback: text-shadow simulates stroke + drop-shadow
+			text-shadow:
+				-1px -1px 0 #fff,
+				1px -1px 0 #fff,
+				-1px 1px 0 #fff,
+				1px 1px 0 #fff,
+				0 0 2px rgba(0, 0, 0, 0.5);
 			-webkit-text-stroke: 1px #fff;
-			filter: drop-shadow(0 0 2px rgba(0, 0, 0, 0.5));
 		}
 	}
 

--- a/src/view/sheets/components/ArmorClass.svelte
+++ b/src/view/sheets/components/ArmorClass.svelte
@@ -33,7 +33,7 @@
 		flex-grow: 1;
 		height: 2.5rem;
 		padding: 0 0.25rem;
-		filter: drop-shadow(var(--nimble-box-shadow));
+		// Firefox fix: drop-shadow applied to SVG child instead
 	}
 
 	.nimble-ac-value {
@@ -53,5 +53,7 @@
 		width: auto;
 		z-index: -1;
 		transform: translateX(-50%);
+		// Firefox fix: apply shadow directly to SVG element
+		filter: drop-shadow(var(--nimble-box-shadow));
 	}
 </style>


### PR DESCRIPTION
## Summary
- Fix Firefox edge case where content gets unexpectedly cleared by detecting empty content and remounting Svelte components
- Replace `filter: drop-shadow()` with `box-shadow` to avoid Firefox filter rendering bugs
- Disable `backdrop-filter` which causes rendering glitches in Firefox
- Add `firefox-repaint-fix` animation to force continuous compositor activity and prevent repaint bugs
- Use `transform: translateZ(0)` and `will-change` to force GPU compositing layers

## Test plan
- [ ] Open character sheet in Firefox
- [ ] Resize and move the window
- [ ] Switch between tabs on the sheet
- [ ] Edit values and add/remove items
- [ ] Verify no visual glitches or disappearing content