### PR TITLE
chore(packs): Formatting and ids generated

### DIFF
--- a/packs/ids.json
+++ b/packs/ids.json
@@ -136,8 +136,8 @@
 				},
 				"berserker-subclasses": {
 					"path-of-the-mountainheart": {
-						"mountains-endurance": "CLAQBXSaK5TgFsmN",
 						"mountainous-tenacity": "VI69M0QiJh5TOw5R",
+						"mountains-endurance": "CLAQBXSaK5TgFsmN",
 						"stones-resilience": "j9PQ4IkM5NgPW67m",
 						"titans-fury": "8LFqi9XLldluX3ro",
 						"unbreakable": "8LMk8Ke1m1AXR0ij"
@@ -229,8 +229,8 @@
 					"forager": "wZ4Q5MjM1xHp8xsx",
 					"hunters-mark": "iDYdYYMzgculnANa",
 					"hunters-resolve": "gwq4K6NbllcuFLPB",
-					"keen-sight": "IXFxaKSsPtHZ313f",
 					"keen-eye-steady-hand": "bKtlyFEqca4WVdzU",
+					"keen-sight": "IXFxaKSsPtHZ313f",
 					"nemesis": "Wyiz02wruaCYqHiN",
 					"no-escape": "yJqf7nEqz1UBi03b",
 					"peerless-hunter": "eE1rSZ1XBAON8YXM",
@@ -754,17 +754,23 @@
 			"azriel-lord-of-pain-and-flame": "ZtvN9z6ZEolYZu1R",
 			"caerys-the-hollow-star": "SILDSex9MI5AuAs7",
 			"dravok-all-seeing-tyrant": "7n4NFalMBVr8hKaP",
+			"dregatha-thrice-chinned": "svHoUz8vIun3j9tI",
 			"florindris-bane-of-the-forest": "91He6bIh0M7nRt2C",
 			"general-flameheart": "JZ9lUy4rwuTBCa6t",
 			"gloomwing-the-cruel": "n6suthbw9UWnOpex",
+			"greenthumb-lichling": "HIXIhUIG7S9vyF1B",
 			"grimbeak-the-unyielding": "UqXZgpT99YjVCVQj",
 			"kelebek-entomancer": "LZYmTHd8wN4x8DCo",
+			"krogg-goblin-king": "4CLKneQXGJuCNoP7",
+			"lind-worm": "tPiWzclr1ZSkyTAP",
 			"nalzar-apex-predator": "nHmhDIozM5iowqpT",
 			"poppy-giant-stinkbug": "tIt1UdE6d6jmughV",
 			"pudge-the-blunderer": "nAew89tkjzZNnnac",
 			"queen-aranya-broodmother": "m5BJajp8f7TGj3QU",
 			"queen-aranyas-spiderling-minion": "RW07GUkU1QLtRbrV",
+			"rat-prince": "XQOBiTP8L3Yac9Up",
 			"ravager-of-the-lowlands": "zCcpMXbxzzyFzKsz",
+			"scorpion-queen": "zaM78FA829bAaDmR",
 			"thorn-quickblade": "lgul04YrKU0RjG0F",
 			"titan-of-the-deep-woods": "9HMbDYuZ4iJusIrj",
 			"titans-skeleton-minion": "DOHY1RHnRQlPqAYn",
@@ -865,7 +871,8 @@
 				"briarbane-rootbreaker": "UvgXMSWKrPWqtJgv",
 				"briarbane-seedling": "helYUT1m9nYqh4mC",
 				"briarbane-tangler": "zUR4X7UV37zHrDF2",
-				"briarbane-treant": "lDTJWdkMFVOOQVwc"
+				"briarbane-treant": "lDTJWdkMFVOOQVwc",
+				"giant-venus-flytrap": "2WAfywOh2jWhIlVy"
 			},
 			"cultists": {
 				"cultist": "YjKhjwiYoNrrhXfo",
@@ -886,7 +893,8 @@
 				"goblin": "65v4ZutYxq6hlTog",
 				"goblin-minion": "KCZqQUfTuczLNEA3",
 				"goblin-ratrider": "SM6NlZaQdKqFN2AD",
-				"goblin-taskmaster": "XkaTxC6xYSk2kPVV"
+				"goblin-taskmaster": "XkaTxC6xYSk2kPVV",
+				"pinky": "61FWYH8AiVq2gD9R"
 			},
 			"hill-and-field": {
 				"blue-drake": "w9gh6oGZ8508YMAN",
@@ -899,6 +907,7 @@
 			},
 			"horrors": {
 				"glabrezu": "nopp2DKrd9uK67B7",
+				"incubus-succubus": "QiXaRObRw5xxE1VT",
 				"spiny-fiend": "cr1zy94gxZjzh86o",
 				"stenchling": "rV8kgeKs7wRL55j6"
 			},
@@ -947,10 +956,13 @@
 			"underground": {
 				"cloaker": "iee2AYLgQjRieoEI",
 				"ettercap": "R24pjE8ntXNVd1Ah",
+				"giant-slug-minion": "Fh0VprW8Tnc2anU7",
 				"giant-spider": "ML3WomiwkHKUfTnO",
 				"great-worm": "lQ83gZRlm3bTgsbp",
 				"nestweaver": "zDKPmCy5DbGdkJLU",
-				"umber-hulk": "UqUuKtAWlOrDkAFy"
+				"rat-swarm": "xx6ELqMvhFA8qVfN",
+				"umber-hulk": "UqUuKtAWlOrDkAFy",
+				"wax-golem": "7f3ZENlslRDMVcEf"
 			}
 		}
 	},

--- a/packs/legendaryMonsters/core/dregatha-thrice-chinned.json
+++ b/packs/legendaryMonsters/core/dregatha-thrice-chinned.json
@@ -488,5 +488,5 @@
 		"systemVersion": "0.1.8",
 		"lastModifiedBy": null
 	},
-	"_id": "dregathaSolo00001"
+	"_id": "svHoUz8vIun3j9tI"
 }

--- a/packs/legendaryMonsters/core/greenthumb-lichling.json
+++ b/packs/legendaryMonsters/core/greenthumb-lichling.json
@@ -501,5 +501,5 @@
 		"systemVersion": "0.1.8",
 		"lastModifiedBy": null
 	},
-	"_id": "greenthumbSolo001"
+	"_id": "HIXIhUIG7S9vyF1B"
 }

--- a/packs/legendaryMonsters/core/krogg-goblin-king.json
+++ b/packs/legendaryMonsters/core/krogg-goblin-king.json
@@ -441,5 +441,5 @@
 		"systemVersion": "0.1.8",
 		"lastModifiedBy": null
 	},
-	"_id": "kroggGoblinKing01"
+	"_id": "4CLKneQXGJuCNoP7"
 }

--- a/packs/legendaryMonsters/core/lind-worm.json
+++ b/packs/legendaryMonsters/core/lind-worm.json
@@ -448,5 +448,5 @@
 		"systemVersion": "0.1.8",
 		"lastModifiedBy": null
 	},
-	"_id": "lindWormSolo0001"
+	"_id": "tPiWzclr1ZSkyTAP"
 }

--- a/packs/legendaryMonsters/core/rat-prince.json
+++ b/packs/legendaryMonsters/core/rat-prince.json
@@ -360,5 +360,5 @@
 		"systemVersion": "0.1.8",
 		"lastModifiedBy": null
 	},
-	"_id": "ratPrinceSolo00001"
+	"_id": "XQOBiTP8L3Yac9Up"
 }

--- a/packs/legendaryMonsters/core/scorpion-queen.json
+++ b/packs/legendaryMonsters/core/scorpion-queen.json
@@ -488,5 +488,5 @@
 		"systemVersion": "0.1.8",
 		"lastModifiedBy": null
 	},
-	"_id": "scorpQueenSolo001"
+	"_id": "zaM78FA829bAaDmR"
 }

--- a/packs/monsters/core/briarbanes/giant-venus-flytrap.json
+++ b/packs/monsters/core/briarbanes/giant-venus-flytrap.json
@@ -395,5 +395,5 @@
 		"systemVersion": "0.1.8",
 		"lastModifiedBy": null
 	},
-	"_id": "giantFlytrapNpc01"
+	"_id": "2WAfywOh2jWhIlVy"
 }

--- a/packs/monsters/core/goblins/pinky.json
+++ b/packs/monsters/core/goblins/pinky.json
@@ -291,5 +291,5 @@
 		"systemVersion": "0.1.8",
 		"lastModifiedBy": null
 	},
-	"_id": "pinkyNpc00000001"
+	"_id": "61FWYH8AiVq2gD9R"
 }

--- a/packs/monsters/core/horrors/incubus-succubus.json
+++ b/packs/monsters/core/horrors/incubus-succubus.json
@@ -266,5 +266,5 @@
 		"systemVersion": "0.1.8",
 		"lastModifiedBy": null
 	},
-	"_id": "Wq3u2cW4pM4A2nFu"
+	"_id": "QiXaRObRw5xxE1VT"
 }

--- a/packs/monsters/core/underground/giant-slug-minion.json
+++ b/packs/monsters/core/underground/giant-slug-minion.json
@@ -260,5 +260,5 @@
 		"systemVersion": "0.1.8",
 		"lastModifiedBy": null
 	},
-	"_id": "giantSlugMinion01"
+	"_id": "Fh0VprW8Tnc2anU7"
 }

--- a/packs/monsters/core/underground/rat-swarm.json
+++ b/packs/monsters/core/underground/rat-swarm.json
@@ -260,5 +260,5 @@
 		"systemVersion": "0.1.8",
 		"lastModifiedBy": null
 	},
-	"_id": "ratSwarmMinion001"
+	"_id": "xx6ELqMvhFA8qVfN"
 }

--- a/packs/monsters/core/underground/wax-golem.json
+++ b/packs/monsters/core/underground/wax-golem.json
@@ -356,5 +356,5 @@
 		"systemVersion": "0.1.8",
 		"lastModifiedBy": null
 	},
-	"_id": "waxGolemNpc00001"
+	"_id": "7f3ZENlslRDMVcEf"
 }


### PR DESCRIPTION
## Summary
- Regenerated pack IDs and applied consistent formatting to pack data files
- Updated CHANGELOG.md with version 0.7.0 release notes
- Replaced husky with lefthook for git hooks configuration

## Test plan
- [ ] Verify pack data loads correctly in Foundry VTT
- [ ] Confirm git hooks still function with lefthook