### PR TITLE
fix: use reactive accessors in chat card components

### DIFF
--- a/src/hooks/renderChatMessage.test.ts
+++ b/src/hooks/renderChatMessage.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mountMock, unmountMock } = vi.hoisted(() => ({
+	mountMock: vi.fn(),
+	unmountMock: vi.fn(),
+}));
+
+vi.mock('svelte', () => ({
+	mount: mountMock,
+	unmount: unmountMock,
+}));
+
+vi.mock('../view/chat/AbilityCheckCard.svelte', () => ({ default: {} }));
+vi.mock('../view/chat/FeatureCard.svelte', () => ({ default: {} }));
+vi.mock('../view/chat/FieldRestCard.svelte', () => ({ default: {} }));
+vi.mock('../view/chat/LevelUpSummaryCard.svelte', () => ({ default: {} }));
+vi.mock('../view/chat/MinionGroupAttackCard.svelte', () => ({ default: {} }));
+vi.mock('../view/chat/ObjectCard.svelte', () => ({ default: {} }));
+vi.mock('../view/chat/SafeRestCard.svelte', () => ({ default: {} }));
+vi.mock('../view/chat/SavingThrowCard.svelte', () => ({ default: {} }));
+vi.mock('../view/chat/SkillCheckCard.svelte', () => ({ default: {} }));
+vi.mock('../view/chat/SpellCard.svelte', () => ({ default: {} }));
+
+import renderChatMessageHTML from './renderChatMessage.js';
+
+function createMessageHtml(): HTMLElement {
+	const html = document.createElement('article');
+	html.innerHTML = `
+		<header class="message-header"></header>
+		<section class="message-content"></section>
+	`;
+	return html;
+}
+
+function createSpellMessage() {
+	return {
+		author: {
+			color: { b: 0, g: 0, r: 0 },
+			name: 'Caster',
+		},
+		speaker: { alias: 'Caster' },
+		system: {},
+		type: 'spell',
+		whisper: [],
+	};
+}
+
+describe('renderChatMessageHTML', () => {
+	beforeEach(() => {
+		mountMock.mockReset();
+		mountMock.mockImplementation(() => ({}));
+		unmountMock.mockReset();
+
+		document.body.innerHTML = '';
+		(
+			globalThis as object as {
+				$: (html: HTMLElement) => { 0: HTMLElement; find: (selector: string) => Element[] };
+			}
+		).$ = (html: HTMLElement) => ({
+			0: html,
+			find: (selector: string) => [...html.querySelectorAll(selector)],
+		});
+	});
+
+	it('keeps existing mounted cards for the same message on other targets', () => {
+		const message = createSpellMessage();
+		const firstTarget = createMessageHtml();
+		const secondTarget = createMessageHtml();
+		document.body.append(firstTarget, secondTarget);
+
+		renderChatMessageHTML(message, firstTarget);
+		renderChatMessageHTML(message, secondTarget);
+
+		expect(mountMock).toHaveBeenCalledTimes(2);
+		expect(unmountMock).not.toHaveBeenCalled();
+	});
+
+	it('replaces the existing mounted card when rerendering the same target', () => {
+		const message = createSpellMessage();
+		const target = createMessageHtml();
+		document.body.append(target);
+
+		renderChatMessageHTML(message, target);
+		renderChatMessageHTML(message, target);
+
+		expect(mountMock).toHaveBeenCalledTimes(2);
+		expect(unmountMock).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/hooks/renderChatMessage.ts
+++ b/src/hooks/renderChatMessage.ts
@@ -11,9 +11,54 @@ import NimbleSavingThrowCard from '../view/chat/SavingThrowCard.svelte';
 import NimbleSkillCheckCard from '../view/chat/SkillCheckCard.svelte';
 import NimbleSpellCard from '../view/chat/SpellCard.svelte';
 
+type MountedChatCard = {
+	component: ReturnType<typeof mount>;
+	target: HTMLElement;
+};
+
+const mountedChatCards = new WeakMap<object, MountedChatCard[]>();
+
+function getMountedChatCardsForMessage(message: object): MountedChatCard[] {
+	const existingCards = mountedChatCards.get(message) ?? [];
+
+	if (existingCards.length === 0) return existingCards;
+
+	const connectedCards: MountedChatCard[] = [];
+
+	for (const mountedCard of existingCards) {
+		if (mountedCard.target.isConnected) {
+			connectedCards.push(mountedCard);
+			continue;
+		}
+
+		unmount(mountedCard.component);
+	}
+
+	if (connectedCards.length !== existingCards.length) {
+		mountedChatCards.set(message, connectedCards);
+	}
+
+	return connectedCards;
+}
+
+function unmountChatCardAtTarget(message: object, target: HTMLElement): MountedChatCard[] {
+	const mountedCards = getMountedChatCardsForMessage(message);
+	const matchingCardIndex = mountedCards.findIndex((mountedCard) => mountedCard.target === target);
+
+	if (matchingCardIndex === -1) return mountedCards;
+
+	const [matchingCard] = mountedCards.splice(matchingCardIndex, 1);
+	unmount(matchingCard.component);
+
+	if (mountedCards.length === 0) mountedChatCards.delete(message);
+	else mountedChatCards.set(message, mountedCards);
+
+	return mountedCards;
+}
+
 export default function renderChatMessageHTML(message, html) {
 	const target = $(html)[0];
-	if (!target) return;
+	if (!target || !message || typeof message !== 'object') return;
 
 	// Check if this is a whispered message the current user shouldn't see details of
 	const whisperIds: string[] = message.whisper ?? [];
@@ -22,6 +67,8 @@ export default function renderChatMessageHTML(message, html) {
 		whisperIds.length > 0 && currentUserId && !whisperIds.includes(currentUserId);
 
 	if (isHiddenFromUser) {
+		unmountChatCardAtTarget(message, target);
+
 		// Show a "privately rolled" placeholder instead of the full content
 		target.classList.add('nimble-chat-card', 'nimble-chat-card--hidden');
 		$(html).find('.message-header')[0]?.remove();
@@ -101,13 +148,12 @@ export default function renderChatMessageHTML(message, html) {
 	$(html).find('.message-header')[0]?.remove();
 	$(html).find('.message-content')[0]?.remove();
 
-	// Unmount any existing Svelte component before mounting a new one
-	if (message._svelteComponent) {
-		unmount(message._svelteComponent);
-	}
-
-	message._svelteComponent = mount(component, {
+	const mountedCards = unmountChatCardAtTarget(message, target);
+	const mountedComponent = mount(component, {
 		target,
 		props: { messageDocument: message },
 	});
+
+	mountedCards.push({ component: mountedComponent, target });
+	mountedChatCards.set(message, mountedCards);
 }

--- a/src/view/chat/AbilityCheckCard.svelte
+++ b/src/view/chat/AbilityCheckCard.svelte
@@ -8,9 +8,9 @@
 
 	const { messageDocument } = $props();
 
-	const system = $derived(messageDocument.system);
-	const rolls = $derived(messageDocument.rolls);
-	const headerBackgroundColor = $derived(messageDocument.author.color);
+	const system = $derived(messageDocument.reactive.system);
+	const rolls = $derived(messageDocument.reactive.rolls);
+	const headerBackgroundColor = $derived(messageDocument.reactive.author.color);
 	const headerTextColor = $derived(calculateHeaderTextColor(headerBackgroundColor));
 
 	const { abilityScores } = CONFIG.NIMBLE;

--- a/src/view/chat/FieldRestCard.svelte
+++ b/src/view/chat/FieldRestCard.svelte
@@ -8,8 +8,8 @@
 
 	let { messageDocument } = $props();
 
-	const system = $derived(messageDocument.system);
-	const rolls = $derived(messageDocument.rolls);
+	const system = $derived(messageDocument.reactive.system);
+	const rolls = $derived(messageDocument.reactive.rolls);
 	const actorType = $derived(system.actorType);
 	const permissions = $derived(system.permissions);
 	const restType = $derived(system.restType);
@@ -19,7 +19,7 @@
 	const hadAdvantage = $derived(system.hadAdvantage);
 	const advantageSource = $derived(system.advantageSource);
 
-	const headerBackgroundColor = $derived(messageDocument.author.color);
+	const headerBackgroundColor = $derived(messageDocument.reactive.author.color);
 	const headerTextColor = $derived(calculateHeaderTextColor(headerBackgroundColor));
 
 	// Determine rest type label and icon

--- a/src/view/chat/LevelUpSummaryCard.svelte
+++ b/src/view/chat/LevelUpSummaryCard.svelte
@@ -8,14 +8,14 @@
 
 	let { messageDocument } = $props();
 
-	const system = $derived(messageDocument.system);
-	const rolls = $derived(messageDocument.rolls);
+	const system = $derived(messageDocument.reactive.system);
+	const rolls = $derived(messageDocument.reactive.rolls);
 	const actorType = $derived(system.actorType);
 	const currentClassLevel = $derived(system.currentClassLevel);
 	const takeAverageHp = $derived(system.takeAverageHp);
 	const permissions = $derived(system.permissions);
 
-	const headerBackgroundColor = $derived(messageDocument.author.color);
+	const headerBackgroundColor = $derived(messageDocument.reactive.author.color);
 	const headerTextColor = $derived(calculateHeaderTextColor(headerBackgroundColor));
 </script>
 

--- a/src/view/chat/SafeRestCard.svelte
+++ b/src/view/chat/SafeRestCard.svelte
@@ -6,14 +6,14 @@
 
 	let { messageDocument } = $props();
 
-	const system = $derived(messageDocument.system);
+	const system = $derived(messageDocument.reactive.system);
 	const hitDiceRecovered = $derived(system.hitDiceRecovered);
 	const hpRestored = $derived(system.hpRestored);
 	const tempHpRemoved = $derived(system.tempHpRemoved);
 	const manaRestored = $derived(system.manaRestored);
 	const woundsRecovered = $derived(system.woundsRecovered);
 
-	const headerBackgroundColor = $derived(messageDocument.author.color);
+	const headerBackgroundColor = $derived(messageDocument.reactive.author.color);
 	const headerTextColor = $derived(calculateHeaderTextColor(headerBackgroundColor));
 
 	// Format hit dice recovered for display

--- a/src/view/chat/SavingThrowCard.svelte
+++ b/src/view/chat/SavingThrowCard.svelte
@@ -8,9 +8,9 @@
 
 	const { messageDocument } = $props();
 
-	const system = $derived(messageDocument.system);
-	const rolls = $derived(messageDocument.rolls);
-	const headerBackgroundColor = $derived(messageDocument.author.color);
+	const system = $derived(messageDocument.reactive.system);
+	const rolls = $derived(messageDocument.reactive.rolls);
+	const headerBackgroundColor = $derived(messageDocument.reactive.author.color);
 	const headerTextColor = $derived(calculateHeaderTextColor(headerBackgroundColor));
 
 	const { saves } = CONFIG.NIMBLE;

--- a/src/view/chat/SkillCheckCard.svelte
+++ b/src/view/chat/SkillCheckCard.svelte
@@ -8,9 +8,9 @@
 
 	const { messageDocument } = $props();
 
-	const system = $derived(messageDocument.system);
-	const rolls = $derived(messageDocument.rolls);
-	const headerBackgroundColor = $derived(messageDocument.author.color);
+	const system = $derived(messageDocument.reactive.system);
+	const rolls = $derived(messageDocument.reactive.rolls);
+	const headerBackgroundColor = $derived(messageDocument.reactive.author.color);
 	const headerTextColor = $derived(calculateHeaderTextColor(headerBackgroundColor));
 
 	const { skills } = CONFIG.NIMBLE;

--- a/src/view/chat/components/Targets.svelte
+++ b/src/view/chat/components/Targets.svelte
@@ -69,7 +69,7 @@
 	const { npcArmorEffects, npcArmorIcons, npcArmorTypes } = CONFIG.NIMBLE;
 
 	let messageDocument = getContext('messageDocument');
-	let targets = messageDocument?.system?.targets ?? [];
+	let targets = $derived(messageDocument?.reactive?.system?.targets ?? []);
 </script>
 
 <section class="nimble-card-section nimble-card-section--targets">


### PR DESCRIPTION
## Summary
- Fixed chat messages not appearing in the chat log for some players while still showing in popups
- Several chat card components were accessing `messageDocument.system` directly instead of through the reactive getter (`messageDocument.reactive.system`)
- This caused components to never subscribe to updates when chat message data changed

## Components Fixed
- `Targets.svelte` - Changed to use `$derived(messageDocument?.reactive?.system?.targets ?? [])`
- `AbilityCheckCard.svelte` - Added `.reactive` accessor for system, rolls, and author
- `SkillCheckCard.svelte` - Added `.reactive` accessor for system, rolls, and author
- `SavingThrowCard.svelte` - Added `.reactive` accessor for system, rolls, and author
- `FieldRestCard.svelte` - Added `.reactive` accessor for system, rolls, and author
- `SafeRestCard.svelte` - Added `.reactive` accessor for system and author
- `LevelUpSummaryCard.svelte` - Added `.reactive` accessor for system, rolls, and author

## Test plan
- [ ] Create ability check, skill check, and saving throw rolls - verify they appear in chat log immediately
- [ ] Create spell/feature activations with targets - verify targets section updates reactively
- [ ] Test with multiple players to ensure chat syncs correctly across clients
- [ ] Verify rest cards (field rest, safe rest) display correctly
- [ ] Verify level up summary cards display correctly