### PR TITLE
feat: apply hit dice size bonus rules on level up

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -439,7 +439,7 @@
 			"skillPoints": "Skill Points",
 			"editSkillPoints": "Edit Skill Points",
 			"confirmSkillPointAssignments": "Confirm Skill Point Assignments",
-			"pointsRemaining": "({remainingSkillPoints} Points Remaining)",
+			"pointsRemaining": "{remainingSkillPoints} Points Remaining",
 			"maxSkillBonus": "Max skill bonus is +12.",
 			"onlyOneNewPointAndOneTransferAllowed": "Only 1 new point and 1 transfer are allowed per level-up.",
 			"reduceAnotherSkillFirstToAddSkillPoint": "Reduce another skill first to add a skill point.",

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -414,7 +414,12 @@
 			"skillPointsOverMax": "One or more skills would exceed the 12 point cap. Please reallocate skill points before submitting.",
 			"completeAllSelections": "Complete all selections before submitting",
 			"skillPointsOverMaxTooltip": "A skill would exceed the 12 point cap",
-			"completeAllSelectionsTooltip": "Complete all selections before submitting"
+			"completeAllSelectionsTooltip": "Complete all selections before submitting",
+			"hpIncrease": "HP Increase",
+			"hitDiceLabel": "Hit Dice:",
+			"rollHitDice": "Roll Hit Dice",
+			"rollHitDiceTooltip": "Roll your Hit Die with advantage and increase your max HP by that much.",
+			"takeAverage": "Take Average ({average})"
 		},
 		"levelDownDialog": {
 			"level": "Level",

--- a/src/config.ts
+++ b/src/config.ts
@@ -667,6 +667,11 @@ const levelUpDialog = {
 	completeAllSelections: 'NIMBLE.levelUpDialog.completeAllSelections',
 	skillPointsOverMaxTooltip: 'NIMBLE.levelUpDialog.skillPointsOverMaxTooltip',
 	completeAllSelectionsTooltip: 'NIMBLE.levelUpDialog.completeAllSelectionsTooltip',
+	hpIncrease: 'NIMBLE.levelUpDialog.hpIncrease',
+	hitDiceLabel: 'NIMBLE.levelUpDialog.hitDiceLabel',
+	rollHitDice: 'NIMBLE.levelUpDialog.rollHitDice',
+	rollHitDiceTooltip: 'NIMBLE.levelUpDialog.rollHitDiceTooltip',
+	takeAverage: 'NIMBLE.levelUpDialog.takeAverage',
 };
 
 const skillCheckDialog = {

--- a/src/migration/MigrationRunnerBase.ts
+++ b/src/migration/MigrationRunnerBase.ts
@@ -9,7 +9,7 @@ interface CollectionDiff<T = any> {
 class MigrationRunnerBase {
 	migrations: MigrationBase[];
 
-	static LATEST_SCHEMA_VERSION = 5;
+	static LATEST_SCHEMA_VERSION = 7;
 
 	static RECOMMENDED_SAFE_VERSION = 0;
 

--- a/src/migration/migrations/Migration006DwarfMaxHitDice.ts
+++ b/src/migration/migrations/Migration006DwarfMaxHitDice.ts
@@ -1,0 +1,52 @@
+import { MigrationBase } from '../MigrationBase.js';
+
+const DWARF_SOURCE_ID = 'Compendium.nimble.ancestries.Item.hyVaEOLNSagYECwm';
+
+const STOUT_MAX_HIT_DICE_RULE = {
+	type: 'maxHitDice',
+	label: 'Stout',
+	value: '2',
+	dieSize: 0,
+};
+
+/**
+ * Migration to add max hit dice rule to Dwarf ancestry items.
+ *
+ * The Dwarf ancestry has a "Stout" trait that should:
+ * - Grant +2 max Hit Dice
+ *
+ * This migration adds the maxHitDice rule to existing Dwarf ancestry items on actors.
+ */
+class Migration006DwarfMaxHitDice extends MigrationBase {
+	static override readonly version = 6;
+
+	override readonly version = Migration006DwarfMaxHitDice.version;
+
+	override async updateItem(source: any): Promise<void> {
+		// Only process ancestry items
+		if (source.type !== 'ancestry') return;
+
+		// Check if this is the Dwarf ancestry by sourceId or name
+		const isDwarf = source.flags?.core?.sourceId === DWARF_SOURCE_ID || source.name === 'Dwarf';
+
+		if (!isDwarf) return;
+
+		// Initialize rules array if it doesn't exist
+		if (!source.system.rules) {
+			source.system.rules = [];
+		}
+
+		// Check if rule already exists
+		const hasMaxHitDiceRule = source.system.rules.some(
+			(rule: any) => rule.type === 'maxHitDice' && rule.label === 'Stout',
+		);
+
+		// Add missing rule
+		if (!hasMaxHitDiceRule) {
+			source.system.rules.push(STOUT_MAX_HIT_DICE_RULE);
+			console.log(`Nimble Migration | ${source.name}: added Stout max hit dice rule`);
+		}
+	}
+}
+
+export { Migration006DwarfMaxHitDice };

--- a/src/migration/migrations/Migration007WildOneHitDiceAdvantage.ts
+++ b/src/migration/migrations/Migration007WildOneHitDiceAdvantage.ts
@@ -1,0 +1,52 @@
+import { MigrationBase } from '../MigrationBase.js';
+
+const WILD_ONE_SOURCE_ID = 'Compendium.nimble.backgrounds.Item.LWkH3GfYt0uU8qDj';
+
+const HIT_DICE_ADVANTAGE_RULE = {
+	type: 'hitDiceAdvantage',
+	label: 'Wild One',
+	condition: 'in the wild',
+};
+
+/**
+ * Migration to add hit dice advantage rule to Wild One background items.
+ *
+ * The Wild One background should:
+ * - Grant hit dice advantage while field resting in the wild
+ *
+ * This migration adds the hitDiceAdvantage rule to existing Wild One background items on actors.
+ */
+class Migration007WildOneHitDiceAdvantage extends MigrationBase {
+	static override readonly version = 7;
+
+	override readonly version = Migration007WildOneHitDiceAdvantage.version;
+
+	override async updateItem(source: any): Promise<void> {
+		// Only process background items
+		if (source.type !== 'background') return;
+
+		// Check if this is the Wild One background by sourceId or name
+		const isWildOne =
+			source.flags?.core?.sourceId === WILD_ONE_SOURCE_ID || source.name === 'Wild One';
+
+		if (!isWildOne) return;
+
+		// Initialize rules array if it doesn't exist
+		if (!source.system.rules) {
+			source.system.rules = [];
+		}
+
+		// Check if rule already exists
+		const hasHitDiceAdvantageRule = source.system.rules.some(
+			(rule: any) => rule.type === 'hitDiceAdvantage' && rule.label === 'Wild One',
+		);
+
+		// Add missing rule
+		if (!hasHitDiceAdvantageRule) {
+			source.system.rules.push(HIT_DICE_ADVANTAGE_RULE);
+			console.log(`Nimble Migration | ${source.name}: added hit dice advantage rule`);
+		}
+	}
+}
+
+export { Migration007WildOneHitDiceAdvantage };

--- a/src/migration/migrations/index.ts
+++ b/src/migration/migrations/index.ts
@@ -3,3 +3,5 @@ export { Migration002ItemPrices } from './Migration002ItemPrices.js';
 export { Migration003OozelingConstructRules } from './Migration003OozelingConstructRules.js';
 export { Migration004SpellbladeCombatMana } from './Migration004SpellbladeCombatMana.js';
 export { Migration005SpellUpcastEffect } from './Migration005SpellUpcastEffect.js';
+export { Migration006DwarfMaxHitDice } from './Migration006DwarfMaxHitDice.js';
+export { Migration007WildOneHitDiceAdvantage } from './Migration007WildOneHitDiceAdvantage.js';

--- a/src/view/dialogs/EditHitPointsDialog.svelte
+++ b/src/view/dialogs/EditHitPointsDialog.svelte
@@ -1,5 +1,6 @@
 <script>
 	import getDeterministicBonus from '../../dice/getDeterministicBonus.js';
+	import { incrementDieSize } from '../../managers/HitDiceManager.js';
 
 	const startingHpByHitDie = {
 		6: 10,
@@ -20,6 +21,9 @@
 	}
 
 	let { document, dialog } = $props();
+
+	// Get hit dice size bonus from rules (e.g., Oozeling's Odd Constitution)
+	const hitDiceSizeBonus = document.system.attributes?.hitDiceSizeBonus ?? 0;
 
 	let classHpData = $state([]);
 	let hpBonus = $state(document.system.attributes.hp.bonus || 0);
@@ -53,14 +57,18 @@
 	let totalRuleBonus = $derived(ruleBonuses.reduce((acc, b) => acc + b.value, 0));
 
 	$effect(() => {
-		classHpData = Object.values(document.classes ?? {}).map((cls) => ({
-			id: cls.id,
-			name: cls.name,
-			hitDie: cls.system.hitDieSize,
-			startingHp: startingHpByHitDie[cls.system.hitDieSize] || 0,
-			hpData: [...cls.system.hpData],
-			maxHp: cls.maxHp,
-		}));
+		classHpData = Object.values(document.classes ?? {}).map((cls) => {
+			// Apply hit dice size bonus to get effective size for display
+			const effectiveHitDie = incrementDieSize(cls.system.hitDieSize, hitDiceSizeBonus);
+			return {
+				id: cls.id,
+				name: cls.name,
+				hitDie: effectiveHitDie,
+				startingHp: startingHpByHitDie[cls.system.hitDieSize] || 0,
+				hpData: [...cls.system.hpData],
+				maxHp: cls.maxHp,
+			};
+		});
 	});
 
 	function updateHpData(classIndex, levelIndex, value) {

--- a/src/view/dialogs/components/levelUpHelper/HitPointSelection.svelte
+++ b/src/view/dialogs/components/levelUpHelper/HitPointSelection.svelte
@@ -1,72 +1,135 @@
-<script>
-	let { document, hitPointRollSelection = $bindable() } = $props();
+<script lang="ts">
+	import type { NimbleCharacter } from '../../../../documents/actor/character.js';
+	import type { NimbleClassItem } from '../../../../documents/item/class.js';
+	import { incrementDieSize } from '../../../../managers/HitDiceManager.js';
+
+	interface Props {
+		document: NimbleCharacter;
+		hitPointRollSelection: string;
+	}
+
+	let { document, hitPointRollSelection = $bindable() }: Props = $props();
+
+	const characterClass: NimbleClassItem | undefined = document?.classes
+		? (Object.values(document.classes)[0] as NimbleClassItem | undefined)
+		: undefined;
+
+	const baseHitDieSize = characterClass?.system?.hitDieSize ?? 6;
+	const hitDiceSizeBonus =
+		(document?.system?.attributes as { hitDiceSizeBonus?: number } | undefined)?.hitDiceSizeBonus ??
+		0;
+	const effectiveHitDieSize = incrementDieSize(baseHitDieSize, hitDiceSizeBonus);
+	const averageHp = Math.ceil((effectiveHitDieSize + 1) / 2);
 </script>
 
 <section>
 	<header class="nimble-section-header">
-		<h3 class="nimble-heading" data-heading-variant="section">Hit Points</h3>
+		<h3 class="nimble-heading" data-heading-variant="section">HP Increase</h3>
 	</header>
 
-	<div class="nimble-hit-point-roll-selection">
-		<label
-			class="nimble-hit-point-roll-selection__option"
-			class:nimble-hit-point-roll-selection__option--selected={hitPointRollSelection === 'roll'}
-		>
-			<i class="fa-solid fa-dice"></i>
-			Roll Hit Points
+	<div class="nimble-hit-point-selection">
+		<div class="nimble-hit-point-selection__hit-dice">
+			<span class="nimble-hit-point-selection__hit-dice-label">Hit Dice:</span>
+			<span class="nimble-hit-point-selection__die-box">d{effectiveHitDieSize}</span>
+		</div>
 
-			<input
-				class="nimble-hit-point-roll-selection__input"
-				type="radio"
-				name="{document.id}-hit-points"
-				value="roll"
-				bind:group={hitPointRollSelection}
-			/>
-		</label>
+		<div class="nimble-hit-point-selection__options">
+			<label
+				class="nimble-hit-point-selection__option"
+				class:nimble-hit-point-selection__option--selected={hitPointRollSelection === 'roll'}
+				data-tooltip="Roll your Hit Die with advantage and increase your max HP by that much."
+			>
+				<i class="fa-solid fa-dice"></i>
+				Roll Hit Dice
 
-		<label
-			class="nimble-hit-point-roll-selection__option"
-			class:nimble-hit-point-roll-selection__option--selected={hitPointRollSelection === 'average'}
-		>
-			<i class="fa-solid fa-gauge"></i>
-			Take Average
+				<input
+					class="nimble-hit-point-selection__input"
+					type="radio"
+					name="{document.id}-hit-points"
+					value="roll"
+					bind:group={hitPointRollSelection}
+				/>
+			</label>
 
-			<input
-				class="nimble-hit-point-roll-selection__input"
-				type="radio"
-				name="{document.id}-hit-points"
-				value="average"
-				bind:group={hitPointRollSelection}
-			/>
-		</label>
+			<label
+				class="nimble-hit-point-selection__option"
+				class:nimble-hit-point-selection__option--selected={hitPointRollSelection === 'average'}
+			>
+				<i class="fa-solid fa-gauge"></i>
+				Take Average ({averageHp})
+
+				<input
+					class="nimble-hit-point-selection__input"
+					type="radio"
+					name="{document.id}-hit-points"
+					value="average"
+					bind:group={hitPointRollSelection}
+				/>
+			</label>
+		</div>
 	</div>
 </section>
 
 <style lang="scss">
-	.nimble-hit-point-roll-selection {
+	.nimble-hit-point-selection {
 		display: flex;
-		gap: 0.5rem;
+		align-items: center;
+		gap: 1rem;
 		margin-block-end: 0.75rem;
 		font-size: var(--nimble-sm-text);
 		font-weight: 500;
 
+		&__hit-dice {
+			display: flex;
+			align-items: center;
+			gap: 0.5rem;
+		}
+
+		&__hit-dice-label {
+			font-weight: 500;
+		}
+
+		&__die-box {
+			display: inline-flex;
+			align-items: center;
+			justify-content: center;
+			min-width: 2.25rem;
+			height: 2.25rem;
+			padding: 0.25rem 0.5rem;
+			font-size: 0.9em;
+			font-weight: 700;
+			border: 1px solid currentColor;
+			border-radius: 5px;
+			opacity: 0.7;
+		}
+
+		&__options {
+			display: flex;
+			gap: 0.5rem;
+		}
+
 		&__option {
 			display: flex;
-			align-self: center;
+			align-items: center;
 			justify-content: center;
 			gap: 0.5rem;
 			width: fit-content;
 			padding: 0.5rem 1rem;
 			line-height: 1;
-			border: 1px solid black;
+			border: 1px solid var(--nimble-input-border-color);
 			border-radius: 4px;
 			box-shadow: var(--nimble-card-box-shadow);
 			cursor: pointer;
 			transition: var(--nimble-standard-transition);
 
+			&:hover:not(&--selected) {
+				background: var(--nimble-hint-background-color);
+			}
+
 			&--selected {
-				color: var(--nimble-light-text-color);
-				background: hsl(0, 0%, 24%);
+				color: var(--nimble-navigation-active-text-color);
+				background: #842c2b;
+				border-color: var(--nimble-input-border-color);
 			}
 		}
 

--- a/src/view/dialogs/components/levelUpHelper/HitPointSelection.svelte
+++ b/src/view/dialogs/components/levelUpHelper/HitPointSelection.svelte
@@ -24,12 +24,16 @@
 
 <section>
 	<header class="nimble-section-header">
-		<h3 class="nimble-heading" data-heading-variant="section">HP Increase</h3>
+		<h3 class="nimble-heading" data-heading-variant="section">
+			{CONFIG.NIMBLE.levelUpDialog.hpIncrease}
+		</h3>
 	</header>
 
 	<div class="nimble-hit-point-selection">
 		<div class="nimble-hit-point-selection__hit-dice">
-			<span class="nimble-hit-point-selection__hit-dice-label">Hit Dice:</span>
+			<span class="nimble-hit-point-selection__hit-dice-label">
+				{CONFIG.NIMBLE.levelUpDialog.hitDiceLabel}
+			</span>
 			<span class="nimble-hit-point-selection__die-box">d{effectiveHitDieSize}</span>
 		</div>
 
@@ -37,10 +41,10 @@
 			<label
 				class="nimble-hit-point-selection__option"
 				class:nimble-hit-point-selection__option--selected={hitPointRollSelection === 'roll'}
-				data-tooltip="Roll your Hit Die with advantage and increase your max HP by that much."
+				data-tooltip={CONFIG.NIMBLE.levelUpDialog.rollHitDiceTooltip}
 			>
 				<i class="fa-solid fa-dice"></i>
-				Roll Hit Dice
+				{CONFIG.NIMBLE.levelUpDialog.rollHitDice}
 
 				<input
 					class="nimble-hit-point-selection__input"
@@ -56,7 +60,7 @@
 				class:nimble-hit-point-selection__option--selected={hitPointRollSelection === 'average'}
 			>
 				<i class="fa-solid fa-gauge"></i>
-				Take Average ({averageHp})
+				{game.i18n.format(CONFIG.NIMBLE.levelUpDialog.takeAverage, { average: averageHp })}
 
 				<input
 					class="nimble-hit-point-selection__input"

--- a/src/view/dialogs/components/levelUpHelper/HitPointSelection.svelte
+++ b/src/view/dialogs/components/levelUpHelper/HitPointSelection.svelte
@@ -90,17 +90,13 @@
 		}
 
 		&__die-box {
-			display: inline-flex;
-			align-items: center;
-			justify-content: center;
-			min-width: 2.25rem;
-			height: 2.25rem;
 			padding: 0.25rem 0.5rem;
-			font-size: 0.9em;
+			font-size: var(--nimble-sm-text);
 			font-weight: 700;
-			border: 1px solid currentColor;
-			border-radius: 5px;
-			opacity: 0.7;
+			color: var(--nimble-dark-text-color);
+			background: var(--nimble-input-background-color);
+			border: 1px solid var(--nimble-card-border-color);
+			border-radius: 4px;
 		}
 
 		&__options {

--- a/src/view/dialogs/components/levelUpHelper/SkillPointAssignment.svelte
+++ b/src/view/dialogs/components/levelUpHelper/SkillPointAssignment.svelte
@@ -146,11 +146,12 @@
 
 <section>
 	<header class="nimble-section-header">
-		<h3 class="nimble-heading" data-heading-variant="section">
+		<h3 class="nimble-heading" data-heading-variant="section">More Skilled</h3>
+		<span class="nimble-points-remaining">
 			{localize('NIMBLE.skillPointAssignment.pointsRemaining', {
 				remainingSkillPoints: remainingSkillPoints,
 			})}
-		</h3>
+		</span>
 	</header>
 
 	<Hint hintText={hints.skillPointAssignment} />
@@ -250,6 +251,12 @@
 </section>
 
 <style lang="scss">
+	.nimble-points-remaining {
+		font-size: var(--nimble-sm-text);
+		font-weight: 500;
+		color: var(--nimble-medium-text-color);
+	}
+
 	.nimble-skill-config-table {
 		--nimble-button-min-width: 4ch;
 


### PR DESCRIPTION
## Summary
- Apply hitDiceSizeBonus (e.g., Oozeling's Odd Constitution) to HP rolls and averages during level up
- Redesign HP selection UI: move hit dice display outside buttons, show effective die size with cleaner styling
- Update selected button styling to use theme red color for better visibility in both light/dark modes
- Add "More Skilled" header to skill point assignment section with points remaining subtitle
- Add tooltip to Roll Hit Dice button explaining the advantage mechanic

## Test plan
- [ ] Test level up with Oozeling/Construct ancestry to verify hit dice bonus is applied correctly
- [ ] Verify HP roll uses the increased die size (e.g., d8 → d10)
- [ ] Verify Take Average uses the increased die size for calculation
- [ ] Check UI appearance in both light and dark modes
- [ ] Verify tooltips display correctly on hover