### PR TITLE
fix: svelte preprocess part of approved builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,8 @@
 			"@evilmartians/lefthook",
 			"@parcel/watcher",
 			"classic-level",
-			"esbuild"
+			"esbuild",
+			"svelte-preprocess"
 		]
 	},
 	"devDependencies": {


### PR DESCRIPTION
Svelte has a pre-install script that needs to be run when you "pnpm install". This PR adds Svelte pre-processor to the approved pre-install scripts