### PR TITLE
fix: add Odd Constitution rules to Oozeling/Construct ancestry

### DIFF
--- a/packs/ancestries/core/exotic/oozelingconstruct.json
+++ b/packs/ancestries/core/exotic/oozelingconstruct.json
@@ -5,7 +5,17 @@
 	"system": {
 		"macro": "",
 		"identifier": "",
-		"rules": [],
+		"rules": [
+			{
+				"type": "incrementHitDice",
+				"label": "Odd Constitution",
+				"value": "1"
+			},
+			{
+				"type": "maximizeHitDice",
+				"label": "Odd Constitution"
+			}
+		],
 		"description": "<p>What even is a “PeOpLe“ anyway? So what if your heart pumps oil instead of blood, so what if you don't even have a heart!? If you can squish yourself into a pair of pants, or swing a sword like everyone else, who's to say you can't be a pEOpLe, too?!</p><hr><p><strong>Odd Constitution</strong> </p><p>Increment your Hit Dice one step (d6 » d8 » d10 » d12 » d20); they always heal you for the maximum amount. Magical healing always heals you for the minimum amount.</p>",
 		"exotic": true,
 		"size": [

--- a/src/hooks/ready.ts
+++ b/src/hooks/ready.ts
@@ -1,9 +1,31 @@
 import { mount } from 'svelte';
 
+import { MigrationList } from '../migration/MigrationList.js';
+import { MigrationRunner } from '../migration/MigrationRunner.js';
+import { MigrationRunnerBase } from '../migration/MigrationRunnerBase.js';
 import CombatTracker from '../view/ui/CombatTracker.svelte';
 import combatStateGuards from './combatStateGuards.js';
 
-export default function ready() {
+export default async function ready() {
+	// Run migrations if needed
+	const worldSchemaVersion = game.settings.get(
+		'nimble' as 'core',
+		'worldSchemaVersion' as 'rollMode',
+	) as unknown as number;
+	const latestSchemaVersion = MigrationRunnerBase.LATEST_SCHEMA_VERSION;
+
+	if (worldSchemaVersion < latestSchemaVersion) {
+		console.log(
+			`Nimble | Migration needed: world schema version ${worldSchemaVersion} < latest schema version ${latestSchemaVersion}`,
+		);
+		const migrations = MigrationList.constructFromVersion(worldSchemaVersion);
+		const runner = new MigrationRunner(migrations);
+		await runner.runMigration();
+	} else {
+		console.log(
+			`Nimble | No migration needed: world schema version ${worldSchemaVersion} is up to date`,
+		);
+	}
 	game.nimble.conditions.configureStatusEffects();
 
 	const target = document.body;

--- a/src/migration/MigrationRunnerBase.ts
+++ b/src/migration/MigrationRunnerBase.ts
@@ -9,7 +9,7 @@ interface CollectionDiff<T = any> {
 class MigrationRunnerBase {
 	migrations: MigrationBase[];
 
-	static LATEST_SCHEMA_VERSION = 1;
+	static LATEST_SCHEMA_VERSION = 3;
 
 	static RECOMMENDED_SAFE_VERSION = 0;
 

--- a/src/migration/migrations/Migration003OozelingConstructRules.ts
+++ b/src/migration/migrations/Migration003OozelingConstructRules.ts
@@ -1,0 +1,70 @@
+import { MigrationBase } from '../MigrationBase.js';
+
+const OOZELING_CONSTRUCT_SOURCE_ID = 'Compendium.nimble.ancestries.Item.jYafwBbK4DVALpBf';
+
+const ODD_CONSTITUTION_RULES = [
+	{
+		type: 'incrementHitDice',
+		label: 'Odd Constitution',
+		value: '1',
+	},
+	{
+		type: 'maximizeHitDice',
+		label: 'Odd Constitution',
+	},
+];
+
+/**
+ * Migration to add Odd Constitution rules to Oozeling/Construct ancestry items.
+ *
+ * The Oozeling/Construct ancestry has an "Odd Constitution" trait that should:
+ * - Increment hit dice one step (d6 → d8 → d10 → d12 → d20)
+ * - Make hit dice always heal for maximum amount
+ *
+ * This migration adds the incrementHitDice and maximizeHitDice rules to
+ * existing Oozeling/Construct ancestry items on actors.
+ */
+class Migration003OozelingConstructRules extends MigrationBase {
+	static override readonly version = 3;
+
+	override readonly version = Migration003OozelingConstructRules.version;
+
+	override async updateItem(source: any): Promise<void> {
+		// Only process ancestry items
+		if (source.type !== 'ancestry') return;
+
+		// Check if this is the Oozeling/Construct ancestry by sourceId or name
+		const isOozelingConstruct =
+			source.flags?.core?.sourceId === OOZELING_CONSTRUCT_SOURCE_ID ||
+			source.name === 'Oozeling/Construct';
+
+		if (!isOozelingConstruct) return;
+
+		// Initialize rules array if it doesn't exist
+		if (!source.system.rules) {
+			source.system.rules = [];
+		}
+
+		// Check if rules already exist
+		const hasIncrementRule = source.system.rules.some(
+			(rule: any) => rule.type === 'incrementHitDice' && rule.label === 'Odd Constitution',
+		);
+		const hasMaximizeRule = source.system.rules.some(
+			(rule: any) => rule.type === 'maximizeHitDice' && rule.label === 'Odd Constitution',
+		);
+
+		// Add missing rules
+		if (!hasIncrementRule) {
+			source.system.rules.push(ODD_CONSTITUTION_RULES[0]);
+		}
+		if (!hasMaximizeRule) {
+			source.system.rules.push(ODD_CONSTITUTION_RULES[1]);
+		}
+
+		if (!hasIncrementRule || !hasMaximizeRule) {
+			console.log(`Nimble Migration | ${source.name}: added Odd Constitution rules`);
+		}
+	}
+}
+
+export { Migration003OozelingConstructRules };

--- a/src/migration/migrations/index.ts
+++ b/src/migration/migrations/index.ts
@@ -1,2 +1,3 @@
 export { Migration001AttackSequenceItems } from './Migration001AttackSequenceItems.js';
 export { Migration002ItemPrices } from './Migration002ItemPrices.js';
+export { Migration003OozelingConstructRules } from './Migration003OozelingConstructRules.js';


### PR DESCRIPTION
## Summary
- Add `incrementHitDice` and `maximizeHitDice` rules to the Oozeling/Construct ancestry to implement the "Odd Constitution" trait
- Create Migration003 to update existing actors with this ancestry
- Add auto-migration support on world load with version comparison logging

## Details
The Oozeling/Construct ancestry has an "Odd Constitution" trait that should:
- Increment hit dice one step (d6 → d8 → d10 → d12 → d20)
- Make hit dice always heal for the maximum amount

This was previously described in the ancestry description but not implemented as rules.

## Test plan
- [ ] Create a new character with Oozeling/Construct ancestry and verify hit dice are incremented and maximized
- [ ] Load a world with an existing Oozeling/Construct character and verify migration runs and adds the rules
- [ ] Check browser console for migration version logging on world load