### PR TITLE
fix: symlink permissions error on windows

### DIFF
--- a/build/worktreeSetup.mjs
+++ b/build/worktreeSetup.mjs
@@ -271,7 +271,7 @@ async function setupSymlink(customPath) {
 
 	// Create the symlink
 	try {
-		fs.symlinkSync(distDir, targetSymlinkPath, 'dir');
+		fs.symlinkSync(distDir, targetSymlinkPath, 'junction');
 		console.log('Symlink created successfully!');
 	} catch (err) {
 		console.error('Failed to create symlink:', err.message);


### PR DESCRIPTION
Fixes issue with symlink on windows requiring admin when using `dir` as type. 

From node `fs.d.ts`
> When using `'junction'`, the `target` argument will automatically be normalized to an absolute path.