### PR TITLE
fix: journal Source HTML not displaying and Save button inaccessible

### DIFF
--- a/src/scss/vendor/foundry/_editor.scss
+++ b/src/scss/vendor/foundry/_editor.scss
@@ -19,4 +19,60 @@
       padding-bottom: 1rem !important;
     }
   }
+
+  // Source HTML textarea styling
+  textarea {
+    width: 100%;
+    height: 100%;
+    min-height: 200px;
+    padding: 0.5rem;
+    font-family: var(--nimble-mono-font);
+    font-size: var(--nimble-sm-text);
+    color: var(--nimble-code-editor-text-color);
+    background: var(--nimble-code-editor-background-color);
+    border: 1px solid var(--nimble-input-border-color);
+    border-radius: 3px;
+    resize: vertical;
+    box-sizing: border-box;
+  }
+}
+
+// Journal entry page sheet layout fix to prevent editor overlapping Save button
+.system-nimble {
+  .journal-entry-page.text {
+    prose-mirror {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      min-height: 0;
+      overflow: hidden;
+
+      .editor-container {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+        overflow: hidden;
+      }
+
+      .editor-content {
+        flex: 1;
+        overflow-y: auto;
+      }
+
+      textarea {
+        flex: 1;
+        min-height: 0;
+        resize: none;
+      }
+    }
+
+    // Ensure the page footer with Save button remains accessible
+    .page-footer,
+    .sheet-footer {
+      flex-shrink: 0;
+      margin-top: auto;
+      padding: 0.5rem;
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- Add proper styling for ProseMirror editor source mode textarea to make HTML content visible with appropriate colors and fonts
- Fix journal entry page layout to use flex-based constraints preventing the editor from overlapping the Save Entry button footer

## Test plan
- [x] Open a journal entry in Foundry VTT
- [x] Click "Source HTML" button in the editor toolbar
- [x] Verify the HTML content is now visible with proper styling (dark background, light text, monospace font)
- [x] Verify the Save Entry button at the bottom remains accessible and not overlapped by the editor

Fixes #378