### PR TITLE
fix: resolve sheet rendering errors and improve UX

### DIFF
--- a/src/documents/sheets/AncestrySheet.svelte.ts
+++ b/src/documents/sheets/AncestrySheet.svelte.ts
@@ -31,8 +31,8 @@ export default class AncestrySheet extends SvelteApplicationMixin(
 			resizable: true,
 		},
 		position: {
-			width: 288,
-			height: 'auto' as const,
+			width: 350,
+			height: 500,
 		},
 	};
 

--- a/src/documents/sheets/BackgroundSheet.svelte.ts
+++ b/src/documents/sheets/BackgroundSheet.svelte.ts
@@ -23,8 +23,8 @@ export default class BackgroundSheet extends SvelteApplicationMixin(SvelteItemSh
 			resizable: true,
 		},
 		position: {
-			width: 288,
-			height: 'auto' as const,
+			width: 350,
+			height: 500,
 		},
 		actions: {},
 	};

--- a/src/documents/sheets/BoonSheet.svelte.ts
+++ b/src/documents/sheets/BoonSheet.svelte.ts
@@ -26,8 +26,8 @@ export default class BoonSheet extends SvelteApplicationMixin(
 			resizable: true,
 		},
 		position: {
-			width: 288,
-			height: 'auto' as const,
+			width: 350,
+			height: 500,
 		},
 		actions: {},
 	};

--- a/src/documents/sheets/ClassSheet.svelte.ts
+++ b/src/documents/sheets/ClassSheet.svelte.ts
@@ -26,8 +26,8 @@ export default class ClassSheet extends SvelteApplicationMixin(
 			resizable: true,
 		},
 		position: {
-			width: 288,
-			height: 'auto' as const,
+			width: 350,
+			height: 500,
 		},
 		actions: {},
 	};

--- a/src/documents/sheets/FeatureSheet.svelte.ts
+++ b/src/documents/sheets/FeatureSheet.svelte.ts
@@ -32,7 +32,7 @@ export default class FeatureSheet extends SvelteApplicationMixin(
 		},
 		position: {
 			width: 400,
-			height: 'auto' as const,
+			height: 500,
 		},
 		actions: {},
 	};

--- a/src/documents/sheets/MonsterFeatureSheet.svelte.ts
+++ b/src/documents/sheets/MonsterFeatureSheet.svelte.ts
@@ -26,7 +26,7 @@ export default class MonsterFeatureSheet extends SvelteApplicationMixin(
 			resizable: true,
 		},
 		position: {
-			width: 288,
+			width: 350,
 			height: 600,
 		},
 		actions: {},

--- a/src/documents/sheets/NPCSheet.svelte.ts
+++ b/src/documents/sheets/NPCSheet.svelte.ts
@@ -46,7 +46,7 @@ export default class NPCSheet extends SvelteApplicationMixin(
 		},
 		position: {
 			width: 288,
-			height: 'auto' as const,
+			height: 650,
 		},
 	};
 

--- a/src/documents/sheets/ObjectSheet.svelte.ts
+++ b/src/documents/sheets/ObjectSheet.svelte.ts
@@ -26,8 +26,8 @@ export default class ObjectSheet extends SvelteApplicationMixin(
 			resizable: true,
 		},
 		position: {
-			width: 288,
-			height: 'auto' as const,
+			width: 350,
+			height: 500,
 		},
 		actions: {},
 	};

--- a/src/documents/sheets/PlayerCharacterSheet.svelte.ts
+++ b/src/documents/sheets/PlayerCharacterSheet.svelte.ts
@@ -50,7 +50,7 @@ export default class PlayerCharacterSheet extends SvelteApplicationMixin(
 		},
 		position: {
 			width: 336,
-			height: 'auto' as const,
+			height: 850,
 		},
 	};
 

--- a/src/documents/sheets/SpellSheet.svelte.ts
+++ b/src/documents/sheets/SpellSheet.svelte.ts
@@ -26,8 +26,8 @@ export default class SpellSheet extends SvelteApplicationMixin(
 			resizable: true,
 		},
 		position: {
-			width: 288,
-			height: 'auto' as const,
+			width: 350,
+			height: 500,
 		},
 		actions: {},
 	};

--- a/src/documents/sheets/SubclassSheet.svelte.ts
+++ b/src/documents/sheets/SubclassSheet.svelte.ts
@@ -26,8 +26,8 @@ export default class SubclassSheet extends SvelteApplicationMixin(
 			resizable: true,
 		},
 		position: {
-			width: 288,
-			height: 'auto' as const,
+			width: 350,
+			height: 500,
 		},
 		actions: {},
 	};

--- a/src/view/chat/AbilityCheckCard.svelte
+++ b/src/view/chat/AbilityCheckCard.svelte
@@ -22,9 +22,7 @@
 
 	const label = $derived(`${abilityScores[abilityKey]} Check`);
 
-	$effect(() => {
-		setContext('message', messageDocument);
-	});
+	setContext('message', messageDocument);
 </script>
 
 <CardHeader {messageDocument} />

--- a/src/view/chat/FeatureCard.svelte
+++ b/src/view/chat/FeatureCard.svelte
@@ -44,9 +44,7 @@
 	const headerBackgroundColor = $derived(messageDocument.reactive.author.color);
 	const headerTextColor = $derived(calculateHeaderTextColor(headerBackgroundColor));
 
-	$effect(() => {
-		setContext('messageDocument', messageDocument);
-	});
+	setContext('messageDocument', messageDocument);
 </script>
 
 <CardHeader {messageDocument} />

--- a/src/view/chat/FieldRestCard.svelte
+++ b/src/view/chat/FieldRestCard.svelte
@@ -48,9 +48,7 @@
 		rolls?.length ? prepareRollTooltip(actorType, permissions, rolls[0]) : '',
 	);
 
-	$effect(() => {
-		setContext('message', messageDocument);
-	});
+	setContext('message', messageDocument);
 </script>
 
 <CardHeader {messageDocument} />

--- a/src/view/chat/LevelUpSummaryCard.svelte
+++ b/src/view/chat/LevelUpSummaryCard.svelte
@@ -19,9 +19,7 @@
 	const headerBackgroundColor = $derived(messageDocument.author.color);
 	const headerTextColor = $derived(calculateHeaderTextColor(headerBackgroundColor));
 
-	$effect(() => {
-		setContext('message', messageDocument);
-	});
+	setContext('message', messageDocument);
 </script>
 
 <CardHeader {messageDocument} />

--- a/src/view/chat/MinionGroupAttackCard.svelte
+++ b/src/view/chat/MinionGroupAttackCard.svelte
@@ -111,9 +111,7 @@
 		});
 	}
 
-	$effect(() => {
-		setContext('messageDocument', messageDocument);
-	});
+	setContext('messageDocument', messageDocument);
 </script>
 
 <CardHeader {messageDocument} />

--- a/src/view/chat/ObjectCard.svelte
+++ b/src/view/chat/ObjectCard.svelte
@@ -28,9 +28,7 @@
 
 	let subheading = $derived(getCardSubheading(activation, isCritical, isMiss));
 
-	$effect(() => {
-		setContext('messageDocument', messageDocument);
-	});
+	setContext('messageDocument', messageDocument);
 </script>
 
 <CardHeader {messageDocument} />

--- a/src/view/chat/SafeRestCard.svelte
+++ b/src/view/chat/SafeRestCard.svelte
@@ -30,9 +30,7 @@
 		hitDiceDisplay || hpRestored > 0 || manaRestored > 0 || woundsRecovered > 0,
 	);
 
-	$effect(() => {
-		setContext('message', messageDocument);
-	});
+	setContext('message', messageDocument);
 </script>
 
 <CardHeader {messageDocument} />

--- a/src/view/chat/SpellCard.svelte
+++ b/src/view/chat/SpellCard.svelte
@@ -56,9 +56,7 @@
 		return parts.join(' — ');
 	});
 
-	$effect(() => {
-		setContext('messageDocument', messageDocument);
-	});
+	setContext('messageDocument', messageDocument);
 </script>
 
 <CardHeader {messageDocument} />

--- a/src/view/components/PrimaryNavigationItem.svelte
+++ b/src/view/components/PrimaryNavigationItem.svelte
@@ -13,7 +13,13 @@
 		aria-label={localize(tab.tooltip)}
 		data-tooltip={localize(tab.tooltip)}
 		data-tooltip-direction="UP"
-		onpointerup={(e) => e.button === 0 && (currentTab = tab)}
+		onpointerup={(e) => {
+			if (e.button === 0) {
+				currentTab = tab;
+				// Blur after click so Escape key can close the sheet
+				e.target?.blur?.();
+			}
+		}}
 	>
 		<i class={tab.icon}></i>
 		{localize(tab.label ?? '')}

--- a/src/view/dialogs/CharacterCreationDialog.svelte
+++ b/src/view/dialogs/CharacterCreationDialog.svelte
@@ -364,10 +364,7 @@
 	let stageNumber = $derived(stage.toString().match(/\d+/)[0]);
 
 	setContext('CHARACTER_CREATION_STAGES', CHARACTER_CREATION_STAGES);
-
-	$effect(() => {
-		setContext('dialog', dialog);
-	});
+	setContext('dialog', dialog);
 
 	$effect(() => {
 		scrollIntoView(`${dialog.id}-stage-${stage}`);

--- a/src/view/dialogs/components/characterCreator/StartingEquipmentSelection.svelte
+++ b/src/view/dialogs/components/characterCreator/StartingEquipmentSelection.svelte
@@ -11,6 +11,9 @@
 
 	const CHARACTER_CREATION_STAGES = getContext('CHARACTER_CREATION_STAGES');
 	const dialog = getContext('dialog');
+	const sectionId = $derived(
+		`${dialog?.id ?? 'character-creation'}-stage-${CHARACTER_CREATION_STAGES.STARTING_EQUIPMENT}`,
+	);
 	const { startingEquipment, characterCreationStages } = CONFIG.NIMBLE;
 
 	const hintText = game.i18n.localize(startingEquipment.hint);
@@ -47,10 +50,7 @@
 	}
 </script>
 
-<section
-	class="nimble-character-creation-section"
-	id="{dialog.id}-stage-{CHARACTER_CREATION_STAGES.STARTING_EQUIPMENT}"
->
+<section class="nimble-character-creation-section" id={sectionId}>
 	<header class="nimble-section-header" data-header-variant="character-creator">
 		<h3 class="nimble-heading" data-heading-variant="section">
 			{game.i18n.localize(characterCreationStages.stepFourStartingEquipment)}

--- a/src/view/sheets/AncestrySheet.svelte
+++ b/src/view/sheets/AncestrySheet.svelte
@@ -33,10 +33,8 @@
 
 	let exoticAncestry = $derived(item.reactive.system.exotic);
 
-	$effect(() => {
-		setContext('document', item);
-		setContext('application', sheet);
-	});
+	setContext('document', item);
+	setContext('application', sheet);
 </script>
 
 {#snippet descriptionTab()}

--- a/src/view/sheets/BackgroundSheet.svelte
+++ b/src/view/sheets/BackgroundSheet.svelte
@@ -32,10 +32,8 @@
 
 	let currentTab = $state(navigation[0]);
 
-	$effect(() => {
-		setContext('document', item);
-		setContext('application', sheet);
-	});
+	setContext('document', item);
+	setContext('application', sheet);
 </script>
 
 {#snippet configTab()}

--- a/src/view/sheets/BoonSheet.svelte
+++ b/src/view/sheets/BoonSheet.svelte
@@ -55,10 +55,8 @@
 	let currentTab = $state(navigation[0]);
 	const { boonTypes } = CONFIG.NIMBLE;
 
-	$effect(() => {
-		setContext('document', item);
-		setContext('application', sheet);
-	});
+	setContext('document', item);
+	setContext('application', sheet);
 </script>
 
 {#snippet configTab()}

--- a/src/view/sheets/ClassSheet.svelte
+++ b/src/view/sheets/ClassSheet.svelte
@@ -178,10 +178,8 @@
 	let weaponProficiencies = $derived(item.reactive.system.weaponProficiencies);
 	let featureGroups = $derived(item.reactive.system.groupIdentifiers || []);
 
-	$effect(() => {
-		setContext('document', item);
-		setContext('application', sheet);
-	});
+	setContext('document', item);
+	setContext('application', sheet);
 </script>
 
 {#snippet configTab()}

--- a/src/view/sheets/FeatureSheet.svelte
+++ b/src/view/sheets/FeatureSheet.svelte
@@ -97,10 +97,8 @@
 
 	let currentTab = $state(navigation[0]);
 
-	$effect(() => {
-		setContext('document', item);
-		setContext('application', sheet);
-	});
+	setContext('document', item);
+	setContext('application', sheet);
 </script>
 
 {#snippet activationConfigTab()}

--- a/src/view/sheets/MonsterFeatureSheet.svelte
+++ b/src/view/sheets/MonsterFeatureSheet.svelte
@@ -47,10 +47,8 @@
 
 	let { item, sheet } = $props();
 
-	$effect(() => {
-		setContext('document', item);
-		setContext('application', sheet);
-	});
+	setContext('document', item);
+	setContext('application', sheet);
 </script>
 
 {#snippet activationConfigTab()}

--- a/src/view/sheets/ObjectSheet.svelte
+++ b/src/view/sheets/ObjectSheet.svelte
@@ -114,10 +114,8 @@
 	let objectType = $derived(item.reactive.system.objectType);
 	let objectSizeType = $derived(item.reactive.system.objectSizeType);
 
-	$effect(() => {
-		setContext('document', item);
-		setContext('application', sheet);
-	});
+	setContext('document', item);
+	setContext('application', sheet);
 </script>
 
 {#snippet activationConfigTab()}

--- a/src/view/sheets/SpellSheet.svelte
+++ b/src/view/sheets/SpellSheet.svelte
@@ -55,10 +55,8 @@
 	let currentTab = $state(navigation[0]);
 	let metadata = $derived(prepareSpellMetaData(item.reactive) ?? '');
 
-	$effect(() => {
-		setContext('document', item);
-		setContext('application', sheet);
-	});
+	setContext('document', item);
+	setContext('application', sheet);
 </script>
 
 <header class="nimble-sheet__header nimble-sheet__header--spell">

--- a/src/view/sheets/SubclassSheet.svelte
+++ b/src/view/sheets/SubclassSheet.svelte
@@ -34,10 +34,8 @@
 	let currentTab = $state(navigation[0]);
 	let parentClass = $derived(item.system.parentClass);
 
-	$effect(() => {
-		setContext('document', item);
-		setContext('application', sheet);
-	});
+	setContext('document', item);
+	setContext('application', sheet);
 </script>
 
 {#snippet configTab()}

--- a/src/view/sheets/components/Editor.svelte
+++ b/src/view/sheets/components/Editor.svelte
@@ -1,11 +1,14 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { tick } from 'svelte';
 
 	type EditorOptions = foundry.applications.elements.HTMLProseMirrorElement.ProseMirrorInputConfig;
 	type EnrichOptions = foundry.applications.ux.TextEditor.implementation.EnrichmentOptions;
 
 	interface ProseMirrorElement extends HTMLElement {
 		_getValue?(): string;
+		open?(): void;
+		isDirty?(): boolean;
 	}
 
 	interface Props {
@@ -25,6 +28,16 @@
 		editorOptions = {} as EditorOptions,
 		enrichOptions = {} as EnrichOptions,
 	}: Props = $props();
+
+	// Check if content is empty (no text or just whitespace/empty tags)
+	function isContentEmpty(html: string): boolean {
+		if (!html) return true;
+		// Strip HTML tags and check if there's any actual text content
+		const textContent = html.replace(/<[^>]*>/g, '').trim();
+		return textContent.length === 0;
+	}
+
+	let isEmpty = $derived(isContentEmpty(content));
 
 	// Build Options - using $derived to avoid state_referenced_locally warnings
 	const mergedEditorOptions = $derived(
@@ -53,7 +66,89 @@
 		) as EnrichOptions,
 	);
 
+	let containerElem: HTMLElement;
 	let proseMirrorElem: HTMLElement;
+	let isEditorActive = $state(false);
+	let contentWhenEditClicked = $state<string | null>(null);
+	let currentEditorContent = $state<string>('');
+
+	// Capture editor content when edit is first opened; clear when closed. Also focus the editable area.
+	$effect(() => {
+		if (isEditorActive && contentWhenEditClicked === null) {
+			tick().then(() => {
+				const proseMirror = containerElem?.querySelector(
+					'prose-mirror',
+				) as ProseMirrorElement | null;
+				if (proseMirror && typeof proseMirror._getValue === 'function') {
+					const value = proseMirror._getValue();
+					contentWhenEditClicked = value;
+					currentEditorContent = value;
+				}
+				// Auto-focus the text field when editor opens
+				const root = proseMirror?.shadowRoot ?? proseMirror;
+				const editable =
+					root?.querySelector<HTMLElement>('[contenteditable="true"]') ??
+					root?.querySelector<HTMLElement>('.editor-content');
+				editable?.focus();
+			});
+		} else if (!isEditorActive) {
+			contentWhenEditClicked = null;
+		}
+	});
+
+	const isSaveDisabled = $derived(
+		contentWhenEditClicked === null || currentEditorContent === contentWhenEditClicked,
+	);
+
+	function activateEditor() {
+		// Click the hidden toggle button in the top right (same one that works on hover)
+		const toggleButton = containerElem?.querySelector(
+			'prose-mirror button.toggle',
+		) as HTMLButtonElement | null;
+		if (toggleButton && !toggleButton.disabled) {
+			toggleButton.click();
+		}
+	}
+
+	function saveEditor() {
+		console.log('saveEditor');
+		const proseMirror = containerElem?.querySelector('prose-mirror') as ProseMirrorElement | null;
+		if (!proseMirror) return;
+
+		// Get the current value and save it to the document
+		if (typeof proseMirror._getValue === 'function') {
+			console.log('proseMirror._getValue', proseMirror._getValue);
+			const value = proseMirror._getValue();
+			console.log('value', value);
+			document.update({ [field]: value });
+		}
+
+		// Dispatch a 'save' event on the proseMirror element to trigger save handlers
+		proseMirror.dispatchEvent(new Event('save', { bubbles: true }));
+
+		// Remove active class and refresh to close the editor
+		proseMirror.classList.remove('active');
+
+		// Force a re-render by calling _refresh if available
+		if (typeof (proseMirror as any)._refresh === 'function') {
+			console.log('proseMirror._refresh', (proseMirror as any)._refresh);
+			(proseMirror as any)._refresh();
+		}
+	}
+
+	function observeEditorState() {
+		// Watch for the .active class on the prose-mirror element
+		const proseMirror = containerElem?.querySelector('prose-mirror');
+		if (!proseMirror) return;
+
+		const observer = new MutationObserver(() => {
+			isEditorActive = proseMirror.classList.contains('active');
+		});
+
+		observer.observe(proseMirror, { attributes: true, attributeFilter: ['class'] });
+
+		return () => observer.disconnect();
+	}
 
 	// Create Editor element and assign it
 	onMount(async () => {
@@ -68,6 +163,7 @@
 
 		// Listen for save events from ProseMirror and update the document
 		element.addEventListener('save', (event: Event) => {
+			console.log('save event', event);
 			const target = event.target as ProseMirrorElement;
 			if (target?._getValue) {
 				const value = target._getValue();
@@ -75,38 +171,158 @@
 			}
 		});
 
+		// Track current content so we can disable Save when unchanged
+		element.addEventListener('input', () => {
+			if (typeof element._getValue === 'function') {
+				currentEditorContent = element._getValue();
+			}
+		});
+
 		// Properly insert the element to maintain event bubbling
 		proseMirrorElem.replaceWith(element);
+
+		// Start observing editor state for active class changes
+		return observeEditorState();
 	});
 </script>
 
-<div bind:this={proseMirrorElem} class="nimble-editor-wrapper"></div>
+<div
+	bind:this={containerElem}
+	class="nimble-editor-container"
+	class:nimble-editor-container--empty={isEmpty}
+>
+	<div bind:this={proseMirrorElem} class="nimble-editor-wrapper"></div>
+
+	{#if isEmpty && editable && !isEditorActive}
+		<div class="nimble-editor-empty-state">
+			<span class="nimble-editor-empty-state__text">No description</span>
+			<button
+				type="button"
+				class="nimble-editor-empty-state__edit-button"
+				aria-label="Edit description"
+				data-tooltip="Edit description"
+				onclick={activateEditor}
+			>
+				<i class="fa-solid fa-edit"></i>
+			</button>
+		</div>
+	{/if}
+
+	{#if isEditorActive}
+		<div class="nimble-editor-save-bar">
+			<button
+				type="button"
+				class="nimble-button"
+				data-button-variant="basic"
+				data-tooltip={isSaveDisabled ? 'No changes to save' : undefined}
+				onclick={saveEditor}
+				disabled={isSaveDisabled}
+			>
+				<i class="nimble-button__icon fa-solid fa-save"></i>
+				Save
+			</button>
+		</div>
+	{/if}
+</div>
 
 <style lang="scss">
+	.nimble-editor-container {
+		position: relative;
+		height: 100%;
+		display: block;
+	}
+
 	.nimble-editor-wrapper {
 		height: 100%;
 		display: block;
+	}
 
-		:global(prose-mirror) {
-			height: 100%;
-			display: block;
+	:global(prose-mirror) {
+		height: 100%;
+		display: block;
+	}
+
+	:global(.editor-container) {
+		height: 100%;
+		display: flex;
+		flex-direction: column;
+	}
+
+	:global(.editor-content) {
+		height: 100%;
+		overflow-y: auto;
+		flex: 1;
+		padding-bottom: 1rem !important;
+	}
+
+	:global(.editor-menu) {
+		flex-shrink: 0;
+	}
+
+	.nimble-editor-empty-state {
+		position: absolute;
+		inset: 0;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: 0.75rem;
+		pointer-events: none;
+		z-index: 1;
+
+		&__text {
+			color: var(--nimble-medium-text-color, #888);
+			font-size: var(--nimble-sm-text, 0.875rem);
+			font-style: italic;
+			opacity: 0.7;
 		}
 
-		:global(.editor-container) {
-			height: 100%;
+		&__edit-button {
+			pointer-events: auto;
 			display: flex;
-			flex-direction: column;
-		}
+			align-items: center;
+			justify-content: center;
+			width: 2rem;
+			height: 2rem;
+			border-radius: 50%;
+			border: 1px solid var(--nimble-border-color, rgba(0, 0, 0, 0.2));
+			background: var(--nimble-button-background, rgba(0, 0, 0, 0.05));
+			color: var(--nimble-medium-text-color, #666);
+			cursor: pointer;
+			transition: all 0.15s ease;
 
-		:global(.editor-content) {
-			height: 100%;
-			overflow-y: auto;
-			flex: 1;
-			padding-bottom: 1rem !important;
-		}
+			&:hover {
+				background: var(--nimble-button-hover-background, rgba(0, 0, 0, 0.1));
+				color: var(--nimble-dark-text-color, #333);
+				border-color: var(--nimble-border-color-hover, rgba(0, 0, 0, 0.3));
+			}
 
-		:global(.editor-menu) {
-			flex-shrink: 0;
+			i {
+				font-size: 0.875rem;
+			}
+		}
+	}
+
+	.nimble-editor-save-bar {
+		position: absolute;
+		bottom: 0;
+		left: 0;
+		right: 0;
+		display: flex;
+		justify-content: flex-end;
+		padding: 0.5rem;
+		background: linear-gradient(to top, var(--nimble-sheet-background, #f0f0f0) 60%, transparent);
+		z-index: 10;
+
+		--nimble-button-height: 32px;
+		--nimble-button-padding: 2px 8px;
+		--nimble-button-font-size: var(--nimble-sm-text);
+
+		.nimble-button {
+			&:disabled {
+				opacity: 0.6;
+				cursor: not-allowed;
+			}
 		}
 	}
 </style>

--- a/src/view/sheets/components/Editor.svelte
+++ b/src/view/sheets/components/Editor.svelte
@@ -7,6 +7,7 @@
 
 	interface ProseMirrorElement extends HTMLElement {
 		_getValue?(): string;
+		_refresh?(): void;
 		open?(): void;
 		isDirty?(): boolean;
 	}
@@ -111,15 +112,12 @@
 	}
 
 	function saveEditor() {
-		console.log('saveEditor');
 		const proseMirror = containerElem?.querySelector('prose-mirror') as ProseMirrorElement | null;
 		if (!proseMirror) return;
 
 		// Get the current value and save it to the document
 		if (typeof proseMirror._getValue === 'function') {
-			console.log('proseMirror._getValue', proseMirror._getValue);
 			const value = proseMirror._getValue();
-			console.log('value', value);
 			document.update({ [field]: value });
 		}
 
@@ -130,9 +128,8 @@
 		proseMirror.classList.remove('active');
 
 		// Force a re-render by calling _refresh if available
-		if (typeof (proseMirror as any)._refresh === 'function') {
-			console.log('proseMirror._refresh', (proseMirror as any)._refresh);
-			(proseMirror as any)._refresh();
+		if (typeof proseMirror._refresh === 'function') {
+			proseMirror._refresh();
 		}
 	}
 
@@ -163,7 +160,6 @@
 
 		// Listen for save events from ProseMirror and update the document
 		element.addEventListener('save', (event: Event) => {
-			console.log('save event', event);
 			const target = event.target as ProseMirrorElement;
 			if (target?._getValue) {
 				const value = target._getValue();

--- a/src/view/sheets/pages/NPCNotesTab.svelte
+++ b/src/view/sheets/pages/NPCNotesTab.svelte
@@ -23,6 +23,7 @@
 <style lang="scss">
 	:global(.nimble-sheet__body--notes) {
 		height: 100% !important;
+		min-height: 200px;
 		display: block !important;
 		overflow: visible !important;
 	}

--- a/src/view/sheets/pages/PlayerCharacterBioTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterBioTab.svelte
@@ -121,6 +121,7 @@
 	.nimble-notes-section {
 		display: block;
 		height: 100%;
+		min-height: 200px;
 		align-content: flex-start;
 		grid-area: notes;
 


### PR DESCRIPTION
## Summary
- Fix `setContext` calls in sheets and chat cards to run synchronously during component initialization instead of inside `$effect()` blocks, which was causing "Cannot read properties of undefined (reading 'reactive')" errors when opening spell sheets
- Increase PC sheet default height to 850px for better bio tab visibility
- Add min-height to bio tab notes section to prevent collapse when empty
- Blur navigation buttons after click so Escape key closes sheet properly

## Test plan
- [x] Open a PC sheet and verify it renders correctly
- [x] Switch between tabs on the PC sheet
- [x] Press Escape after switching tabs - should close the sheet
- [x] Open the Bio tab and verify the notes editor is visible even when empty
- [x] Click the edit button on a Spell from the PC sheet spells tab - should open the spell sheet without errors
- [x] Test other item sheets (Feature, Object, Class, etc.) open without errors