### PR TITLE
fix: enable editing saves on NPC monster sheets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,17 +9,20 @@
 ### Development Setup
 
 1. **Clone the repository:**
+
    ```bash
    git clone https://github.com/Nimble-Co/FoundryVTT-Nimble.git
    cd FoundryVTT-Nimble
    ```
 
 2. **Install dependencies:**
+
    ```bash
    pnpm install
    ```
 
 3. **Start the development server:**
+
    ```bash
    pnpm dev
    ```
@@ -92,7 +95,7 @@ FoundryVTT-Nimble/
 
 ### Development Tools
 
-- **[`package.json`](package.json)** - Project dependencies and npm scripts
+- **[`package.json`](package.json)** - Project dependencies and pnpm scripts
 - **[`compendia.mjs`](compendia.mjs)** - Script for building game content compendia
 
 ## 🏗️ Architecture

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -27,7 +27,7 @@ pre-push:
       exclude: "packs/**"
       run: npx @biomejs/biome check --no-errors-on-unmatched --error-on-warnings --files-ignore-unknown=true {push_files} 2>&1 | sed -E 's/\x1b\[[0-9;]*[a-zA-Z]//g; s/\x1b\]11;rgb:[^;]*;[^R]*R//g'
     typecheck:
-      run: npm run type-check 2>&1 | sed -E 's/\x1b\[[0-9;]*[a-zA-Z]//g; s/\x1b\]11;rgb:[^;]*;[^R]*R//g'
+      run: pnpm run type-check 2>&1 | sed -E 's/\x1b\[[0-9;]*[a-zA-Z]//g; s/\x1b\]11;rgb:[^;]*;[^R]*R//g'
     tests:
       glob: "*.{js,ts,mjs,mts,svelte}"
-      run: npm run test 2>&1 | sed -E 's/\x1b\[[0-9;]*[a-zA-Z]//g; s/\x1b\]11;rgb:[^;]*;[^R]*R//g'
+      run: pnpm run test 2>&1 | sed -E 's/\x1b\[[0-9;]*[a-zA-Z]//g; s/\x1b\]11;rgb:[^;]*;[^R]*R//g'

--- a/src/view/dialogs/NPCMetaConfigDialog.svelte
+++ b/src/view/dialogs/NPCMetaConfigDialog.svelte
@@ -57,7 +57,7 @@
 		</label>
 	{/if}
 
-	<MovementSpeed {actor} showDefaultSpeed={true} />
+	<MovementSpeed {actor} showDefaultSpeed editingEnabled />
 </section>
 
 <style>

--- a/src/view/sheets/components/MovementSpeed.svelte
+++ b/src/view/sheets/components/MovementSpeed.svelte
@@ -3,9 +3,10 @@
 
 	const { movementTypes, movementTypeIcons } = CONFIG.NIMBLE;
 
-	let { actor, showDefaultSpeed = false } = $props();
+	let { actor, showDefaultSpeed = false, editingEnabled: editingEnabledProp } = $props();
 	let flags = $derived(actor?.reactive.flags.nimble);
-	let editingEnabled = $derived(flags?.editingEnabled ?? false);
+	let editingEnabledFromFlags = $derived(flags?.editingEnabled ?? false);
+	let editingEnabled = $derived(editingEnabledProp ?? editingEnabledFromFlags);
 
 	// Access the full reactive movement object to ensure proper reactivity tracking
 	let movement = $derived(actor.reactive.system.attributes.movement);

--- a/src/view/sheets/components/SavingThrows.svelte
+++ b/src/view/sheets/components/SavingThrows.svelte
@@ -11,12 +11,13 @@
 		);
 	}
 
-	let { characterSavingThrows } = $props();
+	let { characterSavingThrows, editingEnabled: editingEnabledProp } = $props();
 
 	const { saves, savingThrows, savingThrowAbbreviations } = CONFIG.NIMBLE;
 	const actor = getContext('actor');
 	let flags = $derived(actor.reactive.flags.nimble);
-	let editingEnabled = $derived(flags?.editingEnabled ?? false);
+	let editingEnabledFromFlags = $derived(flags?.editingEnabled ?? false);
+	let editingEnabled = $derived(editingEnabledProp ?? editingEnabledFromFlags);
 </script>
 
 {#snippet savingThrowSnippet(saveKey, save)}

--- a/src/view/sheets/pages/NPCCoreTab.svelte
+++ b/src/view/sheets/pages/NPCCoreTab.svelte
@@ -442,7 +442,7 @@
 
 <section class="nimble-sheet__body nimble-sheet__body--npc">
 	<section class="nimble-monster-sheet-section nimble-monster-sheet-section--defenses">
-		<SavingThrows characterSavingThrows={actor.reactive.system.savingThrows} />
+		<SavingThrows characterSavingThrows={actor.reactive.system.savingThrows} editingEnabled />
 
 		<MovementSpeed {actor} showDefaultSpeed={false} />
 


### PR DESCRIPTION
## Summary
- Add `editingEnabled` prop to `SavingThrows` component, mirroring the pattern used in the movement speed fix (#397)
- Pass `editingEnabled` to `SavingThrows` in `NPCCoreTab` so the saves config button is visible and functional

## Test plan
- [ ] Open an NPC/monster sheet
- [ ] Verify the saves edit button (pencil icon) is visible next to the saves header
- [ ] Click the edit button and confirm the saving throw config dialog opens