### PR TITLE
feat: add data-driven unarmed damage rule system

### DIFF
--- a/packs/classFeatures/core/zephyr/zephyr-progression/swift-fists.json
+++ b/packs/classFeatures/core/zephyr/zephyr-progression/swift-fists.json
@@ -5,8 +5,15 @@
 	"img": "icons/skills/melee/unarmed-punch-fist.webp",
 	"system": {
 		"macro": "",
-		"identifier": "",
-		"rules": [],
+		"identifier": "swift-fists",
+		"rules": [
+			{
+				"id": "swift-fists-unarmed-damage",
+				"type": "unarmedDamage",
+				"label": "Swift Fists",
+				"value": "1d4 + @abilities.strength.mod"
+			}
+		],
 		"activation": {
 			"acquireTargetsFromTemplate": false,
 			"cost": {

--- a/src/config/registerRulesConfig.ts
+++ b/src/config/registerRulesConfig.ts
@@ -17,6 +17,7 @@ import { SavingThrowBonusRule } from '../models/rules/savingThrowBonus.js';
 import { SavingThrowRollModeRule } from '../models/rules/savingThrowRollMode.js';
 import { SkillBonusRule } from '../models/rules/skillBonus.js';
 import { SpeedBonusRule } from '../models/rules/speedBonus.js';
+import { UnarmedDamageRule } from '../models/rules/unarmedDamage.js';
 
 export default function registerRulesConfig() {
 	const ruleTypes = {
@@ -39,6 +40,7 @@ export default function registerRulesConfig() {
 		savingThrowRollMode: 'NIMBLE.ruleTypes.savingThrowRollMode',
 		skillBonus: 'NIMBLE.ruleTypes.skillBonus',
 		speedBonus: 'NIMBLE.ruleTypes.speedBonus',
+		unarmedDamage: 'NIMBLE.ruleTypes.unarmedDamage',
 	};
 
 	const ruleDataModels = {
@@ -61,6 +63,7 @@ export default function registerRulesConfig() {
 		savingThrowRollMode: SavingThrowRollModeRule,
 		skillBonus: SkillBonusRule,
 		speedBonus: SpeedBonusRule,
+		unarmedDamage: UnarmedDamageRule,
 	} as const;
 
 	return { ruleDataModels, ruleTypes };

--- a/src/dice/DamageRoll.test.ts
+++ b/src/dice/DamageRoll.test.ts
@@ -529,7 +529,12 @@ describe('DamageRoll.fromData', () => {
 			expect(roll.formula).toBe('1d6');
 			expect(roll.originalFormula).toBe('1d6');
 			expect(roll.data).toEqual({ test: 'value' });
-			expect(roll.options).toEqual({ canCrit: true, canMiss: true, rollMode: 0 });
+			expect(roll.options).toEqual({
+				canCrit: true,
+				canMiss: true,
+				rollMode: 0,
+				primaryDieAsDamage: true,
+			});
 		});
 
 		it('should preserve parent class properties', () => {
@@ -546,7 +551,12 @@ describe('DamageRoll.fromData', () => {
 
 			expect(roll.formula).toBe('1d6+2');
 			expect(roll.data).toEqual({ level: 3 });
-			expect(roll.options).toEqual({ canCrit: true, canMiss: true, rollMode: 1 });
+			expect(roll.options).toEqual({
+				canCrit: true,
+				canMiss: true,
+				rollMode: 1,
+				primaryDieAsDamage: true,
+			});
 		});
 	});
 });

--- a/src/dice/DamageRoll.ts
+++ b/src/dice/DamageRoll.ts
@@ -17,6 +17,13 @@ declare namespace DamageRoll {
 		rollMode: number;
 		primaryDieValue: number;
 		primaryDieModifier: number;
+		/**
+		 * Whether the primary die's base result contributes to damage.
+		 * When false, the primary die is used only for hit/miss/crit detection,
+		 * and its base value is excluded from damage (explosions still count).
+		 * Default: true
+		 */
+		primaryDieAsDamage?: boolean;
 	}
 
 	interface SerializedData {
@@ -36,6 +43,7 @@ declare namespace DamageRoll {
 		isMiss?: boolean;
 		_total?: number;
 		_formula?: string;
+		excludedPrimaryDieValue?: number;
 	}
 
 	type Evaluated<T extends DamageRoll> = T & {
@@ -58,6 +66,12 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 
 	override _formula: string = '';
 
+	/**
+	 * The base value of the primary die that was excluded from damage
+	 * (only set when primaryDieAsDamage is false)
+	 */
+	excludedPrimaryDieValue: number = 0;
+
 	constructor(formula: string, data: DamageRoll.Data = {}, options?: DamageRoll.Options) {
 		super(formula, data, options);
 
@@ -65,6 +79,7 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 		this.options.canCrit ??= true;
 		this.options.canMiss ??= true;
 		this.options.rollMode ??= 0;
+		this.options.primaryDieAsDamage ??= true;
 		this.originalFormula = formula;
 		this._formula = formula;
 
@@ -223,6 +238,20 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 		if (primaryTerm) {
 			if (this.options.canCrit) this.isCritical = primaryTerm.exploded;
 			if (this.options.canMiss) this.isMiss = primaryTerm.isMiss;
+
+			// When primaryDieAsDamage is false, exclude the base die value from damage
+			// (explosions still count toward damage)
+			if (!this.options.primaryDieAsDamage) {
+				// Find the first result (the base roll, not explosion rolls)
+				// The base result is the one that may have exploded: true flag
+				const baseResult = primaryTerm.results.find((r) => r.active && !r.discarded);
+				if (baseResult) {
+					this.excludedPrimaryDieValue = baseResult.result;
+					// Adjust the total by subtracting the base die value
+					const internals = this as object as { _total: number };
+					internals._total = (this._total ?? 0) - this.excludedPrimaryDieValue;
+				}
+			}
 		}
 
 		return this as DamageRoll.Evaluated<this>;
@@ -235,6 +264,7 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 			originalFormula: this.originalFormula,
 			isMiss: this.isMiss,
 			isCritical: this.isCritical,
+			excludedPrimaryDieValue: this.excludedPrimaryDieValue,
 		};
 	}
 
@@ -326,6 +356,9 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 				roll.primaryDie = primaryTerm;
 			}
 		}
+
+		// Restore excludedPrimaryDieValue if it was serialized
+		roll.excludedPrimaryDieValue = data.excludedPrimaryDieValue ?? 0;
 
 		return roll as FixedInstanceType<T>;
 	}

--- a/src/migration/migrations/Migration010SwiftFistsUnarmedDamage.ts
+++ b/src/migration/migrations/Migration010SwiftFistsUnarmedDamage.ts
@@ -1,0 +1,59 @@
+import { MigrationBase } from '../MigrationBase.js';
+
+const SWIFT_FISTS_SOURCE_ID = 'Compendium.nimble.class-features.Item.kHJVcWe64VhHsOFu';
+
+const UNARMED_DAMAGE_RULE = {
+	id: 'swift-fists-unarmed-damage',
+	type: 'unarmedDamage',
+	label: 'Swift Fists',
+	value: '1d4 + @abilities.strength.mod',
+};
+
+/**
+ * Migration to add unarmedDamage rule to Swift Fists feature items.
+ *
+ * The Swift Fists feature (Zephyr class) modifies unarmed strike damage:
+ * - Core rules: "roll 1d4; on hit: deal 1 + STR damage"
+ * - Swift Fists: "damage is 1d4+STR"
+ *
+ * This migration adds the unarmedDamage rule to existing Swift Fists feature items on actors.
+ */
+class Migration010SwiftFistsUnarmedDamage extends MigrationBase {
+	static override readonly version = 10;
+
+	override readonly version = Migration010SwiftFistsUnarmedDamage.version;
+
+	override async updateItem(source: any): Promise<void> {
+		// Only process feature items
+		if (source.type !== 'feature') return;
+
+		// Check if this is the Swift Fists feature by sourceId or name
+		const isSwiftFists =
+			source.flags?.core?.sourceId === SWIFT_FISTS_SOURCE_ID || source.name === 'Swift Fists';
+
+		if (!isSwiftFists) return;
+
+		// Initialize rules array if it doesn't exist
+		if (!source.system.rules) {
+			source.system.rules = [];
+		}
+
+		// Check if rule already exists
+		const hasUnarmedDamageRule = source.system.rules.some(
+			(rule: any) => rule.type === 'unarmedDamage',
+		);
+
+		// Add missing rule
+		if (!hasUnarmedDamageRule) {
+			source.system.rules.push(UNARMED_DAMAGE_RULE);
+			console.log(`Nimble Migration | ${source.name}: added Swift Fists unarmed damage rule`);
+		}
+
+		// Also ensure identifier is set
+		if (!source.system.identifier) {
+			source.system.identifier = 'swift-fists';
+		}
+	}
+}
+
+export { Migration010SwiftFistsUnarmedDamage };

--- a/src/migration/migrations/index.ts
+++ b/src/migration/migrations/index.ts
@@ -7,3 +7,4 @@ export { Migration006DwarfMaxHitDice } from './Migration006DwarfMaxHitDice.js';
 export { Migration007WildOneHitDiceAdvantage } from './Migration007WildOneHitDiceAdvantage.js';
 export { Migration008FieldMedicHealingPotionBonus } from './Migration008FieldMedicHealingPotionBonus.js';
 export { Migration009HealingEffects } from './Migration009HealingEffects.js';
+export { Migration010SwiftFistsUnarmedDamage } from './Migration010SwiftFistsUnarmedDamage.js';

--- a/src/models/rules/unarmedDamage.ts
+++ b/src/models/rules/unarmedDamage.ts
@@ -1,0 +1,52 @@
+import { NimbleBaseRule } from './base.js';
+
+// Default unarmed damage per core rules: "roll 1d4; on hit: deal 1 + STR damage"
+const DEFAULT_UNARMED_DAMAGE = '1 + @abilities.strength.mod';
+
+function schema() {
+	const { fields } = foundry.data;
+
+	return {
+		value: new fields.StringField({
+			required: true,
+			nullable: false,
+			initial: '1d4 + @abilities.strength.mod',
+		}),
+		type: new fields.StringField({ required: true, nullable: false, initial: 'unarmedDamage' }),
+	};
+}
+
+declare namespace UnarmedDamageRule {
+	type Schema = NimbleBaseRule.Schema & ReturnType<typeof schema>;
+}
+
+class UnarmedDamageRule extends NimbleBaseRule<UnarmedDamageRule.Schema> {
+	declare value: string;
+
+	static override defineSchema(): UnarmedDamageRule.Schema {
+		return {
+			...NimbleBaseRule.defineSchema(),
+			...schema(),
+		};
+	}
+
+	override tooltipInfo(): string {
+		return super.tooltipInfo(new Map([['value', 'string']]));
+	}
+
+	/**
+	 * Apply the unarmed damage formula to the actor
+	 */
+	override afterPrepareData(): void {
+		const { item } = this;
+		if (!item.isEmbedded) return;
+		if (!this.test()) return;
+
+		const { actor } = item;
+
+		// Set the unarmed damage formula on the actor
+		foundry.utils.setProperty(actor.system, 'unarmedDamage', this.value);
+	}
+}
+
+export { UnarmedDamageRule, DEFAULT_UNARMED_DAMAGE };


### PR DESCRIPTION
## Summary
Adds a data-driven rule system for modifying unarmed strike damage, allowing class features like Swift Fists to customize unarmed damage formulas.

### Changes
- Add `unarmedDamage` rule that allows features to set custom unarmed strike damage
- Add `primaryDieAsDamage` option to DamageRoll for proper handling of custom formulas
- Update Swift Fists (Zephyr) to use the new rule system
- Add migration to convert existing Swift Fists features

### Technical Details
- The rule system evaluates active effects on actors to determine unarmed damage
- Default unarmed damage is `1 + @abilities.strength.mod` (no die roll)
- Swift Fists changes this to `1d4 + 1 + @abilities.strength.mod`

## Test plan
- [ ] Character without Swift Fists deals `1 + STR` unarmed damage
- [ ] Character with Swift Fists deals `1d4 + 1 + STR` unarmed damage
- [ ] Migration converts existing Swift Fists features correctly