### PR TITLE
fix: add grid-area styles to inventory and features delete buttons

### DIFF
--- a/src/view/sheets/pages/PlayerCharacterFeaturesTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterFeaturesTab.svelte
@@ -212,6 +212,7 @@
 
 							<button
 								class="nimble-button"
+								style="grid-area: configureButton"
 								data-button-variant="icon"
 								type="button"
 								aria-label="Configure {item.reactive.name}"
@@ -222,6 +223,7 @@
 
 							<button
 								class="nimble-button"
+								style="grid-area: deleteButton"
 								data-button-variant="icon"
 								type="button"
 								aria-label="Delete {item.reactive.name}"
@@ -266,6 +268,7 @@
 
 									<button
 										class="nimble-button"
+										style="grid-area: configureButton"
 										data-button-variant="icon"
 										type="button"
 										aria-label="Configure {subclass.reactive.name}"
@@ -276,6 +279,7 @@
 
 									<button
 										class="nimble-button"
+										style="grid-area: deleteButton"
 										data-button-variant="icon"
 										type="button"
 										aria-label="Delete {subclass.reactive.name}"

--- a/src/view/sheets/pages/PlayerCharacterInventoryTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterInventoryTab.svelte
@@ -261,6 +261,7 @@
 
 							<button
 								class="nimble-button"
+								style="grid-area: configureButton"
 								data-button-variant="icon"
 								type="button"
 								aria-label="Configure {item.name}"
@@ -271,6 +272,7 @@
 
 							<button
 								class="nimble-button"
+								style="grid-area: deleteButton"
 								data-button-variant="icon"
 								type="button"
 								aria-label="Delete {item.name}"


### PR DESCRIPTION
## Summary
- Fixes unresponsive delete buttons in inventory and features tabs
- Buttons lacked explicit `grid-area` CSS assignments, causing auto-placement to put them in unexpected positions
- Added `style="grid-area: configureButton"` and `style="grid-area: deleteButton"` to match the working pattern in PlayerCharacterSpellsTab

## Test plan
- [ ] Open a character sheet
- [ ] Go to Inventory tab and verify delete buttons work for items
- [ ] Go to Features tab and verify delete buttons work for features and subclasses
- [ ] Verify quantity input fields are editable (for non-slot-type items without armor rules)