### PR TITLE
fix(items): fix vicious weapon/spell mechanics and roll dialog display

### DIFF
--- a/packs/legendaryMonsters/core/dravok-all-seeing-tyrant.json
+++ b/packs/legendaryMonsters/core/dravok-all-seeing-tyrant.json
@@ -791,7 +791,7 @@
 							"id": "SqqL7WHNreF474eJ",
 							"type": "damage",
 							"damageType": "piercing",
-							"formula": "1d4x+1d4x+1d4x+1d4x",
+							"formula": "1d4",
 							"parentContext": null,
 							"parentNode": null,
 							"canCrit": true,
@@ -799,19 +799,154 @@
 							"on": {
 								"hit": [
 									{
-										"id": "G811z6HFSAyW7uzA",
-										"type": "note",
-										"noteType": "warning",
-										"text": "[Vicious not modeled]\nFor every 4 rolled, roll an extra 1d4",
-										"parentContext": "hit",
-										"parentNode": "SqqL7WHNreF474eJ"
-									},
-									{
 										"id": "a3P1uHz3p99oSEW8",
 										"type": "damageOutcome",
 										"outcome": "fullDamage",
 										"parentContext": "hit",
 										"parentNode": "SqqL7WHNreF474eJ"
+									}
+								],
+								"criticalHit": [
+									{
+										"id": "maw1CritNote",
+										"type": "note",
+										"noteType": "warning",
+										"text": "CRIT",
+										"parentContext": "criticalHit",
+										"parentNode": "SqqL7WHNreF474eJ"
+									},
+									{
+										"id": "maw1ViciousDamage",
+										"type": "damage",
+										"damageType": "piercing",
+										"formula": "1d4",
+										"parentContext": "criticalHit",
+										"parentNode": "SqqL7WHNreF474eJ",
+										"ignoreArmor": true,
+										"on": {}
+									}
+								]
+							}
+						},
+						{
+							"id": "maw2Damage",
+							"type": "damage",
+							"damageType": "piercing",
+							"formula": "1d4",
+							"parentContext": null,
+							"parentNode": null,
+							"canCrit": true,
+							"canMiss": true,
+							"on": {
+								"hit": [
+									{
+										"id": "maw2DamageOutcome",
+										"type": "damageOutcome",
+										"outcome": "fullDamage",
+										"parentContext": "hit",
+										"parentNode": "maw2Damage"
+									}
+								],
+								"criticalHit": [
+									{
+										"id": "maw2CritNote",
+										"type": "note",
+										"noteType": "warning",
+										"text": "CRIT",
+										"parentContext": "criticalHit",
+										"parentNode": "maw2Damage"
+									},
+									{
+										"id": "maw2ViciousDamage",
+										"type": "damage",
+										"damageType": "piercing",
+										"formula": "1d4",
+										"parentContext": "criticalHit",
+										"parentNode": "maw2Damage",
+										"ignoreArmor": true,
+										"on": {}
+									}
+								]
+							}
+						},
+						{
+							"id": "maw3Damage",
+							"type": "damage",
+							"damageType": "piercing",
+							"formula": "1d4",
+							"parentContext": null,
+							"parentNode": null,
+							"canCrit": true,
+							"canMiss": true,
+							"on": {
+								"hit": [
+									{
+										"id": "maw3DamageOutcome",
+										"type": "damageOutcome",
+										"outcome": "fullDamage",
+										"parentContext": "hit",
+										"parentNode": "maw3Damage"
+									}
+								],
+								"criticalHit": [
+									{
+										"id": "maw3CritNote",
+										"type": "note",
+										"noteType": "warning",
+										"text": "CRIT",
+										"parentContext": "criticalHit",
+										"parentNode": "maw3Damage"
+									},
+									{
+										"id": "maw3ViciousDamage",
+										"type": "damage",
+										"damageType": "piercing",
+										"formula": "1d4",
+										"parentContext": "criticalHit",
+										"parentNode": "maw3Damage",
+										"ignoreArmor": true,
+										"on": {}
+									}
+								]
+							}
+						},
+						{
+							"id": "maw4Damage",
+							"type": "damage",
+							"damageType": "piercing",
+							"formula": "1d4",
+							"parentContext": null,
+							"parentNode": null,
+							"canCrit": true,
+							"canMiss": true,
+							"on": {
+								"hit": [
+									{
+										"id": "maw4DamageOutcome",
+										"type": "damageOutcome",
+										"outcome": "fullDamage",
+										"parentContext": "hit",
+										"parentNode": "maw4Damage"
+									}
+								],
+								"criticalHit": [
+									{
+										"id": "maw4CritNote",
+										"type": "note",
+										"noteType": "warning",
+										"text": "CRIT",
+										"parentContext": "criticalHit",
+										"parentNode": "maw4Damage"
+									},
+									{
+										"id": "maw4ViciousDamage",
+										"type": "damage",
+										"damageType": "piercing",
+										"formula": "1d4",
+										"parentContext": "criticalHit",
+										"parentNode": "maw4Damage",
+										"ignoreArmor": true,
+										"on": {}
 									}
 								]
 							}

--- a/packs/spells/core/wind/razor-wind.json
+++ b/packs/spells/core/wind/razor-wind.json
@@ -32,21 +32,22 @@
 					"on": {
 						"criticalHit": [
 							{
-								"id": "XG1PDj3LuzwZfbFT",
-								"type": "damage",
-								"damageType": "slashing",
-								"formula": "1d4",
-								"parentContext": "criticalHit",
-								"parentNode": "6pEXpZ8znbQP6LiP",
-								"on": {}
-							},
-							{
 								"id": "enoNfbb3InpTsMUg",
 								"type": "note",
 								"noteType": "warning",
 								"text": "CRIT",
 								"parentContext": "criticalHit",
 								"parentNode": "6pEXpZ8znbQP6LiP"
+							},
+							{
+								"id": "XG1PDj3LuzwZfbFT",
+								"type": "damage",
+								"damageType": "slashing",
+								"formula": "1d4",
+								"parentContext": "criticalHit",
+								"parentNode": "6pEXpZ8znbQP6LiP",
+								"ignoreArmor": true,
+								"on": {}
 							}
 						],
 						"hit": [

--- a/src/dice/terms/PrimaryDie.ts
+++ b/src/dice/terms/PrimaryDie.ts
@@ -17,7 +17,10 @@ class PrimaryDie extends foundry.dice.terms.Die {
 
 	get isMiss() {
 		if (!this._evaluated) return undefined;
-		return this.results.some((r) => r.result === 1 && r.active && !r.discarded && !r.exploded);
+		// If any die exploded (crit), the roll cannot also be a miss
+		// Only the initial roll can miss, not explosion dice
+		if (this.exploded) return false;
+		return this.results.some((r) => r.result === 1 && r.active && !r.discarded);
 	}
 }
 

--- a/src/migration/MigrationRunnerBase.ts
+++ b/src/migration/MigrationRunnerBase.ts
@@ -9,7 +9,7 @@ interface CollectionDiff<T = any> {
 class MigrationRunnerBase {
 	migrations: MigrationBase[];
 
-	static LATEST_SCHEMA_VERSION = 1;
+	static LATEST_SCHEMA_VERSION = 4;
 
 	static RECOMMENDED_SAFE_VERSION = 0;
 

--- a/src/migration/migrations/Migration003ViciousWeaponData.ts
+++ b/src/migration/migrations/Migration003ViciousWeaponData.ts
@@ -1,0 +1,249 @@
+import type {
+	ActionConsequence,
+	DamageNode,
+	DamageOutcomeNode,
+	TextNode,
+} from '#types/effectTree.js';
+import { MigrationBase } from '../MigrationBase.js';
+
+/**
+ * Source structure for item activation effects during migration.
+ * This represents the raw data shape before it's fully validated.
+ */
+interface ItemActivationSource {
+	effects?: DamageNode[];
+}
+
+/**
+ * Source structure for item system data during migration.
+ */
+interface ItemSystemSource {
+	activation?: ItemActivationSource;
+	properties?: {
+		selected?: string[];
+	};
+}
+
+/**
+ * Source structure for items during migration.
+ */
+interface ItemSource {
+	name: string;
+	type: string;
+	system?: ItemSystemSource;
+}
+
+/**
+ * Migration to fix vicious weapon/spell data.
+ *
+ * Updates items with the vicious property to ensure:
+ * 1. They have a vicious damage die on criticalHit
+ * 2. The vicious damage die does NOT have canCrit (only primary die crits)
+ * 3. The vicious damage has ignoreArmor: true
+ *
+ * Also updates Dravok's Terrible Maw to use 4 separate damage effects.
+ */
+class Migration003ViciousWeaponData extends MigrationBase {
+	static override readonly version = 4;
+
+	override readonly version = Migration003ViciousWeaponData.version;
+
+	override async updateItem(source: ItemSource): Promise<void> {
+		// Handle vicious weapons/spells
+		if (this.#hasViciousProperty(source)) {
+			this.#updateViciousItem(source);
+		}
+
+		// Handle Dravok's Terrible Maw specifically
+		if (source.name === 'Terrible Maw' && source.type === 'monsterFeature') {
+			this.#updateTerribleMaw(source);
+		}
+	}
+
+	#hasViciousProperty(source: ItemSource): boolean {
+		const selectedProperties = source.system?.properties?.selected;
+		if (!Array.isArray(selectedProperties)) return false;
+		return selectedProperties.includes('vicious');
+	}
+
+	#updateViciousItem(source: ItemSource): void {
+		const effects = source.system?.activation?.effects;
+		if (!Array.isArray(effects)) return;
+
+		for (const effect of effects) {
+			if (effect.type !== 'damage' || !effect.canCrit) continue;
+
+			// Ensure on property and criticalHit array exist
+			if (!effect.on) effect.on = {};
+			if (!effect.on.criticalHit) effect.on.criticalHit = [];
+
+			// Check if vicious damage already exists
+			const hasCritDamage = effect.on.criticalHit.some(
+				(e): e is DamageNode => e.type === 'damage' && e.parentContext === 'criticalHit',
+			);
+
+			if (!hasCritDamage) {
+				this.#addViciousDamage(source, effect);
+			} else {
+				this.#fixExistingViciousDamage(source, effect.on.criticalHit);
+			}
+		}
+	}
+
+	#addViciousDamage(source: ItemSource, effect: DamageNode): void {
+		const criticalHit = effect.on?.criticalHit;
+		if (!criticalHit) return;
+
+		// Add CRIT note if not present
+		const hasCritNote = criticalHit.some(
+			(e): e is TextNode => e.type === 'note' && e.parentContext === 'criticalHit',
+		);
+
+		if (!hasCritNote) {
+			const critNote: TextNode = {
+				id: foundry.utils.randomID(),
+				type: 'note',
+				noteType: 'warning',
+				text: 'CRIT',
+				parentContext: 'criticalHit',
+				parentNode: effect.id,
+			};
+			criticalHit.unshift(critNote);
+		}
+
+		// Add vicious damage die
+		const viciousDamage: DamageNode = {
+			id: foundry.utils.randomID(),
+			type: 'damage',
+			damageType: effect.damageType,
+			formula: this.#extractBaseDie(effect.formula),
+			parentContext: 'criticalHit',
+			parentNode: effect.id,
+			ignoreArmor: true,
+			on: {},
+		};
+		criticalHit.push(viciousDamage);
+
+		console.log(`Nimble Migration | ${source.name}: added vicious crit damage`);
+	}
+
+	#fixExistingViciousDamage(
+		source: ItemSource,
+		criticalHit: ActionConsequence['criticalHit'],
+	): void {
+		if (!criticalHit) return;
+
+		for (const critEffect of criticalHit) {
+			if (critEffect.type === 'damage' && critEffect.parentContext === 'criticalHit') {
+				const damageEffect = critEffect as DamageNode;
+
+				if (damageEffect.canCrit) {
+					delete damageEffect.canCrit;
+					console.log(`Nimble Migration | ${source.name}: removed canCrit from vicious damage`);
+				}
+
+				// Remove nested criticalHit if present (vicious dice shouldn't chain-crit)
+				if (damageEffect.on?.criticalHit) {
+					damageEffect.on = {};
+					console.log(
+						`Nimble Migration | ${source.name}: removed nested criticalHit from vicious damage`,
+					);
+				}
+
+				// Ensure ignoreArmor is set
+				if (!damageEffect.ignoreArmor) {
+					damageEffect.ignoreArmor = true;
+				}
+			}
+		}
+	}
+
+	#updateTerribleMaw(source: ItemSource): void {
+		const effects = source.system?.activation?.effects;
+		if (!Array.isArray(effects) || effects.length === 0) return;
+
+		const firstEffect = effects[0];
+
+		// Check if already migrated (has 4 separate 1d4 effects)
+		if (effects.length >= 4 && effects.every((e) => e.formula === '1d4')) {
+			// Already migrated, just fix any canCrit issues on vicious dice
+			for (const effect of effects) {
+				if (effect.on?.criticalHit) {
+					this.#fixExistingViciousDamage(source, effect.on.criticalHit);
+				}
+			}
+			return;
+		}
+
+		// Check if using old combined formula
+		if (!firstEffect.formula?.includes('4d4') && !firstEffect.formula?.includes('1d4x')) {
+			return;
+		}
+
+		console.log(`Nimble Migration | Terrible Maw: converting to 4 separate damage effects`);
+
+		// Create 4 separate damage effects
+		const newEffects: DamageNode[] = [];
+		for (let i = 1; i <= 4; i++) {
+			const effectId = foundry.utils.randomID();
+
+			const damageOutcome: DamageOutcomeNode = {
+				id: foundry.utils.randomID(),
+				type: 'damageOutcome',
+				outcome: 'fullDamage',
+				parentContext: 'hit',
+				parentNode: effectId,
+			};
+
+			const critNote: TextNode = {
+				id: foundry.utils.randomID(),
+				type: 'note',
+				noteType: 'warning',
+				text: 'CRIT',
+				parentContext: 'criticalHit',
+				parentNode: effectId,
+			};
+
+			const viciousDamage: DamageNode = {
+				id: foundry.utils.randomID(),
+				type: 'damage',
+				damageType: 'piercing',
+				formula: '1d4',
+				parentContext: 'criticalHit',
+				parentNode: effectId,
+				ignoreArmor: true,
+				on: {},
+			};
+
+			const damageNode: DamageNode = {
+				id: effectId,
+				type: 'damage',
+				damageType: 'piercing',
+				formula: '1d4',
+				parentContext: null,
+				parentNode: null,
+				canCrit: true,
+				canMiss: true,
+				on: {
+					hit: [damageOutcome],
+					criticalHit: [critNote, viciousDamage],
+				},
+			};
+
+			newEffects.push(damageNode);
+		}
+
+		// Replace effects array
+		source.system!.activation!.effects = newEffects;
+	}
+
+	/**
+	 * Extract the base die from a formula (e.g., "1d4+@dexterity" -> "1d4")
+	 */
+	#extractBaseDie(formula: string): string {
+		const match = formula.match(/\d+d\d+/);
+		return match ? match[0] : '1d4';
+	}
+}
+
+export { Migration003ViciousWeaponData };

--- a/src/migration/migrations/index.ts
+++ b/src/migration/migrations/index.ts
@@ -1,2 +1,3 @@
 export { Migration001AttackSequenceItems } from './Migration001AttackSequenceItems.js';
 export { Migration002ItemPrices } from './Migration002ItemPrices.js';
+export { Migration003ViciousWeaponData } from './Migration003ViciousWeaponData.js';

--- a/src/view/dataPreparationHelpers/rollTooltips/prepareRollTooltipDiceResults.ts
+++ b/src/view/dataPreparationHelpers/rollTooltips/prepareRollTooltipDiceResults.ts
@@ -1,9 +1,29 @@
-export default function prepareRollTooltipDiceResults({ faces, results }) {
-	return results.reduce((acc, { rerolled, discarded, result }) => {
-		const isCritical = (faces === 20 && result === 20) || result === faces;
+interface DieResult {
+	result: number;
+	rerolled?: boolean;
+	discarded?: boolean;
+	exploded?: boolean;
+}
 
+interface DicePart {
+	faces: number;
+	results: DieResult[];
+}
+
+export default function prepareRollTooltipDiceResults({ faces, results }: DicePart): string {
+	// If any die exploded (crit), subsequent 1s are not fumbles
+	// Only the initial roll can fumble - explosion dice cannot miss
+	const hasExploded = results.some((r) => r.exploded);
+
+	return results.reduce((acc, { rerolled, discarded, result, exploded }) => {
+		const isCritical = (faces === 20 && result === 20) || result === faces;
 		const isDiscarded = discarded || rerolled;
-		const isFumble = result === 1;
+
+		// A fumble only occurs if:
+		// 1. The result is 1
+		// 2. No explosion happened (if any die exploded, the roll is a crit and can't fumble)
+		// 3. This specific die didn't explode (edge case: rolled 1 then somehow exploded)
+		const isFumble = result === 1 && !hasExploded && !exploded;
 
 		let classes = `nimble-die nimble-die--${faces}`;
 

--- a/src/view/dialogs/ItemActivationConfigDialog.svelte
+++ b/src/view/dialogs/ItemActivationConfigDialog.svelte
@@ -14,6 +14,7 @@
 
 	// Get all damage effects from the item's activation effects
 	// This searches recursively through the effects tree, including sharedRolls
+	// Only includes damage effects that apply on normal hits (not crit-only damage)
 	let damageEffects = $derived.by(() => {
 		const effects = item.system.activation?.effects ?? [];
 		const allDamageEffects = [];
@@ -21,7 +22,14 @@
 		// Flatten the tree to get all effects including those in sharedRolls
 		const flattened = flattenEffectsTree(effects);
 		for (const effect of flattened) {
-			if (effect.type === 'damage') {
+			// Only include damage effects that apply on normal hits
+			// Exclude crit-only damage (parentContext === "criticalHit") and miss effects
+			if (
+				effect.type === 'damage' &&
+				(effect.parentContext === null ||
+					effect.parentContext === 'hit' ||
+					effect.parentContext === 'sharedRolls')
+			) {
 				allDamageEffects.push({
 					formula: effect.formula || '0',
 					damageType: effect.damageType,
@@ -29,28 +37,7 @@
 			}
 		}
 
-		// Also check sharedRolls directly (before flattening removes them)
-		// This ensures we catch all damage effects in sharedRolls
-		for (const effect of effects) {
-			if (effect.type === 'savingThrow' && effect.sharedRolls) {
-				for (const sharedRoll of effect.sharedRolls) {
-					if (sharedRoll.type === 'damage') {
-						// Check if we already have this damage effect
-						const exists = allDamageEffects.some(
-							(d) => d.formula === sharedRoll.formula && d.damageType === sharedRoll.damageType,
-						);
-						if (!exists) {
-							allDamageEffects.push({
-								formula: sharedRoll.formula || '0',
-								damageType: sharedRoll.damageType,
-							});
-						}
-					}
-				}
-			}
-		}
-
-		// If still no damage effects found, return a default one
+		// If no damage effects found, return a default one
 		if (allDamageEffects.length === 0) {
 			return [{ formula: '0' }];
 		}


### PR DESCRIPTION
## Summary
- Exclude crit-only damage from the roll dialog display so vicious weapons don't show duplicate dice
- Implement proper vicious property for Dravok's Terrible Maw (4 separate damage effects, each can crit independently)
- Fix Razor Wind vicious damage structure

## Test plan
- [ ] Verify Sling and Sickle no longer show duplicate damage dice in roll dialog
- [ ] Test Dravok's Terrible Maw - each of the 4 d4s should be able to crit independently and add a vicious d4
- [ ] Test Razor Wind - should add vicious d4 on crit, vicious die should not crit itself