### PR TITLE
feat(hooks): add item activation hooks and chat message flags

### DIFF
--- a/src/documents/item/base.svelte.ts
+++ b/src/documents/item/base.svelte.ts
@@ -199,6 +199,14 @@ class NimbleBaseItem<ItemType extends SystemItemTypes = SystemItemTypes> extends
 				style: CONST.CHAT_MESSAGE_STYLES.OTHER,
 				sound: CONFIG.sounds.dice,
 				rolls,
+				flags: {
+					nimble: {
+						itemId: this.id,
+						itemUuid: this.uuid,
+						actorId: this.actor?.id,
+						tokenUuid: this.actor?.token?.uuid,
+					},
+				},
 				system: {
 					actorName: this.actor?.name ?? '',
 					actorType: this.actor?.type ?? '',

--- a/src/documents/item/base.svelte.ts
+++ b/src/documents/item/base.svelte.ts
@@ -166,6 +166,27 @@ class NimbleBaseItem<ItemType extends SystemItemTypes = SystemItemTypes> extends
 		}
 		const { isCritical, isMiss } = rolls.find((roll) => roll instanceof DamageRoll) ?? {};
 
+		/**
+		 * A hook event that fires before an item is used.
+		 * @function nimble.preUseItem
+		 * @memberof hookEvents
+		 * @param {Item} item           The item being used
+		 * @param {Object} context       Additional context about the item use
+		 * @param {Roll[]} context.rolls The rolls associated with the item use
+		 * @param {boolean} [context.isCritical] Whether the item use resulted in a critical hit
+		 * @param {boolean} [context.isMiss] Whether the item use resulted in a miss
+		 * @param {Token[]} context.targets The targets of the item use
+		 * @returns {boolean}  Explicitly return `false` to prevent the item from being used.
+		 */
+		// @ts-expect-error - nimble.preUseItem is a custom hook
+		const allowed = Hooks.call('nimble.preUseItem', this, {
+			rolls,
+			isCritical,
+			isMiss,
+			targets: Array.from(game.user?.targets ?? []),
+		});
+		if (!allowed) return null;
+
 		// Only allow hiding rolls for GM users rolling for non-PC actors
 		const canHideRoll = game.user?.isGM && this.actor?.type !== 'character';
 		const shouldHide = rollHidden && canHideRoll;
@@ -201,6 +222,29 @@ class NimbleBaseItem<ItemType extends SystemItemTypes = SystemItemTypes> extends
 		}
 
 		const chatCard = await ChatMessage.create(chatData as unknown as ChatMessage.CreateData);
+
+		if (chatCard) {
+			/**
+			 * A hook event that fires after an item has been used.
+			 * @function nimble.useItem
+			 * @memberof hookEvents
+			 * @param {Item} item                The item that was used
+			 * @param {ChatMessage} chatMessage   The chat message created by the item use
+			 * @param {Object} context            Additional context about the item use
+			 * @param {Roll[]} context.rolls      The rolls associated with the item use
+			 * @param {boolean} [context.isCritical] Whether the item use resulted in a critical hit
+			 * @param {boolean} [context.isMiss]  Whether the item use resulted in a miss
+			 * @param {Token[]} context.targets   The targets of the item use
+			 */
+			// @ts-expect-error - nimble.useItem is custom
+			Hooks.callAll('nimble.useItem', this, chatCard, {
+				rolls,
+				isCritical,
+				isMiss,
+				targets: Array.from(game.user?.targets ?? []),
+			});
+		}
+
 		return chatCard ?? null;
 	}
 

--- a/src/documents/item/spell.ts
+++ b/src/documents/item/spell.ts
@@ -35,6 +35,30 @@ export class NimbleSpellItem extends NimbleBaseItem {
 			return null;
 		}
 
+		const { isCritical, isMiss } = rolls.find((roll) => roll instanceof DamageRoll) ?? {};
+
+		/**
+		 * A hook event that fires before an item is used.
+		 * @function nimble.preUseItem
+		 * @memberof hookEvents
+		 * @param {Item} item           The item being used
+		 * @param {Object} context       Additional context about the item use
+		 * @param {Roll[]} context.rolls The rolls associated with the item use
+		 * @param {boolean} [context.isCritical] Whether the item use resulted in a critical hit
+		 * @param {boolean} [context.isMiss] Whether the item use resulted in a miss
+		 * @param {Token[]} context.targets The targets of the item use
+		 * @returns {boolean}  Explicitly return `false` to prevent the item from being used.
+		 */
+		// @ts-expect-error - nimble.preUseItem is a custom hook
+		const allowed = Hooks.call('nimble.preUseItem', this, {
+			rolls,
+			isCritical,
+			isMiss,
+			targets: Array.from(game.user?.targets ?? []),
+			upcast: manager.upcastResult,
+		});
+		if (!allowed) return null;
+
 		// Deduct mana for tiered spells (cantrips are free)
 		if (this.system.tier > 0 && this.actor) {
 			// Use upcast amount if available, otherwise use base tier cost
@@ -44,8 +68,6 @@ export class NimbleSpellItem extends NimbleBaseItem {
 				'system.resources.mana.current': Math.max(0, currentMana - manaSpent),
 			} as any);
 		}
-
-		const { isCritical, isMiss } = rolls.find((roll) => roll instanceof DamageRoll) ?? {};
 
 		// Only allow hiding rolls for GM users rolling for non-PC actors
 		const canHideRoll = game.user?.isGM && this.actor?.type !== 'character';
@@ -84,6 +106,29 @@ export class NimbleSpellItem extends NimbleBaseItem {
 		}
 
 		const chatCard = await ChatMessage.create(chatData as unknown as ChatMessage.CreateData);
+
+		if (chatCard) {
+			/**
+			 * A hook event that fires after an item has been used.
+			 * @function nimble.useItem
+			 * @memberof hookEvents
+			 * @param {Item} item                The item that was used
+			 * @param {ChatMessage} chatMessage   The chat message created by the item use
+			 * @param {Object} context            Additional context about the item use
+			 * @param {Roll[]} context.rolls      The rolls associated with the item use
+			 * @param {boolean} [context.isCritical] Whether the item use resulted in a critical hit
+			 * @param {boolean} [context.isMiss]  Whether the item use resulted in a miss
+			 * @param {Token[]} context.targets   The targets of the item use
+			 */
+			Hooks.callAll('nimble.useItem' as any, this, chatCard, {
+				rolls,
+				isCritical,
+				isMiss,
+				targets: Array.from(game.user?.targets ?? []),
+				upcast: manager.upcastResult,
+			});
+		}
+
 		return chatCard || null;
 	}
 

--- a/src/documents/item/spell.ts
+++ b/src/documents/item/spell.ts
@@ -81,6 +81,14 @@ export class NimbleSpellItem extends NimbleBaseItem {
 				style: CONST.CHAT_MESSAGE_STYLES.OTHER,
 				sound: CONFIG.sounds.dice,
 				rolls,
+				flags: {
+					nimble: {
+						itemId: this.id,
+						itemUuid: this.uuid,
+						actorId: this.actor?.id,
+						tokenUuid: this.actor?.token?.uuid,
+					},
+				},
 				system: {
 					actorName: this.actor?.name ?? '',
 					actorType: this.actor?.type ?? '',


### PR DESCRIPTION
## Hooks
Exposes two new system hooks on the item activation pipeline:

- `nimble.preUseItem`: Fires before an item is used (after rolls are resolved, before chat message creation and mana deduction). Listeners can return false to cancel the activation.
- `nimble.useItem`: Fires after an item has been used and the chat message has been created. Non-cancellable.
Both hooks provide the item, rolls, critical/miss state, and current targets. The spell override additionally includes upcast data.

## Chat message flags
Item activation chat messages now include flags.nimble with itemId, itemUuid, actorId, and tokenUuid. This enables modules like [AutomatedAnimations](https://github.com/theripper93/autoanimations) to discover the source item/token/actor from chat messages using their [generic system handler](https://github.com/theripper93/autoanimations/blob/main/src/system-support/aa-chatmessage.js).

Closes #353, #347 

## Note
This should give basic access for most modules, if there are more hooks that need to be added we will have to take those case by case, unless anyone knows of more hooks that we need to expose.