### PR TITLE
Subclasses Compendium Folders

### DIFF
--- a/build/lib/LevelDB.mjs
+++ b/build/lib/LevelDB.mjs
@@ -1,104 +1,118 @@
 import { ClassicLevel } from 'classic-level';
 import path from 'path';
-import systemJSON from '../../public/system.json' with { type: 'json'};
+import systemJSON from '../../public/system.json' with { type: 'json' };
 
 export default class LevelDatabase extends ClassicLevel {
-  #dbKey;
+	#dbKey;
 
-  #embeddedKeys;
+	#embeddedKeys;
 
-  #documentDb;
+	#documentDb;
 
-  #embeddedDbs;
+	#embeddedDbs;
 
-  constructor(location, options) {
-    const dbOptions = options.dbOptions ?? { keyEncoding: 'utf8', valueEncoding: 'json' };
-    super(location, dbOptions);
+	constructor(location, options) {
+		const dbOptions = options.dbOptions ?? { keyEncoding: 'utf8', valueEncoding: 'json' };
+		super(location, dbOptions);
 
-    const { dbKey, embeddedKeys } = this.#getDBKeys(options.packName);
+		const { dbKey, embeddedKeys } = this.#getDBKeys(options.packName);
 
-    this.dbOptions = dbOptions;
-    this.#dbKey = dbKey;
-    this.#embeddedKeys = embeddedKeys ?? [];
+		this.dbOptions = dbOptions;
+		this.#dbKey = dbKey;
+		this.#embeddedKeys = embeddedKeys ?? [];
 
-    this.#documentDb = this.sublevel(dbKey, dbOptions);
+		this.#documentDb = this.sublevel(dbKey, dbOptions);
 
-    if (this.#embeddedKeys.length) {
-      this.#embeddedDbs = this.#embeddedKeys.map((key) => ({
-        key: key.replaceAll('.', '-'),
-        db: this.sublevel(`${this.#dbKey}.${key}`, dbOptions)
-      }));
-    }
-  }
+		if (this.#embeddedKeys.length) {
+			this.#embeddedDbs = this.#embeddedKeys.map((key) => ({
+				key: key.replaceAll('.', '-'),
+				db: this.sublevel(`${this.#dbKey}.${key}`, dbOptions),
+			}));
+		}
+	}
 
-  #getDBKeys(packName) {
-    const metadata = systemJSON.packs
-      .find((p) => path.basename(p.path).split('.')[0] === packName);
+	#getDBKeys(packName) {
+		const metadata = systemJSON.packs.find((p) => path.basename(p.path).split('.')[0] === packName);
 
-    if (!metadata) throw Error(`[ERROR] - Pack ${packName} isn't setup in system.json.`);
+		if (!metadata) throw Error(`[ERROR] - Pack ${packName} isn't setup in system.json.`);
 
-    let dbKey = null;
-    if (metadata.type === 'JournalEntry') dbKey = 'journal';
-    else if (metadata.type === 'RollTable') dbKey = 'tables';
-    else dbKey = `${metadata.type.toLowerCase()}s`;
+		let dbKey = null;
+		if (metadata.type === 'JournalEntry') dbKey = 'journal';
+		else if (metadata.type === 'RollTable') dbKey = 'tables';
+		else dbKey = `${metadata.type.toLowerCase()}s`;
 
-    let embeddedKeys = [];
-    if (dbKey === 'actors') embeddedKeys = ['effects', 'items', 'items.effects'];
-    if (dbKey === 'items') embeddedKeys = ['effects'];
-    else if (dbKey === 'journal') embeddedKeys = ['pages'];
-    else if (dbKey === 'tables') embeddedKeys = ['results'];
+		let embeddedKeys = [];
+		if (dbKey === 'actors') embeddedKeys = ['effects', 'items', 'items.effects'];
+		if (dbKey === 'items') embeddedKeys = ['effects'];
+		else if (dbKey === 'journal') embeddedKeys = ['pages'];
+		else if (dbKey === 'tables') embeddedKeys = ['results'];
 
-    return { dbKey, embeddedKeys };
-  }
+		return { dbKey, embeddedKeys };
+	}
 
-  async createPack(docs) {
-    const docBatch = this.#documentDb.batch();
-    const embeddedBatches = this.#embeddedDbs.reduce((acc, { key, db }) => {
-      acc[key] = db.batch();
-      return acc;
-    }, {});
+	async createPack(docs, options = {}) {
+		const folders = Array.isArray(options.folders) ? options.folders : [];
 
-    for (const source of docs) {
-      if (this.#embeddedKeys.length) {
-        this.#embeddedKeys.forEach((key) => {
-          if (key === 'items.effects') return; // TODO:: Make this generic
-          if (this.#dbKey === 'actors' && key === 'items') {
-            const items = source[key];
+		const docBatch = this.#documentDb.batch();
+		const embeddedBatches = this.#embeddedDbs.reduce((acc, { key, db }) => {
+			acc[key] = db.batch();
+			return acc;
+		}, {});
+		const folderDb = folders.length > 0 ? this.sublevel('folders', this.dbOptions) : null;
+		const folderBatch = folderDb ? folderDb.batch() : null;
 
-            // Do effects
-            for (const item of items) {
-              const { effects } = item;
-              this.#addDataToBatch(effects, embeddedBatches['items-effects'], `${source._id}.${item._id}`);
-            }
+		for (const source of docs) {
+			if (this.#embeddedKeys.length) {
+				this.#embeddedKeys.forEach((key) => {
+					if (key === 'items.effects') return; // TODO:: Make this generic
+					if (this.#dbKey === 'actors' && key === 'items') {
+						const items = source[key];
 
-            // Do items
-            this.#addDataToBatch(items, embeddedBatches[key], source._id);
-          } else {
-            const embeddedDocs = source[key];
-            this.#addDataToBatch(embeddedDocs, embeddedBatches[key], source._id);
-          }
-        });
-      }
-      docBatch.put(source._id ?? '', source);
-    }
+						// Do effects
+						for (const item of items) {
+							const { effects } = item;
+							this.#addDataToBatch(
+								effects,
+								embeddedBatches['items-effects'],
+								`${source._id}.${item._id}`,
+							);
+						}
 
-    await docBatch.write();
-    for await (const batch of Object.values(embeddedBatches)) {
-      if (batch.length) await batch.write();
-    }
+						// Do items
+						this.#addDataToBatch(items, embeddedBatches[key], source._id);
+					} else {
+						const embeddedDocs = source[key];
+						this.#addDataToBatch(embeddedDocs, embeddedBatches[key], source._id);
+					}
+				});
+			}
+			docBatch.put(source._id ?? '', source);
+		}
 
-    await this.close();
-  }
+		if (folderBatch) {
+			for (const folder of folders) {
+				folderBatch.put(folder._id ?? '', folder);
+			}
+		}
 
-  #addDataToBatch(embeddedDocs, batch, sourceId) {
-    if (Array.isArray(embeddedDocs)) {
-      for (let i = 0; i < embeddedDocs.length; i += 1) {
-        const doc = embeddedDocs[i];
-        if (batch) {
-          batch.put(`${sourceId}.${doc._id}`, doc);
-          embeddedDocs[i] = doc._id ?? '';
-        }
-      }
-    }
-  }
+		await docBatch.write();
+		for await (const batch of Object.values(embeddedBatches)) {
+			if (batch.length) await batch.write();
+		}
+		if (folderBatch?.length) await folderBatch.write();
+
+		await this.close();
+	}
+
+	#addDataToBatch(embeddedDocs, batch, sourceId) {
+		if (Array.isArray(embeddedDocs)) {
+			for (let i = 0; i < embeddedDocs.length; i += 1) {
+				const doc = embeddedDocs[i];
+				if (batch) {
+					batch.put(`${sourceId}.${doc._id}`, doc);
+					embeddedDocs[i] = doc._id ?? '';
+				}
+			}
+		}
+	}
 }

--- a/build/lib/Pack.mjs
+++ b/build/lib/Pack.mjs
@@ -1,120 +1,212 @@
+import crypto from 'crypto';
 import fs from 'fs';
 import { globSync } from 'glob';
 import path from 'path';
-import systemJSON from '../../public/system.json' with { type: 'json'};
+import systemJSON from '../../public/system.json' with { type: 'json' };
 import LevelDatabase from './LevelDB.mjs';
 
 export default class Pack {
-  static #PACK_DEST = path.resolve(process.cwd(), 'public/packs');
+	static #PACK_DEST = path.resolve(process.cwd(), 'public/packs');
 
-  static #packsMetadata = systemJSON.packs;
+	static #packsMetadata = systemJSON.packs;
 
-  constructor(dirName, data) {
-    const metadata = Pack.#packsMetadata
-      .find((p) => path.basename(p.path).split('.')[0] === path.basename(dirName));
+	constructor(dirName, data) {
+		const metadata = Pack.#packsMetadata.find(
+			(p) => path.basename(p.path).split('.')[0] === path.basename(dirName),
+		);
 
-    if (!metadata) throw Error(`[ERROR] - Pack ${dirName} isn't setup in system.json.`);
+		if (!metadata) throw Error(`[ERROR] - Pack ${dirName} isn't setup in system.json.`);
 
-    /** @type {string} */
-    this.systemId = metadata.system;
-    /** @type {string} */
-    this.packId = metadata.name;
-    /** @type {string} */
-    this.documentType = metadata.type;
+		/** @type {string} */
+		this.systemId = metadata.system;
+		/** @type {string} */
+		this.packId = metadata.name;
+		/** @type {string} */
+		this.documentType = metadata.type;
 
-    /** @type {string} */
-    this.dirPath = dirName;
-    /** @type {string} */
-    this.dirName = path.basename(dirName);
-    /** @type {Map<string, any>} */
-    this.data = data;
-  }
+		/** @type {string} */
+		this.dirPath = dirName;
+		/** @type {string} */
+		this.dirName = path.basename(dirName);
+		/** @type {Map<string, any>} */
+		this.data = data;
+		/** @type {any[]} */
+		this.folderDocuments = [];
+	}
 
-  cleanAndValidate() {
-    [...this.data.entries()].map(([file, source]) => {
-      this.#cleanDocument(source);
-      fs.writeFileSync(file, JSON.stringify(source, null, '\t'), { encoding: 'utf-8' });
+	cleanAndValidate() {
+		const folderAssignments = this.#prepareFolderAssignments();
 
-      return source;
-    });
-  }
+		[...this.data.entries()].map(([file, source]) => {
+			this.#cleanDocument(source);
 
-  #cleanDocument(source) {
-    // Clean Flags
-    if (!source.flags) source.flags = {};
-    delete source.flags?.exportSource;
-    delete source.flags?.importSource;
+			const folderId = source?._id ? folderAssignments.get(source._id) : null;
+			if (folderId) source.folder = folderId;
 
-    Object.entries(source.flags).forEach(([flagId, flag]) => {
-      if (!['core', 'nimble'].includes(flagId)) delete source.flags[flagId];
+			fs.writeFileSync(file, JSON.stringify(source, null, '\t'), { encoding: 'utf-8' });
 
-      if (Object.keys(flag).length === 0) delete source.flags[flag];
-    });
+			return source;
+		});
+	}
 
-    // Empty document folder data
-    source.folder = null;
+	#prepareFolderAssignments() {
+		this.folderDocuments = [];
 
-    // Reset ownership data
-    if (source.ownership) delete source.ownership;
+		// Restrict folder generation to the subclasses pack only.
+		if (this.dirName !== 'subclasses') return new Map();
 
-    // Update _stats data
-    // const stats = {
-    //   coreVersion: systemJSON.compatibility.minimum,
-    //   systemId: systemJSON.id,
-    //   systemVersion: systemJSON.version
-    // };
-    // source._stats = stats;
+		/** @type {any[]} */
+		const subclasses = [...this.data.values()].filter(
+			(source) => source?.type === 'subclass' && typeof source?.system?.parentClass === 'string',
+		);
+		if (subclasses.length === 0) return new Map();
 
-    // TODO: Update migration data
+		const statsTemplate = this.#getFolderStatsTemplate(subclasses);
+		const classIds = [
+			...new Set(
+				subclasses.map((source) => source.system.parentClass.trim().toLowerCase()).filter(Boolean),
+			),
+		].sort((a, b) => this.#toDisplayClassName(a).localeCompare(this.#toDisplayClassName(b)));
 
-    // Recurse for sub documents
-    if (Array.isArray(source?.effects)) source.effects.forEach((e) => this.#cleanDocument(e));
-    if (Array.isArray(source?.items)) source.items.forEach((i) => this.#cleanDocument(i));
-  }
+		const foldersByClass = classIds.reduce((acc, classId, index) => {
+			const folder = {
+				_id: this.#getStableFolderId(classId),
+				_stats: { ...statsTemplate },
+				color: null,
+				description: '',
+				flags: {},
+				folder: null,
+				name: this.#toDisplayClassName(classId),
+				sort: index * 10,
+				sorting: 'a',
+				type: this.documentType,
+			};
 
-  async saveAsPack() {
-    if (!fs.lstatSync(Pack.#PACK_DEST, { throwIfNoEntry: false })?.isDirectory()) {
-      fs.mkdirSync(Pack.#PACK_DEST);
-    }
+			acc.set(classId, folder);
+			return acc;
+		}, new Map());
 
-    const outDir = path.join(Pack.#PACK_DEST, this.dirName);
-    if (fs.lstatSync(outDir, { throwIfNoEntry: false })?.isDirectory()) {
-      fs.rmSync(outDir, { recursive: true });
-    }
+		this.folderDocuments = [...foldersByClass.values()];
 
-    this.cleanAndValidate();
+		return subclasses.reduce((acc, source) => {
+			const classId = source.system.parentClass.trim().toLowerCase();
+			const folder = foldersByClass.get(classId);
+			if (folder && source._id) acc.set(source._id, folder._id);
+			return acc;
+		}, new Map());
+	}
 
-    const db = new LevelDatabase(outDir, { packName: this.dirName });
-    await db.createPack([...this.data.values()]);
-    const count = this.data.size;
+	#getFolderStatsTemplate(sources) {
+		const sourceStats = sources.find((source) => source?._stats)?._stats;
+		const now = Date.now();
 
-    console.log(`[INFO] - Pack "${this.packId}" with ${count} documents built successfully.`);
+		return {
+			coreVersion:
+				sourceStats?.coreVersion ??
+				String(systemJSON.compatibility.verified ?? systemJSON.compatibility.minimum),
+			systemId: sourceStats?.systemId ?? systemJSON.id,
+			systemVersion: sourceStats?.systemVersion ?? systemJSON.version,
+			createdTime: sourceStats?.createdTime ?? now,
+			modifiedTime: sourceStats?.modifiedTime ?? now,
+			lastModifiedBy: sourceStats?.lastModifiedBy ?? 'system',
+		};
+	}
 
-    return count;
-  }
+	#toDisplayClassName(classId) {
+		if (classId === 'the-cheat') return 'The Cheat';
 
-  saveAsJSON() { }
+		return classId
+			.replace(/[-_]+/g, ' ')
+			.split(' ')
+			.filter(Boolean)
+			.map((word) => `${word.charAt(0).toUpperCase()}${word.slice(1)}`)
+			.join(' ');
+	}
 
-  static loadJSONFiles(dirPath) {
-    const filenames = globSync(`${dirPath}/**/*.json`);
-    const files = new Map();
+	#getStableFolderId(classId) {
+		return crypto
+			.createHash('sha1')
+			.update(`nimble-subclasses-folder:${classId}`)
+			.digest('hex')
+			.slice(0, 16);
+	}
 
-    for (const file of filenames) {
-      let jsonData;
+	#cleanDocument(source) {
+		// Clean Flags
+		if (!source.flags) source.flags = {};
+		delete source.flags?.exportSource;
+		delete source.flags?.importSource;
 
-      try {
-        jsonData = JSON.parse(fs.readFileSync(file, { encoding: 'utf-8' }).toString());
-      } catch (err) {
-        console.error(err);
-        console.warn(`[ERROR] - ${file} failed to parse.`);
-        continue;
-      }
+		Object.entries(source.flags).forEach(([flagId, flag]) => {
+			if (!['core', 'nimble'].includes(flagId)) delete source.flags[flagId];
 
-      if (!jsonData) continue;
+			if (Object.keys(flag).length === 0) delete source.flags[flag];
+		});
 
-      files.set(file, jsonData);
-    }
+		// Empty document folder data
+		source.folder = null;
 
-    return new Pack(dirPath, files);
-  }
+		// Reset ownership data
+		if (source.ownership) delete source.ownership;
+
+		// Update _stats data
+		// const stats = {
+		//   coreVersion: systemJSON.compatibility.minimum,
+		//   systemId: systemJSON.id,
+		//   systemVersion: systemJSON.version
+		// };
+		// source._stats = stats;
+
+		// TODO: Update migration data
+
+		// Recurse for sub documents
+		if (Array.isArray(source?.effects)) source.effects.forEach((e) => this.#cleanDocument(e));
+		if (Array.isArray(source?.items)) source.items.forEach((i) => this.#cleanDocument(i));
+	}
+
+	async saveAsPack() {
+		if (!fs.lstatSync(Pack.#PACK_DEST, { throwIfNoEntry: false })?.isDirectory()) {
+			fs.mkdirSync(Pack.#PACK_DEST);
+		}
+
+		const outDir = path.join(Pack.#PACK_DEST, this.dirName);
+		if (fs.lstatSync(outDir, { throwIfNoEntry: false })?.isDirectory()) {
+			fs.rmSync(outDir, { recursive: true });
+		}
+
+		this.cleanAndValidate();
+
+		const db = new LevelDatabase(outDir, { packName: this.dirName });
+		await db.createPack([...this.data.values()], { folders: this.folderDocuments });
+		const count = this.data.size;
+
+		console.log(`[INFO] - Pack "${this.packId}" with ${count} documents built successfully.`);
+
+		return count;
+	}
+
+	saveAsJSON() {}
+
+	static loadJSONFiles(dirPath) {
+		const filenames = globSync(`${dirPath}/**/*.json`);
+		const files = new Map();
+
+		for (const file of filenames) {
+			let jsonData;
+
+			try {
+				jsonData = JSON.parse(fs.readFileSync(file, { encoding: 'utf-8' }).toString());
+			} catch (err) {
+				console.error(err);
+				console.warn(`[ERROR] - ${file} failed to parse.`);
+				continue;
+			}
+
+			if (!jsonData) continue;
+
+			files.set(file, jsonData);
+		}
+
+		return new Pack(dirPath, files);
+	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -527,6 +527,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -550,6 +551,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -1568,6 +1570,7 @@
 			"version": "2.5.1",
 			"resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
 			"integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
+			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,
@@ -1607,6 +1610,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1627,6 +1631,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1647,6 +1652,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1667,6 +1673,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1687,6 +1694,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1707,6 +1715,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1727,6 +1736,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1747,6 +1757,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1767,6 +1778,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1787,6 +1799,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1807,6 +1820,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1827,6 +1841,7 @@
 			"cpu": [
 				"ia32"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1847,6 +1862,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1914,6 +1930,7 @@
 			"resolved": "git+ssh://git@github.com/foundry-vtt-types/pixi-assets.git#1a8b22552ddc747fcaae7ad65a2514a4a9869f8c",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/css-font-loading-module": "^0.0.12"
 			},
@@ -1954,6 +1971,7 @@
 			"resolved": "git+ssh://git@github.com/foundry-vtt-types/pixi-compressed-textures.git#890bd5cf9f92d6e48103b733513ccb603e5d1a36",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"peerDependencies": {
 				"@pixi/assets": "github:foundry-vtt-types/pixi-assets#main",
 				"@pixi/core": "github:foundry-vtt-types/pixi-core#main"
@@ -1964,13 +1982,15 @@
 			"resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-7.4.3.tgz",
 			"integrity": "sha512-QGmwJUNQy/vVEHzL6VGQvnwawLZ1wceZMI8HwJAT4/I2uAzbBeFDdmCS8WsTpSWLZjF/DszDc1D8BFp4pVJ5UQ==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@pixi/core": {
 			"version": "7.4.3",
 			"resolved": "git+ssh://git@github.com/foundry-vtt-types/pixi-core.git#b2554df0b43183980830a08d92a960ede78ad25e",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@pixi/color": "7.4.3",
 				"@pixi/constants": "7.4.3",
@@ -1992,6 +2012,7 @@
 			"integrity": "sha512-b5m2dAaoNAVdxz1oDaxl3XZ059NEOcNtGkxTOZ4EYCw/jcp9sZXkgSROHRzsGn4k+NugH7+9MP4Id2Z0kkdUhw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"peerDependencies": {
 				"@pixi/core": "7.4.3"
 			}
@@ -2002,6 +2023,7 @@
 			"integrity": "sha512-o3j/5Dxq6WDVS6eHfURB/cf/MP+NcsF/eC5PnbSHjXxJmDE7PoTVwLvxexm5uuvNRpFh/6/Fn0V8Vl4gV8sc8w==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"peerDependencies": {
 				"@pixi/core": "7.4.3",
 				"@pixi/display": "7.4.3"
@@ -2090,6 +2112,7 @@
 			"integrity": "sha512-wWLivD8/URb8A7X4TqCZGG39C91IE+aOuWY/z9NCz5Z6WvA/VWnsc5fLTlO+ggjGHgKF0cSucCXZfUe1wm0AOQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"peerDependencies": {
 				"@pixi/core": "7.4.3",
 				"@pixi/display": "7.4.3",
@@ -2113,7 +2136,8 @@
 			"resolved": "https://registry.npmjs.org/@pixi/math/-/math-7.4.3.tgz",
 			"integrity": "sha512-/uJOVhR2DOZ+zgdI6Bs/CwcXT4bNRKsS+TqX3ekRIxPCwaLra+Qdm7aDxT5cTToDzdxbKL5+rwiLu3Y1egILDw==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@pixi/mesh": {
 			"version": "7.4.3",
@@ -2121,6 +2145,7 @@
 			"integrity": "sha512-CikqFPtKvU3Zj986/MSoC8X39CWv5CEpiEW/tYp47p4tgQNDSkNWYnDiNYgb+4VX6pNsBrgX4DALLdTR17SlSA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"peerDependencies": {
 				"@pixi/core": "7.4.3",
 				"@pixi/display": "7.4.3"
@@ -2241,6 +2266,7 @@
 			"integrity": "sha512-iNBrpOFF9nXDT6m2jcyYy6l/sRzklLDDck1eFHprHZwvNquY2nzRfh+RGBCecxhBcijiLJ3fsZN33fP0LDXkvw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"peerDependencies": {
 				"@pixi/core": "7.4.3",
 				"@pixi/display": "7.4.3"
@@ -2286,6 +2312,7 @@
 			"integrity": "sha512-IAF0iu04rPg3oiL0HZsEZI44fpJxq3UZ4xTmx8l1RyhhSXiElLvvSlSH57vt/BKMQZtCs+AqEit7yn8heK2+nQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"peerDependencies": {
 				"@pixi/core": "7.4.3",
 				"@pixi/sprite": "7.4.3"
@@ -2323,6 +2350,7 @@
 			"resolved": "git+ssh://git@github.com/foundry-vtt-types/pixi-ticker.git#6a2756560f67a81fafbb1914b56d8974b6f34085",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@pixi/extensions": "7.4.3",
 				"@pixi/settings": "7.4.3",
@@ -2749,6 +2777,7 @@
 			"integrity": "sha512-YZs/OSKOQAQCnJvM/P+F1URotNnYNeU3P2s4oIpzm1uFaqUEqRxUB0g5ejMjEb5Gjb9/PiBI5Ktrq4rUUF8UVQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@sveltejs/vite-plugin-svelte-inspector": "^5.0.0",
 				"debug": "^4.4.1",
@@ -3118,6 +3147,7 @@
 			"integrity": "sha512-BnOroVl1SgrPLywqxyqdJ4l3S2MsKVLDVxZvjI1Eoe8ev2r3kGDo+PcMihNmDE+6/KjkTubSJnmqGZZjQSBq/g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.46.2",
 				"@typescript-eslint/types": "8.46.2",
@@ -3463,6 +3493,7 @@
 			"integrity": "sha512-F9jI5rSstNknPlTlPN2gcc4gpbaagowuRzw/OJzl368dvPun668Q182S8Q8P9PITgGCl5LAKXpzuue106eM4wA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@vitest/utils": "4.0.8",
 				"fflate": "^0.8.2",
@@ -3615,6 +3646,7 @@
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -3870,7 +3902,7 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
 			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"fill-range": "^7.1.1"
@@ -4448,6 +4480,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
 			"integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"bin": {
@@ -4984,6 +5017,7 @@
 			"integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -5481,7 +5515,7 @@
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
 			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"to-regex-range": "^5.0.1"
@@ -6245,7 +6279,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
 			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -6265,7 +6299,7 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
 			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-extglob": "^2.1.1"
@@ -6288,7 +6322,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.12.0"
@@ -6470,6 +6504,7 @@
 			"integrity": "sha512-h0Un1ieD+HUrzBH6dJXhod3ifSghk5Hw/2Y4/KHBziPlZecrFyE9YOTPU6eOs0V9pYl8gOs86fkr/KN8lUX39A==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@keyv/serialize": "^1.1.1"
 			}
@@ -6996,7 +7031,7 @@
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
 			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"braces": "^3.0.3",
@@ -7010,7 +7045,7 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
 			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8.6"
@@ -7300,6 +7335,7 @@
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
 			"integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+			"dev": true,
 			"license": "MIT",
 			"optional": true
 		},
@@ -7658,6 +7694,7 @@
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -7698,6 +7735,7 @@
 			"resolved": "git+ssh://git@github.com/foundry-vtt-types/pixi.js.git#a8414afd3a1141c3ef94e62079e7861723029c2c",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@pixi/accessibility": "7.4.3",
 				"@pixi/app": "7.4.3",
@@ -7765,6 +7803,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -7780,6 +7819,7 @@
 			"integrity": "sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==",
 			"devOptional": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"lilconfig": "^2.0.5",
 				"yaml": "^1.10.2"
@@ -7888,6 +7928,7 @@
 			"integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"cssesc": "^3.0.0",
 				"util-deprecate": "^1.0.2"
@@ -7977,6 +8018,7 @@
 			"integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
 			},
@@ -8600,6 +8642,7 @@
 			"integrity": "sha512-t+YPtOQHpGW1QWsh1CHQ5cPIr9lbbGZLZnbihP/D/qZj/yuV68m8qarcV17nvkOX81BCrvzAlq2klCQFZghyTg==",
 			"devOptional": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"chokidar": "^4.0.0",
 				"immutable": "^5.0.2",
@@ -9484,6 +9527,7 @@
 			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.42.2.tgz",
 			"integrity": "sha512-iSry5jsBHispVczyt9UrBX/1qu3HQ/UyKPAIjqlvlu3o/eUvc+kpyMyRS2O4HLLx4MvLurLGIUOyyP11pyD59g==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@jridgewell/remapping": "^2.3.4",
 				"@jridgewell/sourcemap-codec": "^1.5.0",
@@ -9806,7 +9850,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
 			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-number": "^7.0.0"
@@ -9897,6 +9941,7 @@
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -9983,6 +10028,7 @@
 			"integrity": "sha512-ZWyE8YXEXqJrrSLvYgrRP7p62OziLW7xI5HYGWFzOvupfAlrLvURSzv/FyGyy0eidogEM3ujU+kUG1zuHgb6Ug==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.25.0",
 				"fdir": "^6.5.0",
@@ -10096,6 +10142,7 @@
 			"integrity": "sha512-urzu3NCEV0Qa0Y2PwvBtRgmNtxhj5t5ULw7cuKhIHh3OrkKTLlut0lnBOv9qe5OvbkMH2g38G7KPDCTpIytBVg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@vitest/expect": "4.0.8",
 				"@vitest/mocker": "4.0.8",

--- a/packs/subclasses/core/berserker/path-of-the-mountainheart.json
+++ b/packs/subclasses/core/berserker/path-of-the-mountainheart.json
@@ -11,7 +11,7 @@
 		"resources": []
 	},
 	"effects": [],
-	"folder": null,
+	"folder": "4bc63d233b215758",
 	"flags": {},
 	"_stats": {
 		"coreVersion": "13.347",

--- a/packs/subclasses/core/berserker/path-of-the-red-mist.json
+++ b/packs/subclasses/core/berserker/path-of-the-red-mist.json
@@ -1,5 +1,5 @@
 {
-	"folder": null,
+	"folder": "4bc63d233b215758",
 	"name": "Path of the Red Mist",
 	"type": "subclass",
 	"img": "icons/skills/melee/strike-sword-blood-red.webp",

--- a/packs/subclasses/core/commander/champion-of-the-bulwark.json
+++ b/packs/subclasses/core/commander/champion-of-the-bulwark.json
@@ -11,7 +11,7 @@
 		"resources": []
 	},
 	"effects": [],
-	"folder": null,
+	"folder": "10ca6859977b85a3",
 	"flags": {},
 	"_stats": {
 		"coreVersion": "13.347",

--- a/packs/subclasses/core/commander/champion-of-the-vanguard.json
+++ b/packs/subclasses/core/commander/champion-of-the-vanguard.json
@@ -11,7 +11,7 @@
 		"resources": []
 	},
 	"effects": [],
-	"folder": null,
+	"folder": "10ca6859977b85a3",
 	"flags": {},
 	"_stats": {
 		"coreVersion": "13.347",

--- a/packs/subclasses/core/commander/spellblade.json
+++ b/packs/subclasses/core/commander/spellblade.json
@@ -1,5 +1,5 @@
 {
-	"folder": null,
+	"folder": "10ca6859977b85a3",
 	"name": "Spellblade",
 	"type": "subclass",
 	"img": "icons/weapons/swords/sword-runed-glowing.webp",

--- a/packs/subclasses/core/hunter/beastmaster.json
+++ b/packs/subclasses/core/hunter/beastmaster.json
@@ -1,5 +1,5 @@
 {
-	"folder": null,
+	"folder": "d3c9f5ece75c4fb4",
 	"name": "Beastmaster",
 	"type": "subclass",
 	"img": "icons/creatures/abilities/paw-print-yellow.webp",

--- a/packs/subclasses/core/hunter/keeper-of-the-shadowpath.json
+++ b/packs/subclasses/core/hunter/keeper-of-the-shadowpath.json
@@ -1,5 +1,5 @@
 {
-	"folder": null,
+	"folder": "d3c9f5ece75c4fb4",
 	"name": "Keeper of the Shadowpath",
 	"type": "subclass",
 	"img": "icons/magic/nature/stealth-hide-eyes-green.webp",

--- a/packs/subclasses/core/hunter/keeper-of-the-wildheart.json
+++ b/packs/subclasses/core/hunter/keeper-of-the-wildheart.json
@@ -1,5 +1,5 @@
 {
-	"folder": null,
+	"folder": "d3c9f5ece75c4fb4",
 	"name": "Keeper of the Wildheart",
 	"type": "subclass",
 	"img": "icons/magic/nature/root-vines-face-glow-green.webp",

--- a/packs/subclasses/core/mage/invoker-of-chaos.json
+++ b/packs/subclasses/core/mage/invoker-of-chaos.json
@@ -1,5 +1,5 @@
 {
-	"folder": null,
+	"folder": "5b9d52290963bc16",
 	"name": "Invoker of Chaos",
 	"type": "subclass",
 	"img": "icons/magic/light/explosion-impact-purple.webp",

--- a/packs/subclasses/core/mage/invoker-of-control.json
+++ b/packs/subclasses/core/mage/invoker-of-control.json
@@ -1,5 +1,5 @@
 {
-	"folder": null,
+	"folder": "5b9d52290963bc16",
 	"name": "Invoker of Control",
 	"type": "subclass",
 	"img": "icons/skills/melee/unarmed-punch-fist.webp",

--- a/packs/subclasses/core/oathsworn/oath-of-refuge.json
+++ b/packs/subclasses/core/oathsworn/oath-of-refuge.json
@@ -1,5 +1,5 @@
 {
-	"folder": null,
+	"folder": "5b10bca2f83f39b6",
 	"name": "Oath of Refuge",
 	"type": "subclass",
 	"img": "icons/skills/melee/shield-block-bash-blue.webp",

--- a/packs/subclasses/core/oathsworn/oath-of-vengeance.json
+++ b/packs/subclasses/core/oathsworn/oath-of-vengeance.json
@@ -1,5 +1,5 @@
 {
-	"folder": null,
+	"folder": "5b10bca2f83f39b6",
 	"name": "Oath of Vengeance",
 	"type": "subclass",
 	"img": "icons/skills/melee/hand-grip-sword-orange.webp",

--- a/packs/subclasses/core/oathsworn/oathbreaker.json
+++ b/packs/subclasses/core/oathsworn/oathbreaker.json
@@ -1,5 +1,5 @@
 {
-	"folder": null,
+	"folder": "5b10bca2f83f39b6",
 	"name": "Oathbreaker",
 	"type": "subclass",
 	"img": "icons/magic/unholy/hand-weapon-glow-black-green.webp",

--- a/packs/subclasses/core/shadowmancer/pact-of-the-abyssal-depths.json
+++ b/packs/subclasses/core/shadowmancer/pact-of-the-abyssal-depths.json
@@ -1,5 +1,5 @@
 {
-	"folder": null,
+	"folder": "851fc31235994743",
 	"name": "Pact of the Abyssal Depths",
 	"type": "subclass",
 	"img": "icons/magic/water/beam-ice-impact.webp",

--- a/packs/subclasses/core/shadowmancer/pact-of-the-red-dragon.json
+++ b/packs/subclasses/core/shadowmancer/pact-of-the-red-dragon.json
@@ -1,5 +1,5 @@
 {
-	"folder": null,
+	"folder": "851fc31235994743",
 	"name": "Pact of the Red Dragon",
 	"type": "subclass",
 	"img": "icons/magic/fire/flame-burning-eye.webp",

--- a/packs/subclasses/core/shadowmancer/reaver.json
+++ b/packs/subclasses/core/shadowmancer/reaver.json
@@ -1,5 +1,5 @@
 {
-	"folder": null,
+	"folder": "851fc31235994743",
 	"name": "Reaver",
 	"type": "subclass",
 	"img": "icons/magic/unholy/silhouette-robe-evil-glow.webp",

--- a/packs/subclasses/core/shepherd/luminary-of-malice.json
+++ b/packs/subclasses/core/shepherd/luminary-of-malice.json
@@ -1,5 +1,5 @@
 {
-	"folder": null,
+	"folder": "25484cbba09884d1",
 	"name": "Luminary of Malice",
 	"type": "subclass",
 	"img": "icons/magic/death/hand-withered-gray.webp",

--- a/packs/subclasses/core/shepherd/luminary-of-mercy.json
+++ b/packs/subclasses/core/shepherd/luminary-of-mercy.json
@@ -1,5 +1,5 @@
 {
-	"folder": null,
+	"folder": "25484cbba09884d1",
 	"name": "Luminary of Mercy",
 	"type": "subclass",
 	"img": "icons/magic/holy/barrier-shield-winged-blue.webp",

--- a/packs/subclasses/core/songweaver/herald-of-courage.json
+++ b/packs/subclasses/core/songweaver/herald-of-courage.json
@@ -1,5 +1,5 @@
 {
-	"folder": null,
+	"folder": "aa4530bc9f750ff0",
 	"name": "Herald of Courage",
 	"type": "subclass",
 	"img": "icons/skills/melee/unarmed-punch-fist-yellow-red.webp",

--- a/packs/subclasses/core/songweaver/herald-of-snark.json
+++ b/packs/subclasses/core/songweaver/herald-of-snark.json
@@ -1,5 +1,5 @@
 {
-	"folder": null,
+	"folder": "aa4530bc9f750ff0",
 	"name": "Herald of Snark",
 	"type": "subclass",
 	"img": "icons/magic/sonic/scream-wail-shout-teal.webp",

--- a/packs/subclasses/core/stormshifter/circle-of-fang-and-claw.json
+++ b/packs/subclasses/core/stormshifter/circle-of-fang-and-claw.json
@@ -1,5 +1,5 @@
 {
-	"folder": null,
+	"folder": "4385682fef661839",
 	"name": "Circle of Fang & Claw",
 	"type": "subclass",
 	"img": "icons/magic/nature/wolf-paw-glow-large-orange.webp",

--- a/packs/subclasses/core/stormshifter/circle-of-sky-and-storm.json
+++ b/packs/subclasses/core/stormshifter/circle-of-sky-and-storm.json
@@ -1,5 +1,5 @@
 {
-	"folder": null,
+	"folder": "4385682fef661839",
 	"name": "Circle of Sky & Storm",
 	"type": "subclass",
 	"img": "icons/magic/lightning/bolt-strike-clouds-blue.webp",

--- a/packs/subclasses/core/the-cheat/tools-of-the-scoundrel.json
+++ b/packs/subclasses/core/the-cheat/tools-of-the-scoundrel.json
@@ -1,5 +1,5 @@
 {
-	"folder": null,
+	"folder": "cbc115f144c900ef",
 	"name": "Tools of the Scoundrel",
 	"type": "subclass",
 	"img": "icons/equipment/head/hood-purple-mask.webp",

--- a/packs/subclasses/core/the-cheat/tools-of-the-silent-blade.json
+++ b/packs/subclasses/core/the-cheat/tools-of-the-silent-blade.json
@@ -1,5 +1,5 @@
 {
-	"folder": null,
+	"folder": "cbc115f144c900ef",
 	"name": "Tools of the Silent Blade",
 	"type": "subclass",
 	"img": "icons/weapons/daggers/dagger-simple-violet.webp",

--- a/packs/subclasses/core/zephyr/way-of-flame.json
+++ b/packs/subclasses/core/zephyr/way-of-flame.json
@@ -1,5 +1,5 @@
 {
-	"folder": null,
+	"folder": "ac8ca72c60e337f7",
 	"name": "Way of Flame",
 	"type": "subclass",
 	"img": "icons/magic/fire/flame-burning-earth-orange.webp",

--- a/packs/subclasses/core/zephyr/way-of-pain.json
+++ b/packs/subclasses/core/zephyr/way-of-pain.json
@@ -1,5 +1,5 @@
 {
-	"folder": null,
+	"folder": "ac8ca72c60e337f7",
 	"name": "Way of Pain",
 	"type": "subclass",
 	"img": "icons/skills/wounds/injury-face-impact-orange.webp",


### PR DESCRIPTION
### Summary of Changes
   - Implemented subclasses compendium folder grouping by hero class, so folders are real compendium folders and work with Collapse All Folders.
   - Added subclasses-only folder generation and item assignment in Pack.mjs.
   - Added folder persistence support in the pack writer in LevelDB.mjs (writes folders sublevel entries).
   - Updated all subclass source docs under packs/subclasses/core/... (26 files) from "folder": null to class folder IDs. 

### Resulting folder groups
   - Berserker, Commander, Hunter, Mage, Oathsworn, Shadowmancer, Shepherd, Songweaver, Stormshifter, The Cheat, Zephyr.

### What was verified
- Collapse All Folders Button working.
- Built subclasses pack produced:
   - 11 folders
   - 26 subclass items
   - 0 items missing folder assignment

<img width="385" height="1207" alt="Screenshot 2026-02-10 183211" src="https://github.com/user-attachments/assets/174cba33-0613-4964-a596-3be92bbd7fd7" />
<img width="380" height="1207" alt="Screenshot 2026-02-10 183239" src="https://github.com/user-attachments/assets/d9351479-b866-45f1-ba44-c48b115c04b3" />
