### PR TITLE
Fix/npc flat bonuses not applying

### DIFF
--- a/src/documents/actor/minion.ts
+++ b/src/documents/actor/minion.ts
@@ -25,6 +25,11 @@ export class NimbleMinion extends NimbleBaseActor {
 
 	override prepareDerivedData() {
 		super.prepareDerivedData();
+
+		const actorData = this.system;
+		Object.entries(actorData.savingThrows).forEach(([_, save]) => {
+			save.mod = save.bonus ?? 0;
+		});
 	}
 
 	async editMetadata() {

--- a/src/documents/actor/npc.ts
+++ b/src/documents/actor/npc.ts
@@ -23,6 +23,11 @@ export class NimbleNPC extends NimbleBaseActor {
 
 	override prepareDerivedData() {
 		super.prepareDerivedData();
+
+		const actorData = this.system;
+		Object.entries(actorData.savingThrows).forEach(([_, save]) => {
+			save.mod = save.bonus ?? 0;
+		});
 	}
 
 	async editMetadata() {

--- a/src/documents/actor/soloMonster.ts
+++ b/src/documents/actor/soloMonster.ts
@@ -25,6 +25,11 @@ export class NimbleSoloMonster extends NimbleBaseActor {
 
 	override prepareDerivedData() {
 		super.prepareDerivedData();
+
+		const actorData = this.system;
+		Object.entries(actorData.savingThrows).forEach(([_, save]) => {
+			save.mod = save.bonus ?? 0;
+		});
 	}
 
 	async activateBloodiedFeature(options: { visibilityMode?: string } = {}) {


### PR DESCRIPTION
## Fix: NPC saving throw flat bonuses not applied to rolls

Flat bonuses configured on NPC, Minion, and Solo Monster saving throws were stored correctly but never included in the actual roll formula. The `prepareDerivedData()` method in these actor classes didn't compute `save.mod` from `save.bonus`, so the roll system always saw a modifier of 0.

This adds the missing calculation to all three classes, mirroring the existing logic in `character.ts`.

### Testing checklist

- [ ] Create or open an **NPC** actor, set a non-zero flat bonus on a saving throw (e.g. STR +3), roll the save, and confirm the bonus appears in the roll formula
- [ ] Repeat for a **Minion** actor
- [ ] Repeat for a **Solo Monster** actor
- [ ] Verify **Character** saving throws still work correctly (no regression)
- [ ] Verify that rules/effects modifying `savingThrows.*.bonus` are reflected in the roll for NPC-type actors

Fixes #304 