### PR TITLE
chore: add JSDoc documentation to dice roll attack functions

### DIFF
--- a/src/dice/DamageRoll.ts
+++ b/src/dice/DamageRoll.ts
@@ -6,16 +6,26 @@ import { PrimaryDie } from './terms/PrimaryDie.js';
 const Terms = foundry.dice.terms;
 
 declare namespace DamageRoll {
+	/** Roll data for damage rolls. */
 	interface Data extends Record<string, number | string | boolean | object | null> {}
 
+	/** Configuration options for damage rolls. */
 	interface Options extends foundry.dice.Roll.Options {
+		/** Whether this roll can score a critical hit (exploding die). */
 		canCrit: boolean;
+		/** Whether this roll can miss (rolling a 1 on the primary die). */
 		canMiss: boolean;
+		/** The minimum roll value needed to score a critical hit. */
 		criticalThreshold?: number;
+		/** The damage type for this roll (e.g., "fire", "slashing"). */
 		damageType?: string;
+		/** The maximum roll value that counts as a fumble/miss. */
 		fumbleThreshold?: number;
+		/** The roll mode: positive for advantage, negative for disadvantage, 0 for normal. */
 		rollMode: number;
+		/** A predetermined value for the primary die result. */
 		primaryDieValue: number;
+		/** A modifier to add to the primary die result. */
 		primaryDieModifier: number;
 		/**
 		 * Whether the primary die's base result contributes to damage.
@@ -26,6 +36,7 @@ declare namespace DamageRoll {
 		primaryDieAsDamage?: boolean;
 	}
 
+	/** Data structure for serializing/deserializing a DamageRoll. */
 	interface SerializedData {
 		formula: string;
 		terms?: foundry.dice.Roll.Data['terms'] | foundry.dice.terms.RollTerm[] | object[];
@@ -46,6 +57,10 @@ declare namespace DamageRoll {
 		excludedPrimaryDieValue?: number;
 	}
 
+	/**
+	 * Represents an evaluated DamageRoll with guaranteed total value.
+	 * @template T - The DamageRoll type being evaluated.
+	 */
 	type Evaluated<T extends DamageRoll> = T & {
 		_evaluated: true;
 		_total: number;
@@ -53,15 +68,42 @@ declare namespace DamageRoll {
 	};
 }
 
+/**
+ * A specialized roll class for handling damage calculations in the Nimble system.
+ *
+ * DamageRoll extends Foundry's Roll class with support for:
+ * - Critical hit detection via exploding primary dice
+ * - Miss detection when rolling a 1 on the primary die
+ * - Advantage/disadvantage on damage (roll multiple primary dice, keep highest/lowest)
+ * - Automatic separation and tracking of the "primary die" from the formula
+ *
+ * The primary die is the first die term in the formula and determines critical/miss status.
+ * When the primary die explodes (rolls max value), the roll is a critical hit.
+ * When the primary die rolls a 1, the roll is a miss.
+ *
+ * @extends {foundry.dice.Roll<DamageRoll.Data>}
+ *
+ * @example
+ * ```typescript
+ * const roll = new DamageRoll("2d6+3", actorData, { canCrit: true, canMiss: true, rollMode: 0 });
+ * await roll.evaluate();
+ * if (roll.isCritical) console.log("Critical hit!");
+ * if (roll.isMiss) console.log("Miss!");
+ * ```
+ */
 class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 	declare options: DamageRoll.Options;
 
+	/** Whether this roll resulted in a critical hit. Undefined until evaluated. */
 	isCritical: undefined | boolean = undefined;
 
+	/** Whether this roll resulted in a miss. Undefined until evaluated. */
 	isMiss: undefined | boolean = undefined;
 
+	/** The original formula before preprocessing (e.g., before primary die extraction). */
 	originalFormula: string;
 
+	/** The primary die term used for critical/miss detection. */
 	primaryDie: PrimaryDie | undefined = undefined;
 
 	override _formula: string = '';
@@ -72,6 +114,13 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 	 */
 	excludedPrimaryDieValue: number = 0;
 
+	/*
+	 * Creates a new DamageRoll instance.
+	 *
+	 * @param formula - The dice formula for the damage roll (e.g., "2d6+3").
+	 * @param data - Roll data containing actor/item attributes for formula resolution.
+	 * @param options - Configuration options including critical/miss settings and roll mode.
+	 */
 	constructor(formula: string, data: DamageRoll.Data = {}, options?: DamageRoll.Options) {
 		super(formula, data, options);
 
@@ -96,6 +145,19 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 	/** ------------------------------------------------------ */
 	/**                  Data Prep Helpers                     */
 	/** ------------------------------------------------------ */
+
+	/**
+	 * Preprocesses the roll formula to extract and configure the primary die.
+	 *
+	 * This method separates the first die term from the formula as the "primary die",
+	 * which is used for critical hit and miss detection. The primary die is configured with:
+	 * - Explosion modifier ('x') for critical detection if canCrit is true
+	 * - Keep highest ('kh') or keep lowest ('kl') modifiers based on rollMode
+	 *
+	 * @param _formula - The original dice formula (unused, kept for signature compatibility).
+	 * @param _data - Roll data (unused, kept for signature compatibility).
+	 * @param options - Roll options containing canCrit, canMiss, and rollMode settings.
+	 */
 	_preProcessFormula(_formula: string, _data: DamageRoll.Data, options: DamageRoll.Options) {
 		// Separate out the primary die
 		if (options.canCrit || options.canMiss) {
@@ -211,6 +273,15 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 	/** ------------------------------------------------------ */
 	/**                       Helpers                          */
 	/** ------------------------------------------------------ */
+
+	/**
+	 * Updates the face count of the primary die term.
+	 *
+	 * Use this method to change the primary die size after roll creation
+	 * (e.g., when a feature modifies the damage die).
+	 *
+	 * @param dieSize - The new number of faces for the primary die (e.g., 8 for a d8).
+	 */
 	updatePrimaryTerm(dieSize: number) {
 		if (!this.primaryDie) return;
 
@@ -228,6 +299,17 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 	/** ------------------------------------------------------ */
 	/**                       Overrides                        */
 	/** ------------------------------------------------------ */
+
+	/**
+	 * Evaluates the roll and determines critical/miss status.
+	 *
+	 * After evaluation, checks the primary die's results to determine:
+	 * - `isCritical`: true if the primary die exploded (rolled max value)
+	 * - `isMiss`: true if the primary die rolled a 1
+	 *
+	 * @param options - Evaluation options passed to the parent Roll class.
+	 * @returns The evaluated roll with isCritical and isMiss populated.
+	 */
 	override async _evaluate(
 		options?: InexactPartial<foundry.dice.Roll.Options>,
 	): Promise<DamageRoll.Evaluated<this>> {
@@ -257,6 +339,13 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 		return this as DamageRoll.Evaluated<this>;
 	}
 
+	/**
+	 * Serializes the roll to a JSON-compatible object for storage or transmission.
+	 *
+	 * Includes all DamageRoll-specific properties: originalFormula, isMiss, and isCritical.
+	 *
+	 * @returns The serialized roll data.
+	 */
 	override toJSON() {
 		return {
 			...super.toJSON(),
@@ -271,18 +360,37 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 	/** ------------------------------------------------------ */
 	/**                    Static Methods                      */
 	/** ------------------------------------------------------ */
+
+	/**
+	 * Type guard to check if terms array contains RollTerm instances.
+	 *
+	 * @param terms - The terms array to check.
+	 * @returns True if all items in the array are RollTerm instances.
+	 */
 	private static _isRollTermArray(
 		terms: DamageRoll.SerializedData['terms'],
 	): terms is foundry.dice.terms.RollTerm[] {
 		return Array.isArray(terms) && terms.every((t) => t instanceof foundry.dice.terms.RollTerm);
 	}
 
+	/**
+	 * Sets the internal evaluated state of a roll.
+	 *
+	 * @param roll - The DamageRoll to mark as evaluated.
+	 * @param total - The total value to set.
+	 */
 	private static _setEvaluatedState(roll: DamageRoll, total: number): void {
 		const internals = roll as object as { _evaluated: boolean; _total: number };
 		internals._evaluated = true;
 		internals._total = total;
 	}
 
+	/**
+	 * Creates a base Roll from serialized data for reconstruction.
+	 *
+	 * @param data - The serialized roll data.
+	 * @returns A base Roll instance with reconstructed terms.
+	 */
 	private static _baseRollFromSerializedData(data: DamageRoll.SerializedData): Roll<AnyObject> {
 		// Temporarily remove the class property to avoid infinite recursion
 		// when calling the parent's fromData method
@@ -294,12 +402,31 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 		return foundry.dice.Roll.fromData(dataWithoutClass as object as foundry.dice.Roll.Data);
 	}
 
+	/**
+	 * Converts a standard Foundry Roll into a DamageRoll instance.
+	 *
+	 * @param roll - The Roll instance to convert.
+	 * @returns A new DamageRoll with the same formula, data, options, and evaluated state.
+	 */
 	static fromRoll(roll) {
 		const newRoll = new DamageRoll(roll.formula, roll.data, roll.options);
 		Object.assign(newRoll, roll);
 		return newRoll;
 	}
 
+	/**
+	 * Reconstructs a DamageRoll from serialized data.
+	 *
+	 * This method properly restores all DamageRoll-specific state including:
+	 * - The primary die term
+	 * - Critical and miss status
+	 * - Original formula
+	 * - Evaluated state
+	 *
+	 * @template T - The Roll constructor type.
+	 * @param data - The serialized roll data from `toJSON()`.
+	 * @returns A fully reconstructed DamageRoll instance.
+	 */
 	static override fromData<T extends foundry.dice.Roll.AnyConstructor>(
 		this: T,
 		data: DamageRoll.SerializedData,

--- a/src/dice/DicePool.ts
+++ b/src/dice/DicePool.ts
@@ -1,12 +1,19 @@
 declare namespace NimbleDicePool {
+	/** Roll data for dice pools. */
 	interface Data extends foundry.dice.Roll.Data {
 		[key: string]: unknown;
 	}
 
+	/** Configuration options for dice pools. */
 	interface Options extends foundry.dice.Roll.Options {
+		/** A descriptive label for the dice pool. */
 		label: string;
 	}
 
+	/**
+	 * Represents an evaluated NimbleDicePool with guaranteed total value.
+	 * @template T - The NimbleDicePool type being evaluated.
+	 */
 	type Evaluated<T extends NimbleDicePool> = T & {
 		_evaluated: true;
 		_total: number;
@@ -14,15 +21,46 @@ declare namespace NimbleDicePool {
 	};
 }
 
+/**
+ * A dice pool manager that allows dynamic manipulation of dice before rolling.
+ *
+ * NimbleDicePool extends Foundry's Roll class to provide:
+ * - Tracking of dice counts by face value (e.g., how many d6s, d8s, etc.)
+ * - Dynamic addition and removal of dice from the pool
+ * - Reset functionality to restore the pool to its original state
+ *
+ * This is useful for systems that allow players to build up dice pools
+ * before making a roll, such as adding bonus dice from abilities.
+ *
+ * @extends {foundry.dice.Roll<NimbleDicePool.Data>}
+ *
+ * @example
+ * ```typescript
+ * const pool = new NimbleDicePool("2d6+1d8", {}, { label: "Damage Pool" });
+ * pool.addDieToPool(6, 1);  // Add another d6
+ * pool.removeDieFromPool(8, 1);  // Remove the d8
+ * await pool.evaluate();
+ * ```
+ */
 class NimbleDicePool extends foundry.dice.Roll<NimbleDicePool.Data> {
 	declare options: NimbleDicePool.Options;
 
+	/** Map of die face counts to number of dice (e.g., 6 -> 2 means 2d6). */
 	dieSizes: Map<number, number>;
 
+	/** Total number of dice currently in the pool. */
 	numDice = 0;
 
+	/** The original formula before any modifications. */
 	originalFormula: string;
 
+	/**
+	 * Creates a new NimbleDicePool instance.
+	 *
+	 * @param formula - The initial dice formula (e.g., "2d6+1d8").
+	 * @param data - Roll data for formula variable resolution.
+	 * @param options - Configuration options including the pool label.
+	 */
 	constructor(
 		formula: string,
 		data: NimbleDicePool.Data = {} as NimbleDicePool.Data,
@@ -49,18 +87,40 @@ class NimbleDicePool extends foundry.dice.Roll<NimbleDicePool.Data> {
 		});
 	}
 
+	/**
+	 * Gets the descriptive label for this dice pool.
+	 * @returns The label configured in options.
+	 */
 	get label(): string {
 		return this.options.label;
 	}
 
+	/**
+	 * Gets the largest die size in the pool.
+	 * @returns The maximum face count among all dice in the pool.
+	 */
 	get largestDie(): number {
 		return Math.max(...Array.from(this.dieSizes.keys()));
 	}
 
+	/**
+	 * Gets the smallest die size in the pool.
+	 * @returns The minimum face count among all dice in the pool.
+	 */
 	get smallestDie(): number {
 		return Math.min(...Array.from(this.dieSizes.keys()));
 	}
 
+	/**
+	 * Adds dice to the pool.
+	 *
+	 * If dice of the specified size already exist in the pool, increments their count.
+	 * Otherwise, creates a new die term with the specified size.
+	 *
+	 * @param dieSize - The face count of the die to add (e.g., 6 for a d6).
+	 * @param value - The number of dice to add.
+	 * @returns The updated roll formula after adding the dice.
+	 */
 	addDieToPool(dieSize: number, value: number) {
 		if (this.dieSizes.has(dieSize)) {
 			const term = this.terms.find(
@@ -93,6 +153,16 @@ class NimbleDicePool extends foundry.dice.Roll<NimbleDicePool.Data> {
 		return this.formula;
 	}
 
+	/**
+	 * Removes dice from the pool.
+	 *
+	 * If removing would reduce the count to zero or below, removes the die term entirely.
+	 * Shows an error notification if the requested die size doesn't exist in the pool.
+	 *
+	 * @param dieSize - The face count of the die to remove (e.g., 6 for a d6).
+	 * @param value - The number of dice to remove.
+	 * @returns The updated roll formula after removing the dice.
+	 */
 	removeDieFromPool(dieSize: number, value: number) {
 		if (!this.dieSizes.has(dieSize)) {
 			ui.notifications?.error(`No d${dieSize} in roll ${this.formula}`);
@@ -120,6 +190,12 @@ class NimbleDicePool extends foundry.dice.Roll<NimbleDicePool.Data> {
 		return this.formula;
 	}
 
+	/**
+	 * Resets the dice pool to its original state.
+	 *
+	 * Recreates the pool from the original formula, discarding any
+	 * dice that were added or removed since construction.
+	 */
 	resetPool() {
 		const clean = new NimbleDicePool(this.originalFormula, this.data, this.options);
 		this.terms = clean.terms;
@@ -128,6 +204,11 @@ class NimbleDicePool extends foundry.dice.Roll<NimbleDicePool.Data> {
 		this.resetFormula();
 	}
 
+	/**
+	 * Rolls dice from the pool.
+	 *
+	 * @todo Support multiple die sizes - currently not implemented.
+	 */
 	rollFromPool() {
 		// TODO: Support multiple die sizes
 	}

--- a/src/dice/NimbleRoll.ts
+++ b/src/dice/NimbleRoll.ts
@@ -1,13 +1,23 @@
 import type { NimbleRollData } from '#types/rollData.d.ts';
 
 declare namespace NimbleRoll {
+	/**
+	 * Roll data for NimbleRoll, extending the base roll data with prompt tracking.
+	 */
 	type Data = NimbleRollData & {
+		/** Whether this roll was prompted to the user for input. */
 		prompted?: boolean;
+		/** The ID of the user who responded to the roll prompt, or null if not prompted. */
 		respondentId?: string | null;
 	};
 
+	/** Options for configuring a NimbleRoll. */
 	type Options = foundry.dice.Roll.Options;
 
+	/**
+	 * Represents an evaluated NimbleRoll with guaranteed total value.
+	 * @template T - The NimbleRoll type being evaluated.
+	 */
 	type Evaluated<T extends NimbleRoll> = T & {
 		_evaluated: true;
 		_total: number;
@@ -15,7 +25,27 @@ declare namespace NimbleRoll {
 	};
 }
 
+/**
+ * A custom roll class extending Foundry's Roll system with additional data tracking
+ * for the Nimble system. Tracks whether rolls were prompted and who responded.
+ *
+ * @extends {foundry.dice.Roll<NimbleRoll.Data>}
+ *
+ * @example
+ * ```typescript
+ * const roll = new NimbleRoll("1d20+5", { prompted: true });
+ * await roll.evaluate();
+ * console.log(roll.total);
+ * ```
+ */
 class NimbleRoll extends foundry.dice.Roll<NimbleRoll.Data> {
+	/**
+	 * Creates a new NimbleRoll instance.
+	 *
+	 * @param formula - The dice formula to roll (e.g., "1d20+5").
+	 * @param data - Roll data containing actor/item attributes and prompt tracking.
+	 * @param options - Additional options for the roll.
+	 */
 	constructor(formula: string, data: NimbleRoll.Data = {}, options?: NimbleRoll.Options) {
 		super(formula, data, options);
 
@@ -24,6 +54,11 @@ class NimbleRoll extends foundry.dice.Roll<NimbleRoll.Data> {
 		this.data.respondentId ??= null;
 	}
 
+	/**
+	 * Serializes the roll to a JSON-compatible object for storage or transmission.
+	 *
+	 * @returns The serialized roll data including all NimbleRoll-specific properties.
+	 */
 	override toJSON() {
 		return {
 			...super.toJSON(),
@@ -34,6 +69,14 @@ class NimbleRoll extends foundry.dice.Roll<NimbleRoll.Data> {
 	/** ------------------------------------------------------ */
 	/**                    Static Methods                      */
 	/** ------------------------------------------------------ */
+
+	/**
+	 * Converts a standard Foundry Roll into a NimbleRoll instance.
+	 *
+	 * @template D - The type of roll data.
+	 * @param roll - The Roll instance to convert.
+	 * @returns A new NimbleRoll with the same formula, data, and evaluated state.
+	 */
 	static fromRoll<D extends NimbleRoll.Data>(roll: Roll<D>): NimbleRoll {
 		const newRoll = new NimbleRoll(roll.formula, roll.data, roll.options);
 		Object.assign(newRoll, roll);

--- a/src/dice/constructD20RollFormula.ts
+++ b/src/dice/constructD20RollFormula.ts
@@ -1,21 +1,49 @@
 import constructD20Term from './constructD20Term.js';
 import simplifyOperatorTerms from './simplifyOperatorTerms.js';
 
+/**
+ * Options for constructing a d20 roll formula.
+ */
 export type D20RollOptions = {
+	/** The actor making the roll, used to get roll data for variable resolution. */
 	actor: NimbleBaseActor;
+	/** Optional item associated with the roll (e.g., a weapon or spell). */
 	item?: NimbleBaseItem | undefined;
+	/** Minimum value for the d20 roll (e.g., 10 for reliable talent). */
 	minRoll: number;
+	/** Array of modifiers to add to the roll, each with an optional label and value. */
 	modifiers: { label?: string | undefined; value: number | string }[];
+	/** Roll mode: positive for advantage, negative for disadvantage, 0 for normal. */
 	rollMode: number;
 };
 
 /**
- * A helper function to construct a roll formula from an array of component values.
+ * Constructs a complete d20 roll formula from component parts.
  *
- * Values which are undefined, null, or 0 are not included in the resulting formula, and some
- * arithmetic simplification is performed on the resulting formula for presentational purposes.
+ * This function builds a valid dice formula by:
+ * 1. Creating the d20 term with advantage/disadvantage and minimum roll modifiers
+ * 2. Adding all provided modifiers with their labels as flavor text
+ * 3. Filtering out null, undefined, and zero values
+ * 4. Simplifying redundant operators (e.g., "+ -" becomes "-")
  *
- * @returns {string} A valid roll formula that can be passed to Roll.
+ * @param options - Configuration options for the roll formula.
+ * @param options.actor - The actor making the roll.
+ * @param options.item - Optional item for additional roll data context.
+ * @param options.minRoll - Minimum d20 value (e.g., 10 for reliable talent).
+ * @param options.modifiers - Array of modifiers to add to the formula.
+ * @param options.rollMode - Advantage (positive), disadvantage (negative), or normal (0).
+ * @returns An object containing the constructed `rollFormula` string.
+ *
+ * @example
+ * ```typescript
+ * const result = constructD20RollFormula({
+ *   actor: myActor,
+ *   minRoll: 1,
+ *   modifiers: [{ label: "Strength", value: 3 }, { label: "Proficiency", value: 2 }],
+ *   rollMode: 1  // advantage
+ * });
+ * // result.rollFormula might be "2d20kh + 3[Strength] + 2[Proficiency]"
+ * ```
  */
 export default function constructD20RollFormula({
 	actor,

--- a/src/dice/constructD20Term.ts
+++ b/src/dice/constructD20Term.ts
@@ -1,9 +1,40 @@
+/**
+ * Options for constructing a d20 die term.
+ */
 export type d20TermOptions = {
+	/** The actor making the roll (currently unused but reserved for future features). */
 	actor: Actor;
+	/** Minimum value for the d20 roll (e.g., 10 for reliable talent). */
 	minRoll: number;
+	/** Roll mode: positive for advantage, negative for disadvantage, 0 for normal. */
 	rollMode: number;
 };
 
+/**
+ * Constructs the d20 portion of a roll formula with advantage/disadvantage and minimum roll support.
+ *
+ * This function builds a d20 term string based on:
+ * - **rollMode**: Determines advantage/disadvantage
+ *   - Positive: Roll multiple d20s and keep highest (e.g., `2d20kh` for advantage)
+ *   - Negative: Roll multiple d20s and keep lowest (e.g., `2d20kl` for disadvantage)
+ *   - Zero: Roll a single d20
+ * - **minRoll**: Adds a minimum modifier (e.g., `1d20min10` for reliable talent)
+ *
+ * @param options - Configuration options for the d20 term.
+ * @param options.actor - The actor making the roll (reserved for future use).
+ * @param options.minRoll - Minimum d20 value. Values > 1 add a `min` modifier.
+ * @param options.rollMode - Advantage level (positive), disadvantage level (negative), or normal (0).
+ * @returns A d20 term string (e.g., "1d20", "2d20kh", "2d20min10kl").
+ *
+ * @example
+ * ```typescript
+ * constructD20Term({ actor, minRoll: 1, rollMode: 0 });  // "1d20"
+ * constructD20Term({ actor, minRoll: 1, rollMode: 1 });  // "2d20kh" (advantage)
+ * constructD20Term({ actor, minRoll: 1, rollMode: -1 }); // "2d20kl" (disadvantage)
+ * constructD20Term({ actor, minRoll: 10, rollMode: 0 }); // "1d20min10" (reliable talent)
+ * constructD20Term({ actor, minRoll: 10, rollMode: 1 }); // "2d20min10kh"
+ * ```
+ */
 export default function constructD20Term({ actor: _actor, minRoll, rollMode }: d20TermOptions) {
 	let d20Term = '1d20';
 

--- a/src/dice/getDeterministicBonus.ts
+++ b/src/dice/getDeterministicBonus.ts
@@ -1,19 +1,40 @@
-/**
- * A helper function for determining the deterministic bonus given a formula.
- *
- * @param formula   - A roll formula.
- * @param rollData  - Actor data used to determine the value of attribute references used in
- *                    the roll formula.
- * @param options   - Options passed to Roll#evaluateSync
- *                    Default `{}`
- *
- * @returns The resulting deterministic bonus, or null is one could not be
- *          calculated.
- */
 import type { NimbleRollData } from '#types/rollData.d.ts';
 
+/** Roll data type for deterministic bonus calculation. */
 type DeterministicBonusRollData = NimbleRollData;
 
+/**
+ * Calculates the deterministic (static) bonus value from a roll formula.
+ *
+ * This function evaluates a formula synchronously to determine its total numeric value.
+ * It's useful for:
+ * - Calculating flat bonuses from formulas like "@abilities.str.mod + 2"
+ * - Resolving attribute references to their actual numeric values
+ * - Validating that a formula produces a valid result
+ *
+ * The function handles various edge cases:
+ * - Returns `null` for null/undefined formulas
+ * - Returns `0` for empty strings or zero values
+ * - Shows an error notification and returns `null` for invalid formulas
+ *
+ * @param formula - A roll formula (string) or numeric value to evaluate.
+ * @param rollData - Actor data used to resolve attribute references (e.g., `@abilities.str.mod`).
+ * @param options - Evaluation options.
+ * @param options.strict - If true, throws on invalid formulas instead of returning null.
+ * @returns The calculated numeric bonus, or `null` if the formula is invalid.
+ *
+ * @example
+ * ```typescript
+ * // Simple numeric formula
+ * getDeterministicBonus("5 + 3"); // 8
+ *
+ * // With actor data
+ * const bonus = getDeterministicBonus("@abilities.str.mod + 2", actor.getRollData());
+ *
+ * // Returns null for invalid formulas
+ * getDeterministicBonus("invalid formula"); // null (with error notification)
+ * ```
+ */
 export default function getDeterministicBonus(
 	formula: string | number,
 	rollData: DeterministicBonusRollData = {},

--- a/src/dice/simplifyOperatorTerms.ts
+++ b/src/dice/simplifyOperatorTerms.ts
@@ -1,11 +1,25 @@
 /**
- * A helper function to strip redundant operators from an array of RollTerms and to perform
- * arithmetic simplification.
+ * Strips redundant operators from an array of RollTerms and performs arithmetic simplification.
  *
- * A new array of RollTerm objects is returned.
+ * This function cleans up roll formulas for better readability by:
+ * - Replacing consecutive `+ -` operators with a single `-`
+ * - Replacing double `- -` operators with a single `+`
+ * - Removing `+` operators that directly follow `+`, `*`, or `/`
+ * - Removing trailing operator terms from the end of the formula
  *
- * @param {Array<RollTerm>} terms An array of RollTerm objects that form a valid roll formula.
- * @returns {Array<RollTerm>} A new array of RollTerm objects.
+ * A new array of RollTerm objects is returned; the original array is not modified.
+ *
+ * @param terms - An array of RollTerm objects that form a valid roll formula.
+ * @returns A new array of RollTerm objects with simplified operators.
+ *
+ * @example
+ * ```typescript
+ * // Formula "1d20 + -3" becomes "1d20 - 3"
+ * // Formula "1d20 - -3" becomes "1d20 + 3"
+ * // Formula "1d20 + + 3" becomes "1d20 + 3"
+ * const simplified = simplifyOperatorTerms(roll.terms);
+ * const formula = Roll.getFormula(simplified);
+ * ```
  */
 export default function simplifyOperatorTerms(terms) {
 	const Terms = foundry.dice.terms;

--- a/src/dice/terms/PrimaryDie.ts
+++ b/src/dice/terms/PrimaryDie.ts
@@ -1,20 +1,62 @@
 import type { InexactPartial } from 'fvtt-types/utils';
 
 declare namespace PrimaryDie {
+	/** Term data for configuring a PrimaryDie. */
 	interface TermData extends foundry.dice.terms.Die.TermData {}
 }
 
+/**
+ * A specialized die term that tracks critical hit and miss status for damage rolls.
+ *
+ * PrimaryDie extends Foundry's Die term to provide:
+ * - `exploded` getter: Checks if the die exploded (rolled max value), indicating a critical hit
+ * - `isMiss` getter: Checks if the die rolled a 1, indicating a miss
+ *
+ * This term is automatically created by DamageRoll when processing the first die in a formula.
+ * The explosion modifier ('x') is added to detect critical hits.
+ *
+ * @extends {foundry.dice.terms.Die}
+ *
+ * @example
+ * ```typescript
+ * const primary = new PrimaryDie({ number: 1, faces: 6, modifiers: ['x'] });
+ * await primary.evaluate();
+ * if (primary.exploded) console.log("Critical!");
+ * if (primary.isMiss) console.log("Miss!");
+ * ```
+ */
 class PrimaryDie extends foundry.dice.terms.Die {
+	/**
+	 * Creates a new PrimaryDie instance.
+	 *
+	 * @param termData - Configuration for the die including number, faces, and modifiers.
+	 */
 	constructor(termData?: InexactPartial<PrimaryDie.TermData>) {
 		super(termData);
 		if (!this.modifiers) this.modifiers = [];
 	}
 
+	/**
+	 * Whether the die exploded (rolled maximum value), indicating a critical hit.
+	 *
+	 * @returns `true` if any result exploded, `false` if none did, or `undefined` if not yet evaluated.
+	 */
 	get exploded() {
 		if (!this._evaluated) return undefined;
 		return this.results.some((r) => r.exploded);
 	}
 
+	/**
+	 * Whether the die resulted in a miss (rolled a 1 on an active, non-discarded result).
+	 *
+	 * A result is considered a miss if it:
+	 * - Has a value of 1
+	 * - Is marked as active
+	 * - Is not discarded (e.g., from keep highest/lowest)
+	 * - Did not trigger an explosion
+	 *
+	 * @returns `true` if the roll is a miss, `false` if not, or `undefined` if not yet evaluated.
+	 */
 	get isMiss() {
 		if (!this._evaluated) return undefined;
 		return this.results.some((r) => r.result === 1 && r.active && !r.discarded && !r.exploded);

--- a/src/managers/ItemActivationManager.ts
+++ b/src/managers/ItemActivationManager.ts
@@ -20,6 +20,20 @@ const dependencies = {
 
 export const testDependencies = dependencies;
 
+/**
+ * Normalizes and validates a damage roll formula string.
+ *
+ * This function cleans up potentially malformed damage formulas by:
+ * - Trimming whitespace and normalizing multiple spaces
+ * - Fixing common OCR/input errors in dice notation (e.g., 'O' -> '0', 'l' -> '1')
+ * - Extracting valid dice expressions from complex strings
+ * - Validating the resulting formula
+ *
+ * If the formula cannot be normalized to a valid roll formula, returns '0'.
+ *
+ * @param formula - The formula to normalize (may be malformed or contain errors).
+ * @returns A valid, normalized roll formula string.
+ */
 function normalizeDamageRollFormula(formula: unknown): string {
 	const normalized = typeof formula === 'string' ? formula.replace(/\s+/g, ' ').trim() : '';
 	if (!normalized) return '0';
@@ -65,15 +79,43 @@ function normalizeDamageRollFormula(formula: unknown): string {
 	return normalizedDiceFaces;
 }
 
+/**
+ * Manages the activation of items (weapons, spells, abilities) including roll generation.
+ *
+ * ItemActivationManager orchestrates the complete item activation flow:
+ * - Displaying configuration dialogs for roll options
+ * - Handling spell upcasting and scaling
+ * - Creating DamageRoll instances for damage effects
+ * - Creating standard Roll instances for healing effects
+ * - Processing effect trees and storing roll results
+ *
+ * The manager supports both interactive activation (with dialogs) and fast-forward
+ * activation (skipping dialogs with predetermined options).
+ *
+ * @example
+ * ```typescript
+ * const manager = new ItemActivationManager(item, { fastForward: false });
+ * const { rolls, activation } = await manager.getData();
+ * // Use rolls for chat message, activation contains updated effect data
+ * ```
+ */
 class ItemActivationManager {
 	#item: NimbleBaseItem;
 
 	#options: ItemActivationManager.ActivationOptions;
 
+	/** The activation data from the item, potentially modified by upcasting. */
 	activationData: any;
 
+	/** Result of spell upcasting, if applicable. */
 	upcastResult: UpcastResult | null = null;
 
+	/**
+	 * Creates a new ItemActivationManager.
+	 *
+	 * @param item - The item being activated.
+	 * @param options - Configuration options for the activation.
+	 */
 	constructor(item: NimbleBaseItem, options: ItemActivationManager.ActivationOptions) {
 		this.#item = item;
 		this.#options = options;
@@ -83,10 +125,27 @@ class ItemActivationManager {
 		);
 	}
 
+	/**
+	 * Gets the actor that owns the item being activated.
+	 * @returns The actor, or null if the item has no parent actor.
+	 */
 	get actor() {
 		return this.#item.actor;
 	}
 
+	/**
+	 * Prepares and returns all data needed for item activation.
+	 *
+	 * This is the main entry point for item activation. It:
+	 * 1. Determines if dialogs should be shown based on options and item type
+	 * 2. Displays appropriate dialogs (ItemActivationConfigDialog or SpellUpcastDialog)
+	 * 3. Applies upcast modifications for spells
+	 * 4. Creates rolls for all damage and healing effects
+	 * 5. Returns the rolls and updated activation data
+	 *
+	 * @returns Object containing `rolls` (array of Roll/DamageRoll), `activation` data,
+	 *          and `rollHidden` flag. Returns `{ activation: null, rolls: null }` if cancelled.
+	 */
 	async getData() {
 		const options = this.#options;
 
@@ -199,6 +258,21 @@ class ItemActivationManager {
 		return { rolls, activation: this.activationData, rollHidden: dialogData.rollHidden ?? false };
 	}
 
+	/**
+	 * Creates Roll instances for all damage and healing effects in the activation.
+	 *
+	 * Processes the effect tree and creates:
+	 * - DamageRoll for the first damage effect (with critical/miss tracking)
+	 * - Standard Roll for subsequent damage effects and all healing effects
+	 *
+	 * Special handling:
+	 * - Skips rolling for certain item types (ancestry, background, boon, class, subclass)
+	 * - Applies healing potion bonuses to consumable healing effects
+	 * - Minions cannot score critical hits
+	 *
+	 * @param dialogData - Configuration from the activation dialog.
+	 * @returns Array of evaluated Roll/DamageRoll instances.
+	 */
 	async #getRolls(dialogData: ItemActivationManager.DialogData): Promise<(Roll | DamageRoll)[]> {
 		if (['ancestry', 'background', 'boon', 'class', 'subclass'].includes(this.#item.type))
 			return [];
@@ -290,18 +364,41 @@ class ItemActivationManager {
 		return formula.replace(/(\d*)d(\d+)/, `${newCount}d${diceSize}`);
 	}
 
+	/**
+	 * Creates default dialog data when skipping the activation dialog.
+	 *
+	 * @param options - The roll options to use as defaults.
+	 * @returns Default dialog data based on the provided options.
+	 */
 	#getDefaultDialogData(options): ItemActivationManager.DialogData {
 		return {
 			...options,
 		};
 	}
 
+	/**
+	 * Gets the domain set for modifier lookup.
+	 *
+	 * @returns A set of domain strings applicable to this item activation.
+	 */
 	#getItemDomain(): Set<string> {
 		const domain = new Set<string>();
 
 		return domain;
 	}
 
+	/**
+	 * Gets measured template configuration data based on the item's area of effect.
+	 *
+	 * Creates template configuration for various shape types:
+	 * - circle: Standard circular area
+	 * - cone: Cone-shaped area with configurable angle
+	 * - emanation: Circular area that scales with token size
+	 * - line: Ray/line area with width
+	 * - square: Square area (rendered as rotated rectangle)
+	 *
+	 * @returns Template configuration object, or undefined if no template shape is defined.
+	 */
 	#getTemplateData() {
 		const item = this.#item;
 		interface TemplateShape {
@@ -383,26 +480,48 @@ class ItemActivationManager {
 }
 
 namespace ItemActivationManager {
+	/**
+	 * Options for configuring item activation behavior.
+	 */
 	export interface ActivationOptions {
+		/** Whether to execute the item's custom macro after activation. */
 		executeMacro?: boolean;
+		/** Skip dialogs and use provided/default values directly. */
 		fastForward?: boolean;
+		/** Roll mode: positive for advantage, negative for disadvantage, 0 for normal. */
 		rollMode?: number;
+		/** How the roll should be displayed (public, private, blind, self). */
 		visibilityMode?: keyof foundry.CONST.DICE_ROLL_MODES;
+		/** Override formula for the damage roll. */
 		rollFormula?: string;
+		/** Predetermined value for the primary damage die. */
 		primaryDieValue?: number;
+		/** Modifier to apply to the primary die roll. */
 		primaryDieModifier?: string;
+		/** Whether to hide the roll from other players. */
 		rollHidden?: boolean;
 	}
 
+	/**
+	 * Data returned from the activation configuration dialog.
+	 */
 	export interface DialogData {
+		/** Roll mode selected in the dialog. */
 		rollMode: number | undefined;
+		/** Modified roll formula from the dialog. */
 		rollFormula?: string;
+		/** Primary die value if predetermined. */
 		primaryDieValue?: number;
+		/** Modifier for the primary die. */
 		primaryDieModifier?: string;
+		/** Upcast configuration for spells. */
 		upcast?: {
+			/** Amount of mana to spend on upcasting. */
 			manaToSpend: number;
+			/** Index of the upcast choice selected. */
 			choiceIndex?: number;
 		};
+		/** Whether to hide the roll. */
 		rollHidden?: boolean;
 	}
 }

--- a/src/managers/ModifierManager.ts
+++ b/src/managers/ModifierManager.ts
@@ -3,30 +3,85 @@
 import localize from '../utils/localize.js';
 
 declare namespace ModifierManager {
+	/**
+	 * Options specifying the type and context of a roll for modifier calculation.
+	 */
 	interface RollDataOptions {
+		/** The ability key for ability checks (e.g., "str", "dex"). */
 		abilityKey?: string;
+		/** Optional item associated with the roll. */
 		item?: NimbleBaseItem | undefined;
+		/** Minimum roll value (e.g., for reliable talent). */
 		minRoll?: number | undefined;
+		/** Roll mode: positive for advantage, negative for disadvantage. */
 		rollMode?: number | undefined;
+		/** The save key for saving throws (e.g., "fortitude", "reflex"). */
 		saveKey?: string | undefined;
+		/** The skill key for skill checks (e.g., "athletics", "stealth"). */
 		skillKey?: string | undefined;
+		/** Additional situational modifiers as a formula string. */
 		situationalMods?: string | undefined;
+		/** The type of roll being made. */
 		type: 'abilityCheck' | 'savingThrow' | 'skillCheck';
 	}
 
+	/**
+	 * A modifier to be applied to a roll, with optional label for display.
+	 */
 	type Modifier = { label?: string | undefined; value: number | string };
 }
 
+/**
+ * Manages the collection and calculation of modifiers for d20 rolls.
+ *
+ * ModifierManager builds appropriate modifier lists based on:
+ * - Roll type (ability check, saving throw, skill check)
+ * - Actor type (character, monster, solo monster)
+ * - Relevant ability scores, saves, or skills
+ * - Situational modifiers provided by the user
+ *
+ * Different actor types may have different modifier sources:
+ * - Characters: Full ability modifiers, skill bonuses, save bonuses
+ * - Solo Monsters: Simplified modifier structure
+ *
+ * @example
+ * ```typescript
+ * const manager = new ModifierManager(actor, {
+ *   type: 'skillCheck',
+ *   skillKey: 'athletics'
+ * });
+ * const modifiers = manager.getModifiers();
+ * // modifiers might be [{ label: "Athletics", value: 5 }]
+ * ```
+ */
 class ModifierManager {
+	/** The actor whose modifiers are being calculated. */
 	actor: NimbleBaseActor;
 
+	/** The roll configuration specifying what type of roll and relevant keys. */
 	rollData: ModifierManager.RollDataOptions;
 
+	/**
+	 * Creates a new ModifierManager.
+	 *
+	 * @param actor - The actor making the roll.
+	 * @param rollData - Configuration specifying the roll type and relevant keys.
+	 */
 	constructor(actor: NimbleBaseActor, rollData: ModifierManager.RollDataOptions) {
 		this.actor = actor;
 		this.rollData = rollData;
 	}
 
+	/**
+	 * Gets all applicable modifiers for the configured roll type.
+	 *
+	 * Returns different modifiers based on roll type:
+	 * - abilityCheck: Ability modifier + situational
+	 * - savingThrow: Save modifier + situational
+	 * - skillCheck: Skill modifier + situational
+	 *
+	 * @returns Array of modifiers to apply to the roll, with null values filtered out.
+	 */
 	getModifiers(): ModifierManager.Modifier[] {
 		switch (this.rollData.type) {
 			case 'abilityCheck':
@@ -44,6 +99,10 @@ class ModifierManager {
 	/**               Handlers                 */
 	/** -------------------------------------- */
 
+	/**
+	 * Gets modifiers for an ability check.
+	 * Solo monsters only get situational modifiers; others get ability + situational.
+	 */
 	#getAbilityCheckModifiers() {
 		if (this.actor.isType('soloMonster')) {
 			return [this.#getSituationalModifiers()];
@@ -52,10 +111,18 @@ class ModifierManager {
 		return [this.#getAbilityModifier(), this.#getSituationalModifiers()];
 	}
 
+	/**
+	 * Gets modifiers for a saving throw.
+	 * Includes the save modifier and any situational modifiers.
+	 */
 	#getSavingThrowModifiers() {
 		return [this.#getAbilitySaveModifier(), this.#getSituationalModifiers()];
 	}
 
+	/**
+	 * Gets modifiers for a skill check.
+	 * Includes the skill modifier and any situational modifiers.
+	 */
 	#getSkillCheckModifiers() {
 		return [this.#getSkillCheckModifier(), this.#getSituationalModifiers()];
 	}
@@ -63,6 +130,13 @@ class ModifierManager {
 	/** -------------------------------------- */
 	/**         Ability Modifiers              */
 	/** -------------------------------------- */
+
+	/**
+	 * Gets the ability modifier for the configured ability key.
+	 * Only applies to character actors.
+	 *
+	 * @returns The ability modifier with localized label, or null if not applicable.
+	 */
 	#getAbilityModifier(): ModifierManager.Modifier | null {
 		if (!this.actor.isType('character')) return null;
 
@@ -81,6 +155,12 @@ class ModifierManager {
 	/** -------------------------------------- */
 	/**        Saving Throw Modifiers          */
 	/** -------------------------------------- */
+
+	/**
+	 * Gets the saving throw modifier for the configured save key.
+	 *
+	 * @returns The save modifier with localized label, or null if no save key configured.
+	 */
 	#getAbilitySaveModifier(): ModifierManager.Modifier | null {
 		const { saveKey } = this.rollData;
 		if (!saveKey) return null;
@@ -97,6 +177,13 @@ class ModifierManager {
 	/** -------------------------------------- */
 	/**         Skill Check Modifiers          */
 	/** -------------------------------------- */
+
+	/**
+	 * Gets the skill modifier for the configured skill key.
+	 * Only applies to character actors.
+	 *
+	 * @returns The skill modifier with localized label, or null if not applicable.
+	 */
 	#getSkillCheckModifier(): ModifierManager.Modifier | null {
 		if (!this.actor.isType('character')) return null;
 
@@ -115,6 +202,15 @@ class ModifierManager {
 	/** -------------------------------------- */
 	/**             Other Modifiers            */
 	/** -------------------------------------- */
+
+	/**
+	 * Gets situational modifiers provided by the user.
+	 *
+	 * These are ad-hoc modifiers entered during roll configuration,
+	 * such as "+2 flanking" or "-4 cover".
+	 *
+	 * @returns A modifier containing the situational modifier formula (may be empty string).
+	 */
 	#getSituationalModifiers(): ModifierManager.Modifier | null {
 		return { value: this.rollData.situationalMods ?? '' };
 	}

--- a/src/utils/getRollFormula.ts
+++ b/src/utils/getRollFormula.ts
@@ -1,6 +1,43 @@
 import constructD20RollFormula from '../dice/constructD20RollFormula.js';
 import { ModifierManager } from '../managers/ModifierManager.js';
 
+/**
+ * Generates a complete d20 roll formula for an actor based on roll configuration.
+ *
+ * This is a convenience function that combines ModifierManager and constructD20RollFormula
+ * to produce a ready-to-use roll formula string. It:
+ * 1. Creates a ModifierManager to collect all applicable modifiers
+ * 2. Passes the modifiers to constructD20RollFormula along with roll options
+ * 3. Returns the simplified, validated formula string
+ *
+ * @param actor - The actor making the roll.
+ * @param rollData - Configuration specifying the roll type, relevant keys, and options.
+ * @param rollData.type - The type of roll ('abilityCheck', 'savingThrow', 'skillCheck').
+ * @param rollData.abilityKey - For ability checks, the ability to use (e.g., "str").
+ * @param rollData.saveKey - For saving throws, the save type (e.g., "fortitude").
+ * @param rollData.skillKey - For skill checks, the skill (e.g., "athletics").
+ * @param rollData.rollMode - Advantage (positive), disadvantage (negative), or normal (0).
+ * @param rollData.minRoll - Minimum d20 value (default 1).
+ * @param rollData.item - Optional item providing additional context.
+ * @returns The complete roll formula string (e.g., "2d20kh + 5[Strength] + 3[Athletics]").
+ *
+ * @example
+ * ```typescript
+ * // Strength check with advantage
+ * const formula = getRollFormula(actor, {
+ *   type: 'abilityCheck',
+ *   abilityKey: 'str',
+ *   rollMode: 1
+ * });
+ * // Returns something like "2d20kh + 3[Strength Mod]"
+ *
+ * // Fortitude save
+ * const saveFormula = getRollFormula(actor, {
+ *   type: 'savingThrow',
+ *   saveKey: 'fortitude'
+ * });
+ * ```
+ */
 export default function getRollFormula(
 	actor: NimbleBaseActor,
 	rollData = {} as ModifierManager.RollDataOptions,


### PR DESCRIPTION
## Summary
- Add comprehensive JSDoc documentation to all TypeScript classes, methods, and functions related to dice roll attacks
- Document 4 dice classes: NimbleRoll, DamageRoll, NimbleDicePool, PrimaryDie
- Document 4 dice utility functions: constructD20RollFormula, constructD20Term, simplifyOperatorTerms, getDeterministicBonus
- Document 2 manager classes: ItemActivationManager, ModifierManager
- Document getRollFormula utility function

## Test plan
- [x] TypeScript type-checking passes
- [x] All existing tests pass (480 tests)
- [x] Documentation-only changes, no functional changes