### PR TITLE
chore: remove warning

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,2 @@
 # .npmrc
 engine-strict=true
-package-manager-strict=true


### PR DESCRIPTION
Remove warning when pre-push hooks run.

npm warn Unknown project config "package-manager-strict". This will stop working in the next major version of npm.
Checked 2 files in 2ms. No fixes applied.     