### PR TITLE
fix: prevent elf initiative roll mode from accumulating

### DIFF
--- a/src/documents/actor/character.ts
+++ b/src/documents/actor/character.ts
@@ -202,7 +202,9 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 		});
 
 		// Prepare Initiative Data
-		// TODO: Add logic to account for initiative bonuses
+		// Reset defaultRollMode to 0 before rules apply their modifiers
+		// This prevents accumulation when rules use 'adjust' mode
+		actorData.attributes.initiative.defaultRollMode = 0;
 		actorData.attributes.initiative.mod = actorData.abilities.dexterity.mod;
 
 		// Prepare Class Data


### PR DESCRIPTION
## Summary
- Reset `defaultRollMode` to 0 during data preparation to prevent the `initiativeRollMode` rule from accumulating values across save/reload cycles when using 'adjust' mode

## Root Cause
The elf ancestry's `initiativeRollMode` rule uses `"mode": "adjust"` which adds to the current `defaultRollMode` value. Since this value wasn't being reset during data preparation, it would accumulate each time the character was saved/reloaded, causing the initiative formula to use progressively more dice (e.g., 3d20kh instead of the correct 2d20kh for advantage).

## Test plan
- [ ] Create an elf character
- [ ] Roll initiative and verify it rolls 2d20kh (advantage)
- [ ] Save the character and reload
- [ ] Roll initiative again and verify it still rolls 2d20kh (not 3d20kh or more)

Fixes #363