### PR TITLE
fix: allow non-GM players to apply damage and simplify defeat sync

### DIFF
--- a/packs/classFeatures/core/the-cheat/the-cheat-progression/twist-the-blade-2.json
+++ b/packs/classFeatures/core/the-cheat/the-cheat-progression/twist-the-blade-2.json
@@ -37,9 +37,11 @@
 		"featureType": "class",
 		"class": "the-cheat",
 		"group": "the-cheat-progression",
-		"gainedAtLevel": 13,
+		"gainedAtLevel": 5,
 		"subclass": false,
-		"gainedAtLevels": [13]
+		"gainedAtLevels": [
+			5
+		]
 	},
 	"effects": [],
 	"flags": {},

--- a/src/documents/chatMessage.test.ts
+++ b/src/documents/chatMessage.test.ts
@@ -3,11 +3,6 @@ import { NimbleChatMessage } from './chatMessage.js';
 
 type TestGlobals = {
 	fromUuidSync: ReturnType<typeof vi.fn>;
-	game: {
-		user: {
-			isGM: boolean;
-		};
-	};
 	ui: {
 		notifications: {
 			info: ReturnType<typeof vi.fn>;
@@ -247,7 +242,6 @@ describe('NimbleChatMessage.undoHealing', () => {
 describe('NimbleChatMessage.applyDamage', () => {
 	beforeEach(() => {
 		globals().fromUuidSync = vi.fn();
-		globals().game.user.isGM = true;
 	});
 
 	it('applies damage to target actor and consumes temporary hit points first', async () => {
@@ -304,28 +298,5 @@ describe('NimbleChatMessage.applyDamage', () => {
 
 		expect(globals().fromUuidSync).not.toHaveBeenCalled();
 		expect(globals().ui.notifications.warn).toHaveBeenCalledWith('No targets selected');
-	});
-
-	it('does not apply damage when the current user is not a GM', async () => {
-		const actor = {
-			system: {
-				attributes: {
-					hp: {
-						value: 10,
-						temp: 2,
-						max: 10,
-					},
-				},
-			},
-			update: vi.fn().mockResolvedValue(undefined),
-		};
-
-		globals().game.user.isGM = false;
-		globals().fromUuidSync.mockReturnValue({ actor });
-
-		const message = createActivationMessage();
-		await message.applyDamage(4, { outcome: 'fullDamage' });
-
-		expect(actor.update).not.toHaveBeenCalled();
 	});
 });

--- a/src/documents/chatMessage.ts
+++ b/src/documents/chatMessage.ts
@@ -226,7 +226,6 @@ class NimbleChatMessage extends ChatMessage {
 
 	async applyDamage(value: number, options?: Record<string, unknown>): Promise<void> {
 		if (!this.isActivationCard()) return;
-		if (!game.user?.isGM) return;
 
 		if (options?.outcome === 'noDamage') {
 			ui.notifications?.info('No damage to apply.');

--- a/src/hooks/combatantDefeatSync.test.ts
+++ b/src/hooks/combatantDefeatSync.test.ts
@@ -125,43 +125,6 @@ describe('registerCombatantDefeatSync', () => {
 		});
 	});
 
-	it('does not restore character actions on hp-only updates while alive', async () => {
-		const callbacks = createHookCapture(globals().Hooks.on);
-		const registerCombatantDefeatSync = (await import('./combatantDefeatSync.js')).default;
-		registerCombatantDefeatSync();
-
-		const actor = createMockCombatActor({
-			id: 'actor-2b',
-			hp: 4,
-			woundsValue: 2,
-			woundsMax: 6,
-		});
-		const combatant = createMockCombatant({
-			id: 'combatant-2b',
-			type: 'character',
-			actorId: 'actor-2b',
-			actor,
-			defeated: false,
-			actionsCurrent: 1,
-			actionsMax: 3,
-		});
-		const combat = createMockCombat({
-			id: 'combat-2b',
-			combatants: [combatant],
-			turns: [combatant],
-			activeCombatant: combatant,
-			round: 1,
-		});
-
-		globals().game.combats.contents = [combat];
-
-		const updateActor = callbacks.get('updateActor');
-		updateActor?.(actor, { system: { attributes: { hp: { value: 3 } } } });
-		await flushAsync();
-
-		expect(combat.updateEmbeddedDocuments).not.toHaveBeenCalled();
-	});
-
 	it('uses HP logic for non-character combatants', async () => {
 		const callbacks = createHookCapture(globals().Hooks.on);
 		const registerCombatantDefeatSync = (await import('./combatantDefeatSync.js')).default;
@@ -203,43 +166,6 @@ describe('registerCombatantDefeatSync', () => {
 				'system.actions.base.current': 0,
 			},
 		]);
-	});
-
-	it('does not restore npc actions on hp updates while alive', async () => {
-		const callbacks = createHookCapture(globals().Hooks.on);
-		const registerCombatantDefeatSync = (await import('./combatantDefeatSync.js')).default;
-		registerCombatantDefeatSync();
-
-		const actor = createMockCombatActor({
-			id: 'actor-3b',
-			hp: 7,
-			woundsValue: 0,
-			woundsMax: 6,
-		});
-		const combatant = createMockCombatant({
-			id: 'combatant-3b',
-			type: 'npc',
-			actorId: 'actor-3b',
-			actor,
-			defeated: false,
-			actionsCurrent: 1,
-			actionsMax: 2,
-		});
-		const combat = createMockCombat({
-			id: 'combat-3b',
-			combatants: [combatant],
-			turns: [combatant],
-			activeCombatant: combatant,
-			round: 1,
-		});
-
-		globals().game.combats.contents = [combat];
-
-		const updateActor = callbacks.get('updateActor');
-		updateActor?.(actor, { system: { attributes: { hp: { value: 5 } } } });
-		await flushAsync();
-
-		expect(combat.updateEmbeddedDocuments).not.toHaveBeenCalled();
 	});
 
 	it('advances turn when active combatant becomes defeated and others are alive', async () => {

--- a/src/hooks/combatantDefeatSync.ts
+++ b/src/hooks/combatantDefeatSync.ts
@@ -91,16 +91,9 @@ async function syncActorCombatantDeathState(actor: Actor.Implementation): Promis
 
 		const actionCurrent = getCombatantActionCurrent(combatant);
 		const actionMax = getCombatantActionMax(combatant);
-		let desiredActions: number | null = null;
+		const desiredActions = shouldBeDefeated ? 0 : actionMax;
 
-		// Only touch current actions when defeat state changes, or while a combatant remains defeated.
-		if (shouldBeDefeated) {
-			desiredActions = 0;
-		} else if (combatant.defeated) {
-			desiredActions = actionMax;
-		}
-
-		if (desiredActions !== null && actionCurrent !== desiredActions) {
+		if (actionCurrent !== desiredActions) {
 			update['system.actions.base.current'] = desiredActions;
 			hasChanges = true;
 		}

--- a/src/view/chat/MinionGroupAttackCard.svelte
+++ b/src/view/chat/MinionGroupAttackCard.svelte
@@ -189,18 +189,16 @@
 			<span class="nimble-group-total__value">{Math.max(0, Math.floor(totalDamage))}</span>
 		</div>
 
-		{#if game.user?.isGM}
-			<button
-				class="nimble-button nimble-button--apply-damage"
-				aria-label={i18nLocalize('NIMBLE.nimbleCombatSystemWindow.chat.applyDamage')}
-				data-tooltip={i18nLocalize('NIMBLE.nimbleCombatSystemWindow.chat.applyDamage')}
-				data-tooltip-direction="UP"
-				type="button"
-				onclick={applyTotalDamage}
-			>
-				{i18nLocalize('NIMBLE.nimbleCombatSystemWindow.chat.applyDamage')}
-			</button>
-		{/if}
+		<button
+			class="nimble-button nimble-button--apply-damage"
+			aria-label={i18nLocalize('NIMBLE.nimbleCombatSystemWindow.chat.applyDamage')}
+			data-tooltip={i18nLocalize('NIMBLE.nimbleCombatSystemWindow.chat.applyDamage')}
+			data-tooltip-direction="UP"
+			type="button"
+			onclick={applyTotalDamage}
+		>
+			{i18nLocalize('NIMBLE.nimbleCombatSystemWindow.chat.applyDamage')}
+		</button>
 	</section>
 </article>
 

--- a/src/view/chat/components/RollSummary.svelte
+++ b/src/view/chat/components/RollSummary.svelte
@@ -52,7 +52,7 @@
 	</div>
 {/if}
 
-{#if type === 'damage' && game.user?.isGM}
+{#if type === 'damage'}
 	<button
 		class="nimble-button nimble-button--apply-damage"
 		aria-label="Apply Damage"


### PR DESCRIPTION
## Summary
- Remove GM-only restriction for applying damage from chat cards (allows all players to apply damage)
- Simplify combatantDefeatSync to always set actions based on defeat state
- Fix twist-the-blade-2 gained level (13 → 5)

## Test plan
- [ ] Non-GM player can click "Apply Damage" button on chat cards
- [ ] Combatant actions reset correctly when defeat state changes