### PR TITLE
fix: only show red dice in chat card for hit/miss primary die

### DIFF
--- a/src/dice/DamageRoll.ts
+++ b/src/dice/DamageRoll.ts
@@ -145,6 +145,7 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 						number: 1,
 						faces: firstDieTerm.faces ?? 6,
 						modifiers: [],
+						options: { flavor: 'Primary Die' },
 					});
 
 					// Add rollMode

--- a/src/view/dataPreparationHelpers/rollTooltips/prepareRollTooltipDiceResults.ts
+++ b/src/view/dataPreparationHelpers/rollTooltips/prepareRollTooltipDiceResults.ts
@@ -1,9 +1,11 @@
-export default function prepareRollTooltipDiceResults({ faces, results }) {
+export default function prepareRollTooltipDiceResults({ faces, results, options }) {
+	const isHitMissDie = options?.flavor === 'Primary Die';
+
 	return results.reduce((acc, { rerolled, discarded, result }) => {
 		const isCritical = (faces === 20 && result === 20) || result === faces;
 
 		const isDiscarded = discarded || rerolled;
-		const isFumble = result === 1;
+		const isFumble = isHitMissDie && result === 1;
 
 		let classes = `nimble-die nimble-die--${faces}`;
 


### PR DESCRIPTION
## Summary
- Only dice with the 'Primary Die' flavor now show red styling when rolling a 1
- Regular damage dice, healing dice, skill check dice, and other rolls no longer incorrectly display red highlighting
- Added missing flavor to PrimaryDie in DamageRoll.ts for consistent identification

Closes #364

## Test plan
- [ ] Roll a damage attack that misses (primary die shows 1) - verify the primary die is red
- [ ] Roll damage where a secondary damage die shows 1 - verify it is NOT red
- [ ] Roll a skill check where the die shows 1 - verify it is NOT red
- [ ] Roll a saving throw where the die shows 1 - verify it is NOT red