### PR TITLE
Character Sheet Image moved to avoid overlap

### DIFF
--- a/src/view/sheets/PlayerCharacterSheet.svelte
+++ b/src/view/sheets/PlayerCharacterSheet.svelte
@@ -618,7 +618,7 @@
 				'manaHeading manaHeading'
 				'manaBar manaBar';
 			grid-gap: 0 0.125rem;
-			margin-block-start: -2.25rem;
+			margin-block-start: 0.25rem;
 			margin-inline: 0.25rem;
 		}
 	}
@@ -679,5 +679,6 @@
 
 	.nimble-heading--mana {
 		grid-area: manaHeading;
+		margin-block-start: 0.25rem;
 	}
 </style>


### PR DESCRIPTION
This is a small style change so the Hit Points title row does not overlap with the character image, making the text more readable.

<img width="362" height="383" alt="Screenshot 2026-02-13 160946" src="https://github.com/user-attachments/assets/82ceeee9-cabb-417b-b4bf-835afff828d9" />
<img width="354" height="419" alt="Screenshot 2026-02-13 160912" src="https://github.com/user-attachments/assets/7b69238f-e751-47a2-9b31-909f93c81fc6" />
