### PR TITLE
Spell Compendium Sort fix 

### DIFF
--- a/src/hooks/compendiumSpellsFilter.test.ts
+++ b/src/hooks/compendiumSpellsFilter.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { mapTierForCompendiumDisplay } from './compendiumSpellsFilter.js';
+
+describe('mapTierForCompendiumDisplay', () => {
+	it('maps utility spells to display tier 0', () => {
+		expect(mapTierForCompendiumDisplay(0, ['utilitySpell'])).toBe(0);
+		expect(mapTierForCompendiumDisplay(5, ['range', 'utilitySpell'])).toBe(0);
+	});
+
+	it('maps cantrips (raw tier 0) to display tier 1', () => {
+		expect(mapTierForCompendiumDisplay(0, ['range'])).toBe(1);
+	});
+
+	it('maps tiered spells one level higher for display', () => {
+		expect(mapTierForCompendiumDisplay(1, ['range'])).toBe(2);
+		expect(mapTierForCompendiumDisplay(2, ['concentration'])).toBe(3);
+		expect(mapTierForCompendiumDisplay(9, ['reach'])).toBe(10);
+	});
+
+	it('handles tier values provided as strings from index data', () => {
+		expect(mapTierForCompendiumDisplay('0', ['range'])).toBe(1);
+		expect(mapTierForCompendiumDisplay('3', ['range'])).toBe(4);
+	});
+
+	it('falls back to cantrip display tier for invalid non-utility values', () => {
+		expect(mapTierForCompendiumDisplay(undefined, ['range'])).toBe(1);
+		expect(mapTierForCompendiumDisplay('not-a-number', ['range'])).toBe(1);
+	});
+});

--- a/src/hooks/compendiumSpellsFilter.ts
+++ b/src/hooks/compendiumSpellsFilter.ts
@@ -332,7 +332,10 @@ const SCHOOL_TIER_COLORS: { [key: string]: string } = {
 	wind: '#FFFFFF', // white
 };
 
-function mapTierForCompendiumDisplay(tierValue: unknown, propertiesSelected: unknown): number {
+export function mapTierForCompendiumDisplay(
+	tierValue: unknown,
+	propertiesSelected: unknown,
+): number {
 	const parsedTier =
 		typeof tierValue === 'number' ? tierValue : Number.parseInt(String(tierValue ?? 0), 10) || 0;
 	const isUtilitySpell =

--- a/src/view/chat/components/HealingNode.svelte
+++ b/src/view/chat/components/HealingNode.svelte
@@ -30,7 +30,6 @@
 	let hasTargets = $derived((systemData.targets?.length ?? 0) > 0);
 
 	// Permission check - only GM or the message author can interact with healing buttons
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars -- used in template
 	let canInteract = $derived(game.user?.isGM || messageDocument.author?.id === game.user?.id);
 
 	// Localization


### PR DESCRIPTION
Implemented with a low-complexity, single-file patch.

-   Added mapTierForCompendiumDisplay() to enforce:
    -   utilitySpell -> 0
    -   non-utility spells -> system.tier + 1
-   Updated both normalization branches to use that helper, so sorting headers and tier badges now align with 0=Utility, 1=Cantrip, 2=Tier 1, ....



<img width="369" height="783" alt="Screenshot 2026-03-02 230742" src="https://github.com/user-attachments/assets/2eb0096c-d406-4d65-b94a-a710e836bf02" />

