### PR TITLE
feat: add Heroic Actions tab to PC sheet

### DIFF
--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -449,8 +449,8 @@ Use callback props for child-to-parent communication:
 ### Component Size Guidelines
 
 - **Small components (< 100 lines)**: Keep in single file
-- **Medium components (100-300 lines)**: Consider extracting sub-components
-- **Large components (> 300 lines)**: Definitely split into sub-components
+- **Medium components (100-500 lines)**: Consider extracting sub-components
+- **Large components (> 500 lines)**: Definitely split into sub-components
 
 Signs a component should be split:
 - Multiple unrelated concerns
@@ -1295,7 +1295,7 @@ Use these rules as a pre-review gate. They help keep files focused by extracting
 
 **Components:**
 - [ ] Components used by 2+ features are in `src/view/components/`
-- [ ] Large components (300+ lines) are split into sub-components
+- [ ] Large components (500+ lines) are split into sub-components
 
 **State:**
 - [ ] Loading, empty, and error states are handled

--- a/packs/classFeatures/core/the-cheat/the-cheat-progression/twist-the-blade-2.json
+++ b/packs/classFeatures/core/the-cheat/the-cheat-progression/twist-the-blade-2.json
@@ -39,7 +39,9 @@
 		"group": "the-cheat-progression",
 		"gainedAtLevel": 13,
 		"subclass": false,
-		"gainedAtLevels": [13]
+		"gainedAtLevels": [
+			13
+		]
 	},
 	"effects": [],
 	"flags": {},

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -538,7 +538,8 @@
 			"savingThrowBonus": "Save Bonus",
 			"savingThrowRollMode": "Save Roll Mode",
 			"skillBonus": "Skill Bonus",
-			"speedBonus": "Speed Bonus"
+			"speedBonus": "Speed Bonus",
+			"unarmedDamage": "Unarmed Damage"
 		},
 		"creatureFeatures": {
 			"noFeatures": "No features yet.",
@@ -675,6 +676,167 @@
 			"turn": "turn"
 		},
 		"ui": {
+			"cancel": "Cancel",
+			"heroicActions": {
+				"title": "Heroic Actions",
+				"reactionsTitle": "Heroic Reactions",
+				"reactionsPlaceholder": "Reactions coming soon...",
+				"enterCombat": "Enter combat to use actions",
+				"outsideCombat": "You are outside of combat",
+				"noActions": "You don't have any actions",
+				"noSpells": "You don't have any spells",
+				"endTurn": "End Turn",
+				"rollInitiative": "Roll Initiative",
+				"useActionsFirst": "Use your actions first",
+				"noPermissionEndTurn": "You do not have permission to end turns.",
+				"noPermissionRollInitiative": "You do not have permission to roll initiative.",
+				"selectAttack": "Attack",
+				"selectSpell": "Cast Spell",
+				"noWeapons": "No weapons or attack features found.",
+				"noSpellsFound": "No spells found.",
+				"unarmedStrike": "Unarmed Strike",
+				"feature": "Feature",
+				"mana": "{cost} Mana",
+				"thrown": "Thrown: {distance}",
+				"baseEffect": "Effect",
+				"higherLevelEffect": "At Higher Levels",
+				"cantrip": "Cantrip",
+				"spellTier": "Tier {tier}",
+				"rangeDistance": "Range: {distance}",
+				"reachDistance": "Reach: {distance}",
+				"targetTypes": {
+					"self": "Self",
+					"singleTarget": "Single Target",
+					"twoTargets": "2 Targets",
+					"multiTarget": "{count} Targets",
+					"aoe": "AoE"
+				},
+				"pip": {
+					"spendAction": "Spend action {number}",
+					"restoreAction": "Restore action {number}",
+					"clickToSpend": "Click to spend action",
+					"clickToRestore": "Click to restore action"
+				},
+				"actionsHeader": "Actions",
+				"moveAction": "<p><strong>{name}</strong> used an action to move.</p>",
+				"actions": {
+					"attack": {
+						"label": "Attack",
+						"description": "Strike with a weapon"
+					},
+					"spell": {
+						"label": "Cast a Spell",
+						"description": "Channel magical energy"
+					},
+					"move": {
+						"label": "Move",
+						"description": "Reposition on the battlefield"
+					},
+					"assess": {
+						"label": "Assess",
+						"description": "Study your surroundings"
+					}
+				},
+				"help": {
+					"dialogTitle": "Combat Reference",
+					"tooltip": "What can I do in combat?",
+					"tabs": {
+						"actions": "Actions",
+						"reactions": "Reactions"
+					},
+					"actions": {
+						"intro": "On your turn, you get 3 actions. All 3 recharge at the end of your turn, so spend them all! Generally, doing any single thing costs 1 action.",
+						"footer": "Rushed Attacks: Additional attacks after the first impose cumulative disadvantage.",
+						"attack": {
+							"title": "Attack",
+							"description": "Roll the die listed on your weapon or ability. Rolling a 1 is a miss. Rolling max on the Primary Die is a critical hit - roll again and add! Crits ignore armor."
+						},
+						"spell": {
+							"title": "Cast a Spell",
+							"description": "Requires a free hand (or focus) and the ability to speak. Costs mana equal to the spell's tier (cantrips are free). You can upcast spells for greater effect."
+						},
+						"move": {
+							"title": "Move",
+							"description": "Move up to your speed (usually 6 spaces). You can split movement around other actions and Move multiple times per turn. Difficult terrain halves speed."
+						},
+						"assess": {
+							"title": "Assess",
+							"description": "Make a DC 12 skill check to: Ask a Question (GM answers honestly), Create an Opening (+1 to Primary Die vs target), or Anticipate Danger (-1 to Primary Dice against you). Can't reuse the same skill in an encounter!"
+						},
+						"free": {
+							"title": "Free Actions",
+							"description": "Simple tasks like opening an unlocked door, shouting a phrase, dropping an item, or ending concentration. Limited to once per turn."
+						}
+					},
+					"reactions": {
+						"intro": "Reactions cost 1 action and are used when it's not your turn. Each reaction can only be used once per round, and you'll start your next turn with fewer actions.",
+						"footer": "You can combine reactions (like Interpose + Defend) if you have enough actions to spend!",
+						"defend": {
+							"title": "Defend",
+							"description": "Reduce damage from any single attack by your Armor value. Some damage (like psychic or certain area effects) may not be avoidable at the GM's discretion."
+						},
+						"interpose": {
+							"title": "Interpose",
+							"description": "When a creature within 2 spaces would be hit, push them aside and become the new target. You enter their space and move them to an adjacent space of your choice."
+						},
+						"opportunity": {
+							"title": "Opportunity Attack",
+							"description": "Make a melee attack with disadvantage against an adjacent enemy as it willingly moves away. Only heroes can make opportunity attacks - monsters cannot."
+						},
+						"help": {
+							"title": "Help",
+							"description": "Grant an ally advantage on a roll if you can explain how you'd help. The GM may call for a skill check or grant it automatically. Limited to one Help per roll."
+						}
+					}
+				},
+				"assess": {
+					"dialogTitle": "Assess Action",
+					"header": "Assess",
+					"selectOption": "Select an Option",
+					"selectSkill": "Select a Skill",
+					"selectSkillPlaceholder": "Choose a skill...",
+					"selectTarget": "Target",
+					"noTargetsHint": "Target a token on the canvas to select it",
+					"tooManyTargetsHint": "You can only target one creature at a time for this action",
+					"cannotTargetSelf": "You cannot target yourself. Target another creature on the canvas.",
+					"rollToAssess": "Roll {skill}",
+					"success": "Success",
+					"failure": "Failure",
+					"askQuestion": {
+						"title": "Ask a Question",
+						"chatTitle": "Assess: Ask a Question",
+						"description": "Ask the GM a question about the situation. They must answer truthfully based on what your character could reasonably perceive.",
+						"success": "<p><strong>{name}</strong> used an action to assess and may ask the GM one question. The GM will answer honestly.</p>",
+						"failure": "<p><strong>{name}</strong> used an action to assess but failed to glean any useful information.</p>"
+					},
+					"createOpening": {
+						"title": "Create an Opening",
+						"chatTitle": "Assess: Create an Opening",
+						"description": "Your next attack against the target gains +1 to the Primary Die this round.",
+						"success": "<p><strong>{name}</strong> used an action to assess <strong>{target}</strong> and create an opening. Their next attack against <strong>{target}</strong> gains <strong>+1 to the Primary Die</strong>.</p>",
+						"failure": "<p><strong>{name}</strong> used an action to assess <strong>{target}</strong> but failed to create an opening.</p>"
+					},
+					"anticipateDanger": {
+						"title": "Anticipate Danger",
+						"chatTitle": "Assess: Anticipate Danger",
+						"description": "All Primary Dice rolled against you are reduced by 1 this round.",
+						"success": "<p><strong>{name}</strong> used an action to assess and anticipate danger. All Primary Dice rolled against them are <strong>reduced by 1</strong> this round.</p>",
+						"failure": "<p><strong>{name}</strong> used an action to assess but failed to anticipate danger.</p>"
+					}
+				},
+				"move": {
+					"title": "Move",
+					"dialogTitle": "Move Action",
+					"confirmTitle": "Did you move?",
+					"confirmDescription": "Confirm that you've repositioned your character on the battlefield.",
+					"yourMovement": "Your Movement",
+					"spaces": "spaces",
+					"noMovement": "No movement speeds available",
+					"actionCost": "This will use 1 action",
+					"confirm": "Use Action to Move",
+					"cancel": "Cancel"
+				}
+			},
 			"clearAll": "Clear All",
 			"conditions": "Conditions",
 			"condition": "Condition",

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -789,6 +789,10 @@
 						}
 					}
 				},
+				"collapse": "Collapse",
+				"expand": "Expand",
+				"unknown": "Unknown",
+				"targetLabel": "Target:",
 				"assess": {
 					"dialogTitle": "Assess Action",
 					"header": "Assess",
@@ -800,6 +804,7 @@
 					"tooManyTargetsHint": "You can only target one creature at a time for this action",
 					"cannotTargetSelf": "You cannot target yourself. Target another creature on the canvas.",
 					"rollToAssess": "Roll {skill}",
+					"checkVsDC": "{skill} Check vs DC {dc}",
 					"success": "Success",
 					"failure": "Failure",
 					"askQuestion": {

--- a/public/system.json
+++ b/public/system.json
@@ -75,6 +75,7 @@
 		},
 		"ChatMessage": {
 			"abilityCheck": {},
+			"assessAction": {},
 			"boon": {},
 			"damage": {},
 			"feature": {},

--- a/src/dice/DamageRoll.ts
+++ b/src/dice/DamageRoll.ts
@@ -242,9 +242,13 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 			// When primaryDieAsDamage is false, exclude the base die value from damage
 			// (explosions still count toward damage)
 			if (!this.options.primaryDieAsDamage) {
-				// Find the first result (the base roll, not explosion rolls)
-				// The base result is the one that may have exploded: true flag
-				const baseResult = primaryTerm.results.find((r) => r.active && !r.discarded);
+				// Find the base roll result, not explosion rolls.
+				// When a die explodes, it gets the `exploded: true` flag, so we look for that first.
+				// If no explosion occurred, fall back to the first active, non-discarded result.
+				// This handles advantage/disadvantage where dice results may be reordered.
+				const baseResult =
+					primaryTerm.results.find((r) => r.active && !r.discarded && r.exploded) ??
+					primaryTerm.results.find((r) => r.active && !r.discarded);
 				if (baseResult) {
 					this.excludedPrimaryDieValue = baseResult.result;
 					// Adjust the total by subtracting the base die value

--- a/src/dice/DamageRoll.ts
+++ b/src/dice/DamageRoll.ts
@@ -242,13 +242,9 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 			// When primaryDieAsDamage is false, exclude the base die value from damage
 			// (explosions still count toward damage)
 			if (!this.options.primaryDieAsDamage) {
-				// Find the base roll result, not explosion rolls.
-				// When a die explodes, it gets the `exploded: true` flag, so we look for that first.
-				// If no explosion occurred, fall back to the first active, non-discarded result.
-				// This handles advantage/disadvantage where dice results may be reordered.
-				const baseResult =
-					primaryTerm.results.find((r) => r.active && !r.discarded && r.exploded) ??
-					primaryTerm.results.find((r) => r.active && !r.discarded);
+				// Find the first result (the base roll, not explosion rolls)
+				// The base result is the one that may have exploded: true flag
+				const baseResult = primaryTerm.results.find((r) => r.active && !r.discarded);
 				if (baseResult) {
 					this.excludedPrimaryDieValue = baseResult.result;
 					// Adjust the total by subtracting the base die value

--- a/src/documents/sheets/PlayerCharacterSheet.svelte.ts
+++ b/src/documents/sheets/PlayerCharacterSheet.svelte.ts
@@ -48,7 +48,7 @@ export default class PlayerCharacterSheet extends SvelteApplicationMixin(
 			icon: 'fa-solid fa-user',
 			resizable: true,
 		},
-		position: { ...SHEET_DEFAULTS.playerCharacter },
+		position: SHEET_DEFAULTS.playerCharacter,
 	};
 
 	protected override async _prepareContext(

--- a/src/documents/sheets/PlayerCharacterSheet.svelte.ts
+++ b/src/documents/sheets/PlayerCharacterSheet.svelte.ts
@@ -48,7 +48,7 @@ export default class PlayerCharacterSheet extends SvelteApplicationMixin(
 			icon: 'fa-solid fa-user',
 			resizable: true,
 		},
-		position: SHEET_DEFAULTS.playerCharacter,
+		position: { ...SHEET_DEFAULTS.playerCharacter },
 	};
 
 	protected override async _prepareContext(

--- a/src/documents/sheets/sheetDefaults.ts
+++ b/src/documents/sheets/sheetDefaults.ts
@@ -5,6 +5,7 @@ export const SHEET_DEFAULTS = {
 	playerCharacter: {
 		width: 367,
 		height: 850,
+		minWidth: 367,
 	},
 	npc: {
 		width: 332,

--- a/src/documents/sheets/sheetDefaults.ts
+++ b/src/documents/sheets/sheetDefaults.ts
@@ -5,7 +5,6 @@ export const SHEET_DEFAULTS = {
 	playerCharacter: {
 		width: 367,
 		height: 850,
-		minWidth: 367,
 	},
 	npc: {
 		width: 332,

--- a/src/documents/sheets/sheetDefaults.ts
+++ b/src/documents/sheets/sheetDefaults.ts
@@ -3,7 +3,7 @@
  */
 export const SHEET_DEFAULTS = {
 	playerCharacter: {
-		width: 332,
+		width: 367,
 		height: 850,
 	},
 	npc: {

--- a/src/migration/migrations/Migration010SwiftFistsUnarmedDamage.ts
+++ b/src/migration/migrations/Migration010SwiftFistsUnarmedDamage.ts
@@ -27,9 +27,9 @@ class Migration010SwiftFistsUnarmedDamage extends MigrationBase {
 		// Only process feature items
 		if (source.type !== 'feature') return;
 
-		// Check if this is the Swift Fists feature by sourceId or name
-		const isSwiftFists =
-			source.flags?.core?.sourceId === SWIFT_FISTS_SOURCE_ID || source.name === 'Swift Fists';
+		// Check if this is the Swift Fists feature by sourceId
+		// Name-only matching is avoided to prevent false positives with homebrew items
+		const isSwiftFists = source.flags?.core?.sourceId === SWIFT_FISTS_SOURCE_ID;
 
 		if (!isSwiftFists) return;
 

--- a/src/models/rules/unarmedDamage.ts
+++ b/src/models/rules/unarmedDamage.ts
@@ -1,8 +1,5 @@
 import { NimbleBaseRule } from './base.js';
 
-// Default unarmed damage per core rules: "roll 1d4; on hit: deal 1 + STR damage"
-const DEFAULT_UNARMED_DAMAGE = '1 + @abilities.strength.mod';
-
 function schema() {
 	const { fields } = foundry.data;
 
@@ -49,4 +46,4 @@ class UnarmedDamageRule extends NimbleBaseRule<UnarmedDamageRule.Schema> {
 	}
 }
 
-export { UnarmedDamageRule, DEFAULT_UNARMED_DAMAGE };
+export { UnarmedDamageRule };

--- a/src/scss/base/_theme.scss
+++ b/src/scss/base/_theme.scss
@@ -82,4 +82,12 @@
 	--nimble-roll-success-background-color: hsl(120, 30%, 25%);
 	--nimble-roll-failure-color: hsl(0, 65%, 60%);
 	--nimble-roll-failure-background-color: hsl(0, 40%, 25%);
+
+	/** HEROIC ACTIONS **/
+	--nimble-action-icon-color: hsl(210, 70%, 65%);
+	--nimble-action-info-background: hsla(45, 70%, 50%, 0.15);
+	--nimble-action-info-border-color: hsla(45, 70%, 50%, 0.4);
+	--nimble-action-info-text-color: hsl(45, 60%, 65%);
+	--nimble-action-info-icon-color: hsl(45, 70%, 55%);
+	--nimble-action-button-icon-color: hsl(210, 70%, 65%);
 }

--- a/src/scss/base/_variables.scss
+++ b/src/scss/base/_variables.scss
@@ -134,6 +134,14 @@
 	--nimble-rule-background-color: hsl(210, 30%, 95%);
 	--nimble-rule-border-color: hsl(210, 40%, 75%);
 
+	/** HEROIC ACTIONS **/
+	--nimble-action-icon-color: hsl(210, 60%, 45%);
+	--nimble-action-info-background: hsla(45, 70%, 50%, 0.15);
+	--nimble-action-info-border-color: hsla(45, 70%, 40%, 0.5);
+	--nimble-action-info-text-color: hsl(45, 70%, 28%);
+	--nimble-action-info-icon-color: hsl(45, 80%, 35%);
+	--nimble-action-button-icon-color: hsl(210, 65%, 45%);
+
 	/** ANIMATION **/
 	--nimble-standard-transition: all 0.15s ease-in-out;
 	--nimble-slow-transition: all 0.25s ease-in-out;

--- a/src/scss/components/_sheet.scss
+++ b/src/scss/components/_sheet.scss
@@ -30,6 +30,7 @@
 			background-color: var(--nimble-select-option-background-color);
 		}
 	}
+
 	.window-resize-handle {
 		z-index: 200 !important;
 		pointer-events: all !important;
@@ -108,7 +109,7 @@
 		--nimble-sheet-body-padding-block-start: 0.5rem;
 
 		&:not(.minimized) {
-			min-width: 332px;
+			min-width: 367px;
 			min-height: 550px;
 			background: transparent;
 			border: 0;

--- a/src/utils/assessOptions.ts
+++ b/src/utils/assessOptions.ts
@@ -1,0 +1,54 @@
+/**
+ * DC for Assess action skill checks
+ */
+export const ASSESS_DC = 12;
+
+/**
+ * Configuration for Assess action options
+ */
+export interface AssessOption {
+	id: string;
+	icon: string;
+	titleKey: string;
+	chatTitleKey: string;
+	descriptionKey: string;
+	successKey: string;
+	failureKey: string;
+	requiresTarget: boolean;
+}
+
+/**
+ * Available Assess action options
+ */
+export const assessOptions: AssessOption[] = [
+	{
+		id: 'ask-question',
+		icon: 'fa-solid fa-circle-question',
+		titleKey: 'NIMBLE.ui.heroicActions.assess.askQuestion.title',
+		chatTitleKey: 'NIMBLE.ui.heroicActions.assess.askQuestion.chatTitle',
+		descriptionKey: 'NIMBLE.ui.heroicActions.assess.askQuestion.description',
+		successKey: 'NIMBLE.ui.heroicActions.assess.askQuestion.success',
+		failureKey: 'NIMBLE.ui.heroicActions.assess.askQuestion.failure',
+		requiresTarget: false,
+	},
+	{
+		id: 'create-opening',
+		icon: 'fa-solid fa-crosshairs',
+		titleKey: 'NIMBLE.ui.heroicActions.assess.createOpening.title',
+		chatTitleKey: 'NIMBLE.ui.heroicActions.assess.createOpening.chatTitle',
+		descriptionKey: 'NIMBLE.ui.heroicActions.assess.createOpening.description',
+		successKey: 'NIMBLE.ui.heroicActions.assess.createOpening.success',
+		failureKey: 'NIMBLE.ui.heroicActions.assess.createOpening.failure',
+		requiresTarget: true,
+	},
+	{
+		id: 'anticipate-danger',
+		icon: 'fa-solid fa-shield',
+		titleKey: 'NIMBLE.ui.heroicActions.assess.anticipateDanger.title',
+		chatTitleKey: 'NIMBLE.ui.heroicActions.assess.anticipateDanger.chatTitle',
+		descriptionKey: 'NIMBLE.ui.heroicActions.assess.anticipateDanger.description',
+		successKey: 'NIMBLE.ui.heroicActions.assess.anticipateDanger.success',
+		failureKey: 'NIMBLE.ui.heroicActions.assess.anticipateDanger.failure',
+		requiresTarget: false,
+	},
+];

--- a/src/utils/evaluateFormula.ts
+++ b/src/utils/evaluateFormula.ts
@@ -8,7 +8,7 @@
  */
 export function evaluateFormula(
 	formula: string | undefined,
-	actor: { getRollData: () => object },
+	actor: { getRollData: () => Record<string, unknown> },
 ): string {
 	if (!formula) return '';
 
@@ -31,7 +31,7 @@ export function evaluateFormula(
 			} else {
 				try {
 					const evaluated = Roll.safeEval(trimmed);
-					if (typeof evaluated === 'number' && !isNaN(evaluated)) {
+					if (typeof evaluated === 'number' && !Number.isNaN(evaluated)) {
 						simplified.push(String(Math.floor(evaluated)));
 					} else {
 						simplified.push(trimmed);

--- a/src/utils/evaluateFormula.ts
+++ b/src/utils/evaluateFormula.ts
@@ -1,0 +1,58 @@
+/**
+ * Evaluates a roll formula by substituting actor data and simplifying numeric parts.
+ * Preserves dice notation (e.g., "1d6") while evaluating static math expressions.
+ *
+ * @param formula - The roll formula to evaluate (e.g., "1d6 + @abilities.strength.mod")
+ * @param actor - The actor to get roll data from
+ * @returns The simplified formula string
+ */
+export function evaluateFormula(
+	formula: string | undefined,
+	actor: { getRollData: () => object },
+): string {
+	if (!formula) return '';
+
+	try {
+		const rollData = actor.getRollData();
+		const substituted = Roll.replaceFormulaData(formula, rollData, { missing: '0' });
+
+		const parts = substituted.split(/([+-])/);
+		const simplified: string[] = [];
+
+		for (const part of parts) {
+			const trimmed = part.trim();
+			if (!trimmed) continue;
+
+			if (trimmed === '+' || trimmed === '-') {
+				simplified.push(trimmed);
+			} else if (/^\d*d\d+/i.test(trimmed)) {
+				// Keep dice notation as-is
+				simplified.push(trimmed);
+			} else {
+				try {
+					const evaluated = Roll.safeEval(trimmed);
+					if (typeof evaluated === 'number' && !isNaN(evaluated)) {
+						simplified.push(String(Math.floor(evaluated)));
+					} else {
+						simplified.push(trimmed);
+					}
+				} catch {
+					simplified.push(trimmed);
+				}
+			}
+		}
+
+		let result = simplified.join(' ').replace(/\s+/g, ' ').trim();
+		// Remove "+ 0" or "- 0" terms
+		result = result.replace(/[+-]\s*0(?!\d)/g, '').trim();
+		// Clean up leading operators and double operators
+		result = result
+			.replace(/^\s*[+-]\s*/, '')
+			.replace(/[+-]\s*[+-]/g, '+')
+			.trim();
+
+		return result || formula;
+	} catch {
+		return formula;
+	}
+}

--- a/src/utils/movementSpeeds.ts
+++ b/src/utils/movementSpeeds.ts
@@ -1,0 +1,43 @@
+export interface MovementSpeed {
+	type: string;
+	value: number;
+	label: string;
+	icon: string;
+}
+
+/**
+ * Get the movement speeds for an actor, formatted for display.
+ * @param actor - The actor to get movement speeds from
+ * @returns Array of movement speed objects with type, value, label, and icon
+ */
+export function getMovementSpeeds(actor: {
+	system?: { attributes?: { movement?: Record<string, number> } };
+}): MovementSpeed[] {
+	const { movementTypes, movementTypeIcons } = CONFIG.NIMBLE;
+	const movement = actor.system?.attributes?.movement ?? {};
+	const speeds: MovementSpeed[] = [];
+
+	// Always show walk first if it exists
+	if (movement.walk > 0) {
+		speeds.push({
+			type: 'walk',
+			value: movement.walk,
+			label: game.i18n.localize(movementTypes.walk),
+			icon: movementTypeIcons.walk,
+		});
+	}
+
+	// Add other movement types if non-zero
+	for (const type of ['fly', 'climb', 'swim', 'burrow']) {
+		if (movement[type] > 0) {
+			speeds.push({
+				type,
+				value: movement[type],
+				label: game.i18n.localize(movementTypes[type]),
+				icon: movementTypeIcons[type],
+			});
+		}
+	}
+
+	return speeds;
+}

--- a/src/utils/targeting.ts
+++ b/src/utils/targeting.ts
@@ -1,0 +1,30 @@
+import localize from './localize.js';
+
+/**
+ * Get currently targeted tokens, excluding tokens belonging to the specified actor.
+ * @param actorId - The actor ID to exclude (typically the acting character)
+ * @returns Array of targeted tokens that don't belong to the specified actor
+ */
+export function getTargetedTokens(actorId: string): Token[] {
+	const targets = Array.from(game.user?.targets ?? []);
+	return targets.filter((token) => token.actor?.id !== actorId);
+}
+
+/**
+ * Get currently targeted tokens that belong to the specified actor (self-targeting).
+ * @param actorId - The actor ID to check for
+ * @returns Array of targeted tokens that belong to the specified actor
+ */
+export function getInvalidTargets(actorId: string): Token[] {
+	const targets = Array.from(game.user?.targets ?? []);
+	return targets.filter((token) => token.actor?.id === actorId);
+}
+
+/**
+ * Get the display name for a token.
+ * @param token - The token to get the name from
+ * @returns The token's actor name, token name, or localized "Unknown" fallback
+ */
+export function getTargetName(token: Token | null | undefined): string {
+	return token?.actor?.name || token?.name || localize('NIMBLE.ui.heroicActions.unknown');
+}

--- a/src/view/chat/AssessActionCard.svelte
+++ b/src/view/chat/AssessActionCard.svelte
@@ -2,6 +2,7 @@
 	import calculateHeaderTextColor from '../dataPreparationHelpers/calculateHeaderTextColor.js';
 	import { getRollModeSummary } from '../dataPreparationHelpers/getRollModeSummary.js';
 	import prepareRollTooltip from '../dataPreparationHelpers/rollTooltips/prepareRollTooltip.js';
+	import localize from '../../utils/localize.js';
 
 	import CardHeader from './components/CardHeader.svelte';
 	import RollSummary from './components/RollSummary.svelte';
@@ -30,8 +31,16 @@
 	const target = $derived(system.target);
 	const targetName = $derived(system.targetName);
 
-	const label = $derived(`${skills[skillKey]} Check vs DC ${dc}`);
-	const resultLabel = $derived(isSuccess ? 'SUCCESS' : 'FAILED');
+	const label = $derived(
+		localize('NIMBLE.ui.heroicActions.assess.checkVsDC', { skill: skills[skillKey], dc }),
+	);
+	const resultLabel = $derived(
+		localize(
+			isSuccess
+				? 'NIMBLE.ui.heroicActions.assess.success'
+				: 'NIMBLE.ui.heroicActions.assess.failure',
+		),
+	);
 	const hintClass = $derived(isSuccess ? 'nimble-hint--success' : 'nimble-hint--warning');
 	const hintIcon = $derived(
 		isSuccess ? 'fa-solid fa-circle-check' : 'fa-solid fa-circle-exclamation',
@@ -60,8 +69,17 @@
 						alt={targetName}
 					/>
 				{/if}
+			{:catch}
+				<!-- Token lookup failed, show fallback image -->
+				<img
+					class="assess-action-card__target-img"
+					src="icons/svg/mystery-man.svg"
+					alt={targetName}
+				/>
 			{/await}
-			<span class="assess-action-card__target-label">Target:</span>
+			<span class="assess-action-card__target-label"
+				>{localize('NIMBLE.ui.heroicActions.targetLabel')}</span
+			>
 			<span class="assess-action-card__target-name">{targetName}</span>
 		</div>
 	{/if}

--- a/src/view/chat/components/DamageRoll.svelte
+++ b/src/view/chat/components/DamageRoll.svelte
@@ -40,18 +40,30 @@
 	const { actorType, permissions } = messageDocument.system;
 
 	let { damageType, ignoreArmor = false, outcome, roll } = $props();
-	let { options: rollOptions } = $derived(roll);
+	let rollOptions = $derived(roll?.options ?? {});
 	let label = $derived(damageTypes[damageType] ?? '');
 	let multiplier = $derived(getDamageMultiplier(outcome));
 	let secondaryInfo = $derived(getSecondaryInformation(outcome, ignoreArmor, rollOptions).trim());
 </script>
 
-<RollSummary
-	{label}
-	tooltip={prepareRollTooltip(actorType, permissions, Roll.fromData(roll))}
-	subheading={secondaryInfo}
-	total={Math.ceil(roll.total * multiplier)}
-	type="damage"
-	options={{ damageType, ignoreArmor, outcome, rollOptions }}
-	showRollDetails={rollOptions.primaryDieValue != '0' || rollOptions?.primaryDieModifier != '0'}
-/>
+{#if roll?.class}
+	<RollSummary
+		{label}
+		tooltip={prepareRollTooltip(actorType, permissions, Roll.fromData(roll))}
+		subheading={secondaryInfo}
+		total={Math.ceil(roll.total * multiplier)}
+		type="damage"
+		options={{ damageType, ignoreArmor, outcome, rollOptions }}
+		showRollDetails={rollOptions.primaryDieValue != '0' || rollOptions?.primaryDieModifier != '0'}
+	/>
+{:else}
+	<RollSummary
+		{label}
+		tooltip={null}
+		subheading={secondaryInfo}
+		total={Math.ceil((roll?.total ?? 0) * multiplier)}
+		type="damage"
+		options={{ damageType, ignoreArmor, outcome, rollOptions }}
+		showRollDetails={false}
+	/>
+{/if}

--- a/src/view/dialogs/AssessActionDialog.svelte
+++ b/src/view/dialogs/AssessActionDialog.svelte
@@ -1,7 +1,7 @@
 <script>
 	import { onMount, onDestroy } from 'svelte';
 	import localize from '../../utils/localize.js';
-	import { createAssessDialogState } from './AssessActionDialog.svelte.js';
+	import { createAssessDialogState } from './AssessActionDialog.svelte.ts';
 
 	// ============================================================================
 	// Props
@@ -13,7 +13,12 @@
 	// State
 	// ============================================================================
 
-	const state = createAssessDialogState(document, dialog, deductActionPip, inCombat);
+	const state = createAssessDialogState(
+		() => document,
+		dialog,
+		() => deductActionPip,
+		() => inCombat,
+	);
 
 	let cleanupHook = null;
 

--- a/src/view/dialogs/AssessActionDialog.svelte
+++ b/src/view/dialogs/AssessActionDialog.svelte
@@ -1,61 +1,62 @@
 <script>
 	import { onMount, onDestroy } from 'svelte';
 	import localize from '../../utils/localize.js';
+	import { ASSESS_DC, assessOptions } from '../../utils/assessOptions.js';
+	import { getTargetedTokens, getInvalidTargets, getTargetName } from '../../utils/targeting.js';
 
-	const ASSESS_DC = 12;
+	// ============================================================================
+	// Props
+	// ============================================================================
 
-	const assessOptions = [
-		{
-			id: 'ask-question',
-			icon: 'fa-solid fa-circle-question',
-			titleKey: 'NIMBLE.ui.heroicActions.assess.askQuestion.title',
-			chatTitleKey: 'NIMBLE.ui.heroicActions.assess.askQuestion.chatTitle',
-			descriptionKey: 'NIMBLE.ui.heroicActions.assess.askQuestion.description',
-			successKey: 'NIMBLE.ui.heroicActions.assess.askQuestion.success',
-			failureKey: 'NIMBLE.ui.heroicActions.assess.askQuestion.failure',
-			requiresTarget: false,
-		},
-		{
-			id: 'create-opening',
-			icon: 'fa-solid fa-crosshairs',
-			titleKey: 'NIMBLE.ui.heroicActions.assess.createOpening.title',
-			chatTitleKey: 'NIMBLE.ui.heroicActions.assess.createOpening.chatTitle',
-			descriptionKey: 'NIMBLE.ui.heroicActions.assess.createOpening.description',
-			successKey: 'NIMBLE.ui.heroicActions.assess.createOpening.success',
-			failureKey: 'NIMBLE.ui.heroicActions.assess.createOpening.failure',
-			requiresTarget: true,
-		},
-		{
-			id: 'anticipate-danger',
-			icon: 'fa-solid fa-shield',
-			titleKey: 'NIMBLE.ui.heroicActions.assess.anticipateDanger.title',
-			chatTitleKey: 'NIMBLE.ui.heroicActions.assess.anticipateDanger.chatTitle',
-			descriptionKey: 'NIMBLE.ui.heroicActions.assess.anticipateDanger.description',
-			successKey: 'NIMBLE.ui.heroicActions.assess.anticipateDanger.success',
-			failureKey: 'NIMBLE.ui.heroicActions.assess.anticipateDanger.failure',
-			requiresTarget: false,
-		},
-	];
+	let { document, dialog, deductActionPip, inCombat = false } = $props();
 
-	function getTargetedTokens(actorId) {
-		const targets = Array.from(game.user?.targets ?? []);
-		// Filter out tokens belonging to the same actor (can't target self)
-		return targets.filter((token) => token.actor?.id !== actorId);
-	}
+	// ============================================================================
+	// Constants
+	// ============================================================================
 
-	function getInvalidTargets(actorId) {
-		const targets = Array.from(game.user?.targets ?? []);
-		// Return tokens that were filtered out (self-targeting)
-		return targets.filter((token) => token.actor?.id === actorId);
-	}
+	const { skills: skillNames } = CONFIG.NIMBLE;
 
-	function getTargetName(token) {
-		return token?.actor?.name || token?.name || 'Unknown';
-	}
+	// ============================================================================
+	// State
+	// ============================================================================
 
-	// Track targeting changes reactively
+	let selectedOption = $state(null);
+	let selectedSkill = $state(null);
+	let selectedTarget = $state(null);
 	let targetingVersion = $state(0);
 	let hookId = null;
+
+	// ============================================================================
+	// Derived Values
+	// ============================================================================
+
+	let currentOptionRequiresTarget = $derived(
+		assessOptions.find((o) => o.id === selectedOption)?.requiresTarget ?? false,
+	);
+
+	let availableTargets = $derived.by(() => {
+		void targetingVersion;
+		return getTargetedTokens(document.id);
+	});
+
+	let hasTargetedSelf = $derived.by(() => {
+		void targetingVersion;
+		return getInvalidTargets(document.id).length > 0;
+	});
+
+	let sortedSkills = $derived(
+		Object.entries(skillNames).sort(([, nameA], [, nameB]) => nameA.localeCompare(nameB)),
+	);
+
+	let isSubmitDisabled = $derived(
+		!selectedOption ||
+			!selectedSkill ||
+			(currentOptionRequiresTarget && availableTargets.length !== 1),
+	);
+
+	// ============================================================================
+	// Lifecycle
+	// ============================================================================
 
 	onMount(() => {
 		hookId = Hooks.on('targetToken', () => {
@@ -69,20 +70,35 @@
 		}
 	});
 
+	// ============================================================================
+	// Effects
+	// ============================================================================
+
+	$effect(() => {
+		if (currentOptionRequiresTarget && availableTargets.length === 1) {
+			selectedTarget = availableTargets[0];
+		} else if (currentOptionRequiresTarget && availableTargets.length !== 1) {
+			selectedTarget = null;
+		}
+	});
+
+	$effect(() => {
+		if (!currentOptionRequiresTarget) {
+			selectedTarget = null;
+		}
+	});
+
+	// ============================================================================
+	// Event Handlers
+	// ============================================================================
+
 	async function handleSubmit() {
 		if (!selectedOption || !selectedSkill) return;
 
 		const option = assessOptions.find((o) => o.id === selectedOption);
 
-		// Check if target is required but not selected
 		if (option.requiresTarget && !selectedTarget) return;
 
-		// Only deduct action pip if in combat
-		if (inCombat) {
-			await deductActionPip();
-		}
-
-		// Roll the skill check (skip the roll dialog since we're already in a dialog)
 		const { roll } = await document.rollSkillCheck(selectedSkill, { skipRollDialog: true });
 
 		if (!roll) {
@@ -90,15 +106,16 @@
 			return;
 		}
 
-		// Determine success/failure based on DC 12
+		// Deduct action pip only after roll is confirmed (not cancelled)
+		if (inCombat) {
+			await deductActionPip();
+		}
+
 		const isSuccess = roll.total >= ASSESS_DC;
 		const resultKey = isSuccess ? option.successKey : option.failureKey;
-
-		// Include target name in the message if there's a target
 		const targetName = selectedTarget ? getTargetName(selectedTarget) : null;
 		const resultMessage = localize(resultKey, { name: document.name, target: targetName });
 
-		// Create chat message with proper type for Svelte rendering
 		await ChatMessage.create({
 			author: game.user?.id,
 			speaker: ChatMessage.getSpeaker({ actor: document }),
@@ -127,59 +144,6 @@
 			target: selectedTarget?.document.uuid,
 		});
 	}
-
-	let { document, dialog, deductActionPip, inCombat = false } = $props();
-
-	const { skills: skillNames } = CONFIG.NIMBLE;
-
-	let selectedOption = $state(null);
-	let selectedSkill = $state(null);
-	let selectedTarget = $state(null);
-
-	// Check if the current option requires a target
-	let currentOptionRequiresTarget = $derived(
-		assessOptions.find((o) => o.id === selectedOption)?.requiresTarget ?? false,
-	);
-
-	// Get available targets (currently targeted tokens) - depends on targetingVersion for reactivity
-	let availableTargets = $derived.by(() => {
-		// Reference targetingVersion to trigger reactivity when targeting changes
-		void targetingVersion;
-		return getTargetedTokens(document.id);
-	});
-
-	// Track if the user has targeted themselves (to show a helpful message)
-	let hasTargetedSelf = $derived.by(() => {
-		void targetingVersion;
-		return getInvalidTargets(document.id).length > 0;
-	});
-
-	// Auto-select target if exactly one is targeted
-	$effect(() => {
-		if (currentOptionRequiresTarget && availableTargets.length === 1) {
-			selectedTarget = availableTargets[0];
-		} else if (currentOptionRequiresTarget && availableTargets.length !== 1) {
-			selectedTarget = null;
-		}
-	});
-
-	// Clear target when switching to an option that doesn't require it
-	$effect(() => {
-		if (!currentOptionRequiresTarget) {
-			selectedTarget = null;
-		}
-	});
-
-	let sortedSkills = $derived(
-		Object.entries(skillNames).sort(([, nameA], [, nameB]) => nameA.localeCompare(nameB)),
-	);
-
-	// Determine if submit should be disabled (requires exactly one target for Create an Opening)
-	let isSubmitDisabled = $derived(
-		!selectedOption ||
-			!selectedSkill ||
-			(currentOptionRequiresTarget && availableTargets.length !== 1),
-	);
 </script>
 
 <article class="nimble-sheet__body assess-dialog">

--- a/src/view/dialogs/AssessActionDialog.svelte
+++ b/src/view/dialogs/AssessActionDialog.svelte
@@ -1,0 +1,563 @@
+<script>
+	import { onMount, onDestroy } from 'svelte';
+	import localize from '../../utils/localize.js';
+
+	const ASSESS_DC = 12;
+
+	const assessOptions = [
+		{
+			id: 'ask-question',
+			icon: 'fa-solid fa-circle-question',
+			titleKey: 'NIMBLE.ui.heroicActions.assess.askQuestion.title',
+			chatTitleKey: 'NIMBLE.ui.heroicActions.assess.askQuestion.chatTitle',
+			descriptionKey: 'NIMBLE.ui.heroicActions.assess.askQuestion.description',
+			successKey: 'NIMBLE.ui.heroicActions.assess.askQuestion.success',
+			failureKey: 'NIMBLE.ui.heroicActions.assess.askQuestion.failure',
+			requiresTarget: false,
+		},
+		{
+			id: 'create-opening',
+			icon: 'fa-solid fa-crosshairs',
+			titleKey: 'NIMBLE.ui.heroicActions.assess.createOpening.title',
+			chatTitleKey: 'NIMBLE.ui.heroicActions.assess.createOpening.chatTitle',
+			descriptionKey: 'NIMBLE.ui.heroicActions.assess.createOpening.description',
+			successKey: 'NIMBLE.ui.heroicActions.assess.createOpening.success',
+			failureKey: 'NIMBLE.ui.heroicActions.assess.createOpening.failure',
+			requiresTarget: true,
+		},
+		{
+			id: 'anticipate-danger',
+			icon: 'fa-solid fa-shield',
+			titleKey: 'NIMBLE.ui.heroicActions.assess.anticipateDanger.title',
+			chatTitleKey: 'NIMBLE.ui.heroicActions.assess.anticipateDanger.chatTitle',
+			descriptionKey: 'NIMBLE.ui.heroicActions.assess.anticipateDanger.description',
+			successKey: 'NIMBLE.ui.heroicActions.assess.anticipateDanger.success',
+			failureKey: 'NIMBLE.ui.heroicActions.assess.anticipateDanger.failure',
+			requiresTarget: false,
+		},
+	];
+
+	function getTargetedTokens(actorId) {
+		const targets = Array.from(game.user?.targets ?? []);
+		// Filter out tokens belonging to the same actor (can't target self)
+		return targets.filter((token) => token.actor?.id !== actorId);
+	}
+
+	function getInvalidTargets(actorId) {
+		const targets = Array.from(game.user?.targets ?? []);
+		// Return tokens that were filtered out (self-targeting)
+		return targets.filter((token) => token.actor?.id === actorId);
+	}
+
+	function getTargetName(token) {
+		return token?.actor?.name || token?.name || 'Unknown';
+	}
+
+	// Track targeting changes reactively
+	let targetingVersion = $state(0);
+	let hookId = null;
+
+	onMount(() => {
+		hookId = Hooks.on('targetToken', () => {
+			targetingVersion++;
+		});
+	});
+
+	onDestroy(() => {
+		if (hookId !== null) {
+			Hooks.off('targetToken', hookId);
+		}
+	});
+
+	async function handleSubmit() {
+		if (!selectedOption || !selectedSkill) return;
+
+		const option = assessOptions.find((o) => o.id === selectedOption);
+
+		// Check if target is required but not selected
+		if (option.requiresTarget && !selectedTarget) return;
+
+		// Only deduct action pip if in combat
+		if (inCombat) {
+			await deductActionPip();
+		}
+
+		// Roll the skill check (skip the roll dialog since we're already in a dialog)
+		const { roll } = await document.rollSkillCheck(selectedSkill, { skipRollDialog: true });
+
+		if (!roll) {
+			dialog.close();
+			return;
+		}
+
+		// Determine success/failure based on DC 12
+		const isSuccess = roll.total >= ASSESS_DC;
+		const resultKey = isSuccess ? option.successKey : option.failureKey;
+
+		// Include target name in the message if there's a target
+		const targetName = selectedTarget ? getTargetName(selectedTarget) : null;
+		const resultMessage = localize(resultKey, { name: document.name, target: targetName });
+
+		// Create chat message with proper type for Svelte rendering
+		await ChatMessage.create({
+			author: game.user?.id,
+			speaker: ChatMessage.getSpeaker({ actor: document }),
+			sound: CONFIG.sounds.dice,
+			rolls: [roll],
+			type: 'assessAction',
+			system: {
+				actorName: document.name,
+				actorType: document.type,
+				permissions: document.permission,
+				rollMode: 0,
+				skillKey: selectedSkill,
+				dc: ASSESS_DC,
+				isSuccess,
+				optionTitle: localize(option.chatTitleKey),
+				resultMessage,
+				target: selectedTarget ? selectedTarget.document.uuid : null,
+				targetName,
+			},
+		});
+
+		dialog.submit({
+			option: selectedOption,
+			skill: selectedSkill,
+			isSuccess,
+			target: selectedTarget?.document.uuid,
+		});
+	}
+
+	let { document, dialog, deductActionPip, inCombat = false } = $props();
+
+	const { skills: skillNames } = CONFIG.NIMBLE;
+
+	let selectedOption = $state(null);
+	let selectedSkill = $state(null);
+	let selectedTarget = $state(null);
+
+	// Check if the current option requires a target
+	let currentOptionRequiresTarget = $derived(
+		assessOptions.find((o) => o.id === selectedOption)?.requiresTarget ?? false,
+	);
+
+	// Get available targets (currently targeted tokens) - depends on targetingVersion for reactivity
+	let availableTargets = $derived.by(() => {
+		// Reference targetingVersion to trigger reactivity when targeting changes
+		void targetingVersion;
+		return getTargetedTokens(document.id);
+	});
+
+	// Track if the user has targeted themselves (to show a helpful message)
+	let hasTargetedSelf = $derived.by(() => {
+		void targetingVersion;
+		return getInvalidTargets(document.id).length > 0;
+	});
+
+	// Auto-select target if exactly one is targeted
+	$effect(() => {
+		if (currentOptionRequiresTarget && availableTargets.length === 1) {
+			selectedTarget = availableTargets[0];
+		} else if (currentOptionRequiresTarget && availableTargets.length !== 1) {
+			selectedTarget = null;
+		}
+	});
+
+	// Clear target when switching to an option that doesn't require it
+	$effect(() => {
+		if (!currentOptionRequiresTarget) {
+			selectedTarget = null;
+		}
+	});
+
+	let sortedSkills = $derived(
+		Object.entries(skillNames).sort(([, nameA], [, nameB]) => nameA.localeCompare(nameB)),
+	);
+
+	// Determine if submit should be disabled (requires exactly one target for Create an Opening)
+	let isSubmitDisabled = $derived(
+		!selectedOption ||
+			!selectedSkill ||
+			(currentOptionRequiresTarget && availableTargets.length !== 1),
+	);
+</script>
+
+<article class="nimble-sheet__body assess-dialog">
+	<section>
+		<header class="nimble-section-header">
+			<h3 class="nimble-heading" data-heading-variant="section">
+				{localize('NIMBLE.ui.heroicActions.assess.header')}
+			</h3>
+		</header>
+
+		<div class="assess-dialog__options">
+			{#each assessOptions as option}
+				<label class="assess-option" class:assess-option--active={selectedOption === option.id}>
+					<input
+						class="assess-option__input"
+						type="radio"
+						name="assess-option"
+						value={option.id}
+						bind:group={selectedOption}
+					/>
+
+					<i class="assess-option__icon {option.icon}"></i>
+
+					<div class="assess-option__content">
+						<span class="assess-option__title">{localize(option.titleKey)}</span>
+						<span class="assess-option__description">{localize(option.descriptionKey)}</span>
+					</div>
+
+					<div class="assess-option__indicator"></div>
+				</label>
+			{/each}
+		</div>
+	</section>
+
+	<section>
+		<select class="assess-dialog__select" bind:value={selectedSkill}>
+			<option value={null} disabled
+				>{localize('NIMBLE.ui.heroicActions.assess.selectSkillPlaceholder')}</option
+			>
+			{#each sortedSkills as [skillKey, skillName]}
+				<option value={skillKey}>{skillName}</option>
+			{/each}
+		</select>
+	</section>
+
+	{#if currentOptionRequiresTarget}
+		<section>
+			<header class="nimble-section-header">
+				<h3 class="nimble-heading" data-heading-variant="section">
+					{localize('NIMBLE.ui.heroicActions.assess.selectTarget')}
+				</h3>
+			</header>
+
+			{#if availableTargets.length === 0}
+				<div class="assess-dialog__no-targets">
+					<i class="fa-solid fa-crosshairs"></i>
+					{#if hasTargetedSelf}
+						<span>{localize('NIMBLE.ui.heroicActions.assess.cannotTargetSelf')}</span>
+					{:else}
+						<span>{localize('NIMBLE.ui.heroicActions.assess.noTargetsHint')}</span>
+					{/if}
+				</div>
+			{:else if availableTargets.length === 1}
+				<div class="assess-dialog__targets">
+					<div class="assess-target assess-target--active assess-target--single">
+						<img
+							class="assess-target__img"
+							src={availableTargets[0].document?.texture?.src || 'icons/svg/mystery-man.svg'}
+							alt={getTargetName(availableTargets[0])}
+						/>
+						<span class="assess-target__name">{getTargetName(availableTargets[0])}</span>
+						<i class="fa-solid fa-check assess-target__check"></i>
+					</div>
+				</div>
+			{:else}
+				<div class="assess-dialog__no-targets assess-dialog__no-targets--warning">
+					<i class="fa-solid fa-triangle-exclamation"></i>
+					<span>{localize('NIMBLE.ui.heroicActions.assess.tooManyTargetsHint')}</span>
+				</div>
+			{/if}
+		</section>
+	{/if}
+</article>
+
+<footer class="nimble-sheet__footer">
+	<button class="nimble-button" data-button-variant="basic" onclick={() => dialog.close()}>
+		{localize('NIMBLE.ui.cancel')}
+	</button>
+	<button
+		class="nimble-button"
+		data-button-variant="basic"
+		disabled={isSubmitDisabled}
+		onclick={handleSubmit}
+	>
+		<i class="nimble-button__icon fa-solid fa-dice-d20"></i>
+		{#if !selectedOption}
+			{localize('NIMBLE.ui.heroicActions.assess.selectOption')}
+		{:else if !selectedSkill}
+			{localize('NIMBLE.ui.heroicActions.assess.selectSkill')}
+		{:else}
+			{localize('NIMBLE.ui.heroicActions.assess.rollToAssess', {
+				skill: skillNames[selectedSkill],
+			})}
+		{/if}
+	</button>
+</footer>
+
+<style lang="scss">
+	.nimble-sheet__footer {
+		display: flex;
+		gap: 0.5rem;
+
+		[data-button-variant='basic'] {
+			--nimble-button-padding: 0.5rem;
+
+			flex: 1;
+
+			&:disabled {
+				opacity: 0.5;
+				cursor: not-allowed;
+			}
+		}
+	}
+
+	.assess-dialog {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+		padding: 0.75rem;
+
+		&__options {
+			display: flex;
+			flex-direction: column;
+			gap: 0.5rem;
+		}
+
+		&__select {
+			width: 100%;
+			padding: 0.5rem;
+			font-size: var(--nimble-sm-text);
+			font-weight: 500;
+			color: var(--nimble-dark-text-color);
+			background: var(--nimble-input-background-color);
+			border: 1px solid var(--nimble-input-border-color);
+			border-radius: 4px;
+			cursor: pointer;
+
+			&:focus {
+				outline: none;
+				border-color: var(--nimble-input-focus-border-color);
+			}
+		}
+	}
+
+	.assess-option {
+		position: relative;
+		display: flex;
+		align-items: flex-start;
+		gap: 0.75rem;
+		padding: 0.75rem;
+		background: var(--nimble-box-background-color);
+		border: 2px solid var(--nimble-card-border-color);
+		border-radius: 6px;
+		cursor: pointer;
+		transition: all 0.2s ease;
+
+		&:hover:not(&--active) {
+			border-color: var(--nimble-accent-color);
+		}
+
+		&--active {
+			border-color: hsl(45, 60%, 45%);
+			background: hsla(45, 60%, 50%, 0.12);
+			box-shadow: inset 0 0 0 1px hsla(45, 60%, 50%, 0.2);
+		}
+
+		&__input {
+			position: absolute;
+			opacity: 0;
+			pointer-events: none;
+		}
+
+		&__icon {
+			flex-shrink: 0;
+			font-size: var(--nimble-md-text);
+			color: var(--nimble-medium-text-color);
+			transition: color 0.2s ease;
+
+			.assess-option--active & {
+				color: hsl(45, 60%, 40%);
+			}
+		}
+
+		&__content {
+			display: flex;
+			flex-direction: column;
+			gap: 0.25rem;
+			flex: 1;
+			min-width: 0;
+		}
+
+		&__title {
+			font-size: var(--nimble-sm-text);
+			font-weight: 600;
+			color: var(--nimble-dark-text-color);
+			line-height: 1.2;
+			transition: color 0.2s ease;
+
+			.assess-option--active & {
+				color: hsl(45, 50%, 30%);
+			}
+		}
+
+		&__description {
+			font-size: var(--nimble-xs-text);
+			font-weight: 500;
+			color: var(--nimble-medium-text-color);
+			line-height: 1.4;
+		}
+
+		&__indicator {
+			position: absolute;
+			top: 0.5rem;
+			right: 0.5rem;
+			width: 0.625rem;
+			height: 0.625rem;
+			border-radius: 50%;
+			background: transparent;
+			border: 2px solid transparent;
+			transition: all 0.2s ease;
+
+			.assess-option--active & {
+				background: hsl(45, 70%, 50%);
+				border-color: hsl(45, 70%, 40%);
+				box-shadow: 0 0 8px hsla(45, 70%, 50%, 0.6);
+			}
+		}
+	}
+
+	:global(.theme-dark) .assess-option {
+		background: hsl(220, 15%, 18%);
+		border-color: hsl(220, 10%, 30%);
+
+		&:hover:not(.assess-option--active) {
+			border-color: hsl(220, 15%, 45%);
+			background: hsl(220, 15%, 22%);
+		}
+	}
+
+	:global(.theme-dark) .assess-option--active {
+		border-color: hsl(45, 70%, 55%);
+		background: linear-gradient(135deg, hsla(45, 60%, 50%, 0.2) 0%, hsla(45, 60%, 40%, 0.1) 100%);
+		box-shadow:
+			inset 0 0 0 1px hsla(45, 60%, 60%, 0.3),
+			0 0 12px hsla(45, 60%, 50%, 0.15);
+	}
+
+	:global(.theme-dark) .assess-option--active .assess-option__icon {
+		color: hsl(45, 70%, 65%);
+	}
+
+	:global(.theme-dark) .assess-option--active .assess-option__title {
+		color: hsl(45, 60%, 75%);
+	}
+
+	:global(.theme-dark) .assess-option--active .assess-option__description {
+		color: hsl(220, 10%, 80%);
+	}
+
+	:global(.theme-dark) .assess-option--active .assess-option__indicator {
+		background: hsl(45, 70%, 55%);
+		border-color: hsl(45, 70%, 65%);
+		box-shadow: 0 0 10px hsla(45, 70%, 55%, 0.7);
+	}
+
+	.assess-dialog__no-targets {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 1rem;
+		color: var(--nimble-medium-text-color);
+		font-size: var(--nimble-sm-text);
+		text-align: center;
+		background: var(--nimble-box-background-color);
+		border: 1px dashed var(--nimble-card-border-color);
+		border-radius: 4px;
+
+		i {
+			font-size: var(--nimble-lg-text);
+			opacity: 0.5;
+		}
+
+		&--warning {
+			color: #fff;
+			background: hsl(35, 85%, 55%);
+			border-color: hsl(35, 85%, 45%);
+			border-style: solid;
+
+			i {
+				opacity: 1;
+			}
+		}
+	}
+
+	.assess-dialog__targets {
+		display: flex;
+		flex-direction: column;
+		gap: 0.375rem;
+	}
+
+	.assess-target {
+		position: relative;
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.375rem 0.5rem;
+		background: var(--nimble-box-background-color);
+		border: 2px solid var(--nimble-card-border-color);
+		border-radius: 4px;
+		cursor: pointer;
+		transition: all 0.15s ease;
+
+		&:hover:not(&--active) {
+			border-color: var(--nimble-accent-color);
+		}
+
+		&--active {
+			border-color: hsl(45, 60%, 45%);
+			background: hsla(45, 60%, 50%, 0.12);
+		}
+
+		&__input {
+			position: absolute;
+			opacity: 0;
+			pointer-events: none;
+		}
+
+		&__img {
+			width: 1.75rem;
+			height: 1.75rem;
+			border-radius: 3px;
+			object-fit: cover;
+			border: 1px solid var(--nimble-card-border-color);
+		}
+
+		&__name {
+			flex: 1;
+			font-size: var(--nimble-sm-text);
+			font-weight: 500;
+			color: var(--nimble-dark-text-color);
+		}
+
+		&__check {
+			color: hsl(139, 50%, 40%);
+			font-size: var(--nimble-sm-text);
+		}
+
+		&--single {
+			cursor: default;
+		}
+	}
+
+	:global(.theme-dark) .assess-target {
+		background: hsl(220, 15%, 18%);
+		border-color: hsl(220, 10%, 30%);
+
+		&:hover:not(.assess-target--active) {
+			border-color: hsl(220, 15%, 45%);
+		}
+	}
+
+	:global(.theme-dark) .assess-target--active {
+		border-color: hsl(45, 70%, 55%);
+		background: hsla(45, 60%, 50%, 0.15);
+	}
+
+	:global(.theme-dark) .assess-target__check {
+		color: hsl(139, 50%, 55%);
+	}
+</style>

--- a/src/view/dialogs/AssessActionDialog.svelte
+++ b/src/view/dialogs/AssessActionDialog.svelte
@@ -1,8 +1,7 @@
 <script>
 	import { onMount, onDestroy } from 'svelte';
 	import localize from '../../utils/localize.js';
-	import { ASSESS_DC, assessOptions } from '../../utils/assessOptions.js';
-	import { getTargetedTokens, getInvalidTargets, getTargetName } from '../../utils/targeting.js';
+	import { createAssessDialogState } from './AssessActionDialog.svelte.js';
 
 	// ============================================================================
 	// Props
@@ -11,63 +10,23 @@
 	let { document, dialog, deductActionPip, inCombat = false } = $props();
 
 	// ============================================================================
-	// Constants
-	// ============================================================================
-
-	const { skills: skillNames } = CONFIG.NIMBLE;
-
-	// ============================================================================
 	// State
 	// ============================================================================
 
-	let selectedOption = $state(null);
-	let selectedSkill = $state(null);
-	let selectedTarget = $state(null);
-	let targetingVersion = $state(0);
-	let hookId = null;
+	const state = createAssessDialogState(document, dialog, deductActionPip, inCombat);
 
-	// ============================================================================
-	// Derived Values
-	// ============================================================================
-
-	let currentOptionRequiresTarget = $derived(
-		assessOptions.find((o) => o.id === selectedOption)?.requiresTarget ?? false,
-	);
-
-	let availableTargets = $derived.by(() => {
-		void targetingVersion;
-		return getTargetedTokens(document.id);
-	});
-
-	let hasTargetedSelf = $derived.by(() => {
-		void targetingVersion;
-		return getInvalidTargets(document.id).length > 0;
-	});
-
-	let sortedSkills = $derived(
-		Object.entries(skillNames).sort(([, nameA], [, nameB]) => nameA.localeCompare(nameB)),
-	);
-
-	let isSubmitDisabled = $derived(
-		!selectedOption ||
-			!selectedSkill ||
-			(currentOptionRequiresTarget && availableTargets.length !== 1),
-	);
+	let cleanupHook = null;
 
 	// ============================================================================
 	// Lifecycle
 	// ============================================================================
 
 	onMount(() => {
-		hookId = Hooks.on('targetToken', () => {
-			targetingVersion++;
-		});
+		cleanupHook = state.setupTargetingHook(() => state.updateSelectedTarget());
 	});
 
 	onDestroy(() => {
-		if (hookId !== null) {
-			Hooks.off('targetToken', hookId);
-		}
+		if (cleanupHook) cleanupHook();
 	});
 
 	// ============================================================================
@@ -75,75 +34,8 @@
 	// ============================================================================
 
 	$effect(() => {
-		if (currentOptionRequiresTarget && availableTargets.length === 1) {
-			selectedTarget = availableTargets[0];
-		} else if (currentOptionRequiresTarget && availableTargets.length !== 1) {
-			selectedTarget = null;
-		}
+		state.updateSelectedTarget();
 	});
-
-	$effect(() => {
-		if (!currentOptionRequiresTarget) {
-			selectedTarget = null;
-		}
-	});
-
-	// ============================================================================
-	// Event Handlers
-	// ============================================================================
-
-	async function handleSubmit() {
-		if (!selectedOption || !selectedSkill) return;
-
-		const option = assessOptions.find((o) => o.id === selectedOption);
-
-		if (option.requiresTarget && !selectedTarget) return;
-
-		const { roll } = await document.rollSkillCheck(selectedSkill, { skipRollDialog: true });
-
-		if (!roll) {
-			dialog.close();
-			return;
-		}
-
-		// Deduct action pip only after roll is confirmed (not cancelled)
-		if (inCombat) {
-			await deductActionPip();
-		}
-
-		const isSuccess = roll.total >= ASSESS_DC;
-		const resultKey = isSuccess ? option.successKey : option.failureKey;
-		const targetName = selectedTarget ? getTargetName(selectedTarget) : null;
-		const resultMessage = localize(resultKey, { name: document.name, target: targetName });
-
-		await ChatMessage.create({
-			author: game.user?.id,
-			speaker: ChatMessage.getSpeaker({ actor: document }),
-			sound: CONFIG.sounds.dice,
-			rolls: [roll],
-			type: 'assessAction',
-			system: {
-				actorName: document.name,
-				actorType: document.type,
-				permissions: document.permission,
-				rollMode: 0,
-				skillKey: selectedSkill,
-				dc: ASSESS_DC,
-				isSuccess,
-				optionTitle: localize(option.chatTitleKey),
-				resultMessage,
-				target: selectedTarget ? selectedTarget.document.uuid : null,
-				targetName,
-			},
-		});
-
-		dialog.submit({
-			option: selectedOption,
-			skill: selectedSkill,
-			isSuccess,
-			target: selectedTarget?.document.uuid,
-		});
-	}
 </script>
 
 <article class="nimble-sheet__body assess-dialog">
@@ -155,14 +47,17 @@
 		</header>
 
 		<div class="assess-dialog__options">
-			{#each assessOptions as option}
-				<label class="assess-option" class:assess-option--active={selectedOption === option.id}>
+			{#each state.assessOptions as option}
+				<label
+					class="assess-option"
+					class:assess-option--active={state.selectedOption === option.id}
+				>
 					<input
 						class="assess-option__input"
 						type="radio"
 						name="assess-option"
 						value={option.id}
-						bind:group={selectedOption}
+						bind:group={state.selectedOption}
 					/>
 
 					<i class="assess-option__icon {option.icon}"></i>
@@ -179,17 +74,17 @@
 	</section>
 
 	<section>
-		<select class="assess-dialog__select" bind:value={selectedSkill}>
+		<select class="assess-dialog__select" bind:value={state.selectedSkill}>
 			<option value={null} disabled
 				>{localize('NIMBLE.ui.heroicActions.assess.selectSkillPlaceholder')}</option
 			>
-			{#each sortedSkills as [skillKey, skillName]}
+			{#each state.sortedSkills as [skillKey, skillName]}
 				<option value={skillKey}>{skillName}</option>
 			{/each}
 		</select>
 	</section>
 
-	{#if currentOptionRequiresTarget}
+	{#if state.currentOptionRequiresTarget}
 		<section>
 			<header class="nimble-section-header">
 				<h3 class="nimble-heading" data-heading-variant="section">
@@ -197,24 +92,25 @@
 				</h3>
 			</header>
 
-			{#if availableTargets.length === 0}
+			{#if state.availableTargets.length === 0}
 				<div class="assess-dialog__no-targets">
 					<i class="fa-solid fa-crosshairs"></i>
-					{#if hasTargetedSelf}
+					{#if state.hasTargetedSelf}
 						<span>{localize('NIMBLE.ui.heroicActions.assess.cannotTargetSelf')}</span>
 					{:else}
 						<span>{localize('NIMBLE.ui.heroicActions.assess.noTargetsHint')}</span>
 					{/if}
 				</div>
-			{:else if availableTargets.length === 1}
+			{:else if state.availableTargets.length === 1}
 				<div class="assess-dialog__targets">
 					<div class="assess-target assess-target--active assess-target--single">
 						<img
 							class="assess-target__img"
-							src={availableTargets[0].document?.texture?.src || 'icons/svg/mystery-man.svg'}
-							alt={getTargetName(availableTargets[0])}
+							src={state.availableTargets[0].document?.texture?.src || 'icons/svg/mystery-man.svg'}
+							alt={state.getTargetName(state.availableTargets[0])}
 						/>
-						<span class="assess-target__name">{getTargetName(availableTargets[0])}</span>
+						<span class="assess-target__name">{state.getTargetName(state.availableTargets[0])}</span
+						>
 						<i class="fa-solid fa-check assess-target__check"></i>
 					</div>
 				</div>
@@ -235,17 +131,17 @@
 	<button
 		class="nimble-button"
 		data-button-variant="basic"
-		disabled={isSubmitDisabled}
-		onclick={handleSubmit}
+		disabled={state.isSubmitDisabled}
+		onclick={state.handleSubmit}
 	>
 		<i class="nimble-button__icon fa-solid fa-dice-d20"></i>
-		{#if !selectedOption}
+		{#if !state.selectedOption}
 			{localize('NIMBLE.ui.heroicActions.assess.selectOption')}
-		{:else if !selectedSkill}
+		{:else if !state.selectedSkill}
 			{localize('NIMBLE.ui.heroicActions.assess.selectSkill')}
 		{:else}
 			{localize('NIMBLE.ui.heroicActions.assess.rollToAssess', {
-				skill: skillNames[selectedSkill],
+				skill: state.skillNames[state.selectedSkill],
 			})}
 		{/if}
 	</button>

--- a/src/view/dialogs/AssessActionDialog.svelte.ts
+++ b/src/view/dialogs/AssessActionDialog.svelte.ts
@@ -2,8 +2,6 @@ import { ASSESS_DC, assessOptions } from '../../utils/assessOptions.js';
 import localize from '../../utils/localize.js';
 import { getInvalidTargets, getTargetedTokens, getTargetName } from '../../utils/targeting.js';
 
-const { skills: skillNames } = CONFIG.NIMBLE;
-
 interface AssessDialogResult {
 	option: string;
 	skill: string;
@@ -17,6 +15,7 @@ export function createAssessDialogState(
 	deductActionPip: () => Promise<void>,
 	inCombat: boolean,
 ) {
+	const { skills: skillNames } = CONFIG.NIMBLE;
 	let selectedOption = $state<string | null>(null);
 	let selectedSkill = $state<string | null>(null);
 	let selectedTarget = $state<Token | null>(null);

--- a/src/view/dialogs/AssessActionDialog.svelte.ts
+++ b/src/view/dialogs/AssessActionDialog.svelte.ts
@@ -1,0 +1,175 @@
+import { ASSESS_DC, assessOptions } from '../../utils/assessOptions.js';
+import localize from '../../utils/localize.js';
+import { getInvalidTargets, getTargetedTokens, getTargetName } from '../../utils/targeting.js';
+
+const { skills: skillNames } = CONFIG.NIMBLE;
+
+interface AssessDialogResult {
+	option: string;
+	skill: string;
+	isSuccess: boolean;
+	target?: string;
+}
+
+export function createAssessDialogState(
+	document: Actor,
+	dialog: { close: () => void; submit: (result: AssessDialogResult) => void },
+	deductActionPip: () => Promise<void>,
+	inCombat: boolean,
+) {
+	let selectedOption = $state<string | null>(null);
+	let selectedSkill = $state<string | null>(null);
+	let selectedTarget = $state<Token | null>(null);
+	let targetingVersion = $state(0);
+
+	// ============================================================================
+	// Derived Values
+	// ============================================================================
+
+	const currentOptionRequiresTarget = $derived(
+		assessOptions.find((o) => o.id === selectedOption)?.requiresTarget ?? false,
+	);
+
+	const availableTargets = $derived.by(() => {
+		void targetingVersion;
+		return getTargetedTokens(document.id);
+	});
+
+	const hasTargetedSelf = $derived.by(() => {
+		void targetingVersion;
+		return getInvalidTargets(document.id).length > 0;
+	});
+
+	const sortedSkills = $derived(
+		Object.entries(skillNames).sort(([, nameA], [, nameB]) =>
+			(nameA as string).localeCompare(nameB as string),
+		),
+	);
+
+	const isSubmitDisabled = $derived(
+		!selectedOption ||
+			!selectedSkill ||
+			(currentOptionRequiresTarget && availableTargets.length !== 1),
+	);
+
+	// ============================================================================
+	// Effects - must be called in component
+	// ============================================================================
+
+	function setupTargetingHook(onUpdate: () => void): () => void {
+		const hookId = Hooks.on('targetToken', () => {
+			targetingVersion++;
+			onUpdate();
+		});
+		return () => Hooks.off('targetToken', hookId);
+	}
+
+	function updateSelectedTarget(): void {
+		if (currentOptionRequiresTarget && availableTargets.length === 1) {
+			selectedTarget = availableTargets[0];
+		} else if (currentOptionRequiresTarget && availableTargets.length !== 1) {
+			selectedTarget = null;
+		}
+
+		if (!currentOptionRequiresTarget) {
+			selectedTarget = null;
+		}
+	}
+
+	// ============================================================================
+	// Event Handlers
+	// ============================================================================
+
+	async function handleSubmit(): Promise<void> {
+		if (!selectedOption || !selectedSkill) return;
+
+		const option = assessOptions.find((o) => o.id === selectedOption);
+		if (!option) return;
+
+		if (option.requiresTarget && !selectedTarget) return;
+
+		const { roll } = await document.rollSkillCheck(selectedSkill, { skipRollDialog: true });
+
+		if (!roll) {
+			dialog.close();
+			return;
+		}
+
+		// Deduct action pip only after roll is confirmed (not cancelled)
+		if (inCombat) {
+			await deductActionPip();
+		}
+
+		const isSuccess = roll.total >= ASSESS_DC;
+		const resultKey = isSuccess ? option.successKey : option.failureKey;
+		const targetName = selectedTarget ? getTargetName(selectedTarget) : null;
+		const resultMessage = localize(resultKey, { name: document.name, target: targetName });
+
+		await ChatMessage.create({
+			author: game.user?.id,
+			speaker: ChatMessage.getSpeaker({ actor: document }),
+			sound: CONFIG.sounds.dice,
+			rolls: [roll],
+			type: 'assessAction',
+			system: {
+				actorName: document.name,
+				actorType: document.type,
+				permissions: document.permission,
+				rollMode: 0,
+				skillKey: selectedSkill,
+				dc: ASSESS_DC,
+				isSuccess,
+				optionTitle: localize(option.chatTitleKey),
+				resultMessage,
+				target: selectedTarget ? selectedTarget.document.uuid : null,
+				targetName,
+			},
+		});
+
+		dialog.submit({
+			option: selectedOption,
+			skill: selectedSkill,
+			isSuccess,
+			target: selectedTarget?.document.uuid,
+		});
+	}
+
+	return {
+		get selectedOption() {
+			return selectedOption;
+		},
+		set selectedOption(value: string | null) {
+			selectedOption = value;
+		},
+		get selectedSkill() {
+			return selectedSkill;
+		},
+		set selectedSkill(value: string | null) {
+			selectedSkill = value;
+		},
+		get selectedTarget() {
+			return selectedTarget;
+		},
+		get currentOptionRequiresTarget() {
+			return currentOptionRequiresTarget;
+		},
+		get availableTargets() {
+			return availableTargets;
+		},
+		get hasTargetedSelf() {
+			return hasTargetedSelf;
+		},
+		get sortedSkills() {
+			return sortedSkills;
+		},
+		get isSubmitDisabled() {
+			return isSubmitDisabled;
+		},
+		assessOptions,
+		skillNames,
+		getTargetName,
+		setupTargetingHook,
+		updateSelectedTarget,
+		handleSubmit,
+	};
+}

--- a/src/view/dialogs/AssessActionDialog.svelte.ts
+++ b/src/view/dialogs/AssessActionDialog.svelte.ts
@@ -1,3 +1,5 @@
+import type { SkillKeyType } from '#types/skillKey.js';
+import type { NimbleCharacter } from '../../documents/actor/character.js';
 import { ASSESS_DC, assessOptions } from '../../utils/assessOptions.js';
 import localize from '../../utils/localize.js';
 import { getInvalidTargets, getTargetedTokens, getTargetName } from '../../utils/targeting.js';
@@ -10,10 +12,10 @@ interface AssessDialogResult {
 }
 
 export function createAssessDialogState(
-	document: Actor,
+	getDocument: () => NimbleCharacter,
 	dialog: { close: () => void; submit: (result: AssessDialogResult) => void },
-	deductActionPip: () => Promise<void>,
-	inCombat: boolean,
+	getDeductActionPip: () => () => Promise<void>,
+	getInCombat: () => boolean,
 ) {
 	const { skills: skillNames } = CONFIG.NIMBLE;
 	let selectedOption = $state<string | null>(null);
@@ -31,12 +33,12 @@ export function createAssessDialogState(
 
 	const availableTargets = $derived.by(() => {
 		void targetingVersion;
-		return getTargetedTokens(document.id);
+		return getTargetedTokens(getDocument().id ?? '');
 	});
 
 	const hasTargetedSelf = $derived.by(() => {
 		void targetingVersion;
-		return getInvalidTargets(document.id).length > 0;
+		return getInvalidTargets(getDocument().id ?? '').length > 0;
 	});
 
 	const sortedSkills = $derived(
@@ -87,7 +89,9 @@ export function createAssessDialogState(
 
 		if (option.requiresTarget && !selectedTarget) return;
 
-		const { roll } = await document.rollSkillCheck(selectedSkill, { skipRollDialog: true });
+		const { roll } = await getDocument().rollSkillCheck(selectedSkill as SkillKeyType, {
+			skipRollDialog: true,
+		});
 
 		if (!roll) {
 			dialog.close();
@@ -95,25 +99,29 @@ export function createAssessDialogState(
 		}
 
 		// Deduct action pip only after roll is confirmed (not cancelled)
-		if (inCombat) {
-			await deductActionPip();
+		if (getInCombat()) {
+			await getDeductActionPip()();
 		}
 
-		const isSuccess = roll.total >= ASSESS_DC;
+		const isSuccess = (roll.total ?? 0) >= ASSESS_DC;
 		const resultKey = isSuccess ? option.successKey : option.failureKey;
 		const targetName = selectedTarget ? getTargetName(selectedTarget) : null;
-		const resultMessage = localize(resultKey, { name: document.name, target: targetName });
+		const resultMessage = localize(resultKey, {
+			name: getDocument().name,
+			target: targetName ?? '',
+		});
 
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		await ChatMessage.create({
 			author: game.user?.id,
-			speaker: ChatMessage.getSpeaker({ actor: document }),
+			speaker: ChatMessage.getSpeaker({ actor: getDocument() }),
 			sound: CONFIG.sounds.dice,
 			rolls: [roll],
 			type: 'assessAction',
 			system: {
-				actorName: document.name,
-				actorType: document.type,
-				permissions: document.permission,
+				actorName: getDocument().name,
+				actorType: getDocument().type,
+				permissions: getDocument().permission,
 				rollMode: 0,
 				skillKey: selectedSkill,
 				dc: ASSESS_DC,
@@ -123,7 +131,7 @@ export function createAssessDialogState(
 				target: selectedTarget ? selectedTarget.document.uuid : null,
 				targetName,
 			},
-		});
+		} as any);
 
 		dialog.submit({
 			option: selectedOption,

--- a/src/view/dialogs/HeroicActionsHelpDialog.svelte
+++ b/src/view/dialogs/HeroicActionsHelpDialog.svelte
@@ -1,0 +1,268 @@
+<script>
+	import localize from '../../utils/localize.js';
+
+	const HEROIC_ACTIONS = [
+		{
+			id: 'attack',
+			icon: 'fa-solid fa-sword',
+			titleKey: 'NIMBLE.ui.heroicActions.help.actions.attack.title',
+			descriptionKey: 'NIMBLE.ui.heroicActions.help.actions.attack.description',
+		},
+		{
+			id: 'spell',
+			icon: 'fa-solid fa-wand-sparkles',
+			titleKey: 'NIMBLE.ui.heroicActions.help.actions.spell.title',
+			descriptionKey: 'NIMBLE.ui.heroicActions.help.actions.spell.description',
+		},
+		{
+			id: 'move',
+			icon: 'fa-solid fa-person-running',
+			titleKey: 'NIMBLE.ui.heroicActions.help.actions.move.title',
+			descriptionKey: 'NIMBLE.ui.heroicActions.help.actions.move.description',
+		},
+		{
+			id: 'assess',
+			icon: 'fa-solid fa-eye',
+			titleKey: 'NIMBLE.ui.heroicActions.help.actions.assess.title',
+			descriptionKey: 'NIMBLE.ui.heroicActions.help.actions.assess.description',
+		},
+		{
+			id: 'free',
+			icon: 'fa-solid fa-bolt',
+			titleKey: 'NIMBLE.ui.heroicActions.help.actions.free.title',
+			descriptionKey: 'NIMBLE.ui.heroicActions.help.actions.free.description',
+		},
+	];
+
+	const HEROIC_REACTIONS = [
+		{
+			id: 'defend',
+			icon: 'fa-solid fa-shield',
+			titleKey: 'NIMBLE.ui.heroicActions.help.reactions.defend.title',
+			descriptionKey: 'NIMBLE.ui.heroicActions.help.reactions.defend.description',
+		},
+		{
+			id: 'interpose',
+			icon: 'fa-solid fa-people-arrows',
+			titleKey: 'NIMBLE.ui.heroicActions.help.reactions.interpose.title',
+			descriptionKey: 'NIMBLE.ui.heroicActions.help.reactions.interpose.description',
+		},
+		{
+			id: 'opportunity',
+			icon: 'fa-solid fa-bullseye',
+			titleKey: 'NIMBLE.ui.heroicActions.help.reactions.opportunity.title',
+			descriptionKey: 'NIMBLE.ui.heroicActions.help.reactions.opportunity.description',
+		},
+		{
+			id: 'help',
+			icon: 'fa-solid fa-handshake-angle',
+			titleKey: 'NIMBLE.ui.heroicActions.help.reactions.help.title',
+			descriptionKey: 'NIMBLE.ui.heroicActions.help.reactions.help.description',
+		},
+	];
+
+	let activeTab = $state('actions');
+</script>
+
+<article class="nimble-sheet__body help-dialog">
+	<div class="help-dialog__tabs">
+		<button
+			class="help-dialog__tab"
+			class:help-dialog__tab--active={activeTab === 'actions'}
+			type="button"
+			onclick={() => (activeTab = 'actions')}
+		>
+			<i class="fa-solid fa-bolt"></i>
+			{localize('NIMBLE.ui.heroicActions.help.tabs.actions')}
+		</button>
+		<button
+			class="help-dialog__tab"
+			class:help-dialog__tab--active={activeTab === 'reactions'}
+			type="button"
+			onclick={() => (activeTab = 'reactions')}
+		>
+			<i class="fa-solid fa-reply"></i>
+			{localize('NIMBLE.ui.heroicActions.help.tabs.reactions')}
+		</button>
+	</div>
+
+	{#if activeTab === 'actions'}
+		<p class="help-dialog__intro">
+			{localize('NIMBLE.ui.heroicActions.help.actions.intro')}
+		</p>
+
+		<ul class="help-dialog__list">
+			{#each HEROIC_ACTIONS as action (action.id)}
+				<li class="help-item">
+					<div class="help-item__icon">
+						<i class={action.icon}></i>
+					</div>
+					<div class="help-item__content">
+						<h4 class="help-item__title">{localize(action.titleKey)}</h4>
+						<p class="help-item__description">{localize(action.descriptionKey)}</p>
+					</div>
+				</li>
+			{/each}
+		</ul>
+
+		<p class="help-dialog__footer">
+			{localize('NIMBLE.ui.heroicActions.help.actions.footer')}
+		</p>
+	{:else}
+		<p class="help-dialog__intro">
+			{localize('NIMBLE.ui.heroicActions.help.reactions.intro')}
+		</p>
+
+		<ul class="help-dialog__list">
+			{#each HEROIC_REACTIONS as reaction (reaction.id)}
+				<li class="help-item">
+					<div class="help-item__icon">
+						<i class={reaction.icon}></i>
+					</div>
+					<div class="help-item__content">
+						<h4 class="help-item__title">{localize(reaction.titleKey)}</h4>
+						<p class="help-item__description">{localize(reaction.descriptionKey)}</p>
+					</div>
+				</li>
+			{/each}
+		</ul>
+
+		<p class="help-dialog__footer">
+			{localize('NIMBLE.ui.heroicActions.help.reactions.footer')}
+		</p>
+	{/if}
+</article>
+
+<style lang="scss">
+	.help-dialog {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+		padding: 0.75rem;
+
+		&__tabs {
+			display: flex;
+			gap: 0.25rem;
+			padding-bottom: 0.5rem;
+			border-bottom: 1px solid var(--nimble-card-border-color);
+		}
+
+		&__tab {
+			display: flex;
+			align-items: center;
+			gap: 0.5rem;
+			flex: 1;
+			padding: 0.5rem 0.75rem;
+			font-size: var(--nimble-sm-text);
+			font-weight: 600;
+			color: var(--nimble-medium-text-color);
+			background: var(--nimble-box-background-color);
+			border: 2px solid var(--nimble-card-border-color);
+			border-radius: 4px;
+			cursor: pointer;
+			transition: all 0.15s ease;
+			justify-content: center;
+
+			i {
+				font-size: 0.875rem;
+			}
+
+			&:hover:not(&--active) {
+				border-color: var(--nimble-accent-color);
+				color: var(--nimble-dark-text-color);
+			}
+
+			&--active {
+				color: hsl(45, 60%, 35%);
+				background: hsla(45, 60%, 50%, 0.12);
+				border-color: hsl(45, 60%, 45%);
+			}
+		}
+
+		&__intro {
+			margin: 0;
+			padding: 0 0.75rem;
+			font-size: var(--nimble-sm-text);
+			font-weight: 500;
+			color: var(--nimble-dark-text-color);
+			line-height: 1.5;
+		}
+
+		&__list {
+			display: flex;
+			flex-direction: column;
+			gap: 0.5rem;
+			margin: 0;
+			padding: 0;
+			list-style: none;
+		}
+
+		&__footer {
+			margin: 0;
+			padding: 0.5rem 0.75rem;
+			font-size: var(--nimble-sm-text);
+			font-weight: 500;
+			color: var(--nimble-medium-text-color);
+			line-height: 1.4;
+			background: var(--nimble-hint-background-color);
+			border: 1px solid var(--nimble-hint-border-color);
+			border-radius: 4px;
+		}
+	}
+
+	.help-item {
+		display: flex;
+		align-items: flex-start;
+		gap: 0.75rem;
+		padding: 0.625rem;
+		background: var(--nimble-box-background-color);
+		border: 1px solid var(--nimble-card-border-color);
+		border-radius: 4px;
+
+		&__icon {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			width: 2rem;
+			height: 2rem;
+			background: var(--nimble-basic-button-background-color);
+			border-radius: 4px;
+			flex-shrink: 0;
+
+			i {
+				font-size: 0.875rem;
+				color: var(--nimble-medium-text-color);
+			}
+		}
+
+		&__content {
+			display: flex;
+			flex-direction: column;
+			gap: 0.125rem;
+			flex: 1;
+			min-width: 0;
+		}
+
+		&__title {
+			margin: 0;
+			font-size: var(--nimble-sm-text);
+			font-weight: 600;
+			color: var(--nimble-dark-text-color);
+			line-height: 1.3;
+		}
+
+		&__description {
+			margin: 0;
+			font-size: var(--nimble-xs-text);
+			font-weight: 500;
+			color: var(--nimble-medium-text-color);
+			line-height: 1.4;
+		}
+	}
+
+	:global(.theme-dark) .help-dialog__tab--active {
+		color: hsl(45, 70%, 65%);
+		background: linear-gradient(135deg, hsla(45, 60%, 50%, 0.2) 0%, hsla(45, 60%, 40%, 0.1) 100%);
+		border-color: hsl(45, 70%, 55%);
+	}
+</style>

--- a/src/view/dialogs/MoveActionDialog.svelte
+++ b/src/view/dialogs/MoveActionDialog.svelte
@@ -1,0 +1,278 @@
+<script>
+	import localize from '../../utils/localize.js';
+
+	let { document, dialog, deductActionPip, inCombat = false } = $props();
+
+	const { movementTypes, movementTypeIcons } = CONFIG.NIMBLE;
+
+	// Get movement speeds, filtering to only show non-zero values
+	let movementSpeeds = $derived.by(() => {
+		const movement = document.system?.attributes?.movement ?? {};
+		const speeds = [];
+
+		// Always show walk first if it exists
+		if (movement.walk > 0) {
+			speeds.push({
+				type: 'walk',
+				value: movement.walk,
+				label: game.i18n.localize(movementTypes.walk),
+				icon: movementTypeIcons.walk,
+			});
+		}
+
+		// Add other movement types if non-zero
+		for (const type of ['fly', 'climb', 'swim', 'burrow']) {
+			if (movement[type] > 0) {
+				speeds.push({
+					type,
+					value: movement[type],
+					label: game.i18n.localize(movementTypes[type]),
+					icon: movementTypeIcons[type],
+				});
+			}
+		}
+
+		return speeds;
+	});
+
+	async function handleConfirm() {
+		// Deduct action pip if in combat
+		if (inCombat) {
+			await deductActionPip();
+		}
+
+		// Send chat message
+		await ChatMessage.create({
+			speaker: ChatMessage.getSpeaker({ actor: document }),
+			content: localize('NIMBLE.ui.heroicActions.moveAction', { name: document.name }),
+		});
+
+		dialog.submit({ confirmed: true });
+	}
+
+	function handleCancel() {
+		dialog.close();
+	}
+</script>
+
+<article class="nimble-sheet__body move-dialog">
+	<section class="move-dialog__content">
+		<div class="move-dialog__icon-wrapper">
+			<i class="fa-solid fa-person-running move-dialog__icon"></i>
+		</div>
+
+		<h3 class="move-dialog__title">{localize('NIMBLE.ui.heroicActions.move.confirmTitle')}</h3>
+
+		<p class="move-dialog__description">
+			{localize('NIMBLE.ui.heroicActions.move.confirmDescription')}
+		</p>
+
+		{#if movementSpeeds.length > 0}
+			<div class="move-dialog__speeds">
+				<span class="move-dialog__speeds-label"
+					>{localize('NIMBLE.ui.heroicActions.move.yourMovement')}</span
+				>
+				<div class="move-dialog__speeds-list">
+					{#each movementSpeeds as speed}
+						<div class="move-dialog__speed">
+							<i class={speed.icon}></i>
+							<span class="move-dialog__speed-value">{speed.value}</span>
+							<span class="move-dialog__speed-label">{speed.label}</span>
+						</div>
+					{/each}
+				</div>
+			</div>
+		{/if}
+
+		<div class="move-dialog__warning">
+			<i class="fa-solid fa-circle-info"></i>
+			<span>{localize('NIMBLE.ui.heroicActions.move.actionCost')}</span>
+		</div>
+	</section>
+</article>
+
+<footer class="nimble-sheet__footer move-dialog__footer">
+	<button class="nimble-button" data-button-variant="basic" onclick={handleCancel}>
+		{localize('NIMBLE.ui.heroicActions.move.cancel')}
+	</button>
+	<button class="nimble-button" data-button-variant="primary" onclick={handleConfirm}>
+		<i class="fa-solid fa-check"></i>
+		{localize('NIMBLE.ui.heroicActions.move.confirm')}
+	</button>
+</footer>
+
+<style lang="scss">
+	.move-dialog {
+		padding: 1.25rem;
+
+		&__content {
+			display: flex;
+			flex-direction: column;
+			align-items: center;
+			gap: 0.75rem;
+			text-align: center;
+		}
+
+		&__icon-wrapper {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			width: 3.5rem;
+			height: 3.5rem;
+			background: linear-gradient(135deg, hsl(210, 60%, 50%) 0%, hsl(210, 70%, 40%) 100%);
+			border-radius: 50%;
+			box-shadow: 0 4px 12px hsla(210, 70%, 40%, 0.3);
+		}
+
+		&__icon {
+			font-size: 1.5rem;
+			color: white;
+		}
+
+		&__title {
+			margin: 0;
+			font-size: var(--nimble-lg-text);
+			font-weight: 700;
+			color: var(--nimble-dark-text-color);
+		}
+
+		&__description {
+			margin: 0;
+			font-size: var(--nimble-sm-text);
+			font-weight: 500;
+			color: var(--nimble-medium-text-color);
+			line-height: 1.5;
+		}
+
+		&__speeds {
+			display: flex;
+			flex-direction: column;
+			align-items: center;
+			gap: 0.5rem;
+			width: 100%;
+			padding: 0.75rem;
+			background: var(--nimble-box-background-color);
+			border: 1px solid var(--nimble-card-border-color);
+			border-radius: 8px;
+		}
+
+		&__speeds-label {
+			font-size: var(--nimble-xs-text);
+			font-weight: 600;
+			color: var(--nimble-medium-text-color);
+			text-transform: uppercase;
+			letter-spacing: 0.05em;
+		}
+
+		&__speeds-list {
+			display: flex;
+			flex-wrap: wrap;
+			justify-content: center;
+			gap: 0.75rem;
+		}
+
+		&__speed {
+			display: flex;
+			align-items: center;
+			gap: 0.375rem;
+			padding: 0.375rem 0.625rem;
+			background: var(--nimble-basic-button-background-color);
+			border-radius: 4px;
+
+			i {
+				font-size: 0.875rem;
+				color: hsl(210, 60%, 50%);
+			}
+		}
+
+		&__speed-value {
+			font-size: var(--nimble-md-text);
+			font-weight: 700;
+			color: var(--nimble-dark-text-color);
+		}
+
+		&__speed-label {
+			font-size: var(--nimble-xs-text);
+			font-weight: 500;
+			color: var(--nimble-medium-text-color);
+		}
+
+		&__warning {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			gap: 0.5rem;
+			padding: 0.5rem 0.75rem;
+			background: hsla(45, 70%, 50%, 0.1);
+			border: 1px solid hsla(45, 70%, 50%, 0.3);
+			border-radius: 6px;
+			font-size: var(--nimble-sm-text);
+			font-weight: 500;
+			color: hsl(45, 60%, 35%);
+
+			i {
+				color: hsl(45, 70%, 45%);
+			}
+		}
+
+		&__footer {
+			display: flex;
+			gap: 0.5rem;
+
+			.nimble-button {
+				flex: 1;
+				padding: 0.625rem 1rem;
+				font-size: var(--nimble-sm-text);
+				font-weight: 600;
+			}
+
+			.nimble-button[data-button-variant='primary'] {
+				background: var(--nimble-box-background-color);
+				border: 2px solid hsl(45, 60%, 45%);
+				color: var(--nimble-dark-text-color);
+
+				&:hover {
+					background: hsla(45, 60%, 50%, 0.15);
+					border-color: hsl(45, 60%, 50%);
+				}
+
+				i {
+					margin-right: 0.375rem;
+					color: hsl(45, 60%, 45%);
+				}
+			}
+		}
+	}
+
+	:global(.theme-dark) .move-dialog {
+		&__warning {
+			background: hsla(45, 70%, 50%, 0.15);
+			border-color: hsla(45, 70%, 50%, 0.4);
+			color: hsl(45, 60%, 65%);
+
+			i {
+				color: hsl(45, 70%, 55%);
+			}
+		}
+
+		&__speed i {
+			color: hsl(210, 70%, 65%);
+		}
+
+		&__footer .nimble-button[data-button-variant='primary'] {
+			background: hsl(220, 15%, 18%);
+			border-color: hsl(45, 70%, 55%);
+			color: hsl(45, 60%, 75%);
+
+			&:hover {
+				background: hsla(45, 60%, 50%, 0.2);
+				border-color: hsl(45, 70%, 60%);
+				color: hsl(45, 60%, 85%);
+			}
+
+			i {
+				color: hsl(45, 70%, 60%);
+			}
+		}
+	}
+</style>

--- a/src/view/dialogs/MoveActionDialog.svelte
+++ b/src/view/dialogs/MoveActionDialog.svelte
@@ -1,39 +1,10 @@
 <script>
 	import localize from '../../utils/localize.js';
+	import { getMovementSpeeds } from '../../utils/movementSpeeds.js';
 
 	let { document, dialog, deductActionPip, inCombat = false } = $props();
 
-	const { movementTypes, movementTypeIcons } = CONFIG.NIMBLE;
-
-	// Get movement speeds, filtering to only show non-zero values
-	let movementSpeeds = $derived.by(() => {
-		const movement = document.system?.attributes?.movement ?? {};
-		const speeds = [];
-
-		// Always show walk first if it exists
-		if (movement.walk > 0) {
-			speeds.push({
-				type: 'walk',
-				value: movement.walk,
-				label: game.i18n.localize(movementTypes.walk),
-				icon: movementTypeIcons.walk,
-			});
-		}
-
-		// Add other movement types if non-zero
-		for (const type of ['fly', 'climb', 'swim', 'burrow']) {
-			if (movement[type] > 0) {
-				speeds.push({
-					type,
-					value: movement[type],
-					label: game.i18n.localize(movementTypes[type]),
-					icon: movementTypeIcons[type],
-				});
-			}
-		}
-
-		return speeds;
-	});
+	let movementSpeeds = $derived(getMovementSpeeds(document));
 
 	async function handleConfirm() {
 		// Deduct action pip if in combat
@@ -181,7 +152,7 @@
 
 			i {
 				font-size: 0.875rem;
-				color: hsl(210, 60%, 50%);
+				color: var(--nimble-action-icon-color);
 			}
 		}
 
@@ -203,15 +174,15 @@
 			justify-content: center;
 			gap: 0.5rem;
 			padding: 0.5rem 0.75rem;
-			background: hsla(45, 70%, 50%, 0.1);
-			border: 1px solid hsla(45, 70%, 50%, 0.3);
+			background: var(--nimble-action-info-background);
+			border: 1px solid var(--nimble-action-info-border-color);
 			border-radius: 6px;
 			font-size: var(--nimble-sm-text);
 			font-weight: 500;
-			color: hsl(45, 60%, 35%);
+			color: var(--nimble-action-info-text-color);
 
 			i {
-				color: hsl(45, 70%, 45%);
+				color: var(--nimble-action-info-icon-color);
 			}
 		}
 
@@ -245,20 +216,6 @@
 	}
 
 	:global(.theme-dark) .move-dialog {
-		&__warning {
-			background: hsla(45, 70%, 50%, 0.15);
-			border-color: hsla(45, 70%, 50%, 0.4);
-			color: hsl(45, 60%, 65%);
-
-			i {
-				color: hsl(45, 70%, 55%);
-			}
-		}
-
-		&__speed i {
-			color: hsl(210, 70%, 65%);
-		}
-
 		&__footer .nimble-button[data-button-variant='primary'] {
 			background: hsl(220, 15%, 18%);
 			border-color: hsl(45, 70%, 55%);

--- a/src/view/sheets/PlayerCharacterSheet.svelte
+++ b/src/view/sheets/PlayerCharacterSheet.svelte
@@ -17,6 +17,7 @@
 	import PlayerCharacterConditionsTab from './pages/PlayerCharacterConditionsTab.svelte';
 	import PlayerCharacterCoreTab from './pages/PlayerCharacterCoreTab.svelte';
 	import PlayerCharacterFeaturesTab from './pages/PlayerCharacterFeaturesTab.svelte';
+	import PlayerCharacterHeroicActionsTab from './pages/PlayerCharacterHeroicActionsTab.svelte';
 	import PlayerCharacterInventoryTab from './pages/PlayerCharacterInventoryTab.svelte';
 	import PlayerCharacterSettingsTab from './pages/PlayerCharacterSettingsTab.svelte';
 	import PlayerCharacterSpellsTab from './pages/PlayerCharacterSpellsTab.svelte';
@@ -192,6 +193,12 @@
 			icon: 'fa-solid fa-home',
 			tooltip: 'Core',
 			name: 'core',
+		},
+		{
+			component: PlayerCharacterHeroicActionsTab,
+			icon: 'fa-solid fa-bolt',
+			tooltip: 'Actions',
+			name: 'actions',
 		},
 		{
 			component: PlayerCharacterConditionsTab,
@@ -620,6 +627,10 @@
 </section>
 
 <style lang="scss">
+	:global(.nimble-sheet--player-character) {
+		min-width: 200px;
+	}
+
 	.nimble-sheet__header {
 		position: relative;
 	}

--- a/src/view/sheets/PlayerCharacterSheet.svelte
+++ b/src/view/sheets/PlayerCharacterSheet.svelte
@@ -627,10 +627,6 @@
 </section>
 
 <style lang="scss">
-	:global(.nimble-sheet--player-character) {
-		min-width: 367px;
-	}
-
 	.nimble-sheet__header {
 		position: relative;
 	}

--- a/src/view/sheets/PlayerCharacterSheet.svelte
+++ b/src/view/sheets/PlayerCharacterSheet.svelte
@@ -627,6 +627,10 @@
 </section>
 
 <style lang="scss">
+	:global(.nimble-sheet--player-character) {
+		min-width: 367px;
+	}
+
 	.nimble-sheet__header {
 		position: relative;
 	}

--- a/src/view/sheets/PlayerCharacterSheet.svelte
+++ b/src/view/sheets/PlayerCharacterSheet.svelte
@@ -628,7 +628,7 @@
 
 <style lang="scss">
 	:global(.nimble-sheet--player-character) {
-		min-width: 200px;
+		min-width: 580px;
 	}
 
 	.nimble-sheet__header {

--- a/src/view/sheets/PlayerCharacterSheet.svelte
+++ b/src/view/sheets/PlayerCharacterSheet.svelte
@@ -627,10 +627,6 @@
 </section>
 
 <style lang="scss">
-	:global(.nimble-sheet--player-character) {
-		min-width: 580px;
-	}
-
 	.nimble-sheet__header {
 		position: relative;
 	}

--- a/src/view/sheets/components/AssessActionPanel.svelte
+++ b/src/view/sheets/components/AssessActionPanel.svelte
@@ -1,98 +1,15 @@
 <script>
 	import localize from '../../../utils/localize.js';
-	import { ASSESS_DC, assessOptions } from '../../../utils/assessOptions.js';
-	import { getTargetedTokens, getInvalidTargets, getTargetName } from '../../../utils/targeting.js';
-
-	const { skills: skillNames } = CONFIG.NIMBLE;
+	import { createAssessPanelState } from './AssessActionPanel.svelte.js';
 
 	let { actor, onDeductAction = async () => {} } = $props();
 
-	let selectedOption = $state(null);
-	let selectedSkill = $state(null);
-	let targetingVersion = $state(0);
+	const state = createAssessPanelState(actor, onDeductAction);
 
 	// Track targeting changes
 	$effect(() => {
-		const hookId = Hooks.on('targetToken', () => {
-			targetingVersion++;
-		});
-		return () => Hooks.off('targetToken', hookId);
+		return state.setupTargetingHook();
 	});
-
-	let currentOptionRequiresTarget = $derived(
-		assessOptions.find((o) => o.id === selectedOption)?.requiresTarget ?? false,
-	);
-
-	let availableTargets = $derived.by(() => {
-		void targetingVersion;
-		return getTargetedTokens(actor.id);
-	});
-
-	let hasTargetedSelf = $derived.by(() => {
-		void targetingVersion;
-		return getInvalidTargets(actor.id).length > 0;
-	});
-
-	let selectedTarget = $derived.by(() => {
-		if (currentOptionRequiresTarget && availableTargets.length === 1) {
-			return availableTargets[0];
-		}
-		return null;
-	});
-
-	let sortedSkills = $derived(
-		Object.entries(skillNames).sort(([, nameA], [, nameB]) => nameA.localeCompare(nameB)),
-	);
-
-	let isSubmitDisabled = $derived(
-		!selectedOption ||
-			!selectedSkill ||
-			(currentOptionRequiresTarget && availableTargets.length !== 1),
-	);
-
-	async function handleRoll() {
-		if (isSubmitDisabled) return;
-
-		const option = assessOptions.find((o) => o.id === selectedOption);
-
-		// Roll the skill check (show the roll dialog)
-		const { roll } = await actor.rollSkillCheck(selectedSkill);
-
-		if (!roll) return;
-
-		// Deduct action pip only after roll is confirmed (not cancelled)
-		await onDeductAction();
-
-		// Determine success/failure based on DC 12
-		const isSuccess = roll.total >= ASSESS_DC;
-		const resultKey = isSuccess ? option.successKey : option.failureKey;
-
-		// Include target name in the message if there's a target
-		const targetName = selectedTarget ? getTargetName(selectedTarget) : null;
-		const resultMessage = localize(resultKey, { name: actor.name, target: targetName });
-
-		// Create chat message
-		await ChatMessage.create({
-			author: game.user?.id,
-			speaker: ChatMessage.getSpeaker({ actor }),
-			sound: CONFIG.sounds.dice,
-			rolls: [roll],
-			type: 'assessAction',
-			system: {
-				actorName: actor.name,
-				actorType: actor.type,
-				permissions: actor.permission,
-				rollMode: 0,
-				skillKey: selectedSkill,
-				dc: ASSESS_DC,
-				isSuccess,
-				optionTitle: localize(option.chatTitleKey),
-				resultMessage,
-				target: selectedTarget ? selectedTarget.document.uuid : null,
-				targetName,
-			},
-		});
-	}
 </script>
 
 <section class="assess-panel">
@@ -104,14 +21,17 @@
 
 	<div class="assess-panel__content">
 		<div class="assess-panel__options">
-			{#each assessOptions as option}
-				<label class="assess-option" class:assess-option--active={selectedOption === option.id}>
+			{#each state.assessOptions as option}
+				<label
+					class="assess-option"
+					class:assess-option--active={state.selectedOption === option.id}
+				>
 					<input
 						class="assess-option__input"
 						type="radio"
 						name="assess-option"
 						value={option.id}
-						bind:group={selectedOption}
+						bind:group={state.selectedOption}
 					/>
 					<i class="assess-option__icon {option.icon}"></i>
 					<div class="assess-option__content">
@@ -123,40 +43,41 @@
 			{/each}
 		</div>
 
-		<select class="assess-panel__select" bind:value={selectedSkill}>
+		<select class="assess-panel__select" bind:value={state.selectedSkill}>
 			<option value={null} disabled>
 				{localize('NIMBLE.ui.heroicActions.assess.selectSkillPlaceholder')}
 			</option>
-			{#each sortedSkills as [skillKey, skillName]}
+			{#each state.sortedSkills as [skillKey, skillName]}
 				<option value={skillKey}>{skillName}</option>
 			{/each}
 		</select>
 
-		{#if currentOptionRequiresTarget}
+		{#if state.currentOptionRequiresTarget}
 			<header class="nimble-section-header">
 				<h3 class="nimble-heading" data-heading-variant="section">
 					{localize('NIMBLE.ui.heroicActions.assess.selectTarget')}
 				</h3>
 			</header>
 
-			{#if availableTargets.length === 0}
+			{#if state.availableTargets.length === 0}
 				<div class="assess-panel__no-targets">
 					<i class="fa-solid fa-crosshairs"></i>
-					{#if hasTargetedSelf}
+					{#if state.hasTargetedSelf}
 						<span>{localize('NIMBLE.ui.heroicActions.assess.cannotTargetSelf')}</span>
 					{:else}
 						<span>{localize('NIMBLE.ui.heroicActions.assess.noTargetsHint')}</span>
 					{/if}
 				</div>
-			{:else if availableTargets.length === 1}
+			{:else if state.availableTargets.length === 1}
 				<div class="assess-panel__targets">
 					<div class="assess-target assess-target--active">
 						<img
 							class="assess-target__img"
-							src={availableTargets[0].document?.texture?.src || 'icons/svg/mystery-man.svg'}
-							alt={getTargetName(availableTargets[0])}
+							src={state.availableTargets[0].document?.texture?.src || 'icons/svg/mystery-man.svg'}
+							alt={state.getTargetName(state.availableTargets[0])}
 						/>
-						<span class="assess-target__name">{getTargetName(availableTargets[0])}</span>
+						<span class="assess-target__name">{state.getTargetName(state.availableTargets[0])}</span
+						>
 						<i class="fa-solid fa-check assess-target__check"></i>
 					</div>
 				</div>
@@ -171,17 +92,17 @@
 		<button
 			class="nimble-button assess-panel__roll"
 			data-button-variant="primary"
-			disabled={isSubmitDisabled}
-			onclick={handleRoll}
+			disabled={state.isSubmitDisabled}
+			onclick={state.handleRoll}
 		>
 			<i class="fa-solid fa-dice-d20"></i>
-			{#if !selectedOption}
+			{#if !state.selectedOption}
 				{localize('NIMBLE.ui.heroicActions.assess.selectOption')}
-			{:else if !selectedSkill}
+			{:else if !state.selectedSkill}
 				{localize('NIMBLE.ui.heroicActions.assess.selectSkill')}
 			{:else}
 				{localize('NIMBLE.ui.heroicActions.assess.rollToAssess', {
-					skill: skillNames[selectedSkill],
+					skill: state.skillNames[state.selectedSkill],
 				})}
 			{/if}
 		</button>

--- a/src/view/sheets/components/AssessActionPanel.svelte
+++ b/src/view/sheets/components/AssessActionPanel.svelte
@@ -1,10 +1,13 @@
 <script>
 	import localize from '../../../utils/localize.js';
-	import { createAssessPanelState } from './AssessActionPanel.svelte.js';
+	import { createAssessPanelState } from './AssessActionPanel.svelte.ts';
 
 	let { actor, onDeductAction = async () => {} } = $props();
 
-	const state = createAssessPanelState(actor, onDeductAction);
+	const state = createAssessPanelState(
+		() => actor,
+		() => onDeductAction,
+	);
 
 	// Track targeting changes
 	$effect(() => {

--- a/src/view/sheets/components/AssessActionPanel.svelte
+++ b/src/view/sheets/components/AssessActionPanel.svelte
@@ -1,40 +1,7 @@
 <script>
 	import localize from '../../../utils/localize.js';
-
-	const ASSESS_DC = 12;
-
-	const assessOptions = [
-		{
-			id: 'ask-question',
-			icon: 'fa-solid fa-circle-question',
-			titleKey: 'NIMBLE.ui.heroicActions.assess.askQuestion.title',
-			chatTitleKey: 'NIMBLE.ui.heroicActions.assess.askQuestion.chatTitle',
-			descriptionKey: 'NIMBLE.ui.heroicActions.assess.askQuestion.description',
-			successKey: 'NIMBLE.ui.heroicActions.assess.askQuestion.success',
-			failureKey: 'NIMBLE.ui.heroicActions.assess.askQuestion.failure',
-			requiresTarget: false,
-		},
-		{
-			id: 'create-opening',
-			icon: 'fa-solid fa-crosshairs',
-			titleKey: 'NIMBLE.ui.heroicActions.assess.createOpening.title',
-			chatTitleKey: 'NIMBLE.ui.heroicActions.assess.createOpening.chatTitle',
-			descriptionKey: 'NIMBLE.ui.heroicActions.assess.createOpening.description',
-			successKey: 'NIMBLE.ui.heroicActions.assess.createOpening.success',
-			failureKey: 'NIMBLE.ui.heroicActions.assess.createOpening.failure',
-			requiresTarget: true,
-		},
-		{
-			id: 'anticipate-danger',
-			icon: 'fa-solid fa-shield',
-			titleKey: 'NIMBLE.ui.heroicActions.assess.anticipateDanger.title',
-			chatTitleKey: 'NIMBLE.ui.heroicActions.assess.anticipateDanger.chatTitle',
-			descriptionKey: 'NIMBLE.ui.heroicActions.assess.anticipateDanger.description',
-			successKey: 'NIMBLE.ui.heroicActions.assess.anticipateDanger.success',
-			failureKey: 'NIMBLE.ui.heroicActions.assess.anticipateDanger.failure',
-			requiresTarget: false,
-		},
-	];
+	import { ASSESS_DC, assessOptions } from '../../../utils/assessOptions.js';
+	import { getTargetedTokens, getInvalidTargets, getTargetName } from '../../../utils/targeting.js';
 
 	const { skills: skillNames } = CONFIG.NIMBLE;
 
@@ -43,20 +10,6 @@
 	let selectedOption = $state(null);
 	let selectedSkill = $state(null);
 	let targetingVersion = $state(0);
-
-	function getTargetedTokens(actorId) {
-		const targets = Array.from(game.user?.targets ?? []);
-		return targets.filter((token) => token.actor?.id !== actorId);
-	}
-
-	function getInvalidTargets(actorId) {
-		const targets = Array.from(game.user?.targets ?? []);
-		return targets.filter((token) => token.actor?.id === actorId);
-	}
-
-	function getTargetName(token) {
-		return token?.actor?.name || token?.name || 'Unknown';
-	}
 
 	// Track targeting changes
 	$effect(() => {
@@ -102,13 +55,13 @@
 
 		const option = assessOptions.find((o) => o.id === selectedOption);
 
-		// Deduct action pip
-		await onDeductAction();
-
 		// Roll the skill check (show the roll dialog)
 		const { roll } = await actor.rollSkillCheck(selectedSkill);
 
 		if (!roll) return;
+
+		// Deduct action pip only after roll is confirmed (not cancelled)
+		await onDeductAction();
 
 		// Determine success/failure based on DC 12
 		const isSuccess = roll.total >= ASSESS_DC;

--- a/src/view/sheets/components/AssessActionPanel.svelte
+++ b/src/view/sheets/components/AssessActionPanel.svelte
@@ -1,0 +1,485 @@
+<script>
+	import localize from '../../../utils/localize.js';
+
+	const ASSESS_DC = 12;
+
+	const assessOptions = [
+		{
+			id: 'ask-question',
+			icon: 'fa-solid fa-circle-question',
+			titleKey: 'NIMBLE.ui.heroicActions.assess.askQuestion.title',
+			chatTitleKey: 'NIMBLE.ui.heroicActions.assess.askQuestion.chatTitle',
+			descriptionKey: 'NIMBLE.ui.heroicActions.assess.askQuestion.description',
+			successKey: 'NIMBLE.ui.heroicActions.assess.askQuestion.success',
+			failureKey: 'NIMBLE.ui.heroicActions.assess.askQuestion.failure',
+			requiresTarget: false,
+		},
+		{
+			id: 'create-opening',
+			icon: 'fa-solid fa-crosshairs',
+			titleKey: 'NIMBLE.ui.heroicActions.assess.createOpening.title',
+			chatTitleKey: 'NIMBLE.ui.heroicActions.assess.createOpening.chatTitle',
+			descriptionKey: 'NIMBLE.ui.heroicActions.assess.createOpening.description',
+			successKey: 'NIMBLE.ui.heroicActions.assess.createOpening.success',
+			failureKey: 'NIMBLE.ui.heroicActions.assess.createOpening.failure',
+			requiresTarget: true,
+		},
+		{
+			id: 'anticipate-danger',
+			icon: 'fa-solid fa-shield',
+			titleKey: 'NIMBLE.ui.heroicActions.assess.anticipateDanger.title',
+			chatTitleKey: 'NIMBLE.ui.heroicActions.assess.anticipateDanger.chatTitle',
+			descriptionKey: 'NIMBLE.ui.heroicActions.assess.anticipateDanger.description',
+			successKey: 'NIMBLE.ui.heroicActions.assess.anticipateDanger.success',
+			failureKey: 'NIMBLE.ui.heroicActions.assess.anticipateDanger.failure',
+			requiresTarget: false,
+		},
+	];
+
+	const { skills: skillNames } = CONFIG.NIMBLE;
+
+	let { actor, onDeductAction = async () => {} } = $props();
+
+	let selectedOption = $state(null);
+	let selectedSkill = $state(null);
+	let targetingVersion = $state(0);
+
+	function getTargetedTokens(actorId) {
+		const targets = Array.from(game.user?.targets ?? []);
+		return targets.filter((token) => token.actor?.id !== actorId);
+	}
+
+	function getInvalidTargets(actorId) {
+		const targets = Array.from(game.user?.targets ?? []);
+		return targets.filter((token) => token.actor?.id === actorId);
+	}
+
+	function getTargetName(token) {
+		return token?.actor?.name || token?.name || 'Unknown';
+	}
+
+	// Track targeting changes
+	$effect(() => {
+		const hookId = Hooks.on('targetToken', () => {
+			targetingVersion++;
+		});
+		return () => Hooks.off('targetToken', hookId);
+	});
+
+	let currentOptionRequiresTarget = $derived(
+		assessOptions.find((o) => o.id === selectedOption)?.requiresTarget ?? false,
+	);
+
+	let availableTargets = $derived.by(() => {
+		void targetingVersion;
+		return getTargetedTokens(actor.id);
+	});
+
+	let hasTargetedSelf = $derived.by(() => {
+		void targetingVersion;
+		return getInvalidTargets(actor.id).length > 0;
+	});
+
+	let selectedTarget = $derived.by(() => {
+		if (currentOptionRequiresTarget && availableTargets.length === 1) {
+			return availableTargets[0];
+		}
+		return null;
+	});
+
+	let sortedSkills = $derived(
+		Object.entries(skillNames).sort(([, nameA], [, nameB]) => nameA.localeCompare(nameB)),
+	);
+
+	let isSubmitDisabled = $derived(
+		!selectedOption ||
+			!selectedSkill ||
+			(currentOptionRequiresTarget && availableTargets.length !== 1),
+	);
+
+	async function handleRoll() {
+		if (isSubmitDisabled) return;
+
+		const option = assessOptions.find((o) => o.id === selectedOption);
+
+		// Deduct action pip
+		await onDeductAction();
+
+		// Roll the skill check (show the roll dialog)
+		const { roll } = await actor.rollSkillCheck(selectedSkill);
+
+		if (!roll) return;
+
+		// Determine success/failure based on DC 12
+		const isSuccess = roll.total >= ASSESS_DC;
+		const resultKey = isSuccess ? option.successKey : option.failureKey;
+
+		// Include target name in the message if there's a target
+		const targetName = selectedTarget ? getTargetName(selectedTarget) : null;
+		const resultMessage = localize(resultKey, { name: actor.name, target: targetName });
+
+		// Create chat message
+		await ChatMessage.create({
+			author: game.user?.id,
+			speaker: ChatMessage.getSpeaker({ actor }),
+			sound: CONFIG.sounds.dice,
+			rolls: [roll],
+			type: 'assessAction',
+			system: {
+				actorName: actor.name,
+				actorType: actor.type,
+				permissions: actor.permission,
+				rollMode: 0,
+				skillKey: selectedSkill,
+				dc: ASSESS_DC,
+				isSuccess,
+				optionTitle: localize(option.chatTitleKey),
+				resultMessage,
+				target: selectedTarget ? selectedTarget.document.uuid : null,
+				targetName,
+			},
+		});
+	}
+</script>
+
+<section class="assess-panel">
+	<header class="nimble-section-header">
+		<h3 class="nimble-heading" data-heading-variant="section">
+			{localize('NIMBLE.ui.heroicActions.assess.header')}
+		</h3>
+	</header>
+
+	<div class="assess-panel__content">
+		<div class="assess-panel__options">
+			{#each assessOptions as option}
+				<label class="assess-option" class:assess-option--active={selectedOption === option.id}>
+					<input
+						class="assess-option__input"
+						type="radio"
+						name="assess-option"
+						value={option.id}
+						bind:group={selectedOption}
+					/>
+					<i class="assess-option__icon {option.icon}"></i>
+					<div class="assess-option__content">
+						<span class="assess-option__title">{localize(option.titleKey)}</span>
+						<span class="assess-option__description">{localize(option.descriptionKey)}</span>
+					</div>
+					<div class="assess-option__indicator"></div>
+				</label>
+			{/each}
+		</div>
+
+		<select class="assess-panel__select" bind:value={selectedSkill}>
+			<option value={null} disabled>
+				{localize('NIMBLE.ui.heroicActions.assess.selectSkillPlaceholder')}
+			</option>
+			{#each sortedSkills as [skillKey, skillName]}
+				<option value={skillKey}>{skillName}</option>
+			{/each}
+		</select>
+
+		{#if currentOptionRequiresTarget}
+			<header class="nimble-section-header">
+				<h3 class="nimble-heading" data-heading-variant="section">
+					{localize('NIMBLE.ui.heroicActions.assess.selectTarget')}
+				</h3>
+			</header>
+
+			{#if availableTargets.length === 0}
+				<div class="assess-panel__no-targets">
+					<i class="fa-solid fa-crosshairs"></i>
+					{#if hasTargetedSelf}
+						<span>{localize('NIMBLE.ui.heroicActions.assess.cannotTargetSelf')}</span>
+					{:else}
+						<span>{localize('NIMBLE.ui.heroicActions.assess.noTargetsHint')}</span>
+					{/if}
+				</div>
+			{:else if availableTargets.length === 1}
+				<div class="assess-panel__targets">
+					<div class="assess-target assess-target--active">
+						<img
+							class="assess-target__img"
+							src={availableTargets[0].document?.texture?.src || 'icons/svg/mystery-man.svg'}
+							alt={getTargetName(availableTargets[0])}
+						/>
+						<span class="assess-target__name">{getTargetName(availableTargets[0])}</span>
+						<i class="fa-solid fa-check assess-target__check"></i>
+					</div>
+				</div>
+			{:else}
+				<div class="assess-panel__no-targets assess-panel__no-targets--warning">
+					<i class="fa-solid fa-triangle-exclamation"></i>
+					<span>{localize('NIMBLE.ui.heroicActions.assess.tooManyTargetsHint')}</span>
+				</div>
+			{/if}
+		{/if}
+
+		<button
+			class="nimble-button assess-panel__roll"
+			data-button-variant="primary"
+			disabled={isSubmitDisabled}
+			onclick={handleRoll}
+		>
+			<i class="fa-solid fa-dice-d20"></i>
+			{#if !selectedOption}
+				{localize('NIMBLE.ui.heroicActions.assess.selectOption')}
+			{:else if !selectedSkill}
+				{localize('NIMBLE.ui.heroicActions.assess.selectSkill')}
+			{:else}
+				{localize('NIMBLE.ui.heroicActions.assess.rollToAssess', {
+					skill: skillNames[selectedSkill],
+				})}
+			{/if}
+		</button>
+	</div>
+</section>
+
+<style lang="scss">
+	.assess-panel {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+
+		&__content {
+			display: flex;
+			flex-direction: column;
+			gap: 0.5rem;
+		}
+
+		&__options {
+			display: flex;
+			flex-direction: column;
+			gap: 0.375rem;
+		}
+
+		&__select {
+			width: 100%;
+			padding: 0.375rem 0.5rem;
+			font-size: var(--nimble-sm-text);
+			font-weight: 500;
+			color: var(--nimble-dark-text-color);
+			background: var(--nimble-input-background-color);
+			border: 1px solid var(--nimble-input-border-color);
+			border-radius: 4px;
+			cursor: pointer;
+
+			&:focus {
+				outline: none;
+				border-color: var(--nimble-input-focus-border-color);
+			}
+		}
+
+		&__no-targets {
+			display: flex;
+			align-items: center;
+			gap: 0.5rem;
+			padding: 0.5rem;
+			color: var(--nimble-medium-text-color);
+			font-size: var(--nimble-sm-text);
+			background: var(--nimble-box-background-color);
+			border: 1px dashed var(--nimble-card-border-color);
+			border-radius: 4px;
+
+			i {
+				font-size: var(--nimble-md-text);
+				opacity: 0.5;
+			}
+
+			&--warning {
+				color: #fff;
+				background: hsl(35, 85%, 55%);
+				border-color: hsl(35, 85%, 45%);
+				border-style: solid;
+
+				i {
+					opacity: 1;
+				}
+			}
+		}
+
+		&__targets {
+			display: flex;
+			flex-direction: column;
+			gap: 0.25rem;
+		}
+
+		&__roll {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			gap: 0.375rem;
+			padding: 0.5rem 0.75rem;
+			font-size: var(--nimble-sm-text);
+			font-weight: 600;
+			margin-top: 0.25rem;
+
+			&:disabled {
+				opacity: 0.5;
+				cursor: not-allowed;
+			}
+
+			i {
+				font-size: 0.875rem;
+			}
+		}
+	}
+
+	.assess-option {
+		position: relative;
+		display: flex;
+		align-items: flex-start;
+		gap: 0.5rem;
+		padding: 0.5rem;
+		background: var(--nimble-box-background-color);
+		border: 2px solid var(--nimble-card-border-color);
+		border-radius: 6px;
+		cursor: pointer;
+		transition: all 0.2s ease;
+
+		&:hover:not(&--active) {
+			border-color: var(--nimble-accent-color);
+		}
+
+		&--active {
+			border-color: hsl(45, 60%, 45%);
+			background: hsla(45, 60%, 50%, 0.12);
+		}
+
+		&__input {
+			position: absolute;
+			opacity: 0;
+			pointer-events: none;
+		}
+
+		&__icon {
+			flex-shrink: 0;
+			font-size: var(--nimble-sm-text);
+			color: var(--nimble-medium-text-color);
+			margin-top: 0.125rem;
+			transition: color 0.2s ease;
+
+			.assess-option--active & {
+				color: hsl(45, 60%, 40%);
+			}
+		}
+
+		&__content {
+			display: flex;
+			flex-direction: column;
+			gap: 0.125rem;
+			flex: 1;
+			min-width: 0;
+		}
+
+		&__title {
+			font-size: var(--nimble-sm-text);
+			font-weight: 600;
+			color: var(--nimble-dark-text-color);
+			line-height: 1.2;
+
+			.assess-option--active & {
+				color: hsl(45, 50%, 30%);
+			}
+		}
+
+		&__description {
+			font-size: var(--nimble-xs-text);
+			font-weight: 500;
+			color: var(--nimble-medium-text-color);
+			line-height: 1.3;
+		}
+
+		&__indicator {
+			position: absolute;
+			top: 0.375rem;
+			right: 0.375rem;
+			width: 0.5rem;
+			height: 0.5rem;
+			border-radius: 50%;
+			background: transparent;
+			transition: all 0.2s ease;
+
+			.assess-option--active & {
+				background: hsl(45, 70%, 50%);
+				box-shadow: 0 0 6px hsla(45, 70%, 50%, 0.6);
+			}
+		}
+	}
+
+	.assess-target {
+		display: flex;
+		align-items: center;
+		gap: 0.375rem;
+		padding: 0.375rem 0.5rem;
+		background: var(--nimble-box-background-color);
+		border: 2px solid var(--nimble-card-border-color);
+		border-radius: 4px;
+
+		&--active {
+			border-color: hsl(45, 60%, 45%);
+			background: hsla(45, 60%, 50%, 0.12);
+		}
+
+		&__img {
+			width: 1.5rem;
+			height: 1.5rem;
+			border-radius: 3px;
+			object-fit: cover;
+			border: 1px solid var(--nimble-card-border-color);
+		}
+
+		&__name {
+			flex: 1;
+			font-size: var(--nimble-sm-text);
+			font-weight: 500;
+			color: var(--nimble-dark-text-color);
+		}
+
+		&__check {
+			color: hsl(139, 50%, 40%);
+			font-size: var(--nimble-sm-text);
+		}
+	}
+
+	:global(.theme-dark) .assess-option {
+		background: hsl(220, 15%, 18%);
+		border-color: hsl(220, 10%, 30%);
+
+		&:hover:not(.assess-option--active) {
+			border-color: hsl(220, 15%, 45%);
+		}
+	}
+
+	:global(.theme-dark) .assess-option--active {
+		border-color: hsl(45, 70%, 55%);
+		background: hsla(45, 60%, 50%, 0.15);
+
+		.assess-option__icon {
+			color: hsl(45, 70%, 65%);
+		}
+
+		.assess-option__title {
+			color: hsl(45, 60%, 75%);
+		}
+
+		.assess-option__indicator {
+			background: hsl(45, 70%, 55%);
+			box-shadow: 0 0 8px hsla(45, 70%, 55%, 0.7);
+		}
+	}
+
+	:global(.theme-dark) .assess-target {
+		background: hsl(220, 15%, 18%);
+		border-color: hsl(220, 10%, 30%);
+	}
+
+	:global(.theme-dark) .assess-target--active {
+		border-color: hsl(45, 70%, 55%);
+		background: hsla(45, 60%, 50%, 0.15);
+	}
+
+	:global(.theme-dark) .assess-target__check {
+		color: hsl(139, 50%, 55%);
+	}
+</style>

--- a/src/view/sheets/components/AssessActionPanel.svelte.ts
+++ b/src/view/sheets/components/AssessActionPanel.svelte.ts
@@ -2,9 +2,8 @@ import { ASSESS_DC, assessOptions } from '../../../utils/assessOptions.js';
 import localize from '../../../utils/localize.js';
 import { getInvalidTargets, getTargetedTokens, getTargetName } from '../../../utils/targeting.js';
 
-const { skills: skillNames } = CONFIG.NIMBLE;
-
 export function createAssessPanelState(actor: Actor, onDeductAction: () => Promise<void>) {
+	const { skills: skillNames } = CONFIG.NIMBLE;
 	let selectedOption = $state<string | null>(null);
 	let selectedSkill = $state<string | null>(null);
 	let targetingVersion = $state(0);

--- a/src/view/sheets/components/AssessActionPanel.svelte.ts
+++ b/src/view/sheets/components/AssessActionPanel.svelte.ts
@@ -1,8 +1,13 @@
+import type { SkillKeyType } from '#types/skillKey.js';
+import type { NimbleCharacter } from '../../../documents/actor/character.js';
 import { ASSESS_DC, assessOptions } from '../../../utils/assessOptions.js';
 import localize from '../../../utils/localize.js';
 import { getInvalidTargets, getTargetedTokens, getTargetName } from '../../../utils/targeting.js';
 
-export function createAssessPanelState(actor: Actor, onDeductAction: () => Promise<void>) {
+export function createAssessPanelState(
+	getActor: () => NimbleCharacter,
+	getOnDeductAction: () => () => Promise<void>,
+) {
 	const { skills: skillNames } = CONFIG.NIMBLE;
 	let selectedOption = $state<string | null>(null);
 	let selectedSkill = $state<string | null>(null);
@@ -18,12 +23,12 @@ export function createAssessPanelState(actor: Actor, onDeductAction: () => Promi
 
 	const availableTargets = $derived.by(() => {
 		void targetingVersion;
-		return getTargetedTokens(actor.id);
+		return getTargetedTokens(getActor().id ?? '');
 	});
 
 	const hasTargetedSelf = $derived.by(() => {
 		void targetingVersion;
-		return getInvalidTargets(actor.id).length > 0;
+		return getInvalidTargets(getActor().id ?? '').length > 0;
 	});
 
 	const selectedTarget = $derived.by(() => {
@@ -61,38 +66,39 @@ export function createAssessPanelState(actor: Actor, onDeductAction: () => Promi
 	// ============================================================================
 
 	async function handleRoll(): Promise<void> {
-		if (isSubmitDisabled) return;
+		if (isSubmitDisabled || !selectedSkill) return;
 
 		const option = assessOptions.find((o) => o.id === selectedOption);
 		if (!option) return;
 
 		// Roll the skill check (show the roll dialog)
-		const { roll } = await actor.rollSkillCheck(selectedSkill);
+		const { roll } = await getActor().rollSkillCheck(selectedSkill as SkillKeyType);
 
 		if (!roll) return;
 
 		// Deduct action pip only after roll is confirmed (not cancelled)
-		await onDeductAction();
+		await getOnDeductAction()();
 
 		// Determine success/failure based on DC 12
-		const isSuccess = roll.total >= ASSESS_DC;
+		const isSuccess = (roll.total ?? 0) >= ASSESS_DC;
 		const resultKey = isSuccess ? option.successKey : option.failureKey;
 
 		// Include target name in the message if there's a target
 		const targetName = selectedTarget ? getTargetName(selectedTarget) : null;
-		const resultMessage = localize(resultKey, { name: actor.name, target: targetName });
+		const resultMessage = localize(resultKey, { name: getActor().name, target: targetName ?? '' });
 
 		// Create chat message
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		await ChatMessage.create({
 			author: game.user?.id,
-			speaker: ChatMessage.getSpeaker({ actor }),
+			speaker: ChatMessage.getSpeaker({ actor: getActor() }),
 			sound: CONFIG.sounds.dice,
 			rolls: [roll],
 			type: 'assessAction',
 			system: {
-				actorName: actor.name,
-				actorType: actor.type,
-				permissions: actor.permission,
+				actorName: getActor().name,
+				actorType: getActor().type,
+				permissions: getActor().permission,
 				rollMode: 0,
 				skillKey: selectedSkill,
 				dc: ASSESS_DC,
@@ -102,7 +108,7 @@ export function createAssessPanelState(actor: Actor, onDeductAction: () => Promi
 				target: selectedTarget ? selectedTarget.document.uuid : null,
 				targetName,
 			},
-		});
+		} as any);
 	}
 
 	return {

--- a/src/view/sheets/components/AssessActionPanel.svelte.ts
+++ b/src/view/sheets/components/AssessActionPanel.svelte.ts
@@ -1,0 +1,146 @@
+import { ASSESS_DC, assessOptions } from '../../../utils/assessOptions.js';
+import localize from '../../../utils/localize.js';
+import { getInvalidTargets, getTargetedTokens, getTargetName } from '../../../utils/targeting.js';
+
+const { skills: skillNames } = CONFIG.NIMBLE;
+
+export function createAssessPanelState(actor: Actor, onDeductAction: () => Promise<void>) {
+	let selectedOption = $state<string | null>(null);
+	let selectedSkill = $state<string | null>(null);
+	let targetingVersion = $state(0);
+
+	// ============================================================================
+	// Derived Values
+	// ============================================================================
+
+	const currentOptionRequiresTarget = $derived(
+		assessOptions.find((o) => o.id === selectedOption)?.requiresTarget ?? false,
+	);
+
+	const availableTargets = $derived.by(() => {
+		void targetingVersion;
+		return getTargetedTokens(actor.id);
+	});
+
+	const hasTargetedSelf = $derived.by(() => {
+		void targetingVersion;
+		return getInvalidTargets(actor.id).length > 0;
+	});
+
+	const selectedTarget = $derived.by(() => {
+		if (currentOptionRequiresTarget && availableTargets.length === 1) {
+			return availableTargets[0];
+		}
+		return null;
+	});
+
+	const sortedSkills = $derived(
+		Object.entries(skillNames).sort(([, nameA], [, nameB]) =>
+			(nameA as string).localeCompare(nameB as string),
+		),
+	);
+
+	const isSubmitDisabled = $derived(
+		!selectedOption ||
+			!selectedSkill ||
+			(currentOptionRequiresTarget && availableTargets.length !== 1),
+	);
+
+	// ============================================================================
+	// Hook Setup
+	// ============================================================================
+
+	function setupTargetingHook(): () => void {
+		const hookId = Hooks.on('targetToken', () => {
+			targetingVersion++;
+		});
+		return () => Hooks.off('targetToken', hookId);
+	}
+
+	// ============================================================================
+	// Event Handlers
+	// ============================================================================
+
+	async function handleRoll(): Promise<void> {
+		if (isSubmitDisabled) return;
+
+		const option = assessOptions.find((o) => o.id === selectedOption);
+		if (!option) return;
+
+		// Roll the skill check (show the roll dialog)
+		const { roll } = await actor.rollSkillCheck(selectedSkill);
+
+		if (!roll) return;
+
+		// Deduct action pip only after roll is confirmed (not cancelled)
+		await onDeductAction();
+
+		// Determine success/failure based on DC 12
+		const isSuccess = roll.total >= ASSESS_DC;
+		const resultKey = isSuccess ? option.successKey : option.failureKey;
+
+		// Include target name in the message if there's a target
+		const targetName = selectedTarget ? getTargetName(selectedTarget) : null;
+		const resultMessage = localize(resultKey, { name: actor.name, target: targetName });
+
+		// Create chat message
+		await ChatMessage.create({
+			author: game.user?.id,
+			speaker: ChatMessage.getSpeaker({ actor }),
+			sound: CONFIG.sounds.dice,
+			rolls: [roll],
+			type: 'assessAction',
+			system: {
+				actorName: actor.name,
+				actorType: actor.type,
+				permissions: actor.permission,
+				rollMode: 0,
+				skillKey: selectedSkill,
+				dc: ASSESS_DC,
+				isSuccess,
+				optionTitle: localize(option.chatTitleKey),
+				resultMessage,
+				target: selectedTarget ? selectedTarget.document.uuid : null,
+				targetName,
+			},
+		});
+	}
+
+	return {
+		get selectedOption() {
+			return selectedOption;
+		},
+		set selectedOption(value: string | null) {
+			selectedOption = value;
+		},
+		get selectedSkill() {
+			return selectedSkill;
+		},
+		set selectedSkill(value: string | null) {
+			selectedSkill = value;
+		},
+		get currentOptionRequiresTarget() {
+			return currentOptionRequiresTarget;
+		},
+		get availableTargets() {
+			return availableTargets;
+		},
+		get hasTargetedSelf() {
+			return hasTargetedSelf;
+		},
+		get selectedTarget() {
+			return selectedTarget;
+		},
+		get sortedSkills() {
+			return sortedSkills;
+		},
+		get isSubmitDisabled() {
+			return isSubmitDisabled;
+		},
+		assessOptions,
+		skillNames,
+		getTargetName,
+		setupTargetingHook,
+		handleRoll,
+	};
+}

--- a/src/view/sheets/components/AttackActionPanel.svelte
+++ b/src/view/sheets/components/AttackActionPanel.svelte
@@ -3,6 +3,9 @@
 	import sortItems from '../../../utils/sortItems.js';
 	import localize from '../../../utils/localize.js';
 	import { getPrimaryDamageFormulaFromActivationEffects } from '../../../utils/activationEffects.js';
+	import { evaluateFormula as evalFormula } from '../../../utils/evaluateFormula.js';
+	import ItemActivationConfigDialog from '../../../documents/dialogs/ItemActivationConfigDialog.svelte.js';
+	import { DamageRoll } from '../../../dice/DamageRoll.js';
 
 	import SearchBar from './SearchBar.svelte';
 
@@ -21,48 +24,7 @@
 	// ============================================================================
 
 	function evaluateFormula(formula) {
-		if (!formula) return '';
-
-		try {
-			const rollData = actor.getRollData();
-			const substituted = Roll.replaceFormulaData(formula, rollData, { missing: '0' });
-
-			const parts = substituted.split(/([+-])/);
-			const simplified = [];
-
-			for (const part of parts) {
-				const trimmed = part.trim();
-				if (!trimmed) continue;
-
-				if (trimmed === '+' || trimmed === '-') {
-					simplified.push(trimmed);
-				} else if (/^\d*d\d+/i.test(trimmed)) {
-					simplified.push(trimmed);
-				} else {
-					try {
-						const evaluated = Roll.safeEval(trimmed);
-						if (typeof evaluated === 'number' && !isNaN(evaluated)) {
-							simplified.push(String(Math.floor(evaluated)));
-						} else {
-							simplified.push(trimmed);
-						}
-					} catch {
-						simplified.push(trimmed);
-					}
-				}
-			}
-
-			let result = simplified.join(' ').replace(/\s+/g, ' ').trim();
-			result = result.replace(/[+-]\s*0(?!\d)/g, '').trim();
-			result = result
-				.replace(/^\s*[+-]\s*/, '')
-				.replace(/[+-]\s*[+-]/g, '+')
-				.trim();
-
-			return result || formula;
-		} catch {
-			return formula;
-		}
+		return evalFormula(formula, actor);
 	}
 
 	// ============================================================================
@@ -153,10 +115,19 @@
 		expandedDescriptions = newSet;
 	}
 
+	function handleKeydown(event, callback) {
+		if (event.key === 'Enter' || event.key === ' ') {
+			event.preventDefault();
+			callback();
+		}
+	}
+
 	// ============================================================================
 	// Unarmed Strike
 	// ============================================================================
 
+	// Default unarmed: roll 1d4 for hit determination, damage is 1 + STR
+	// The 1d4 is excluded from damage total when primaryDieAsDamage is false
 	const DEFAULT_UNARMED_DAMAGE = '1d4 + 1 + @abilities.strength.mod';
 
 	function getUnarmedDamageFormula() {
@@ -175,11 +146,6 @@
 	}
 
 	async function handleUnarmedStrike() {
-		const { default: ItemActivationConfigDialog } = await import(
-			'../../../documents/dialogs/ItemActivationConfigDialog.svelte.js'
-		);
-		const { DamageRoll } = await import('../../../dice/DamageRoll.js');
-
 		const rollFormula = getUnarmedDamageFormula();
 		const primaryDieAsDamage = hasCustomUnarmedDamage();
 
@@ -269,7 +235,7 @@
 				actorName: actor.name,
 				actorType: actor.type,
 				image: unarmedItem.img,
-				permissions: 3,
+				permissions: CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER,
 				rollMode: result.rollMode ?? 0,
 				name: localize('NIMBLE.ui.heroicActions.unarmedStrike'),
 				description: '',
@@ -327,8 +293,13 @@
 		<ul class="attack-panel__list">
 			{#if showUnarmedStrike}
 				<li class="weapon-card">
-					<!-- svelte-ignore a11y_click_events_have_key_events -->
-					<div class="weapon-card__row" role="button" tabindex="0" onclick={handleUnarmedStrike}>
+					<div
+						class="weapon-card__row"
+						role="button"
+						tabindex="0"
+						onclick={handleUnarmedStrike}
+						onkeydown={(e) => handleKeydown(e, handleUnarmedStrike)}
+					>
 						<div class="weapon-card__icon">
 							<i class="fa-solid fa-hand-fist"></i>
 						</div>
@@ -356,7 +327,6 @@
 				{@const isExpanded = expandedDescriptions.has(item._id)}
 				{@const description = getItemDescription(item)}
 				<li class="weapon-card" class:weapon-card--expanded={isExpanded} data-item-id={item._id}>
-					<!-- svelte-ignore a11y_click_events_have_key_events -->
 					<div
 						class="weapon-card__row"
 						role="button"
@@ -364,6 +334,7 @@
 						draggable="true"
 						ondragstart={(event) => sheet._onDragStart(event)}
 						onclick={() => handleItemClick(item._id)}
+						onkeydown={(e) => handleKeydown(e, () => handleItemClick(item._id))}
 					>
 						{#if showEmbeddedDocumentImages}
 							<img class="weapon-card__img" src={item.reactive.img} alt={item.reactive.name} />
@@ -392,7 +363,11 @@
 								class="weapon-card__expand"
 								type="button"
 								onclick={(e) => toggleDescription(item._id, e)}
-								aria-label={isExpanded ? 'Collapse' : 'Expand'}
+								aria-label={localize(
+									isExpanded
+										? 'NIMBLE.ui.heroicActions.collapse'
+										: 'NIMBLE.ui.heroicActions.expand',
+								)}
 							>
 								<i class="fa-solid fa-caret-{isExpanded ? 'up' : 'down'}"></i>
 							</button>
@@ -403,6 +378,8 @@
 						<div class="weapon-card__description">
 							{#await foundry.applications.ux.TextEditor.implementation.enrichHTML(description) then enrichedDescription}
 								{@html enrichedDescription}
+							{:catch}
+								{@html description}
 							{/await}
 						</div>
 					{/if}
@@ -414,7 +391,6 @@
 				{@const isExpanded = expandedDescriptions.has(item._id)}
 				{@const description = getItemDescription(item)}
 				<li class="weapon-card" class:weapon-card--expanded={isExpanded} data-item-id={item._id}>
-					<!-- svelte-ignore a11y_click_events_have_key_events -->
 					<div
 						class="weapon-card__row"
 						role="button"
@@ -422,6 +398,7 @@
 						draggable="true"
 						ondragstart={(event) => sheet._onDragStart(event)}
 						onclick={() => handleItemClick(item._id)}
+						onkeydown={(e) => handleKeydown(e, () => handleItemClick(item._id))}
 					>
 						{#if showEmbeddedDocumentImages}
 							<img class="weapon-card__img" src={item.reactive.img} alt={item.reactive.name} />
@@ -446,7 +423,11 @@
 								class="weapon-card__expand"
 								type="button"
 								onclick={(e) => toggleDescription(item._id, e)}
-								aria-label={isExpanded ? 'Collapse' : 'Expand'}
+								aria-label={localize(
+									isExpanded
+										? 'NIMBLE.ui.heroicActions.collapse'
+										: 'NIMBLE.ui.heroicActions.expand',
+								)}
 							>
 								<i class="fa-solid fa-caret-{isExpanded ? 'up' : 'down'}"></i>
 							</button>
@@ -457,6 +438,8 @@
 						<div class="weapon-card__description">
 							{#await foundry.applications.ux.TextEditor.implementation.enrichHTML(description) then enrichedDescription}
 								{@html enrichedDescription}
+							{:catch}
+								{@html description}
 							{/await}
 						</div>
 					{/if}

--- a/src/view/sheets/components/AttackActionPanel.svelte
+++ b/src/view/sheets/components/AttackActionPanel.svelte
@@ -1,0 +1,645 @@
+<script>
+	import { getContext } from 'svelte';
+	import sortItems from '../../../utils/sortItems.js';
+	import localize from '../../../utils/localize.js';
+	import { getPrimaryDamageFormulaFromActivationEffects } from '../../../utils/activationEffects.js';
+
+	import SearchBar from './SearchBar.svelte';
+
+	const { weaponProperties } = CONFIG.NIMBLE;
+
+	let actor = getContext('actor');
+	let sheet = getContext('application');
+
+	let { onActivateItem = async () => {}, showEmbeddedDocumentImages = true } = $props();
+
+	let searchTerm = $state('');
+	let expandedDescriptions = $state(new Set());
+
+	// ============================================================================
+	// Formula Evaluation
+	// ============================================================================
+
+	function evaluateFormula(formula) {
+		if (!formula) return '';
+
+		try {
+			const rollData = actor.getRollData();
+			const substituted = Roll.replaceFormulaData(formula, rollData, { missing: '0' });
+
+			const parts = substituted.split(/([+-])/);
+			const simplified = [];
+
+			for (const part of parts) {
+				const trimmed = part.trim();
+				if (!trimmed) continue;
+
+				if (trimmed === '+' || trimmed === '-') {
+					simplified.push(trimmed);
+				} else if (/^\d*d\d+/i.test(trimmed)) {
+					simplified.push(trimmed);
+				} else {
+					try {
+						const evaluated = Roll.safeEval(trimmed);
+						if (typeof evaluated === 'number' && !isNaN(evaluated)) {
+							simplified.push(String(Math.floor(evaluated)));
+						} else {
+							simplified.push(trimmed);
+						}
+					} catch {
+						simplified.push(trimmed);
+					}
+				}
+			}
+
+			let result = simplified.join(' ').replace(/\s+/g, ' ').trim();
+			result = result.replace(/[+-]\s*0(?!\d)/g, '').trim();
+			result = result
+				.replace(/^\s*[+-]\s*/, '')
+				.replace(/[+-]\s*[+-]/g, '+')
+				.trim();
+
+			return result || formula;
+		} catch {
+			return formula;
+		}
+	}
+
+	// ============================================================================
+	// Weapon Data
+	// ============================================================================
+
+	let weapons = $derived.by(() => {
+		const weaponItems = actor.reactive.items.filter(
+			(item) => item.type === 'object' && item.system.objectType === 'weapon',
+		);
+
+		if (!searchTerm) return weaponItems;
+
+		const search = searchTerm.toLocaleLowerCase();
+		return weaponItems.filter((item) => item.name.toLocaleLowerCase().includes(search));
+	});
+
+	let showUnarmedStrike = $derived(
+		!searchTerm || 'unarmed strike'.includes(searchTerm.toLocaleLowerCase()),
+	);
+
+	let attackFeatures = $derived.by(() => {
+		const features = actor.reactive.items.filter((item) => {
+			if (item.type !== 'feature') return false;
+
+			const activation = item.system?.activation;
+			if (!activation) return false;
+
+			return activation.cost?.type === 'action' && item.system?.actionType?.includes('attack');
+		});
+
+		if (!searchTerm) return features;
+
+		const search = searchTerm.toLocaleLowerCase();
+		return features.filter((item) => item.name.toLocaleLowerCase().includes(search));
+	});
+
+	function getWeaponDamage(item) {
+		const effects = item.reactive?.system?.activation?.effects ?? item.system?.activation?.effects;
+		const formula = getPrimaryDamageFormulaFromActivationEffects(effects);
+		return evaluateFormula(formula);
+	}
+
+	function getWeaponProperties(item) {
+		const props = item.reactive?.system?.properties ?? item.system?.properties ?? {};
+		const selected = props.selected ?? [];
+
+		return selected
+			.map((key) => {
+				const localeKey = weaponProperties[key];
+				const label = localeKey ? game.i18n.localize(localeKey) : key;
+
+				if (key === 'thrown' && props.thrownRange) {
+					return localize('NIMBLE.ui.heroicActions.thrown', { distance: props.thrownRange });
+				}
+				if (key === 'range' && props.range?.max) {
+					return localize('NIMBLE.npcSheet.range', { distance: props.range.max });
+				}
+				if (key === 'reach' && props.reach?.max) {
+					return localize('NIMBLE.npcSheet.reach', { distance: props.reach.max });
+				}
+
+				return label;
+			})
+			.filter(Boolean);
+	}
+
+	function getItemDescription(item) {
+		const descData = item.reactive?.system?.description ?? item.system?.description;
+		if (!descData) return '';
+
+		const desc = typeof descData === 'object' ? descData.public : descData;
+
+		if (!desc || typeof desc !== 'string') return '';
+
+		const stripped = desc.replace(/<[^>]*>/g, '').trim();
+		return stripped ? desc : '';
+	}
+
+	function toggleDescription(itemId, event) {
+		event.stopPropagation();
+		const newSet = new Set(expandedDescriptions);
+		if (newSet.has(itemId)) {
+			newSet.delete(itemId);
+		} else {
+			newSet.add(itemId);
+		}
+		expandedDescriptions = newSet;
+	}
+
+	// ============================================================================
+	// Unarmed Strike
+	// ============================================================================
+
+	const DEFAULT_UNARMED_DAMAGE = '1d4 + 1 + @abilities.strength.mod';
+
+	function getUnarmedDamageFormula() {
+		return actor.system?.unarmedDamage ?? DEFAULT_UNARMED_DAMAGE;
+	}
+
+	function hasCustomUnarmedDamage() {
+		return actor.system?.unarmedDamage !== undefined;
+	}
+
+	function getUnarmedDamageDisplay() {
+		if (hasCustomUnarmedDamage()) {
+			return evaluateFormula(actor.system.unarmedDamage);
+		}
+		return evaluateFormula('1 + @abilities.strength.mod');
+	}
+
+	async function handleUnarmedStrike() {
+		const { default: ItemActivationConfigDialog } = await import(
+			'../../../documents/dialogs/ItemActivationConfigDialog.svelte.js'
+		);
+		const { DamageRoll } = await import('../../../dice/DamageRoll.js');
+
+		const rollFormula = getUnarmedDamageFormula();
+		const primaryDieAsDamage = hasCustomUnarmedDamage();
+
+		const unarmedItem = {
+			name: localize('NIMBLE.ui.heroicActions.unarmedStrike'),
+			img: 'icons/skills/melee/unarmed-punch-fist.webp',
+			system: {
+				activation: {
+					effects: [
+						{
+							type: 'damage',
+							formula: rollFormula,
+							damageType: 'bludgeoning',
+							canCrit: true,
+							canMiss: true,
+						},
+					],
+				},
+			},
+		};
+
+		const dialog = new ItemActivationConfigDialog(
+			actor,
+			unarmedItem,
+			localize('NIMBLE.ui.heroicActions.unarmedStrike'),
+			{ rollMode: 0 },
+		);
+		await dialog.render(true);
+		const result = await dialog.promise;
+
+		if (!result) return;
+
+		const roll = new DamageRoll(rollFormula, actor.getRollData(), {
+			canCrit: true,
+			canMiss: true,
+			rollMode: result.rollMode ?? 0,
+			primaryDieValue: result.primaryDieValue ?? 0,
+			primaryDieModifier: Number(result.primaryDieModifier) || 0,
+			damageType: 'bludgeoning',
+			primaryDieAsDamage,
+		});
+
+		await roll.evaluate();
+
+		const rollData = roll.toJSON();
+
+		const evaluatedEffects = [
+			{
+				id: 'unarmed-damage',
+				type: 'damage',
+				formula: rollFormula,
+				damageType: 'bludgeoning',
+				canCrit: true,
+				canMiss: true,
+				roll: rollData,
+				parentNode: null,
+				parentContext: null,
+				on: {
+					hit: [
+						{
+							id: 'unarmed-damage-hit',
+							type: 'damageOutcome',
+							parentNode: 'unarmed-damage',
+							parentContext: 'hit',
+						},
+					],
+					criticalHit: [
+						{
+							id: 'unarmed-damage-crit',
+							type: 'damageOutcome',
+							parentNode: 'unarmed-damage',
+							parentContext: 'criticalHit',
+						},
+					],
+				},
+			},
+		];
+
+		const chatData = {
+			author: game.user?.id,
+			flavor: `${actor.name}: ${localize('NIMBLE.ui.heroicActions.unarmedStrike')}`,
+			speaker: ChatMessage.getSpeaker({ actor }),
+			style: CONST.CHAT_MESSAGE_STYLES.OTHER,
+			sound: CONFIG.sounds.dice,
+			rolls: [roll],
+			system: {
+				actorName: actor.name,
+				actorType: actor.type,
+				image: unarmedItem.img,
+				permissions: 3,
+				rollMode: result.rollMode ?? 0,
+				name: localize('NIMBLE.ui.heroicActions.unarmedStrike'),
+				description: '',
+				featureType: 'feature',
+				class: '',
+				attackType: 'reach',
+				attackDistance: 1,
+				isCritical: roll.isCritical,
+				isMiss: roll.isMiss,
+				activation: {
+					effects: evaluatedEffects,
+					cost: { type: 'action', quantity: 1 },
+					duration: { type: 'none', quantity: 1 },
+					targets: { count: 1 },
+				},
+				targets: Array.from(game.user?.targets?.map((token) => token.document.uuid) ?? []),
+			},
+			type: 'feature',
+		};
+
+		await ChatMessage.create(chatData);
+		await onActivateItem(1);
+	}
+
+	async function handleItemClick(itemId) {
+		const item = actor.items.get(itemId);
+		const result = await actor.activateItem(itemId);
+
+		if (result) {
+			const activationCost = item?.system?.activation?.cost;
+			const costType = activationCost?.type;
+			const costQuantity = activationCost?.quantity ?? 1;
+
+			if (costType === 'action') {
+				await onActivateItem(costQuantity);
+			}
+		}
+
+		return result;
+	}
+</script>
+
+<section class="attack-panel">
+	<header class="nimble-section-header">
+		<h3 class="nimble-heading" data-heading-variant="section">
+			{localize('NIMBLE.ui.heroicActions.selectAttack')}
+		</h3>
+	</header>
+
+	<div class="attack-panel__search">
+		<SearchBar bind:searchTerm />
+	</div>
+
+	<div class="attack-panel__content">
+		<ul class="attack-panel__list">
+			{#if showUnarmedStrike}
+				<li class="weapon-card">
+					<!-- svelte-ignore a11y_click_events_have_key_events -->
+					<div class="weapon-card__row" role="button" tabindex="0" onclick={handleUnarmedStrike}>
+						<div class="weapon-card__icon">
+							<i class="fa-solid fa-hand-fist"></i>
+						</div>
+
+						<div class="weapon-card__content">
+							<span class="weapon-card__name">
+								{localize('NIMBLE.ui.heroicActions.unarmedStrike')}
+							</span>
+							<div class="weapon-card__meta">
+								<span class="weapon-card__tag">{localize('NIMBLE.npcSheet.melee')}</span>
+							</div>
+						</div>
+
+						<span class="weapon-card__damage">
+							<i class="fa-solid fa-burst"></i>
+							{getUnarmedDamageDisplay()}
+						</span>
+					</div>
+				</li>
+			{/if}
+
+			{#each sortItems(weapons) as item (item._id)}
+				{@const damage = getWeaponDamage(item)}
+				{@const properties = getWeaponProperties(item)}
+				{@const isExpanded = expandedDescriptions.has(item._id)}
+				{@const description = getItemDescription(item)}
+				<li class="weapon-card" class:weapon-card--expanded={isExpanded} data-item-id={item._id}>
+					<!-- svelte-ignore a11y_click_events_have_key_events -->
+					<div
+						class="weapon-card__row"
+						role="button"
+						tabindex="0"
+						draggable="true"
+						ondragstart={(event) => sheet._onDragStart(event)}
+						onclick={() => handleItemClick(item._id)}
+					>
+						{#if showEmbeddedDocumentImages}
+							<img class="weapon-card__img" src={item.reactive.img} alt={item.reactive.name} />
+						{/if}
+
+						<div class="weapon-card__content">
+							<span class="weapon-card__name">{item.reactive.name}</span>
+							{#if properties.length > 0}
+								<div class="weapon-card__meta">
+									{#each properties as prop}
+										<span class="weapon-card__tag">{prop}</span>
+									{/each}
+								</div>
+							{/if}
+						</div>
+
+						{#if damage}
+							<span class="weapon-card__damage">
+								<i class="fa-solid fa-burst"></i>
+								{damage}
+							</span>
+						{/if}
+
+						{#if description}
+							<button
+								class="weapon-card__expand"
+								type="button"
+								onclick={(e) => toggleDescription(item._id, e)}
+								aria-label={isExpanded ? 'Collapse' : 'Expand'}
+							>
+								<i class="fa-solid fa-caret-{isExpanded ? 'up' : 'down'}"></i>
+							</button>
+						{/if}
+					</div>
+
+					{#if isExpanded && description}
+						<div class="weapon-card__description">
+							{#await foundry.applications.ux.TextEditor.implementation.enrichHTML(description) then enrichedDescription}
+								{@html enrichedDescription}
+							{/await}
+						</div>
+					{/if}
+				</li>
+			{/each}
+
+			{#each sortItems(attackFeatures) as item (item._id)}
+				{@const damage = getWeaponDamage(item)}
+				{@const isExpanded = expandedDescriptions.has(item._id)}
+				{@const description = getItemDescription(item)}
+				<li class="weapon-card" class:weapon-card--expanded={isExpanded} data-item-id={item._id}>
+					<!-- svelte-ignore a11y_click_events_have_key_events -->
+					<div
+						class="weapon-card__row"
+						role="button"
+						tabindex="0"
+						draggable="true"
+						ondragstart={(event) => sheet._onDragStart(event)}
+						onclick={() => handleItemClick(item._id)}
+					>
+						{#if showEmbeddedDocumentImages}
+							<img class="weapon-card__img" src={item.reactive.img} alt={item.reactive.name} />
+						{/if}
+
+						<div class="weapon-card__content">
+							<span class="weapon-card__name">{item.reactive.name}</span>
+							<div class="weapon-card__meta">
+								<span class="weapon-card__tag">{localize('NIMBLE.ui.heroicActions.feature')}</span>
+							</div>
+						</div>
+
+						{#if damage}
+							<span class="weapon-card__damage">
+								<i class="fa-solid fa-burst"></i>
+								{damage}
+							</span>
+						{/if}
+
+						{#if description}
+							<button
+								class="weapon-card__expand"
+								type="button"
+								onclick={(e) => toggleDescription(item._id, e)}
+								aria-label={isExpanded ? 'Collapse' : 'Expand'}
+							>
+								<i class="fa-solid fa-caret-{isExpanded ? 'up' : 'down'}"></i>
+							</button>
+						{/if}
+					</div>
+
+					{#if isExpanded && description}
+						<div class="weapon-card__description">
+							{#await foundry.applications.ux.TextEditor.implementation.enrichHTML(description) then enrichedDescription}
+								{@html enrichedDescription}
+							{/await}
+						</div>
+					{/if}
+				</li>
+			{/each}
+		</ul>
+
+		{#if !showUnarmedStrike && weapons.length === 0 && attackFeatures.length === 0}
+			<p class="attack-panel__empty">{localize('NIMBLE.ui.heroicActions.noWeapons')}</p>
+		{/if}
+	</div>
+</section>
+
+<style lang="scss">
+	.attack-panel {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+
+		&__search {
+			display: flex;
+		}
+
+		&__content {
+			display: flex;
+			flex-direction: column;
+			gap: 0.5rem;
+			max-height: 300px;
+			overflow-y: auto;
+		}
+
+		&__list {
+			display: flex;
+			flex-direction: column;
+			gap: 0.25rem;
+			margin: 0;
+			padding: 0;
+			list-style: none;
+		}
+
+		&__empty {
+			margin: 0;
+			padding: 0.75rem;
+			font-size: var(--nimble-sm-text);
+			font-weight: 500;
+			text-align: center;
+			color: var(--nimble-medium-text-color);
+		}
+	}
+
+	.weapon-card {
+		display: flex;
+		flex-direction: column;
+		background: var(--nimble-box-background-color);
+		border: 1px solid var(--nimble-card-border-color);
+		border-radius: 4px;
+		transition: var(--nimble-standard-transition);
+
+		&:hover {
+			border-color: var(--nimble-box-color);
+			box-shadow: var(--nimble-box-shadow);
+		}
+
+		&__row {
+			display: flex;
+			align-items: center;
+			gap: 0.5rem;
+			padding: 0.5rem;
+			cursor: pointer;
+		}
+
+		&__icon {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			width: 2rem;
+			height: 2rem;
+			background: var(--nimble-basic-button-background-color);
+			border-radius: 3px;
+			flex-shrink: 0;
+
+			i {
+				font-size: 1rem;
+				color: var(--nimble-medium-text-color);
+			}
+		}
+
+		&__img {
+			width: 2rem;
+			height: 2rem;
+			object-fit: cover;
+			border-radius: 3px;
+			flex-shrink: 0;
+		}
+
+		&__content {
+			display: flex;
+			flex-direction: column;
+			gap: 0.125rem;
+			flex: 1;
+			min-width: 0;
+		}
+
+		&__name {
+			font-size: var(--nimble-sm-text);
+			font-weight: 600;
+			color: var(--nimble-dark-text-color);
+			line-height: 1.2;
+		}
+
+		&__meta {
+			display: flex;
+			flex-wrap: wrap;
+			align-items: center;
+			gap: 0.25rem;
+		}
+
+		&__tag {
+			font-size: var(--nimble-xs-text);
+			font-weight: 500;
+			color: var(--nimble-medium-text-color);
+			padding: 0 0.25rem;
+			background: var(--nimble-basic-button-background-color);
+			border-radius: 2px;
+		}
+
+		&__damage {
+			display: inline-flex;
+			align-items: center;
+			gap: 0.375rem;
+			padding: 0.25rem 0.625rem;
+			font-size: var(--nimble-sm-text);
+			font-weight: 600;
+			color: var(--nimble-dark-text-color);
+			background: var(--nimble-basic-button-background-color);
+			border-radius: 3px;
+			flex-shrink: 0;
+
+			i {
+				font-size: 0.875rem;
+				color: hsl(0, 60%, 50%);
+			}
+		}
+
+		&__expand {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			width: 1.5rem;
+			height: 1.5rem;
+			padding: 0;
+			background: transparent;
+			border: none;
+			border-radius: 3px;
+			cursor: pointer;
+			flex-shrink: 0;
+			color: var(--nimble-medium-text-color);
+			transition: all 0.15s ease;
+
+			&:hover {
+				background: var(--nimble-basic-button-background-color);
+				color: var(--nimble-dark-text-color);
+			}
+
+			i {
+				font-size: 0.875rem;
+			}
+		}
+
+		&__description {
+			padding: 0.5rem 0.75rem;
+			font-size: var(--nimble-sm-text);
+			color: var(--nimble-dark-text-color);
+			border-top: 1px solid var(--nimble-card-border-color);
+			line-height: 1.5;
+
+			:global(p) {
+				margin: 0 0 0.5rem;
+
+				&:last-child {
+					margin-bottom: 0;
+				}
+			}
+		}
+	}
+</style>

--- a/src/view/sheets/components/AttackActionPanel.svelte
+++ b/src/view/sheets/components/AttackActionPanel.svelte
@@ -1,281 +1,16 @@
 <script>
 	import { getContext } from 'svelte';
-	import sortItems from '../../../utils/sortItems.js';
 	import localize from '../../../utils/localize.js';
-	import { getPrimaryDamageFormulaFromActivationEffects } from '../../../utils/activationEffects.js';
-	import { evaluateFormula as evalFormula } from '../../../utils/evaluateFormula.js';
-	import ItemActivationConfigDialog from '../../../documents/dialogs/ItemActivationConfigDialog.svelte.js';
-	import { DamageRoll } from '../../../dice/DamageRoll.js';
+	import { createAttackPanelState } from './AttackActionPanel.svelte.js';
 
 	import SearchBar from './SearchBar.svelte';
-
-	const { weaponProperties } = CONFIG.NIMBLE;
 
 	let actor = getContext('actor');
 	let sheet = getContext('application');
 
 	let { onActivateItem = async () => {}, showEmbeddedDocumentImages = true } = $props();
 
-	let searchTerm = $state('');
-	let expandedDescriptions = $state(new Set());
-
-	// ============================================================================
-	// Formula Evaluation
-	// ============================================================================
-
-	function evaluateFormula(formula) {
-		return evalFormula(formula, actor);
-	}
-
-	// ============================================================================
-	// Weapon Data
-	// ============================================================================
-
-	let weapons = $derived.by(() => {
-		const weaponItems = actor.reactive.items.filter(
-			(item) => item.type === 'object' && item.system.objectType === 'weapon',
-		);
-
-		if (!searchTerm) return weaponItems;
-
-		const search = searchTerm.toLocaleLowerCase();
-		return weaponItems.filter((item) => item.name.toLocaleLowerCase().includes(search));
-	});
-
-	let showUnarmedStrike = $derived(
-		!searchTerm || 'unarmed strike'.includes(searchTerm.toLocaleLowerCase()),
-	);
-
-	let attackFeatures = $derived.by(() => {
-		const features = actor.reactive.items.filter((item) => {
-			if (item.type !== 'feature') return false;
-
-			const activation = item.system?.activation;
-			if (!activation) return false;
-
-			return activation.cost?.type === 'action' && item.system?.actionType?.includes('attack');
-		});
-
-		if (!searchTerm) return features;
-
-		const search = searchTerm.toLocaleLowerCase();
-		return features.filter((item) => item.name.toLocaleLowerCase().includes(search));
-	});
-
-	function getWeaponDamage(item) {
-		const effects = item.reactive?.system?.activation?.effects ?? item.system?.activation?.effects;
-		const formula = getPrimaryDamageFormulaFromActivationEffects(effects);
-		return evaluateFormula(formula);
-	}
-
-	function getWeaponProperties(item) {
-		const props = item.reactive?.system?.properties ?? item.system?.properties ?? {};
-		const selected = props.selected ?? [];
-
-		return selected
-			.map((key) => {
-				const localeKey = weaponProperties[key];
-				const label = localeKey ? game.i18n.localize(localeKey) : key;
-
-				if (key === 'thrown' && props.thrownRange) {
-					return localize('NIMBLE.ui.heroicActions.thrown', { distance: props.thrownRange });
-				}
-				if (key === 'range' && props.range?.max) {
-					return localize('NIMBLE.npcSheet.range', { distance: props.range.max });
-				}
-				if (key === 'reach' && props.reach?.max) {
-					return localize('NIMBLE.npcSheet.reach', { distance: props.reach.max });
-				}
-
-				return label;
-			})
-			.filter(Boolean);
-	}
-
-	function getItemDescription(item) {
-		const descData = item.reactive?.system?.description ?? item.system?.description;
-		if (!descData) return '';
-
-		const desc = typeof descData === 'object' ? descData.public : descData;
-
-		if (!desc || typeof desc !== 'string') return '';
-
-		const stripped = desc.replace(/<[^>]*>/g, '').trim();
-		return stripped ? desc : '';
-	}
-
-	function toggleDescription(itemId, event) {
-		event.stopPropagation();
-		const newSet = new Set(expandedDescriptions);
-		if (newSet.has(itemId)) {
-			newSet.delete(itemId);
-		} else {
-			newSet.add(itemId);
-		}
-		expandedDescriptions = newSet;
-	}
-
-	function handleKeydown(event, callback) {
-		if (event.key === 'Enter' || event.key === ' ') {
-			event.preventDefault();
-			callback();
-		}
-	}
-
-	// ============================================================================
-	// Unarmed Strike
-	// ============================================================================
-
-	// Default unarmed: roll 1d4 for hit determination, damage is 1 + STR
-	// The 1d4 is excluded from damage total when primaryDieAsDamage is false
-	const DEFAULT_UNARMED_DAMAGE = '1d4 + 1 + @abilities.strength.mod';
-
-	function getUnarmedDamageFormula() {
-		return actor.system?.unarmedDamage ?? DEFAULT_UNARMED_DAMAGE;
-	}
-
-	function hasCustomUnarmedDamage() {
-		return actor.system?.unarmedDamage !== undefined;
-	}
-
-	function getUnarmedDamageDisplay() {
-		if (hasCustomUnarmedDamage()) {
-			return evaluateFormula(actor.system.unarmedDamage);
-		}
-		return evaluateFormula('1 + @abilities.strength.mod');
-	}
-
-	async function handleUnarmedStrike() {
-		const rollFormula = getUnarmedDamageFormula();
-		const primaryDieAsDamage = hasCustomUnarmedDamage();
-
-		const unarmedItem = {
-			name: localize('NIMBLE.ui.heroicActions.unarmedStrike'),
-			img: 'icons/skills/melee/unarmed-punch-fist.webp',
-			system: {
-				activation: {
-					effects: [
-						{
-							type: 'damage',
-							formula: rollFormula,
-							damageType: 'bludgeoning',
-							canCrit: true,
-							canMiss: true,
-						},
-					],
-				},
-			},
-		};
-
-		const dialog = new ItemActivationConfigDialog(
-			actor,
-			unarmedItem,
-			localize('NIMBLE.ui.heroicActions.unarmedStrike'),
-			{ rollMode: 0 },
-		);
-		await dialog.render(true);
-		const result = await dialog.promise;
-
-		if (!result) return;
-
-		const roll = new DamageRoll(rollFormula, actor.getRollData(), {
-			canCrit: true,
-			canMiss: true,
-			rollMode: result.rollMode ?? 0,
-			primaryDieValue: result.primaryDieValue ?? 0,
-			primaryDieModifier: Number(result.primaryDieModifier) || 0,
-			damageType: 'bludgeoning',
-			primaryDieAsDamage,
-		});
-
-		await roll.evaluate();
-
-		const rollData = roll.toJSON();
-
-		const evaluatedEffects = [
-			{
-				id: 'unarmed-damage',
-				type: 'damage',
-				formula: rollFormula,
-				damageType: 'bludgeoning',
-				canCrit: true,
-				canMiss: true,
-				roll: rollData,
-				parentNode: null,
-				parentContext: null,
-				on: {
-					hit: [
-						{
-							id: 'unarmed-damage-hit',
-							type: 'damageOutcome',
-							parentNode: 'unarmed-damage',
-							parentContext: 'hit',
-						},
-					],
-					criticalHit: [
-						{
-							id: 'unarmed-damage-crit',
-							type: 'damageOutcome',
-							parentNode: 'unarmed-damage',
-							parentContext: 'criticalHit',
-						},
-					],
-				},
-			},
-		];
-
-		const chatData = {
-			author: game.user?.id,
-			flavor: `${actor.name}: ${localize('NIMBLE.ui.heroicActions.unarmedStrike')}`,
-			speaker: ChatMessage.getSpeaker({ actor }),
-			style: CONST.CHAT_MESSAGE_STYLES.OTHER,
-			sound: CONFIG.sounds.dice,
-			rolls: [roll],
-			system: {
-				actorName: actor.name,
-				actorType: actor.type,
-				image: unarmedItem.img,
-				permissions: CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER,
-				rollMode: result.rollMode ?? 0,
-				name: localize('NIMBLE.ui.heroicActions.unarmedStrike'),
-				description: '',
-				featureType: 'feature',
-				class: '',
-				attackType: 'reach',
-				attackDistance: 1,
-				isCritical: roll.isCritical,
-				isMiss: roll.isMiss,
-				activation: {
-					effects: evaluatedEffects,
-					cost: { type: 'action', quantity: 1 },
-					duration: { type: 'none', quantity: 1 },
-					targets: { count: 1 },
-				},
-				targets: Array.from(game.user?.targets?.map((token) => token.document.uuid) ?? []),
-			},
-			type: 'feature',
-		};
-
-		await ChatMessage.create(chatData);
-		await onActivateItem(1);
-	}
-
-	async function handleItemClick(itemId) {
-		const item = actor.items.get(itemId);
-		const result = await actor.activateItem(itemId);
-
-		if (result) {
-			const activationCost = item?.system?.activation?.cost;
-			const costType = activationCost?.type;
-			const costQuantity = activationCost?.quantity ?? 1;
-
-			if (costType === 'action') {
-				await onActivateItem(costQuantity);
-			}
-		}
-
-		return result;
-	}
+	const state = createAttackPanelState(actor, onActivateItem);
 </script>
 
 <section class="attack-panel">
@@ -286,19 +21,19 @@
 	</header>
 
 	<div class="attack-panel__search">
-		<SearchBar bind:searchTerm />
+		<SearchBar bind:searchTerm={state.searchTerm} />
 	</div>
 
 	<div class="attack-panel__content">
 		<ul class="attack-panel__list">
-			{#if showUnarmedStrike}
+			{#if state.showUnarmedStrike}
 				<li class="weapon-card">
 					<div
 						class="weapon-card__row"
 						role="button"
 						tabindex="0"
-						onclick={handleUnarmedStrike}
-						onkeydown={(e) => handleKeydown(e, handleUnarmedStrike)}
+						onclick={state.handleUnarmedStrike}
+						onkeydown={(e) => state.handleKeydown(e, state.handleUnarmedStrike)}
 					>
 						<div class="weapon-card__icon">
 							<i class="fa-solid fa-hand-fist"></i>
@@ -315,17 +50,17 @@
 
 						<span class="weapon-card__damage">
 							<i class="fa-solid fa-burst"></i>
-							{getUnarmedDamageDisplay()}
+							{state.getUnarmedDamageDisplay()}
 						</span>
 					</div>
 				</li>
 			{/if}
 
-			{#each sortItems(weapons) as item (item._id)}
-				{@const damage = getWeaponDamage(item)}
-				{@const properties = getWeaponProperties(item)}
-				{@const isExpanded = expandedDescriptions.has(item._id)}
-				{@const description = getItemDescription(item)}
+			{#each state.sortItems(state.weapons) as item (item._id)}
+				{@const damage = state.getWeaponDamage(item)}
+				{@const properties = state.getWeaponProperties(item)}
+				{@const isExpanded = state.expandedDescriptions.has(item._id)}
+				{@const description = state.getItemDescription(item)}
 				<li class="weapon-card" class:weapon-card--expanded={isExpanded} data-item-id={item._id}>
 					<div
 						class="weapon-card__row"
@@ -333,8 +68,8 @@
 						tabindex="0"
 						draggable="true"
 						ondragstart={(event) => sheet._onDragStart(event)}
-						onclick={() => handleItemClick(item._id)}
-						onkeydown={(e) => handleKeydown(e, () => handleItemClick(item._id))}
+						onclick={() => state.handleItemClick(item._id)}
+						onkeydown={(e) => state.handleKeydown(e, () => state.handleItemClick(item._id))}
 					>
 						{#if showEmbeddedDocumentImages}
 							<img class="weapon-card__img" src={item.reactive.img} alt={item.reactive.name} />
@@ -362,7 +97,7 @@
 							<button
 								class="weapon-card__expand"
 								type="button"
-								onclick={(e) => toggleDescription(item._id, e)}
+								onclick={(e) => state.toggleDescription(item._id, e)}
 								aria-label={localize(
 									isExpanded
 										? 'NIMBLE.ui.heroicActions.collapse'
@@ -386,10 +121,10 @@
 				</li>
 			{/each}
 
-			{#each sortItems(attackFeatures) as item (item._id)}
-				{@const damage = getWeaponDamage(item)}
-				{@const isExpanded = expandedDescriptions.has(item._id)}
-				{@const description = getItemDescription(item)}
+			{#each state.sortItems(state.attackFeatures) as item (item._id)}
+				{@const damage = state.getWeaponDamage(item)}
+				{@const isExpanded = state.expandedDescriptions.has(item._id)}
+				{@const description = state.getItemDescription(item)}
 				<li class="weapon-card" class:weapon-card--expanded={isExpanded} data-item-id={item._id}>
 					<div
 						class="weapon-card__row"
@@ -397,8 +132,8 @@
 						tabindex="0"
 						draggable="true"
 						ondragstart={(event) => sheet._onDragStart(event)}
-						onclick={() => handleItemClick(item._id)}
-						onkeydown={(e) => handleKeydown(e, () => handleItemClick(item._id))}
+						onclick={() => state.handleItemClick(item._id)}
+						onkeydown={(e) => state.handleKeydown(e, () => state.handleItemClick(item._id))}
 					>
 						{#if showEmbeddedDocumentImages}
 							<img class="weapon-card__img" src={item.reactive.img} alt={item.reactive.name} />
@@ -422,7 +157,7 @@
 							<button
 								class="weapon-card__expand"
 								type="button"
-								onclick={(e) => toggleDescription(item._id, e)}
+								onclick={(e) => state.toggleDescription(item._id, e)}
 								aria-label={localize(
 									isExpanded
 										? 'NIMBLE.ui.heroicActions.collapse'
@@ -447,7 +182,7 @@
 			{/each}
 		</ul>
 
-		{#if !showUnarmedStrike && weapons.length === 0 && attackFeatures.length === 0}
+		{#if !state.showUnarmedStrike && state.weapons.length === 0 && state.attackFeatures.length === 0}
 			<p class="attack-panel__empty">{localize('NIMBLE.ui.heroicActions.noWeapons')}</p>
 		{/if}
 	</div>

--- a/src/view/sheets/components/AttackActionPanel.svelte
+++ b/src/view/sheets/components/AttackActionPanel.svelte
@@ -1,16 +1,19 @@
 <script>
 	import { getContext } from 'svelte';
 	import localize from '../../../utils/localize.js';
-	import { createAttackPanelState } from './AttackActionPanel.svelte.js';
+	import { createAttackPanelState } from './AttackActionPanel.svelte.ts';
 
 	import SearchBar from './SearchBar.svelte';
 
-	let actor = getContext('actor');
-	let sheet = getContext('application');
+	const actor = getContext('actor');
+	const sheet = getContext('application');
 
 	let { onActivateItem = async () => {}, showEmbeddedDocumentImages = true } = $props();
 
-	const state = createAttackPanelState(actor, onActivateItem);
+	const state = createAttackPanelState(
+		() => actor,
+		() => onActivateItem,
+	);
 </script>
 
 <section class="attack-panel">

--- a/src/view/sheets/components/AttackActionPanel.svelte.ts
+++ b/src/view/sheets/components/AttackActionPanel.svelte.ts
@@ -1,4 +1,5 @@
 import { DamageRoll } from '../../../dice/DamageRoll.js';
+import type { NimbleCharacter } from '../../../documents/actor/character.js';
 import ItemActivationConfigDialog from '../../../documents/dialogs/ItemActivationConfigDialog.svelte.js';
 import { getPrimaryDamageFormulaFromActivationEffects } from '../../../utils/activationEffects.js';
 import { evaluateFormula as evalFormula } from '../../../utils/evaluateFormula.js';
@@ -9,9 +10,35 @@ import sortItems from '../../../utils/sortItems.js';
 // The 1d4 is excluded from damage total when primaryDieAsDamage is false
 const DEFAULT_UNARMED_DAMAGE = '1d4 + 1 + @abilities.strength.mod';
 
+/** System data for weapon items */
+interface WeaponSystemData {
+	objectType: string;
+	activation?: {
+		effects?: unknown[];
+		cost?: { type: string; quantity: number };
+	};
+	properties?: {
+		selected?: string[];
+		reach?: { max?: number };
+		range?: { max?: number };
+		thrownRange?: number;
+	};
+	description?:
+		| {
+				public?: string;
+		  }
+		| string;
+	actionType?: string;
+}
+
+/** Extended character system data with optional unarmed damage */
+interface CharacterSystemExtension {
+	unarmedDamage?: string;
+}
+
 export function createAttackPanelState(
-	actor: Actor,
-	onActivateItem: (cost: number) => Promise<void>,
+	getActor: () => NimbleCharacter,
+	getOnActivateItem: () => (cost: number) => Promise<void>,
 ) {
 	const { weaponProperties } = CONFIG.NIMBLE;
 	let searchTerm = $state('');
@@ -22,22 +49,27 @@ export function createAttackPanelState(
 	// ============================================================================
 
 	function evaluateFormula(formula: string | undefined): string {
-		return evalFormula(formula, actor);
+		return evalFormula(formula, getActor());
 	}
 
 	// ============================================================================
 	// Weapon Data
 	// ============================================================================
 
+	/** Helper to cast item system data */
+	function getSystemData(item: Item): WeaponSystemData {
+		return item.system as unknown as WeaponSystemData;
+	}
+
 	const weapons = $derived.by(() => {
-		const weaponItems = actor.reactive.items.filter(
-			(item: Item) => item.type === 'object' && item.system.objectType === 'weapon',
+		const weaponItems = getActor().reactive.items.filter(
+			(item) => item.type === 'object' && getSystemData(item).objectType === 'weapon',
 		);
 
 		if (!searchTerm) return weaponItems;
 
 		const search = searchTerm.toLocaleLowerCase();
-		return weaponItems.filter((item: Item) => item.name.toLocaleLowerCase().includes(search));
+		return weaponItems.filter((item) => item.name.toLocaleLowerCase().includes(search));
 	});
 
 	const showUnarmedStrike = $derived(
@@ -45,29 +77,31 @@ export function createAttackPanelState(
 	);
 
 	const attackFeatures = $derived.by(() => {
-		const features = actor.reactive.items.filter((item: Item) => {
+		const features = getActor().reactive.items.filter((item) => {
 			if (item.type !== 'feature') return false;
 
-			const activation = item.system?.activation;
+			const system = getSystemData(item);
+			const activation = system.activation;
 			if (!activation) return false;
 
-			return activation.cost?.type === 'action' && item.system?.actionType?.includes('attack');
+			return activation.cost?.type === 'action' && Boolean(system.actionType?.includes('attack'));
 		});
 
 		if (!searchTerm) return features;
 
 		const search = searchTerm.toLocaleLowerCase();
-		return features.filter((item: Item) => item.name.toLocaleLowerCase().includes(search));
+		return features.filter((item) => item.name.toLocaleLowerCase().includes(search));
 	});
 
 	function getWeaponDamage(item: Item): string {
-		const effects = item.reactive?.system?.activation?.effects ?? item.system?.activation?.effects;
+		const system = getSystemData(item);
+		const effects = system.activation?.effects;
 		const formula = getPrimaryDamageFormulaFromActivationEffects(effects);
-		return evaluateFormula(formula);
+		return evaluateFormula(formula ?? undefined);
 	}
 
 	function getWeaponProperties(item: Item): string[] {
-		const props = item.reactive?.system?.properties ?? item.system?.properties ?? {};
+		const props = getSystemData(item).properties ?? {};
 		const selected = props.selected ?? [];
 
 		return selected
@@ -76,13 +110,15 @@ export function createAttackPanelState(
 				const label = localeKey ? game.i18n.localize(localeKey) : key;
 
 				if (key === 'thrown' && props.thrownRange) {
-					return localize('NIMBLE.ui.heroicActions.thrown', { distance: props.thrownRange });
+					return localize('NIMBLE.ui.heroicActions.thrown', {
+						distance: String(props.thrownRange),
+					});
 				}
 				if (key === 'range' && props.range?.max) {
-					return localize('NIMBLE.npcSheet.range', { distance: props.range.max });
+					return localize('NIMBLE.npcSheet.range', { distance: String(props.range.max) });
 				}
 				if (key === 'reach' && props.reach?.max) {
-					return localize('NIMBLE.npcSheet.reach', { distance: props.reach.max });
+					return localize('NIMBLE.npcSheet.reach', { distance: String(props.reach.max) });
 				}
 
 				return label;
@@ -91,7 +127,7 @@ export function createAttackPanelState(
 	}
 
 	function getItemDescription(item: Item): string {
-		const descData = item.reactive?.system?.description ?? item.system?.description;
+		const descData = getSystemData(item).description;
 		if (!descData) return '';
 
 		const desc = typeof descData === 'object' ? descData.public : descData;
@@ -124,17 +160,22 @@ export function createAttackPanelState(
 	// Unarmed Strike
 	// ============================================================================
 
+	/** Get character system with unarmed damage extension */
+	function getCharacterSystem(): CharacterSystemExtension {
+		return getActor().system as CharacterSystemExtension;
+	}
+
 	function getUnarmedDamageFormula(): string {
-		return actor.system?.unarmedDamage ?? DEFAULT_UNARMED_DAMAGE;
+		return getCharacterSystem().unarmedDamage ?? DEFAULT_UNARMED_DAMAGE;
 	}
 
 	function hasCustomUnarmedDamage(): boolean {
-		return actor.system?.unarmedDamage !== undefined;
+		return getCharacterSystem().unarmedDamage !== undefined;
 	}
 
 	function getUnarmedDamageDisplay(): string {
 		if (hasCustomUnarmedDamage()) {
-			return evaluateFormula(actor.system.unarmedDamage);
+			return evaluateFormula(getCharacterSystem().unarmedDamage);
 		}
 		return evaluateFormula('1 + @abilities.strength.mod');
 	}
@@ -162,7 +203,7 @@ export function createAttackPanelState(
 		};
 
 		const dialog = new ItemActivationConfigDialog(
-			actor,
+			getActor(),
 			unarmedItem,
 			localize('NIMBLE.ui.heroicActions.unarmedStrike'),
 			{ rollMode: 0 },
@@ -172,7 +213,7 @@ export function createAttackPanelState(
 
 		if (!result) return;
 
-		const roll = new DamageRoll(rollFormula, actor.getRollData(), {
+		const roll = new DamageRoll(rollFormula, getActor().getRollData(), {
 			canCrit: true,
 			canMiss: true,
 			rollMode: result.rollMode ?? 0,
@@ -220,14 +261,14 @@ export function createAttackPanelState(
 
 		const chatData = {
 			author: game.user?.id,
-			flavor: `${actor.name}: ${localize('NIMBLE.ui.heroicActions.unarmedStrike')}`,
-			speaker: ChatMessage.getSpeaker({ actor }),
+			flavor: `${getActor().name}: ${localize('NIMBLE.ui.heroicActions.unarmedStrike')}`,
+			speaker: ChatMessage.getSpeaker({ actor: getActor() }),
 			style: CONST.CHAT_MESSAGE_STYLES.OTHER,
 			sound: CONFIG.sounds.dice,
 			rolls: [roll],
 			system: {
-				actorName: actor.name,
-				actorType: actor.type,
+				actorName: getActor().name,
+				actorType: getActor().type,
 				image: unarmedItem.img,
 				permissions: CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER,
 				rollMode: result.rollMode ?? 0,
@@ -250,21 +291,22 @@ export function createAttackPanelState(
 			type: 'feature',
 		};
 
-		await ChatMessage.create(chatData);
-		await onActivateItem(1);
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		await ChatMessage.create(chatData as any);
+		await getOnActivateItem()(1);
 	}
 
 	async function handleItemClick(itemId: string): Promise<unknown> {
-		const item = actor.items.get(itemId);
-		const result = await actor.activateItem(itemId);
+		const item = getActor().items.get(itemId);
+		const result = await getActor().activateItem(itemId);
 
-		if (result) {
-			const activationCost = item?.system?.activation?.cost;
+		if (result && item) {
+			const activationCost = getSystemData(item).activation?.cost;
 			const costType = activationCost?.type;
 			const costQuantity = activationCost?.quantity ?? 1;
 
 			if (costType === 'action') {
-				await onActivateItem(costQuantity);
+				await getOnActivateItem()(costQuantity);
 			}
 		}
 

--- a/src/view/sheets/components/AttackActionPanel.svelte.ts
+++ b/src/view/sheets/components/AttackActionPanel.svelte.ts
@@ -1,0 +1,304 @@
+import { DamageRoll } from '../../../dice/DamageRoll.js';
+import ItemActivationConfigDialog from '../../../documents/dialogs/ItemActivationConfigDialog.svelte.js';
+import { getPrimaryDamageFormulaFromActivationEffects } from '../../../utils/activationEffects.js';
+import { evaluateFormula as evalFormula } from '../../../utils/evaluateFormula.js';
+import localize from '../../../utils/localize.js';
+import sortItems from '../../../utils/sortItems.js';
+
+const { weaponProperties } = CONFIG.NIMBLE;
+
+// Default unarmed: roll 1d4 for hit determination, damage is 1 + STR
+// The 1d4 is excluded from damage total when primaryDieAsDamage is false
+const DEFAULT_UNARMED_DAMAGE = '1d4 + 1 + @abilities.strength.mod';
+
+export function createAttackPanelState(
+	actor: Actor,
+	onActivateItem: (cost: number) => Promise<void>,
+) {
+	let searchTerm = $state('');
+	let expandedDescriptions = $state(new Set<string>());
+
+	// ============================================================================
+	// Formula Evaluation
+	// ============================================================================
+
+	function evaluateFormula(formula: string | undefined): string {
+		return evalFormula(formula, actor);
+	}
+
+	// ============================================================================
+	// Weapon Data
+	// ============================================================================
+
+	const weapons = $derived.by(() => {
+		const weaponItems = actor.reactive.items.filter(
+			(item: Item) => item.type === 'object' && item.system.objectType === 'weapon',
+		);
+
+		if (!searchTerm) return weaponItems;
+
+		const search = searchTerm.toLocaleLowerCase();
+		return weaponItems.filter((item: Item) => item.name.toLocaleLowerCase().includes(search));
+	});
+
+	const showUnarmedStrike = $derived(
+		!searchTerm || 'unarmed strike'.includes(searchTerm.toLocaleLowerCase()),
+	);
+
+	const attackFeatures = $derived.by(() => {
+		const features = actor.reactive.items.filter((item: Item) => {
+			if (item.type !== 'feature') return false;
+
+			const activation = item.system?.activation;
+			if (!activation) return false;
+
+			return activation.cost?.type === 'action' && item.system?.actionType?.includes('attack');
+		});
+
+		if (!searchTerm) return features;
+
+		const search = searchTerm.toLocaleLowerCase();
+		return features.filter((item: Item) => item.name.toLocaleLowerCase().includes(search));
+	});
+
+	function getWeaponDamage(item: Item): string {
+		const effects = item.reactive?.system?.activation?.effects ?? item.system?.activation?.effects;
+		const formula = getPrimaryDamageFormulaFromActivationEffects(effects);
+		return evaluateFormula(formula);
+	}
+
+	function getWeaponProperties(item: Item): string[] {
+		const props = item.reactive?.system?.properties ?? item.system?.properties ?? {};
+		const selected = props.selected ?? [];
+
+		return selected
+			.map((key: string) => {
+				const localeKey = weaponProperties[key];
+				const label = localeKey ? game.i18n.localize(localeKey) : key;
+
+				if (key === 'thrown' && props.thrownRange) {
+					return localize('NIMBLE.ui.heroicActions.thrown', { distance: props.thrownRange });
+				}
+				if (key === 'range' && props.range?.max) {
+					return localize('NIMBLE.npcSheet.range', { distance: props.range.max });
+				}
+				if (key === 'reach' && props.reach?.max) {
+					return localize('NIMBLE.npcSheet.reach', { distance: props.reach.max });
+				}
+
+				return label;
+			})
+			.filter(Boolean);
+	}
+
+	function getItemDescription(item: Item): string {
+		const descData = item.reactive?.system?.description ?? item.system?.description;
+		if (!descData) return '';
+
+		const desc = typeof descData === 'object' ? descData.public : descData;
+
+		if (!desc || typeof desc !== 'string') return '';
+
+		const stripped = desc.replace(/<[^>]*>/g, '').trim();
+		return stripped ? desc : '';
+	}
+
+	function toggleDescription(itemId: string, event: Event): void {
+		event.stopPropagation();
+		const newSet = new Set(expandedDescriptions);
+		if (newSet.has(itemId)) {
+			newSet.delete(itemId);
+		} else {
+			newSet.add(itemId);
+		}
+		expandedDescriptions = newSet;
+	}
+
+	function handleKeydown(event: KeyboardEvent, callback: () => void): void {
+		if (event.key === 'Enter' || event.key === ' ') {
+			event.preventDefault();
+			callback();
+		}
+	}
+
+	// ============================================================================
+	// Unarmed Strike
+	// ============================================================================
+
+	function getUnarmedDamageFormula(): string {
+		return actor.system?.unarmedDamage ?? DEFAULT_UNARMED_DAMAGE;
+	}
+
+	function hasCustomUnarmedDamage(): boolean {
+		return actor.system?.unarmedDamage !== undefined;
+	}
+
+	function getUnarmedDamageDisplay(): string {
+		if (hasCustomUnarmedDamage()) {
+			return evaluateFormula(actor.system.unarmedDamage);
+		}
+		return evaluateFormula('1 + @abilities.strength.mod');
+	}
+
+	async function handleUnarmedStrike(): Promise<void> {
+		const rollFormula = getUnarmedDamageFormula();
+		const primaryDieAsDamage = hasCustomUnarmedDamage();
+
+		const unarmedItem = {
+			name: localize('NIMBLE.ui.heroicActions.unarmedStrike'),
+			img: 'icons/skills/melee/unarmed-punch-fist.webp',
+			system: {
+				activation: {
+					effects: [
+						{
+							type: 'damage',
+							formula: rollFormula,
+							damageType: 'bludgeoning',
+							canCrit: true,
+							canMiss: true,
+						},
+					],
+				},
+			},
+		};
+
+		const dialog = new ItemActivationConfigDialog(
+			actor,
+			unarmedItem,
+			localize('NIMBLE.ui.heroicActions.unarmedStrike'),
+			{ rollMode: 0 },
+		);
+		await dialog.render(true);
+		const result = await dialog.promise;
+
+		if (!result) return;
+
+		const roll = new DamageRoll(rollFormula, actor.getRollData(), {
+			canCrit: true,
+			canMiss: true,
+			rollMode: result.rollMode ?? 0,
+			primaryDieValue: result.primaryDieValue ?? 0,
+			primaryDieModifier: Number(result.primaryDieModifier) || 0,
+			damageType: 'bludgeoning',
+			primaryDieAsDamage,
+		});
+
+		await roll.evaluate();
+
+		const rollData = roll.toJSON();
+
+		const evaluatedEffects = [
+			{
+				id: 'unarmed-damage',
+				type: 'damage',
+				formula: rollFormula,
+				damageType: 'bludgeoning',
+				canCrit: true,
+				canMiss: true,
+				roll: rollData,
+				parentNode: null,
+				parentContext: null,
+				on: {
+					hit: [
+						{
+							id: 'unarmed-damage-hit',
+							type: 'damageOutcome',
+							parentNode: 'unarmed-damage',
+							parentContext: 'hit',
+						},
+					],
+					criticalHit: [
+						{
+							id: 'unarmed-damage-crit',
+							type: 'damageOutcome',
+							parentNode: 'unarmed-damage',
+							parentContext: 'criticalHit',
+						},
+					],
+				},
+			},
+		];
+
+		const chatData = {
+			author: game.user?.id,
+			flavor: `${actor.name}: ${localize('NIMBLE.ui.heroicActions.unarmedStrike')}`,
+			speaker: ChatMessage.getSpeaker({ actor }),
+			style: CONST.CHAT_MESSAGE_STYLES.OTHER,
+			sound: CONFIG.sounds.dice,
+			rolls: [roll],
+			system: {
+				actorName: actor.name,
+				actorType: actor.type,
+				image: unarmedItem.img,
+				permissions: CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER,
+				rollMode: result.rollMode ?? 0,
+				name: localize('NIMBLE.ui.heroicActions.unarmedStrike'),
+				description: '',
+				featureType: 'feature',
+				class: '',
+				attackType: 'reach',
+				attackDistance: 1,
+				isCritical: roll.isCritical,
+				isMiss: roll.isMiss,
+				activation: {
+					effects: evaluatedEffects,
+					cost: { type: 'action', quantity: 1 },
+					duration: { type: 'none', quantity: 1 },
+					targets: { count: 1 },
+				},
+				targets: Array.from(game.user?.targets?.map((token) => token.document.uuid) ?? []),
+			},
+			type: 'feature',
+		};
+
+		await ChatMessage.create(chatData);
+		await onActivateItem(1);
+	}
+
+	async function handleItemClick(itemId: string): Promise<unknown> {
+		const item = actor.items.get(itemId);
+		const result = await actor.activateItem(itemId);
+
+		if (result) {
+			const activationCost = item?.system?.activation?.cost;
+			const costType = activationCost?.type;
+			const costQuantity = activationCost?.quantity ?? 1;
+
+			if (costType === 'action') {
+				await onActivateItem(costQuantity);
+			}
+		}
+
+		return result;
+	}
+
+	return {
+		get searchTerm() {
+			return searchTerm;
+		},
+		set searchTerm(value: string) {
+			searchTerm = value;
+		},
+		get expandedDescriptions() {
+			return expandedDescriptions;
+		},
+		get weapons() {
+			return weapons;
+		},
+		get showUnarmedStrike() {
+			return showUnarmedStrike;
+		},
+		get attackFeatures() {
+			return attackFeatures;
+		},
+		sortItems,
+		getWeaponDamage,
+		getWeaponProperties,
+		getItemDescription,
+		toggleDescription,
+		handleKeydown,
+		getUnarmedDamageDisplay,
+		handleUnarmedStrike,
+		handleItemClick,
+	};
+}

--- a/src/view/sheets/components/AttackActionPanel.svelte.ts
+++ b/src/view/sheets/components/AttackActionPanel.svelte.ts
@@ -5,8 +5,6 @@ import { evaluateFormula as evalFormula } from '../../../utils/evaluateFormula.j
 import localize from '../../../utils/localize.js';
 import sortItems from '../../../utils/sortItems.js';
 
-const { weaponProperties } = CONFIG.NIMBLE;
-
 // Default unarmed: roll 1d4 for hit determination, damage is 1 + STR
 // The 1d4 is excluded from damage total when primaryDieAsDamage is false
 const DEFAULT_UNARMED_DAMAGE = '1d4 + 1 + @abilities.strength.mod';
@@ -15,6 +13,7 @@ export function createAttackPanelState(
 	actor: Actor,
 	onActivateItem: (cost: number) => Promise<void>,
 ) {
+	const { weaponProperties } = CONFIG.NIMBLE;
 	let searchTerm = $state('');
 	let expandedDescriptions = $state(new Set<string>());
 

--- a/src/view/sheets/components/CastSpellActionPanel.svelte
+++ b/src/view/sheets/components/CastSpellActionPanel.svelte
@@ -4,6 +4,7 @@
 	import sortItems from '../../../utils/sortItems.js';
 	import localize from '../../../utils/localize.js';
 	import { flattenActivationEffects } from '../../../utils/activationEffects.js';
+	import { evaluateFormula as evalFormula } from '../../../utils/evaluateFormula.js';
 
 	import SearchBar from './SearchBar.svelte';
 
@@ -22,48 +23,7 @@
 	// ============================================================================
 
 	function evaluateFormula(formula) {
-		if (!formula) return '';
-
-		try {
-			const rollData = actor.getRollData();
-			const substituted = Roll.replaceFormulaData(formula, rollData, { missing: '0' });
-
-			const parts = substituted.split(/([+-])/);
-			const simplified = [];
-
-			for (const part of parts) {
-				const trimmed = part.trim();
-				if (!trimmed) continue;
-
-				if (trimmed === '+' || trimmed === '-') {
-					simplified.push(trimmed);
-				} else if (/^\d*d\d+/i.test(trimmed)) {
-					simplified.push(trimmed);
-				} else {
-					try {
-						const evaluated = Roll.safeEval(trimmed);
-						if (typeof evaluated === 'number' && !isNaN(evaluated)) {
-							simplified.push(String(Math.floor(evaluated)));
-						} else {
-							simplified.push(trimmed);
-						}
-					} catch {
-						simplified.push(trimmed);
-					}
-				}
-			}
-
-			let result = simplified.join(' ').replace(/\s+/g, ' ').trim();
-			result = result.replace(/[+-]\s*0(?!\d)/g, '').trim();
-			result = result
-				.replace(/^\s*[+-]\s*/, '')
-				.replace(/[+-]\s*[+-]/g, '+')
-				.trim();
-
-			return result || formula;
-		} catch {
-			return formula;
-		}
+		return evalFormula(formula, actor);
 	}
 
 	// ============================================================================
@@ -188,6 +148,13 @@
 		expandedDescriptions = newSet;
 	}
 
+	function handleKeydown(event, callback) {
+		if (event.key === 'Enter' || event.key === ' ') {
+			event.preventDefault();
+			callback();
+		}
+	}
+
 	async function handleSpellClick(spellId) {
 		const spell = actor.items.get(spellId);
 		const result = await actor.activateItem(spellId);
@@ -233,7 +200,6 @@
 					{@const spellEffects = getSpellEffects(spell)}
 
 					<li class="spell-card" class:spell-card--expanded={isExpanded} data-item-id={spell._id}>
-						<!-- svelte-ignore a11y_click_events_have_key_events -->
 						<div
 							class="spell-card__row"
 							role="button"
@@ -241,6 +207,7 @@
 							draggable="true"
 							ondragstart={(event) => sheet._onDragStart(event)}
 							onclick={() => handleSpellClick(spell._id)}
+							onkeydown={(e) => handleKeydown(e, () => handleSpellClick(spell._id))}
 						>
 							{#if showEmbeddedDocumentImages}
 								<img class="spell-card__img" src={spell.reactive.img} alt={spell.reactive.name} />
@@ -299,7 +266,11 @@
 									class="spell-card__expand"
 									type="button"
 									onclick={(e) => toggleDescription(spell._id, e)}
-									aria-label={isExpanded ? 'Collapse' : 'Expand'}
+									aria-label={localize(
+										isExpanded
+											? 'NIMBLE.ui.heroicActions.collapse'
+											: 'NIMBLE.ui.heroicActions.expand',
+									)}
 								>
 									<i class="fa-solid fa-caret-{isExpanded ? 'up' : 'down'}"></i>
 								</button>
@@ -313,6 +284,8 @@
 										<strong>{localize('NIMBLE.ui.heroicActions.baseEffect')}</strong>
 										{#await foundry.applications.ux.TextEditor.implementation.enrichHTML(spellEffects.baseEffect) then enrichedEffect}
 											{@html enrichedEffect}
+										{:catch}
+											{@html spellEffects.baseEffect}
 										{/await}
 									</div>
 								{/if}
@@ -321,6 +294,8 @@
 										<strong>{localize('NIMBLE.ui.heroicActions.higherLevelEffect')}</strong>
 										{#await foundry.applications.ux.TextEditor.implementation.enrichHTML(spellEffects.higherLevelEffect) then enrichedEffect}
 											{@html enrichedEffect}
+										{:catch}
+											{@html spellEffects.higherLevelEffect}
 										{/await}
 									</div>
 								{/if}

--- a/src/view/sheets/components/CastSpellActionPanel.svelte
+++ b/src/view/sheets/components/CastSpellActionPanel.svelte
@@ -1,176 +1,16 @@
 <script>
 	import { getContext } from 'svelte';
-	import filterItems from '../../dataPreparationHelpers/filterItems.js';
-	import sortItems from '../../../utils/sortItems.js';
 	import localize from '../../../utils/localize.js';
-	import { flattenActivationEffects } from '../../../utils/activationEffects.js';
-	import { evaluateFormula as evalFormula } from '../../../utils/evaluateFormula.js';
+	import { createSpellPanelState } from './CastSpellActionPanel.svelte.js';
 
 	import SearchBar from './SearchBar.svelte';
-
-	const { activationCostTypes, activationCostTypesPlural } = CONFIG.NIMBLE;
 
 	let actor = getContext('actor');
 	let sheet = getContext('application');
 
 	let { onActivateItem = async () => {}, showEmbeddedDocumentImages = true } = $props();
 
-	let searchTerm = $state('');
-	let expandedDescriptions = $state(new Set());
-
-	// ============================================================================
-	// Formula Evaluation
-	// ============================================================================
-
-	function evaluateFormula(formula) {
-		return evalFormula(formula, actor);
-	}
-
-	// ============================================================================
-	// Spell Data
-	// ============================================================================
-
-	let spells = $derived(filterItems(actor.reactive, ['spell'], searchTerm));
-
-	function getSpellEffect(spell) {
-		const effects =
-			spell.reactive?.system?.activation?.effects ?? spell.system?.activation?.effects;
-		const flattened = flattenActivationEffects(effects);
-
-		for (const node of flattened) {
-			const effectType = node.type;
-			if (effectType !== 'damage' && effectType !== 'healing') continue;
-
-			const formula = node.formula || node.roll;
-			if (typeof formula === 'string' && formula.trim().length > 0) {
-				return {
-					formula: evaluateFormula(formula.trim()),
-					isHealing: effectType === 'healing' || node.damageType === 'healing',
-				};
-			}
-		}
-
-		return null;
-	}
-
-	function getSpellManaCost(spell) {
-		return spell.reactive.system.manaCost ?? 0;
-	}
-
-	function getSpellMetadata(spell) {
-		const { type: activationType, quantity: activationCost } =
-			spell.reactive.system.activation.cost;
-
-		if (!activationType || activationType === 'none') return null;
-
-		if (['action', 'minute', 'hour'].includes(activationType)) {
-			const label =
-				activationCost > 1
-					? activationCostTypesPlural[activationType]
-					: activationCostTypes[activationType];
-			return `${activationCost || 1} ${label}`;
-		}
-
-		if (activationType === 'reaction' || activationType === 'special') {
-			return activationCostTypes[activationType];
-		}
-
-		return null;
-	}
-
-	function getSpellRange(spell) {
-		const props = spell.reactive?.system?.properties ?? spell.system?.properties ?? {};
-		const selected = props.selected ?? [];
-
-		if (selected.includes('range') && props.range?.max) {
-			return localize('NIMBLE.ui.heroicActions.rangeDistance', { distance: props.range.max });
-		}
-		if (selected.includes('reach') && props.reach?.max) {
-			return localize('NIMBLE.ui.heroicActions.reachDistance', { distance: props.reach.max });
-		}
-		return null;
-	}
-
-	function getSpellTargetType(spell) {
-		const activation = spell.reactive?.system?.activation ?? spell.system?.activation;
-		if (!activation) return null;
-
-		if (activation.acquireTargetsFromTemplate) {
-			return localize('NIMBLE.ui.heroicActions.targetTypes.aoe');
-		}
-
-		const targetCount = activation.targets?.count ?? 1;
-
-		if (targetCount === 0) {
-			return localize('NIMBLE.ui.heroicActions.targetTypes.self');
-		}
-		if (targetCount === 1) {
-			return localize('NIMBLE.ui.heroicActions.targetTypes.singleTarget');
-		}
-		if (targetCount === 2) {
-			return localize('NIMBLE.ui.heroicActions.targetTypes.twoTargets');
-		}
-		return localize('NIMBLE.ui.heroicActions.targetTypes.multiTarget', { count: targetCount });
-	}
-
-	function hasContent(text) {
-		if (!text || typeof text !== 'string') return false;
-		const stripped = text.replace(/<[^>]*>/g, '').trim();
-		return stripped.length > 0;
-	}
-
-	function getSpellEffects(spell) {
-		const desc = spell.reactive?.system?.description ?? spell.system?.description;
-		if (!desc) return null;
-
-		const baseEffect = desc.baseEffect;
-		const higherLevelEffect = desc.higherLevelEffect;
-
-		const hasBase = hasContent(baseEffect);
-		const hasHigher = hasContent(higherLevelEffect);
-
-		if (!hasBase && !hasHigher) return null;
-
-		return {
-			baseEffect: hasBase ? baseEffect : null,
-			higherLevelEffect: hasHigher ? higherLevelEffect : null,
-		};
-	}
-
-	function toggleDescription(spellId, event) {
-		event.stopPropagation();
-		const newSet = new Set(expandedDescriptions);
-		if (newSet.has(spellId)) {
-			newSet.delete(spellId);
-		} else {
-			newSet.add(spellId);
-		}
-		expandedDescriptions = newSet;
-	}
-
-	function handleKeydown(event, callback) {
-		if (event.key === 'Enter' || event.key === ' ') {
-			event.preventDefault();
-			callback();
-		}
-	}
-
-	async function handleSpellClick(spellId) {
-		const spell = actor.items.get(spellId);
-		const result = await actor.activateItem(spellId);
-
-		if (result) {
-			const activationCost = spell?.system?.activation?.cost;
-			const costType = activationCost?.type;
-			const costQuantity = activationCost?.quantity ?? 1;
-
-			if (costType === 'action') {
-				await onActivateItem(costQuantity);
-			}
-		}
-
-		return result;
-	}
+	const state = createSpellPanelState(actor, onActivateItem);
 </script>
 
 <section class="spell-panel">
@@ -181,23 +21,23 @@
 	</header>
 
 	<div class="spell-panel__search">
-		<SearchBar bind:searchTerm />
+		<SearchBar bind:searchTerm={state.searchTerm} />
 	</div>
 
 	<div class="spell-panel__content">
-		{#if spells.length > 0}
+		{#if state.spells.length > 0}
 			<ul class="spell-panel__list">
-				{#each sortItems(spells) as spell (spell._id)}
-					{@const meta = getSpellMetadata(spell)}
-					{@const manaCost = getSpellManaCost(spell)}
-					{@const effect = getSpellEffect(spell)}
-					{@const spellRange = getSpellRange(spell)}
+				{#each state.sortItems(state.spells) as spell (spell._id)}
+					{@const meta = state.getSpellMetadata(spell)}
+					{@const manaCost = state.getSpellManaCost(spell)}
+					{@const effect = state.getSpellEffect(spell)}
+					{@const spellRange = state.getSpellRange(spell)}
 					{@const requiresConcentration =
 						spell.reactive.system.properties.selected.includes('concentration')}
 					{@const spellTier = spell.reactive.system.tier}
-					{@const targetType = getSpellTargetType(spell)}
-					{@const isExpanded = expandedDescriptions.has(spell._id)}
-					{@const spellEffects = getSpellEffects(spell)}
+					{@const targetType = state.getSpellTargetType(spell)}
+					{@const isExpanded = state.expandedDescriptions.has(spell._id)}
+					{@const spellEffects = state.getSpellEffects(spell)}
 
 					<li class="spell-card" class:spell-card--expanded={isExpanded} data-item-id={spell._id}>
 						<div
@@ -206,8 +46,8 @@
 							tabindex="0"
 							draggable="true"
 							ondragstart={(event) => sheet._onDragStart(event)}
-							onclick={() => handleSpellClick(spell._id)}
-							onkeydown={(e) => handleKeydown(e, () => handleSpellClick(spell._id))}
+							onclick={() => state.handleSpellClick(spell._id)}
+							onkeydown={(e) => state.handleKeydown(e, () => state.handleSpellClick(spell._id))}
 						>
 							{#if showEmbeddedDocumentImages}
 								<img class="spell-card__img" src={spell.reactive.img} alt={spell.reactive.name} />
@@ -265,7 +105,7 @@
 								<button
 									class="spell-card__expand"
 									type="button"
-									onclick={(e) => toggleDescription(spell._id, e)}
+									onclick={(e) => state.toggleDescription(spell._id, e)}
 									aria-label={localize(
 										isExpanded
 											? 'NIMBLE.ui.heroicActions.collapse'

--- a/src/view/sheets/components/CastSpellActionPanel.svelte
+++ b/src/view/sheets/components/CastSpellActionPanel.svelte
@@ -1,16 +1,19 @@
 <script>
 	import { getContext } from 'svelte';
 	import localize from '../../../utils/localize.js';
-	import { createSpellPanelState } from './CastSpellActionPanel.svelte.js';
+	import { createSpellPanelState } from './CastSpellActionPanel.svelte.ts';
 
 	import SearchBar from './SearchBar.svelte';
 
-	let actor = getContext('actor');
-	let sheet = getContext('application');
+	const actor = getContext('actor');
+	const sheet = getContext('application');
 
 	let { onActivateItem = async () => {}, showEmbeddedDocumentImages = true } = $props();
 
-	const state = createSpellPanelState(actor, onActivateItem);
+	const state = createSpellPanelState(
+		() => actor,
+		() => onActivateItem,
+	);
 </script>
 
 <section class="spell-panel">

--- a/src/view/sheets/components/CastSpellActionPanel.svelte
+++ b/src/view/sheets/components/CastSpellActionPanel.svelte
@@ -1,0 +1,568 @@
+<script>
+	import { getContext } from 'svelte';
+	import filterItems from '../../dataPreparationHelpers/filterItems.js';
+	import sortItems from '../../../utils/sortItems.js';
+	import localize from '../../../utils/localize.js';
+	import { flattenActivationEffects } from '../../../utils/activationEffects.js';
+
+	import SearchBar from './SearchBar.svelte';
+
+	const { activationCostTypes, activationCostTypesPlural } = CONFIG.NIMBLE;
+
+	let actor = getContext('actor');
+	let sheet = getContext('application');
+
+	let { onActivateItem = async () => {}, showEmbeddedDocumentImages = true } = $props();
+
+	let searchTerm = $state('');
+	let expandedDescriptions = $state(new Set());
+
+	// ============================================================================
+	// Formula Evaluation
+	// ============================================================================
+
+	function evaluateFormula(formula) {
+		if (!formula) return '';
+
+		try {
+			const rollData = actor.getRollData();
+			const substituted = Roll.replaceFormulaData(formula, rollData, { missing: '0' });
+
+			const parts = substituted.split(/([+-])/);
+			const simplified = [];
+
+			for (const part of parts) {
+				const trimmed = part.trim();
+				if (!trimmed) continue;
+
+				if (trimmed === '+' || trimmed === '-') {
+					simplified.push(trimmed);
+				} else if (/^\d*d\d+/i.test(trimmed)) {
+					simplified.push(trimmed);
+				} else {
+					try {
+						const evaluated = Roll.safeEval(trimmed);
+						if (typeof evaluated === 'number' && !isNaN(evaluated)) {
+							simplified.push(String(Math.floor(evaluated)));
+						} else {
+							simplified.push(trimmed);
+						}
+					} catch {
+						simplified.push(trimmed);
+					}
+				}
+			}
+
+			let result = simplified.join(' ').replace(/\s+/g, ' ').trim();
+			result = result.replace(/[+-]\s*0(?!\d)/g, '').trim();
+			result = result
+				.replace(/^\s*[+-]\s*/, '')
+				.replace(/[+-]\s*[+-]/g, '+')
+				.trim();
+
+			return result || formula;
+		} catch {
+			return formula;
+		}
+	}
+
+	// ============================================================================
+	// Spell Data
+	// ============================================================================
+
+	let spells = $derived(filterItems(actor.reactive, ['spell'], searchTerm));
+
+	function getSpellEffect(spell) {
+		const effects =
+			spell.reactive?.system?.activation?.effects ?? spell.system?.activation?.effects;
+		const flattened = flattenActivationEffects(effects);
+
+		for (const node of flattened) {
+			const effectType = node.type;
+			if (effectType !== 'damage' && effectType !== 'healing') continue;
+
+			const formula = node.formula || node.roll;
+			if (typeof formula === 'string' && formula.trim().length > 0) {
+				return {
+					formula: evaluateFormula(formula.trim()),
+					isHealing: effectType === 'healing' || node.damageType === 'healing',
+				};
+			}
+		}
+
+		return null;
+	}
+
+	function getSpellManaCost(spell) {
+		return spell.reactive.system.manaCost ?? 0;
+	}
+
+	function getSpellMetadata(spell) {
+		const { type: activationType, quantity: activationCost } =
+			spell.reactive.system.activation.cost;
+
+		if (!activationType || activationType === 'none') return null;
+
+		if (['action', 'minute', 'hour'].includes(activationType)) {
+			const label =
+				activationCost > 1
+					? activationCostTypesPlural[activationType]
+					: activationCostTypes[activationType];
+			return `${activationCost || 1} ${label}`;
+		}
+
+		if (activationType === 'reaction' || activationType === 'special') {
+			return activationCostTypes[activationType];
+		}
+
+		return null;
+	}
+
+	function getSpellRange(spell) {
+		const props = spell.reactive?.system?.properties ?? spell.system?.properties ?? {};
+		const selected = props.selected ?? [];
+
+		if (selected.includes('range') && props.range?.max) {
+			return localize('NIMBLE.ui.heroicActions.rangeDistance', { distance: props.range.max });
+		}
+		if (selected.includes('reach') && props.reach?.max) {
+			return localize('NIMBLE.ui.heroicActions.reachDistance', { distance: props.reach.max });
+		}
+		return null;
+	}
+
+	function getSpellTargetType(spell) {
+		const activation = spell.reactive?.system?.activation ?? spell.system?.activation;
+		if (!activation) return null;
+
+		if (activation.acquireTargetsFromTemplate) {
+			return localize('NIMBLE.ui.heroicActions.targetTypes.aoe');
+		}
+
+		const targetCount = activation.targets?.count ?? 1;
+
+		if (targetCount === 0) {
+			return localize('NIMBLE.ui.heroicActions.targetTypes.self');
+		}
+		if (targetCount === 1) {
+			return localize('NIMBLE.ui.heroicActions.targetTypes.singleTarget');
+		}
+		if (targetCount === 2) {
+			return localize('NIMBLE.ui.heroicActions.targetTypes.twoTargets');
+		}
+		return localize('NIMBLE.ui.heroicActions.targetTypes.multiTarget', { count: targetCount });
+	}
+
+	function hasContent(text) {
+		if (!text || typeof text !== 'string') return false;
+		const stripped = text.replace(/<[^>]*>/g, '').trim();
+		return stripped.length > 0;
+	}
+
+	function getSpellEffects(spell) {
+		const desc = spell.reactive?.system?.description ?? spell.system?.description;
+		if (!desc) return null;
+
+		const baseEffect = desc.baseEffect;
+		const higherLevelEffect = desc.higherLevelEffect;
+
+		const hasBase = hasContent(baseEffect);
+		const hasHigher = hasContent(higherLevelEffect);
+
+		if (!hasBase && !hasHigher) return null;
+
+		return {
+			baseEffect: hasBase ? baseEffect : null,
+			higherLevelEffect: hasHigher ? higherLevelEffect : null,
+		};
+	}
+
+	function toggleDescription(spellId, event) {
+		event.stopPropagation();
+		const newSet = new Set(expandedDescriptions);
+		if (newSet.has(spellId)) {
+			newSet.delete(spellId);
+		} else {
+			newSet.add(spellId);
+		}
+		expandedDescriptions = newSet;
+	}
+
+	async function handleSpellClick(spellId) {
+		const spell = actor.items.get(spellId);
+		const result = await actor.activateItem(spellId);
+
+		if (result) {
+			const activationCost = spell?.system?.activation?.cost;
+			const costType = activationCost?.type;
+			const costQuantity = activationCost?.quantity ?? 1;
+
+			if (costType === 'action') {
+				await onActivateItem(costQuantity);
+			}
+		}
+
+		return result;
+	}
+</script>
+
+<section class="spell-panel">
+	<header class="nimble-section-header">
+		<h3 class="nimble-heading" data-heading-variant="section">
+			{localize('NIMBLE.ui.heroicActions.selectSpell')}
+		</h3>
+	</header>
+
+	<div class="spell-panel__search">
+		<SearchBar bind:searchTerm />
+	</div>
+
+	<div class="spell-panel__content">
+		{#if spells.length > 0}
+			<ul class="spell-panel__list">
+				{#each sortItems(spells) as spell (spell._id)}
+					{@const meta = getSpellMetadata(spell)}
+					{@const manaCost = getSpellManaCost(spell)}
+					{@const effect = getSpellEffect(spell)}
+					{@const spellRange = getSpellRange(spell)}
+					{@const requiresConcentration =
+						spell.reactive.system.properties.selected.includes('concentration')}
+					{@const spellTier = spell.reactive.system.tier}
+					{@const targetType = getSpellTargetType(spell)}
+					{@const isExpanded = expandedDescriptions.has(spell._id)}
+					{@const spellEffects = getSpellEffects(spell)}
+
+					<li class="spell-card" class:spell-card--expanded={isExpanded} data-item-id={spell._id}>
+						<!-- svelte-ignore a11y_click_events_have_key_events -->
+						<div
+							class="spell-card__row"
+							role="button"
+							tabindex="0"
+							draggable="true"
+							ondragstart={(event) => sheet._onDragStart(event)}
+							onclick={() => handleSpellClick(spell._id)}
+						>
+							{#if showEmbeddedDocumentImages}
+								<img class="spell-card__img" src={spell.reactive.img} alt={spell.reactive.name} />
+							{/if}
+
+							<div class="spell-card__content">
+								<div class="spell-card__header">
+									<span class="spell-card__name">{spell.reactive.name},</span>
+									<span class="spell-card__tier"
+										>{spellTier === 0
+											? localize('NIMBLE.ui.heroicActions.cantrip')
+											: localize('NIMBLE.ui.heroicActions.spellTier', {
+													tier: spellTier,
+												})}{meta || requiresConcentration ? ',' : ''}</span
+									>
+									{#if meta}
+										<span class="spell-card__action-cost"
+											>{@html meta}{requiresConcentration ? ',' : ''}</span
+										>
+									{/if}
+									{#if requiresConcentration}
+										<span class="spell-card__tag">C</span>
+									{/if}
+								</div>
+
+								<div class="spell-card__meta">
+									{#if targetType}
+										<span class="spell-card__target-type"
+											>{targetType}{spellRange || manaCost > 0 ? ',' : ''}</span
+										>
+									{/if}
+									{#if spellRange}
+										<span class="spell-card__range">{spellRange}{manaCost > 0 ? ',' : ''}</span>
+									{/if}
+									{#if manaCost > 0}
+										<span class="spell-card__mana">
+											<i class="fa-solid fa-sparkles"></i>
+											{localize('NIMBLE.ui.heroicActions.mana', { cost: manaCost })}
+										</span>
+									{/if}
+								</div>
+							</div>
+
+							{#if effect}
+								<span
+									class="spell-card__effect"
+									class:spell-card__effect--healing={effect.isHealing}
+								>
+									<i class="fa-solid {effect.isHealing ? 'fa-heart' : 'fa-burst'}"></i>
+									{effect.formula}
+								</span>
+							{/if}
+
+							{#if spellEffects}
+								<button
+									class="spell-card__expand"
+									type="button"
+									onclick={(e) => toggleDescription(spell._id, e)}
+									aria-label={isExpanded ? 'Collapse' : 'Expand'}
+								>
+									<i class="fa-solid fa-caret-{isExpanded ? 'up' : 'down'}"></i>
+								</button>
+							{/if}
+						</div>
+
+						{#if isExpanded && spellEffects}
+							<div class="spell-card__description">
+								{#if spellEffects.baseEffect}
+									<div class="spell-card__effect-section">
+										<strong>{localize('NIMBLE.ui.heroicActions.baseEffect')}</strong>
+										{#await foundry.applications.ux.TextEditor.implementation.enrichHTML(spellEffects.baseEffect) then enrichedEffect}
+											{@html enrichedEffect}
+										{/await}
+									</div>
+								{/if}
+								{#if spellEffects.higherLevelEffect}
+									<div class="spell-card__effect-section">
+										<strong>{localize('NIMBLE.ui.heroicActions.higherLevelEffect')}</strong>
+										{#await foundry.applications.ux.TextEditor.implementation.enrichHTML(spellEffects.higherLevelEffect) then enrichedEffect}
+											{@html enrichedEffect}
+										{/await}
+									</div>
+								{/if}
+							</div>
+						{/if}
+					</li>
+				{/each}
+			</ul>
+		{:else}
+			<p class="spell-panel__empty">
+				{localize('NIMBLE.ui.heroicActions.noSpellsFound')}
+			</p>
+		{/if}
+	</div>
+</section>
+
+<style lang="scss">
+	.spell-panel {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+
+		&__search {
+			display: flex;
+		}
+
+		&__content {
+			display: flex;
+			flex-direction: column;
+			gap: 0.5rem;
+			max-height: 300px;
+			overflow-y: auto;
+		}
+
+		&__list {
+			display: flex;
+			flex-direction: column;
+			gap: 0.25rem;
+			margin: 0;
+			padding: 0;
+			list-style: none;
+		}
+
+		&__empty {
+			margin: 0;
+			padding: 0.75rem;
+			font-size: var(--nimble-sm-text);
+			font-weight: 500;
+			text-align: center;
+			color: var(--nimble-medium-text-color);
+		}
+	}
+
+	.spell-card {
+		display: flex;
+		flex-direction: column;
+		background: var(--nimble-box-background-color);
+		border: 1px solid var(--nimble-card-border-color);
+		border-radius: 4px;
+		transition: var(--nimble-standard-transition);
+
+		&:hover {
+			border-color: var(--nimble-box-color);
+			box-shadow: var(--nimble-box-shadow);
+		}
+
+		&__row {
+			display: flex;
+			align-items: center;
+			gap: 0.5rem;
+			padding: 0.5rem;
+			cursor: pointer;
+		}
+
+		&__img {
+			width: 2rem;
+			height: 2rem;
+			object-fit: cover;
+			border-radius: 3px;
+			flex-shrink: 0;
+		}
+
+		&__content {
+			display: flex;
+			flex-direction: column;
+			gap: 0.125rem;
+			flex: 1;
+			min-width: 0;
+		}
+
+		&__header {
+			display: flex;
+			align-items: center;
+			flex-wrap: wrap;
+			gap: 0.375rem;
+		}
+
+		&__name {
+			font-size: var(--nimble-sm-text);
+			font-weight: 600;
+			color: var(--nimble-dark-text-color);
+			line-height: 1.2;
+		}
+
+		&__target-type {
+			font-size: var(--nimble-xs-text);
+			font-weight: 500;
+			color: var(--nimble-medium-text-color);
+		}
+
+		&__tag {
+			font-size: var(--nimble-xs-text);
+			font-weight: 500;
+			color: var(--nimble-medium-text-color);
+			padding: 0 0.25rem;
+			background: var(--nimble-basic-button-background-color);
+			border-radius: 2px;
+		}
+
+		&__tier {
+			font-size: var(--nimble-xs-text);
+			font-weight: 500;
+			color: var(--nimble-medium-text-color);
+		}
+
+		&__meta {
+			display: flex;
+			align-items: center;
+			gap: 0.75rem;
+		}
+
+		&__effect {
+			display: inline-flex;
+			align-items: center;
+			gap: 0.375rem;
+			padding: 0.25rem 0.625rem;
+			font-size: var(--nimble-sm-text);
+			font-weight: 600;
+			color: var(--nimble-dark-text-color);
+			background: var(--nimble-basic-button-background-color);
+			border-radius: 3px;
+			flex-shrink: 0;
+
+			i {
+				font-size: 0.875rem;
+				color: hsl(0, 60%, 50%);
+			}
+
+			&--healing i {
+				color: hsl(139, 50%, 40%);
+			}
+		}
+
+		&__action-cost {
+			font-size: var(--nimble-xs-text);
+			font-weight: 500;
+			color: var(--nimble-medium-text-color);
+		}
+
+		&__range {
+			font-size: var(--nimble-xs-text);
+			font-weight: 500;
+			color: var(--nimble-medium-text-color);
+		}
+
+		&__mana {
+			display: inline-flex;
+			align-items: center;
+			gap: 0.25rem;
+			font-size: var(--nimble-xs-text);
+			font-weight: 500;
+			color: hsl(270, 50%, 45%);
+
+			i {
+				font-size: 0.625rem;
+			}
+		}
+
+		&__expand {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			width: 1.5rem;
+			height: 1.5rem;
+			padding: 0;
+			background: transparent;
+			border: none;
+			border-radius: 3px;
+			cursor: pointer;
+			flex-shrink: 0;
+			color: var(--nimble-medium-text-color);
+			transition: all 0.15s ease;
+
+			&:hover {
+				background: var(--nimble-basic-button-background-color);
+				color: var(--nimble-dark-text-color);
+			}
+
+			i {
+				font-size: 0.875rem;
+			}
+		}
+
+		&__description {
+			padding: 0.5rem 0.75rem;
+			font-size: var(--nimble-sm-text);
+			color: var(--nimble-dark-text-color);
+			border-top: 1px solid var(--nimble-card-border-color);
+			line-height: 1.5;
+
+			:global(p) {
+				margin: 0 0 0.5rem;
+
+				&:last-child {
+					margin-bottom: 0;
+				}
+			}
+		}
+
+		&__effect-section {
+			&:not(:last-child) {
+				margin-bottom: 0.75rem;
+				padding-bottom: 0.75rem;
+				border-bottom: 1px solid var(--nimble-card-border-color);
+			}
+
+			strong {
+				display: block;
+				margin-bottom: 0.25rem;
+				font-size: var(--nimble-xs-text);
+				color: var(--nimble-medium-text-color);
+				text-transform: uppercase;
+				letter-spacing: 0.5px;
+			}
+
+			:global(p) {
+				margin: 0 0 0.5rem;
+
+				&:last-child {
+					margin-bottom: 0;
+				}
+			}
+		}
+	}
+</style>

--- a/src/view/sheets/components/CastSpellActionPanel.svelte.ts
+++ b/src/view/sheets/components/CastSpellActionPanel.svelte.ts
@@ -4,8 +4,6 @@ import localize from '../../../utils/localize.js';
 import sortItems from '../../../utils/sortItems.js';
 import filterItems from '../../dataPreparationHelpers/filterItems.js';
 
-const { activationCostTypes, activationCostTypesPlural } = CONFIG.NIMBLE;
-
 interface SpellEffect {
 	formula: string;
 	isHealing: boolean;
@@ -20,6 +18,7 @@ export function createSpellPanelState(
 	actor: Actor,
 	onActivateItem: (cost: number) => Promise<void>,
 ) {
+	const { activationCostTypes, activationCostTypesPlural } = CONFIG.NIMBLE;
 	let searchTerm = $state('');
 	let expandedDescriptions = $state(new Set<string>());
 

--- a/src/view/sheets/components/CastSpellActionPanel.svelte.ts
+++ b/src/view/sheets/components/CastSpellActionPanel.svelte.ts
@@ -1,3 +1,4 @@
+import type { NimbleCharacter } from '../../../documents/actor/character.js';
 import { flattenActivationEffects } from '../../../utils/activationEffects.js';
 import { evaluateFormula as evalFormula } from '../../../utils/evaluateFormula.js';
 import localize from '../../../utils/localize.js';
@@ -14,9 +15,29 @@ interface SpellEffects {
 	higherLevelEffect: string | null;
 }
 
+/** System data for spell items */
+interface SpellSystemData {
+	manaCost?: number;
+	activation?: {
+		effects?: unknown[];
+		cost?: { type: string; quantity: number };
+		acquireTargetsFromTemplate?: boolean;
+		targets?: { count: number };
+	};
+	properties?: {
+		selected?: string[];
+		reach?: { max?: number };
+		range?: { max?: number };
+	};
+	description?: {
+		baseEffect?: string;
+		higherLevelEffect?: string;
+	};
+}
+
 export function createSpellPanelState(
-	actor: Actor,
-	onActivateItem: (cost: number) => Promise<void>,
+	getActor: () => NimbleCharacter,
+	getOnActivateItem: () => (cost: number) => Promise<void>,
 ) {
 	const { activationCostTypes, activationCostTypesPlural } = CONFIG.NIMBLE;
 	let searchTerm = $state('');
@@ -27,18 +48,22 @@ export function createSpellPanelState(
 	// ============================================================================
 
 	function evaluateFormula(formula: string | undefined): string {
-		return evalFormula(formula, actor);
+		return evalFormula(formula, getActor());
+	}
+
+	/** Helper to cast item system data */
+	function getSystemData(item: Item): SpellSystemData {
+		return item.system as unknown as SpellSystemData;
 	}
 
 	// ============================================================================
 	// Spell Data
 	// ============================================================================
 
-	const spells = $derived(filterItems(actor.reactive, ['spell'], searchTerm));
+	const spells = $derived(filterItems(getActor().reactive, ['spell'], searchTerm));
 
 	function getSpellEffect(spell: Item): SpellEffect | null {
-		const effects =
-			spell.reactive?.system?.activation?.effects ?? spell.system?.activation?.effects;
+		const effects = getSystemData(spell).activation?.effects;
 		const flattened = flattenActivationEffects(effects);
 
 		for (const node of flattened) {
@@ -58,12 +83,14 @@ export function createSpellPanelState(
 	}
 
 	function getSpellManaCost(spell: Item): number {
-		return spell.reactive.system.manaCost ?? 0;
+		return getSystemData(spell).manaCost ?? 0;
 	}
 
 	function getSpellMetadata(spell: Item): string | null {
-		const { type: activationType, quantity: activationCost } =
-			spell.reactive.system.activation.cost;
+		const activation = getSystemData(spell).activation;
+		if (!activation?.cost) return null;
+
+		const { type: activationType, quantity: activationCost } = activation.cost;
 
 		if (!activationType || activationType === 'none') return null;
 
@@ -83,20 +110,24 @@ export function createSpellPanelState(
 	}
 
 	function getSpellRange(spell: Item): string | null {
-		const props = spell.reactive?.system?.properties ?? spell.system?.properties ?? {};
+		const props = getSystemData(spell).properties ?? {};
 		const selected = props.selected ?? [];
 
 		if (selected.includes('range') && props.range?.max) {
-			return localize('NIMBLE.ui.heroicActions.rangeDistance', { distance: props.range.max });
+			return localize('NIMBLE.ui.heroicActions.rangeDistance', {
+				distance: String(props.range.max),
+			});
 		}
 		if (selected.includes('reach') && props.reach?.max) {
-			return localize('NIMBLE.ui.heroicActions.reachDistance', { distance: props.reach.max });
+			return localize('NIMBLE.ui.heroicActions.reachDistance', {
+				distance: String(props.reach.max),
+			});
 		}
 		return null;
 	}
 
 	function getSpellTargetType(spell: Item): string | null {
-		const activation = spell.reactive?.system?.activation ?? spell.system?.activation;
+		const activation = getSystemData(spell).activation;
 		if (!activation) return null;
 
 		if (activation.acquireTargetsFromTemplate) {
@@ -114,7 +145,9 @@ export function createSpellPanelState(
 		if (targetCount === 2) {
 			return localize('NIMBLE.ui.heroicActions.targetTypes.twoTargets');
 		}
-		return localize('NIMBLE.ui.heroicActions.targetTypes.multiTarget', { count: targetCount });
+		return localize('NIMBLE.ui.heroicActions.targetTypes.multiTarget', {
+			count: String(targetCount),
+		});
 	}
 
 	function hasContent(text: unknown): text is string {
@@ -124,7 +157,7 @@ export function createSpellPanelState(
 	}
 
 	function getSpellEffects(spell: Item): SpellEffects | null {
-		const desc = spell.reactive?.system?.description ?? spell.system?.description;
+		const desc = getSystemData(spell).description;
 		if (!desc) return null;
 
 		const baseEffect = desc.baseEffect;
@@ -160,16 +193,16 @@ export function createSpellPanelState(
 	}
 
 	async function handleSpellClick(spellId: string): Promise<unknown> {
-		const spell = actor.items.get(spellId);
-		const result = await actor.activateItem(spellId);
+		const spell = getActor().items.get(spellId);
+		const result = await getActor().activateItem(spellId);
 
-		if (result) {
-			const activationCost = spell?.system?.activation?.cost;
+		if (result && spell) {
+			const activationCost = getSystemData(spell).activation?.cost;
 			const costType = activationCost?.type;
 			const costQuantity = activationCost?.quantity ?? 1;
 
 			if (costType === 'action') {
-				await onActivateItem(costQuantity);
+				await getOnActivateItem()(costQuantity);
 			}
 		}
 

--- a/src/view/sheets/components/CastSpellActionPanel.svelte.ts
+++ b/src/view/sheets/components/CastSpellActionPanel.svelte.ts
@@ -1,0 +1,204 @@
+import { flattenActivationEffects } from '../../../utils/activationEffects.js';
+import { evaluateFormula as evalFormula } from '../../../utils/evaluateFormula.js';
+import localize from '../../../utils/localize.js';
+import sortItems from '../../../utils/sortItems.js';
+import filterItems from '../../dataPreparationHelpers/filterItems.js';
+
+const { activationCostTypes, activationCostTypesPlural } = CONFIG.NIMBLE;
+
+interface SpellEffect {
+	formula: string;
+	isHealing: boolean;
+}
+
+interface SpellEffects {
+	baseEffect: string | null;
+	higherLevelEffect: string | null;
+}
+
+export function createSpellPanelState(
+	actor: Actor,
+	onActivateItem: (cost: number) => Promise<void>,
+) {
+	let searchTerm = $state('');
+	let expandedDescriptions = $state(new Set<string>());
+
+	// ============================================================================
+	// Formula Evaluation
+	// ============================================================================
+
+	function evaluateFormula(formula: string | undefined): string {
+		return evalFormula(formula, actor);
+	}
+
+	// ============================================================================
+	// Spell Data
+	// ============================================================================
+
+	const spells = $derived(filterItems(actor.reactive, ['spell'], searchTerm));
+
+	function getSpellEffect(spell: Item): SpellEffect | null {
+		const effects =
+			spell.reactive?.system?.activation?.effects ?? spell.system?.activation?.effects;
+		const flattened = flattenActivationEffects(effects);
+
+		for (const node of flattened) {
+			const effectType = node.type;
+			if (effectType !== 'damage' && effectType !== 'healing') continue;
+
+			const formula = node.formula || node.roll;
+			if (typeof formula === 'string' && formula.trim().length > 0) {
+				return {
+					formula: evaluateFormula(formula.trim()),
+					isHealing: effectType === 'healing' || node.damageType === 'healing',
+				};
+			}
+		}
+
+		return null;
+	}
+
+	function getSpellManaCost(spell: Item): number {
+		return spell.reactive.system.manaCost ?? 0;
+	}
+
+	function getSpellMetadata(spell: Item): string | null {
+		const { type: activationType, quantity: activationCost } =
+			spell.reactive.system.activation.cost;
+
+		if (!activationType || activationType === 'none') return null;
+
+		if (['action', 'minute', 'hour'].includes(activationType)) {
+			const label =
+				activationCost > 1
+					? activationCostTypesPlural[activationType]
+					: activationCostTypes[activationType];
+			return `${activationCost || 1} ${label}`;
+		}
+
+		if (activationType === 'reaction' || activationType === 'special') {
+			return activationCostTypes[activationType];
+		}
+
+		return null;
+	}
+
+	function getSpellRange(spell: Item): string | null {
+		const props = spell.reactive?.system?.properties ?? spell.system?.properties ?? {};
+		const selected = props.selected ?? [];
+
+		if (selected.includes('range') && props.range?.max) {
+			return localize('NIMBLE.ui.heroicActions.rangeDistance', { distance: props.range.max });
+		}
+		if (selected.includes('reach') && props.reach?.max) {
+			return localize('NIMBLE.ui.heroicActions.reachDistance', { distance: props.reach.max });
+		}
+		return null;
+	}
+
+	function getSpellTargetType(spell: Item): string | null {
+		const activation = spell.reactive?.system?.activation ?? spell.system?.activation;
+		if (!activation) return null;
+
+		if (activation.acquireTargetsFromTemplate) {
+			return localize('NIMBLE.ui.heroicActions.targetTypes.aoe');
+		}
+
+		const targetCount = activation.targets?.count ?? 1;
+
+		if (targetCount === 0) {
+			return localize('NIMBLE.ui.heroicActions.targetTypes.self');
+		}
+		if (targetCount === 1) {
+			return localize('NIMBLE.ui.heroicActions.targetTypes.singleTarget');
+		}
+		if (targetCount === 2) {
+			return localize('NIMBLE.ui.heroicActions.targetTypes.twoTargets');
+		}
+		return localize('NIMBLE.ui.heroicActions.targetTypes.multiTarget', { count: targetCount });
+	}
+
+	function hasContent(text: unknown): text is string {
+		if (!text || typeof text !== 'string') return false;
+		const stripped = text.replace(/<[^>]*>/g, '').trim();
+		return stripped.length > 0;
+	}
+
+	function getSpellEffects(spell: Item): SpellEffects | null {
+		const desc = spell.reactive?.system?.description ?? spell.system?.description;
+		if (!desc) return null;
+
+		const baseEffect = desc.baseEffect;
+		const higherLevelEffect = desc.higherLevelEffect;
+
+		const hasBase = hasContent(baseEffect);
+		const hasHigher = hasContent(higherLevelEffect);
+
+		if (!hasBase && !hasHigher) return null;
+
+		return {
+			baseEffect: hasBase ? baseEffect : null,
+			higherLevelEffect: hasHigher ? higherLevelEffect : null,
+		};
+	}
+
+	function toggleDescription(spellId: string, event: Event): void {
+		event.stopPropagation();
+		const newSet = new Set(expandedDescriptions);
+		if (newSet.has(spellId)) {
+			newSet.delete(spellId);
+		} else {
+			newSet.add(spellId);
+		}
+		expandedDescriptions = newSet;
+	}
+
+	function handleKeydown(event: KeyboardEvent, callback: () => void): void {
+		if (event.key === 'Enter' || event.key === ' ') {
+			event.preventDefault();
+			callback();
+		}
+	}
+
+	async function handleSpellClick(spellId: string): Promise<unknown> {
+		const spell = actor.items.get(spellId);
+		const result = await actor.activateItem(spellId);
+
+		if (result) {
+			const activationCost = spell?.system?.activation?.cost;
+			const costType = activationCost?.type;
+			const costQuantity = activationCost?.quantity ?? 1;
+
+			if (costType === 'action') {
+				await onActivateItem(costQuantity);
+			}
+		}
+
+		return result;
+	}
+
+	return {
+		get searchTerm() {
+			return searchTerm;
+		},
+		set searchTerm(value: string) {
+			searchTerm = value;
+		},
+		get expandedDescriptions() {
+			return expandedDescriptions;
+		},
+		get spells() {
+			return spells;
+		},
+		sortItems,
+		getSpellEffect,
+		getSpellManaCost,
+		getSpellMetadata,
+		getSpellRange,
+		getSpellTargetType,
+		getSpellEffects,
+		toggleDescription,
+		handleKeydown,
+		handleSpellClick,
+	};
+}

--- a/src/view/sheets/components/HeroicActionBox.svelte
+++ b/src/view/sheets/components/HeroicActionBox.svelte
@@ -73,7 +73,7 @@
 			flex-shrink: 0;
 			width: 2.5rem;
 			height: 2.5rem;
-			background: hsl(210, 65%, 50%);
+			background: var(--nimble-action-button-icon-color);
 			border-radius: 4px;
 			box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
 

--- a/src/view/sheets/components/HeroicActionBox.svelte
+++ b/src/view/sheets/components/HeroicActionBox.svelte
@@ -1,0 +1,121 @@
+<script>
+	let {
+		icon = 'fa-solid fa-bolt',
+		label = 'Action',
+		description = '',
+		tooltip = '',
+		disabled = false,
+		expanded = false,
+		onclick = () => {},
+	} = $props();
+</script>
+
+<button
+	class="heroic-action-box"
+	class:heroic-action-box--disabled={disabled}
+	class:heroic-action-box--expanded={expanded}
+	type="button"
+	data-tooltip={tooltip || null}
+	{disabled}
+	{onclick}
+>
+	<div class="heroic-action-box__icon-wrapper">
+		<i class="heroic-action-box__icon {icon}"></i>
+	</div>
+
+	<div class="heroic-action-box__content">
+		<span class="heroic-action-box__label">{label}</span>
+		{#if description}
+			<span class="heroic-action-box__description">{description}</span>
+		{/if}
+	</div>
+
+	{#if expanded}
+		<i class="heroic-action-box__chevron fa-solid fa-chevron-up"></i>
+	{/if}
+</button>
+
+<style lang="scss">
+	.heroic-action-box {
+		position: relative;
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		width: 100%;
+		min-height: 4rem;
+		padding: 0.75rem;
+		background: var(--nimble-box-background-color);
+		border: 1px solid var(--nimble-card-border-color);
+		border-radius: 4px;
+		cursor: pointer;
+		text-align: left;
+		transition: var(--nimble-standard-transition);
+
+		&:hover:not(:disabled) {
+			border-color: var(--nimble-box-color);
+			box-shadow: var(--nimble-box-shadow);
+		}
+
+		&--expanded {
+			border-color: var(--nimble-box-color);
+			background: var(--nimble-input-background-color);
+		}
+
+		&--disabled {
+			cursor: not-allowed;
+			opacity: 0.5;
+		}
+
+		&__icon-wrapper {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			flex-shrink: 0;
+			width: 2.5rem;
+			height: 2.5rem;
+			background: hsl(210, 65%, 50%);
+			border-radius: 4px;
+			box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+
+			.heroic-action-box--disabled & {
+				background: var(--nimble-medium-text-color);
+			}
+		}
+
+		&__icon {
+			font-size: 1.125rem;
+			color: hsl(0, 0%, 100%);
+			text-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+		}
+
+		&__content {
+			display: flex;
+			flex-direction: column;
+			gap: 0.125rem;
+			flex: 1;
+			min-width: 0;
+		}
+
+		&__label {
+			font-size: var(--nimble-sm-text);
+			font-weight: 600;
+			color: var(--nimble-dark-text-color);
+			line-height: 1.3;
+		}
+
+		&__description {
+			font-size: var(--nimble-xs-text);
+			font-weight: 500;
+			color: var(--nimble-medium-text-color);
+			line-height: 1.3;
+		}
+
+		&__chevron {
+			position: absolute;
+			top: 0.5rem;
+			right: 0.5rem;
+			font-size: 0.5rem;
+			color: var(--nimble-medium-text-color);
+		}
+	}
+</style>

--- a/src/view/sheets/components/MoveActionPanel.svelte
+++ b/src/view/sheets/components/MoveActionPanel.svelte
@@ -1,38 +1,10 @@
 <script>
 	import localize from '../../../utils/localize.js';
-
-	const { movementTypes, movementTypeIcons } = CONFIG.NIMBLE;
+	import { getMovementSpeeds } from '../../../utils/movementSpeeds.js';
 
 	let { actor, inCombat = false, actionsRemaining = 0, onDeductAction = async () => {} } = $props();
 
-	let movementSpeeds = $derived.by(() => {
-		const movement = actor.system?.attributes?.movement ?? {};
-		const speeds = [];
-
-		// Always show walk first if it exists
-		if (movement.walk > 0) {
-			speeds.push({
-				type: 'walk',
-				value: movement.walk,
-				label: game.i18n.localize(movementTypes.walk),
-				icon: movementTypeIcons.walk,
-			});
-		}
-
-		// Add other movement types if non-zero
-		for (const type of ['fly', 'climb', 'swim', 'burrow']) {
-			if (movement[type] > 0) {
-				speeds.push({
-					type,
-					value: movement[type],
-					label: game.i18n.localize(movementTypes[type]),
-					icon: movementTypeIcons[type],
-				});
-			}
-		}
-
-		return speeds;
-	});
+	let movementSpeeds = $derived(getMovementSpeeds(actor));
 
 	async function handleMove() {
 		if (!inCombat || actionsRemaining <= 0) return;
@@ -142,7 +114,7 @@
 
 			i {
 				font-size: 0.75rem;
-				color: hsl(210, 60%, 50%);
+				color: var(--nimble-action-icon-color);
 			}
 		}
 
@@ -171,15 +143,15 @@
 			align-items: center;
 			gap: 0.375rem;
 			padding: 0.375rem 0.5rem;
-			background: hsla(45, 70%, 50%, 0.1);
-			border: 1px solid hsla(45, 70%, 50%, 0.3);
+			background: var(--nimble-action-info-background);
+			border: 1px solid var(--nimble-action-info-border-color);
 			border-radius: 4px;
 			font-size: var(--nimble-xs-text);
 			font-weight: 500;
-			color: hsl(45, 60%, 35%);
+			color: var(--nimble-action-info-text-color);
 
 			i {
-				color: hsl(45, 70%, 45%);
+				color: var(--nimble-action-info-icon-color);
 			}
 		}
 
@@ -194,22 +166,6 @@
 
 			i {
 				font-size: 0.875rem;
-			}
-		}
-	}
-
-	:global(.theme-dark) .move-panel {
-		&__speed i {
-			color: hsl(210, 70%, 65%);
-		}
-
-		&__info {
-			background: hsla(45, 70%, 50%, 0.15);
-			border-color: hsla(45, 70%, 50%, 0.4);
-			color: hsl(45, 60%, 65%);
-
-			i {
-				color: hsl(45, 70%, 55%);
 			}
 		}
 	}

--- a/src/view/sheets/components/MoveActionPanel.svelte
+++ b/src/view/sheets/components/MoveActionPanel.svelte
@@ -1,0 +1,216 @@
+<script>
+	import localize from '../../../utils/localize.js';
+
+	const { movementTypes, movementTypeIcons } = CONFIG.NIMBLE;
+
+	let { actor, inCombat = false, actionsRemaining = 0, onDeductAction = async () => {} } = $props();
+
+	let movementSpeeds = $derived.by(() => {
+		const movement = actor.system?.attributes?.movement ?? {};
+		const speeds = [];
+
+		// Always show walk first if it exists
+		if (movement.walk > 0) {
+			speeds.push({
+				type: 'walk',
+				value: movement.walk,
+				label: game.i18n.localize(movementTypes.walk),
+				icon: movementTypeIcons.walk,
+			});
+		}
+
+		// Add other movement types if non-zero
+		for (const type of ['fly', 'climb', 'swim', 'burrow']) {
+			if (movement[type] > 0) {
+				speeds.push({
+					type,
+					value: movement[type],
+					label: game.i18n.localize(movementTypes[type]),
+					icon: movementTypeIcons[type],
+				});
+			}
+		}
+
+		return speeds;
+	});
+
+	async function handleMove() {
+		if (!inCombat || actionsRemaining <= 0) return;
+
+		// Deduct action pip
+		await onDeductAction();
+
+		// Send chat message
+		await ChatMessage.create({
+			speaker: ChatMessage.getSpeaker({ actor }),
+			content: localize('NIMBLE.ui.heroicActions.moveAction', { name: actor.name }),
+		});
+	}
+</script>
+
+<section class="move-panel">
+	<header class="nimble-section-header">
+		<h3 class="nimble-heading" data-heading-variant="section">
+			{localize('NIMBLE.ui.heroicActions.move.title')}
+		</h3>
+	</header>
+
+	<div class="move-panel__content">
+		{#if movementSpeeds.length > 0}
+			<div class="move-panel__speeds">
+				<span class="move-panel__speeds-label">
+					{localize('NIMBLE.ui.heroicActions.move.yourMovement')}
+				</span>
+				<div class="move-panel__speeds-list">
+					{#each movementSpeeds as speed}
+						<div class="move-panel__speed">
+							<i class={speed.icon}></i>
+							<span class="move-panel__speed-value">{speed.value}</span>
+							<span class="move-panel__speed-label">
+								{localize('NIMBLE.ui.heroicActions.move.spaces')}
+							</span>
+						</div>
+					{/each}
+				</div>
+			</div>
+		{:else}
+			<p class="move-panel__no-movement">
+				{localize('NIMBLE.ui.heroicActions.move.noMovement')}
+			</p>
+		{/if}
+
+		<div class="move-panel__info">
+			<i class="fa-solid fa-circle-info"></i>
+			<span>{localize('NIMBLE.ui.heroicActions.move.actionCost')}</span>
+		</div>
+
+		<button
+			class="nimble-button move-panel__confirm"
+			data-button-variant="primary"
+			disabled={!inCombat || actionsRemaining <= 0}
+			onclick={handleMove}
+		>
+			<i class="fa-solid fa-person-running"></i>
+			{localize('NIMBLE.ui.heroicActions.move.confirm')}
+		</button>
+	</div>
+</section>
+
+<style lang="scss">
+	.move-panel {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+
+		&__content {
+			display: flex;
+			flex-direction: column;
+			gap: 0.5rem;
+		}
+
+		&__speeds {
+			display: flex;
+			align-items: center;
+			gap: 0.5rem;
+			padding: 0.5rem;
+			background: var(--nimble-box-background-color);
+			border: 1px solid var(--nimble-card-border-color);
+			border-radius: 6px;
+		}
+
+		&__speeds-label {
+			font-size: var(--nimble-xs-text);
+			font-weight: 600;
+			color: var(--nimble-medium-text-color);
+			text-transform: uppercase;
+			letter-spacing: 0.05em;
+		}
+
+		&__speeds-list {
+			display: flex;
+			flex-wrap: wrap;
+			gap: 0.375rem;
+		}
+
+		&__speed {
+			display: flex;
+			align-items: center;
+			gap: 0.25rem;
+			padding: 0.25rem 0.5rem;
+			background: var(--nimble-basic-button-background-color);
+			border-radius: 4px;
+
+			i {
+				font-size: 0.75rem;
+				color: hsl(210, 60%, 50%);
+			}
+		}
+
+		&__speed-value {
+			font-size: var(--nimble-sm-text);
+			font-weight: 600;
+			color: var(--nimble-dark-text-color);
+		}
+
+		&__speed-label {
+			font-size: var(--nimble-sm-text);
+			font-weight: 500;
+			color: var(--nimble-dark-text-color);
+		}
+
+		&__no-movement {
+			margin: 0;
+			padding: 0.5rem;
+			text-align: center;
+			font-size: var(--nimble-sm-text);
+			color: var(--nimble-medium-text-color);
+		}
+
+		&__info {
+			display: flex;
+			align-items: center;
+			gap: 0.375rem;
+			padding: 0.375rem 0.5rem;
+			background: hsla(45, 70%, 50%, 0.1);
+			border: 1px solid hsla(45, 70%, 50%, 0.3);
+			border-radius: 4px;
+			font-size: var(--nimble-xs-text);
+			font-weight: 500;
+			color: hsl(45, 60%, 35%);
+
+			i {
+				color: hsl(45, 70%, 45%);
+			}
+		}
+
+		&__confirm {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			gap: 0.375rem;
+			padding: 0.5rem 0.75rem;
+			font-size: var(--nimble-sm-text);
+			font-weight: 600;
+
+			i {
+				font-size: 0.875rem;
+			}
+		}
+	}
+
+	:global(.theme-dark) .move-panel {
+		&__speed i {
+			color: hsl(210, 70%, 65%);
+		}
+
+		&__info {
+			background: hsla(45, 70%, 50%, 0.15);
+			border-color: hsla(45, 70%, 50%, 0.4);
+			color: hsl(45, 60%, 65%);
+
+			i {
+				color: hsl(45, 70%, 55%);
+			}
+		}
+	}
+</style>

--- a/src/view/sheets/pages/PlayerCharacterHeroicActionsTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterHeroicActionsTab.svelte
@@ -1,233 +1,19 @@
 <script>
-	import { createSubscriber } from 'svelte/reactivity';
 	import { getContext } from 'svelte';
-	import filterItems from '../../dataPreparationHelpers/filterItems.js';
 	import localize from '../../../utils/localize.js';
-	import GenericDialog from '../../../documents/dialogs/GenericDialog.svelte.js';
+	import { createHeroicActionsTabState } from './PlayerCharacterHeroicActionsTab.svelte.js';
 
 	import AssessActionPanel from '../components/AssessActionPanel.svelte';
 	import AttackActionPanel from '../components/AttackActionPanel.svelte';
 	import CastSpellActionPanel from '../components/CastSpellActionPanel.svelte';
 	import MoveActionPanel from '../components/MoveActionPanel.svelte';
-	import HeroicActionsHelpDialog from '../../dialogs/HeroicActionsHelpDialog.svelte';
 
 	// ============================================================================
-	// Context & Configuration
+	// Context & State
 	// ============================================================================
 
 	let actor = getContext('actor');
-
-	// ============================================================================
-	// Action Definitions (Single source of truth for all heroic actions)
-	// ============================================================================
-
-	const HEROIC_ACTIONS = [
-		{
-			id: 'attack',
-			icon: 'fa-solid fa-sword',
-			labelKey: 'NIMBLE.ui.heroicActions.actions.attack.label',
-			descriptionKey: 'NIMBLE.ui.heroicActions.actions.attack.description',
-			type: 'panel', // Opens a panel
-		},
-		{
-			id: 'spell',
-			icon: 'fa-solid fa-wand-sparkles',
-			labelKey: 'NIMBLE.ui.heroicActions.actions.spell.label',
-			descriptionKey: 'NIMBLE.ui.heroicActions.actions.spell.description',
-			type: 'panel',
-		},
-		{
-			id: 'move',
-			icon: 'fa-solid fa-person-running',
-			labelKey: 'NIMBLE.ui.heroicActions.actions.move.label',
-			descriptionKey: 'NIMBLE.ui.heroicActions.actions.move.description',
-			type: 'panel',
-		},
-		{
-			id: 'assess',
-			icon: 'fa-solid fa-eye',
-			labelKey: 'NIMBLE.ui.heroicActions.actions.assess.label',
-			descriptionKey: 'NIMBLE.ui.heroicActions.actions.assess.description',
-			type: 'panel',
-		},
-	];
-
-	// Top-level tab for switching between Actions and Reactions
-	let activeHeroicTab = $state('actions');
-
-	// ============================================================================
-	// Combat State Management
-	// ============================================================================
-
-	const subscribeCombatState = createSubscriber((update) => {
-		const hookNames = [
-			'combatStart',
-			'createCombat',
-			'updateCombat',
-			'deleteCombat',
-			'createCombatant',
-			'updateCombatant',
-			'deleteCombatant',
-			'canvasInit',
-			'canvasReady',
-		];
-
-		const hookIds = hookNames.map((hookName) => ({
-			hookId: Hooks.on(hookName, () => update()),
-			hookName,
-		}));
-
-		return () => hookIds.forEach(({ hookName, hookId }) => Hooks.off(hookName, hookId));
-	});
-
-	function getActiveCombatForCurrentScene() {
-		const sceneId = canvas?.scene?.id;
-		if (!sceneId) return null;
-
-		const activeCombat = game.combat;
-		if (activeCombat?.active && activeCombat.scene?.id === sceneId) {
-			return activeCombat;
-		}
-
-		const activeByScene = game.combats?.contents?.find(
-			(combat) => combat?.active && combat.scene?.id === sceneId,
-		);
-		if (activeByScene) return activeByScene;
-
-		const viewedCombat = game.combats?.viewed ?? null;
-		if (viewedCombat?.active && viewedCombat.scene?.id === sceneId) {
-			return viewedCombat;
-		}
-
-		return null;
-	}
-
-	function getCombatantInCombat() {
-		const combat = getActiveCombatForCurrentScene();
-		if (!combat) return null;
-		return combat.combatants.find((entry) => entry.actorId === actor.id) ?? null;
-	}
-
-	function getCombatant() {
-		const combat = getActiveCombatForCurrentScene();
-		if (!combat?.started) return null;
-		return combat.combatants.find((entry) => entry.actorId === actor.id) ?? null;
-	}
-
-	function isInActiveCombat() {
-		const combatant = getCombatant();
-		if (!combatant) return false;
-		return combatant.initiative !== null;
-	}
-
-	function getActionsData() {
-		const combatant = getCombatantInCombat();
-		if (!combatant) return { current: 0, max: 3 };
-
-		const actions = combatant.system?.actions?.base;
-		return {
-			current: actions?.current ?? 0,
-			max: actions?.max ?? 3,
-		};
-	}
-
-	async function updateActionPips(newValue) {
-		const combatant = getCombatantInCombat();
-		if (!combatant) return;
-		await combatant.update({ 'system.actions.base.current': newValue });
-	}
-
-	async function deductActionPips(count = 1) {
-		const { current } = getActionsData();
-		if (current > 0) {
-			const newValue = Math.max(0, current - count);
-			await updateActionPips(newValue);
-		}
-	}
-
-	// Reactive combat state
-	let inCombat = $derived.by(() => {
-		subscribeCombatState();
-		return isInActiveCombat();
-	});
-
-	let actionsData = $derived.by(() => {
-		subscribeCombatState();
-		return getActionsData();
-	});
-
-	// ============================================================================
-	// Panel State & Action Handlers
-	// ============================================================================
-
-	let expandedPanel = $state('attack');
-
-	function togglePanel(panelName) {
-		// Attack and Spell act like tabs - clicking the selected one does nothing
-		// You can only switch between them
-		if (expandedPanel === panelName) {
-			return;
-		}
-		expandedPanel = panelName;
-	}
-
-	function handleActionClick(action) {
-		switch (action.type) {
-			case 'panel':
-				togglePanel(action.id);
-				break;
-		}
-	}
-
-	function handleHelpDialog() {
-		GenericDialog.getOrCreate(
-			localize('NIMBLE.ui.heroicActions.help.dialogTitle'),
-			HeroicActionsHelpDialog,
-			{},
-			{ width: 480, uniqueId: 'heroic-actions-help' },
-		).render(true);
-	}
-
-	function isActionDisabled(action) {
-		if (action.requiresCombat) {
-			return !inCombat || actionsData.current <= 0;
-		}
-		if (action.id === 'spell') {
-			return !hasSpells;
-		}
-		return false;
-	}
-
-	function getActionTooltip(action) {
-		const label = localize(action.labelKey);
-
-		if (action.requiresCombat) {
-			if (!inCombat) {
-				return `${label} (${localize('NIMBLE.ui.heroicActions.outsideCombat')})`;
-			}
-			if (actionsData.current <= 0) {
-				return `${label} (${localize('NIMBLE.ui.heroicActions.noActions')})`;
-			}
-		}
-		if (action.id === 'spell' && !hasSpells) {
-			return `${label} (${localize('NIMBLE.ui.heroicActions.noSpells')})`;
-		}
-		return label;
-	}
-
-	// ============================================================================
-	// Spell Data (for hasSpells check)
-	// ============================================================================
-
-	let allSpells = $derived(filterItems(actor.reactive, ['spell'], ''));
-	let hasSpells = $derived(allSpells.length > 0);
-
-	// ============================================================================
-	// Derived State
-	// ============================================================================
-
-	let flags = $derived(actor.reactive.flags.nimble);
-	let showEmbeddedDocumentImages = $derived(flags?.showEmbeddedDocumentImages ?? true);
+	const state = createHeroicActionsTabState(actor);
 </script>
 
 <section class="nimble-sheet__body nimble-sheet__body--player-character">
@@ -236,17 +22,17 @@
 			<div class="heroic-tab-header__tabs">
 				<button
 					class="heroic-tab-header__tab"
-					class:heroic-tab-header__tab--active={activeHeroicTab === 'actions'}
+					class:heroic-tab-header__tab--active={state.activeHeroicTab === 'actions'}
 					type="button"
-					onclick={() => (activeHeroicTab = 'actions')}
+					onclick={() => (state.activeHeroicTab = 'actions')}
 				>
 					{localize('NIMBLE.ui.heroicActions.title')}
 				</button>
 				<button
 					class="heroic-tab-header__tab"
-					class:heroic-tab-header__tab--active={activeHeroicTab === 'reactions'}
+					class:heroic-tab-header__tab--active={state.activeHeroicTab === 'reactions'}
 					type="button"
-					onclick={() => (activeHeroicTab = 'reactions')}
+					onclick={() => (state.activeHeroicTab = 'reactions')}
 				>
 					{localize('NIMBLE.ui.heroicActions.reactionsTitle')}
 				</button>
@@ -258,24 +44,24 @@
 				type="button"
 				aria-label={localize('NIMBLE.ui.heroicActions.help.tooltip')}
 				data-tooltip={localize('NIMBLE.ui.heroicActions.help.tooltip')}
-				onclick={handleHelpDialog}
+				onclick={state.handleHelpDialog}
 			>
 				<i class="fa-solid fa-circle-question"></i>
 			</button>
 		</header>
 
-		{#if activeHeroicTab === 'actions'}
+		{#if state.activeHeroicTab === 'actions'}
 			<div class="heroic-actions-tabs">
-				{#each HEROIC_ACTIONS as action (action.id)}
+				{#each state.HEROIC_ACTIONS as action (action.id)}
 					<button
 						class="heroic-action-tab"
-						class:heroic-action-tab--active={expandedPanel === action.id}
-						class:heroic-action-tab--disabled={isActionDisabled(action)}
+						class:heroic-action-tab--active={state.expandedPanel === action.id}
+						class:heroic-action-tab--disabled={state.isActionDisabled(action)}
 						type="button"
 						aria-label={localize(action.labelKey)}
-						data-tooltip={getActionTooltip(action)}
-						disabled={isActionDisabled(action)}
-						onclick={() => handleActionClick(action)}
+						data-tooltip={state.getActionTooltip(action)}
+						disabled={state.isActionDisabled(action)}
+						onclick={() => state.handleActionClick(action)}
 					>
 						<i class={action.icon}></i>
 						<span class="heroic-action-tab__indicator"></span>
@@ -284,46 +70,46 @@
 			</div>
 		{/if}
 
-		{#if activeHeroicTab === 'reactions'}
+		{#if state.activeHeroicTab === 'reactions'}
 			<div class="heroic-reactions-placeholder">
 				<p>{localize('NIMBLE.ui.heroicActions.reactionsPlaceholder')}</p>
 			</div>
 		{/if}
 	</section>
 
-	{#if activeHeroicTab === 'actions' && expandedPanel === 'attack'}
+	{#if state.activeHeroicTab === 'actions' && state.expandedPanel === 'attack'}
 		<AttackActionPanel
-			{showEmbeddedDocumentImages}
+			showEmbeddedDocumentImages={state.showEmbeddedDocumentImages}
 			onActivateItem={(cost) => {
-				if (inCombat && actionsData.current > 0) {
-					deductActionPips(cost);
+				if (state.inCombat && state.actionsData.current > 0) {
+					state.deductActionPips(cost);
 				}
 			}}
 		/>
 	{/if}
 
-	{#if activeHeroicTab === 'actions' && expandedPanel === 'spell'}
+	{#if state.activeHeroicTab === 'actions' && state.expandedPanel === 'spell'}
 		<CastSpellActionPanel
-			{showEmbeddedDocumentImages}
+			showEmbeddedDocumentImages={state.showEmbeddedDocumentImages}
 			onActivateItem={(cost) => {
-				if (inCombat && actionsData.current > 0) {
-					deductActionPips(cost);
+				if (state.inCombat && state.actionsData.current > 0) {
+					state.deductActionPips(cost);
 				}
 			}}
 		/>
 	{/if}
 
-	{#if activeHeroicTab === 'actions' && expandedPanel === 'move'}
+	{#if state.activeHeroicTab === 'actions' && state.expandedPanel === 'move'}
 		<MoveActionPanel
 			{actor}
-			{inCombat}
-			actionsRemaining={actionsData.current}
-			onDeductAction={() => deductActionPips(1)}
+			inCombat={state.inCombat}
+			actionsRemaining={state.actionsData.current}
+			onDeductAction={() => state.deductActionPips(1)}
 		/>
 	{/if}
 
-	{#if activeHeroicTab === 'actions' && expandedPanel === 'assess'}
-		<AssessActionPanel {actor} onDeductAction={() => deductActionPips(1)} />
+	{#if state.activeHeroicTab === 'actions' && state.expandedPanel === 'assess'}
+		<AssessActionPanel {actor} onDeductAction={() => state.deductActionPips(1)} />
 	{/if}
 </section>
 

--- a/src/view/sheets/pages/PlayerCharacterHeroicActionsTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterHeroicActionsTab.svelte
@@ -3,11 +3,13 @@
 	import { getContext } from 'svelte';
 	import filterItems from '../../dataPreparationHelpers/filterItems.js';
 	import localize from '../../../utils/localize.js';
+	import GenericDialog from '../../../documents/dialogs/GenericDialog.svelte.js';
 
 	import AssessActionPanel from '../components/AssessActionPanel.svelte';
 	import AttackActionPanel from '../components/AttackActionPanel.svelte';
 	import CastSpellActionPanel from '../components/CastSpellActionPanel.svelte';
 	import MoveActionPanel from '../components/MoveActionPanel.svelte';
+	import HeroicActionsHelpDialog from '../../dialogs/HeroicActionsHelpDialog.svelte';
 
 	// ============================================================================
 	// Context & Configuration
@@ -177,14 +179,7 @@
 		}
 	}
 
-	async function handleHelpDialog() {
-		const { default: GenericDialog } = await import(
-			'../../../documents/dialogs/GenericDialog.svelte.js'
-		);
-		const { default: HeroicActionsHelpDialog } = await import(
-			'../../dialogs/HeroicActionsHelpDialog.svelte'
-		);
-
+	function handleHelpDialog() {
 		GenericDialog.getOrCreate(
 			localize('NIMBLE.ui.heroicActions.help.dialogTitle'),
 			HeroicActionsHelpDialog,

--- a/src/view/sheets/pages/PlayerCharacterHeroicActionsTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterHeroicActionsTab.svelte
@@ -1,0 +1,490 @@
+<script>
+	import { createSubscriber } from 'svelte/reactivity';
+	import { getContext } from 'svelte';
+	import filterItems from '../../dataPreparationHelpers/filterItems.js';
+	import localize from '../../../utils/localize.js';
+
+	import AssessActionPanel from '../components/AssessActionPanel.svelte';
+	import AttackActionPanel from '../components/AttackActionPanel.svelte';
+	import CastSpellActionPanel from '../components/CastSpellActionPanel.svelte';
+	import MoveActionPanel from '../components/MoveActionPanel.svelte';
+
+	// ============================================================================
+	// Context & Configuration
+	// ============================================================================
+
+	let actor = getContext('actor');
+
+	// ============================================================================
+	// Action Definitions (Single source of truth for all heroic actions)
+	// ============================================================================
+
+	const HEROIC_ACTIONS = [
+		{
+			id: 'attack',
+			icon: 'fa-solid fa-sword',
+			labelKey: 'NIMBLE.ui.heroicActions.actions.attack.label',
+			descriptionKey: 'NIMBLE.ui.heroicActions.actions.attack.description',
+			type: 'panel', // Opens a panel
+		},
+		{
+			id: 'spell',
+			icon: 'fa-solid fa-wand-sparkles',
+			labelKey: 'NIMBLE.ui.heroicActions.actions.spell.label',
+			descriptionKey: 'NIMBLE.ui.heroicActions.actions.spell.description',
+			type: 'panel',
+		},
+		{
+			id: 'move',
+			icon: 'fa-solid fa-person-running',
+			labelKey: 'NIMBLE.ui.heroicActions.actions.move.label',
+			descriptionKey: 'NIMBLE.ui.heroicActions.actions.move.description',
+			type: 'panel',
+		},
+		{
+			id: 'assess',
+			icon: 'fa-solid fa-eye',
+			labelKey: 'NIMBLE.ui.heroicActions.actions.assess.label',
+			descriptionKey: 'NIMBLE.ui.heroicActions.actions.assess.description',
+			type: 'panel',
+		},
+	];
+
+	// Top-level tab for switching between Actions and Reactions
+	let activeHeroicTab = $state('actions');
+
+	// ============================================================================
+	// Combat State Management
+	// ============================================================================
+
+	const subscribeCombatState = createSubscriber((update) => {
+		const hookNames = [
+			'combatStart',
+			'createCombat',
+			'updateCombat',
+			'deleteCombat',
+			'createCombatant',
+			'updateCombatant',
+			'deleteCombatant',
+			'canvasInit',
+			'canvasReady',
+		];
+
+		const hookIds = hookNames.map((hookName) => ({
+			hookId: Hooks.on(hookName, () => update()),
+			hookName,
+		}));
+
+		return () => hookIds.forEach(({ hookName, hookId }) => Hooks.off(hookName, hookId));
+	});
+
+	function getActiveCombatForCurrentScene() {
+		const sceneId = canvas?.scene?.id;
+		if (!sceneId) return null;
+
+		const activeCombat = game.combat;
+		if (activeCombat?.active && activeCombat.scene?.id === sceneId) {
+			return activeCombat;
+		}
+
+		const activeByScene = game.combats?.contents?.find(
+			(combat) => combat?.active && combat.scene?.id === sceneId,
+		);
+		if (activeByScene) return activeByScene;
+
+		const viewedCombat = game.combats?.viewed ?? null;
+		if (viewedCombat?.active && viewedCombat.scene?.id === sceneId) {
+			return viewedCombat;
+		}
+
+		return null;
+	}
+
+	function getCombatantInCombat() {
+		const combat = getActiveCombatForCurrentScene();
+		if (!combat) return null;
+		return combat.combatants.find((entry) => entry.actorId === actor.id) ?? null;
+	}
+
+	function getCombatant() {
+		const combat = getActiveCombatForCurrentScene();
+		if (!combat?.started) return null;
+		return combat.combatants.find((entry) => entry.actorId === actor.id) ?? null;
+	}
+
+	function isInActiveCombat() {
+		const combatant = getCombatant();
+		if (!combatant) return false;
+		return combatant.initiative !== null;
+	}
+
+	function getActionsData() {
+		const combatant = getCombatantInCombat();
+		if (!combatant) return { current: 0, max: 3 };
+
+		const actions = combatant.system?.actions?.base;
+		return {
+			current: actions?.current ?? 0,
+			max: actions?.max ?? 3,
+		};
+	}
+
+	async function updateActionPips(newValue) {
+		const combatant = getCombatantInCombat();
+		if (!combatant) return;
+		await combatant.update({ 'system.actions.base.current': newValue });
+	}
+
+	async function deductActionPips(count = 1) {
+		const { current } = getActionsData();
+		if (current > 0) {
+			const newValue = Math.max(0, current - count);
+			await updateActionPips(newValue);
+		}
+	}
+
+	// Reactive combat state
+	let inCombat = $derived.by(() => {
+		subscribeCombatState();
+		return isInActiveCombat();
+	});
+
+	let actionsData = $derived.by(() => {
+		subscribeCombatState();
+		return getActionsData();
+	});
+
+	// ============================================================================
+	// Panel State & Action Handlers
+	// ============================================================================
+
+	let expandedPanel = $state('attack');
+
+	function togglePanel(panelName) {
+		// Attack and Spell act like tabs - clicking the selected one does nothing
+		// You can only switch between them
+		if (expandedPanel === panelName) {
+			return;
+		}
+		expandedPanel = panelName;
+	}
+
+	function handleActionClick(action) {
+		switch (action.type) {
+			case 'panel':
+				togglePanel(action.id);
+				break;
+		}
+	}
+
+	async function handleHelpDialog() {
+		const { default: GenericDialog } = await import(
+			'../../../documents/dialogs/GenericDialog.svelte.js'
+		);
+		const { default: HeroicActionsHelpDialog } = await import(
+			'../../dialogs/HeroicActionsHelpDialog.svelte'
+		);
+
+		GenericDialog.getOrCreate(
+			localize('NIMBLE.ui.heroicActions.help.dialogTitle'),
+			HeroicActionsHelpDialog,
+			{},
+			{ width: 480, uniqueId: 'heroic-actions-help' },
+		).render(true);
+	}
+
+	function isActionDisabled(action) {
+		if (action.requiresCombat) {
+			return !inCombat || actionsData.current <= 0;
+		}
+		if (action.id === 'spell') {
+			return !hasSpells;
+		}
+		return false;
+	}
+
+	function getActionTooltip(action) {
+		const label = localize(action.labelKey);
+
+		if (action.requiresCombat) {
+			if (!inCombat) {
+				return `${label} (${localize('NIMBLE.ui.heroicActions.outsideCombat')})`;
+			}
+			if (actionsData.current <= 0) {
+				return `${label} (${localize('NIMBLE.ui.heroicActions.noActions')})`;
+			}
+		}
+		if (action.id === 'spell' && !hasSpells) {
+			return `${label} (${localize('NIMBLE.ui.heroicActions.noSpells')})`;
+		}
+		return label;
+	}
+
+	// ============================================================================
+	// Spell Data (for hasSpells check)
+	// ============================================================================
+
+	let allSpells = $derived(filterItems(actor.reactive, ['spell'], ''));
+	let hasSpells = $derived(allSpells.length > 0);
+
+	// ============================================================================
+	// Derived State
+	// ============================================================================
+
+	let flags = $derived(actor.reactive.flags.nimble);
+	let showEmbeddedDocumentImages = $derived(flags?.showEmbeddedDocumentImages ?? true);
+</script>
+
+<section class="nimble-sheet__body nimble-sheet__body--player-character">
+	<section>
+		<header class="heroic-tab-header">
+			<div class="heroic-tab-header__tabs">
+				<button
+					class="heroic-tab-header__tab"
+					class:heroic-tab-header__tab--active={activeHeroicTab === 'actions'}
+					type="button"
+					onclick={() => (activeHeroicTab = 'actions')}
+				>
+					{localize('NIMBLE.ui.heroicActions.title')}
+				</button>
+				<button
+					class="heroic-tab-header__tab"
+					class:heroic-tab-header__tab--active={activeHeroicTab === 'reactions'}
+					type="button"
+					onclick={() => (activeHeroicTab = 'reactions')}
+				>
+					{localize('NIMBLE.ui.heroicActions.reactionsTitle')}
+				</button>
+			</div>
+
+			<button
+				class="nimble-button heroic-actions__help-button"
+				data-button-variant="icon"
+				type="button"
+				aria-label={localize('NIMBLE.ui.heroicActions.help.tooltip')}
+				data-tooltip={localize('NIMBLE.ui.heroicActions.help.tooltip')}
+				onclick={handleHelpDialog}
+			>
+				<i class="fa-solid fa-circle-question"></i>
+			</button>
+		</header>
+
+		{#if activeHeroicTab === 'actions'}
+			<div class="heroic-actions-tabs">
+				{#each HEROIC_ACTIONS as action (action.id)}
+					<button
+						class="heroic-action-tab"
+						class:heroic-action-tab--active={expandedPanel === action.id}
+						class:heroic-action-tab--disabled={isActionDisabled(action)}
+						type="button"
+						aria-label={localize(action.labelKey)}
+						data-tooltip={getActionTooltip(action)}
+						disabled={isActionDisabled(action)}
+						onclick={() => handleActionClick(action)}
+					>
+						<i class={action.icon}></i>
+						<span class="heroic-action-tab__indicator"></span>
+					</button>
+				{/each}
+			</div>
+		{/if}
+
+		{#if activeHeroicTab === 'reactions'}
+			<div class="heroic-reactions-placeholder">
+				<p>{localize('NIMBLE.ui.heroicActions.reactionsPlaceholder')}</p>
+			</div>
+		{/if}
+	</section>
+
+	{#if activeHeroicTab === 'actions' && expandedPanel === 'attack'}
+		<AttackActionPanel
+			{showEmbeddedDocumentImages}
+			onActivateItem={(cost) => {
+				if (inCombat && actionsData.current > 0) {
+					deductActionPips(cost);
+				}
+			}}
+		/>
+	{/if}
+
+	{#if activeHeroicTab === 'actions' && expandedPanel === 'spell'}
+		<CastSpellActionPanel
+			{showEmbeddedDocumentImages}
+			onActivateItem={(cost) => {
+				if (inCombat && actionsData.current > 0) {
+					deductActionPips(cost);
+				}
+			}}
+		/>
+	{/if}
+
+	{#if activeHeroicTab === 'actions' && expandedPanel === 'move'}
+		<MoveActionPanel
+			{actor}
+			{inCombat}
+			actionsRemaining={actionsData.current}
+			onDeductAction={() => deductActionPips(1)}
+		/>
+	{/if}
+
+	{#if activeHeroicTab === 'actions' && expandedPanel === 'assess'}
+		<AssessActionPanel {actor} onDeductAction={() => deductActionPips(1)} />
+	{/if}
+</section>
+
+<style lang="scss">
+	.heroic-tab-header {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		margin-block-end: 0.25rem;
+
+		&__tabs {
+			display: flex;
+			gap: 0;
+		}
+
+		&__tab {
+			padding: 0.25rem 0.75rem;
+			font-size: var(--nimble-sm-text);
+			font-weight: 700;
+			text-transform: uppercase;
+			color: var(--nimble-medium-text-color);
+			background: transparent;
+			border: none;
+			border-bottom: 2px solid transparent;
+			cursor: pointer;
+			transition: all 0.15s ease;
+
+			&:hover:not(&--active) {
+				color: var(--nimble-dark-text-color);
+			}
+
+			&--active {
+				color: var(--nimble-dark-text-color);
+				border-bottom-color: var(--nimble-accent-color);
+			}
+		}
+	}
+
+	.heroic-actions__help-button {
+		margin-left: auto;
+
+		i {
+			font-size: 0.875rem;
+			color: var(--nimble-medium-text-color);
+		}
+
+		&:hover i {
+			color: var(--nimble-dark-text-color);
+		}
+	}
+
+	.heroic-reactions-placeholder {
+		padding: 1rem;
+		text-align: center;
+		font-size: var(--nimble-sm-text);
+		color: var(--nimble-medium-text-color);
+		font-style: italic;
+
+		p {
+			margin: 0;
+		}
+	}
+
+	// Action tabs (horizontal row)
+	.heroic-actions-tabs {
+		display: flex;
+		gap: 0.25rem;
+	}
+
+	.heroic-action-tab {
+		position: relative;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		flex: 1;
+		height: 2.25rem;
+		padding: 0;
+		background: var(--nimble-box-background-color);
+		border: 2px solid var(--nimble-card-border-color);
+		border-radius: 4px;
+		cursor: pointer;
+		transition: all 0.2s ease;
+
+		i {
+			font-size: 1rem;
+			color: var(--nimble-medium-text-color);
+			transition: color 0.2s ease;
+		}
+
+		&__indicator {
+			position: absolute;
+			top: 0.25rem;
+			right: 0.25rem;
+			width: 0.5rem;
+			height: 0.5rem;
+			border-radius: 50%;
+			background: transparent;
+			border: 2px solid transparent;
+			transition: all 0.2s ease;
+		}
+
+		&:hover:not(:disabled):not(.heroic-action-tab--active) {
+			border-color: var(--nimble-accent-color);
+
+			i {
+				color: var(--nimble-dark-text-color);
+			}
+		}
+
+		&--active {
+			border-color: hsl(45, 60%, 45%);
+			background: hsla(45, 60%, 50%, 0.12);
+			box-shadow: inset 0 0 0 1px hsla(45, 60%, 50%, 0.2);
+
+			i {
+				color: hsl(45, 60%, 40%);
+			}
+
+			.heroic-action-tab__indicator {
+				background: hsl(45, 70%, 50%);
+				border-color: hsl(45, 70%, 40%);
+				box-shadow: 0 0 8px hsla(45, 70%, 50%, 0.6);
+			}
+		}
+
+		&--disabled {
+			opacity: 0.5;
+			cursor: not-allowed;
+		}
+	}
+
+	:global(.theme-dark) .heroic-action-tab {
+		background: hsl(220, 15%, 18%);
+		border-color: hsl(220, 10%, 30%);
+
+		&:hover:not(:disabled):not(.heroic-action-tab--active) {
+			border-color: hsl(220, 15%, 45%);
+			background: hsl(220, 15%, 22%);
+		}
+	}
+
+	:global(.theme-dark) .heroic-action-tab--active {
+		border-color: hsl(45, 70%, 55%);
+		background: linear-gradient(135deg, hsla(45, 60%, 50%, 0.2) 0%, hsla(45, 60%, 40%, 0.1) 100%);
+		box-shadow:
+			inset 0 0 0 1px hsla(45, 60%, 60%, 0.3),
+			0 0 12px hsla(45, 60%, 50%, 0.15);
+	}
+
+	:global(.theme-dark) .heroic-action-tab--active i {
+		color: hsl(45, 70%, 65%);
+	}
+
+	:global(.theme-dark) .heroic-action-tab--active .heroic-action-tab__indicator {
+		background: hsl(45, 70%, 55%);
+		border-color: hsl(45, 70%, 65%);
+		box-shadow: 0 0 10px hsla(45, 70%, 55%, 0.7);
+	}
+</style>

--- a/src/view/sheets/pages/PlayerCharacterHeroicActionsTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterHeroicActionsTab.svelte
@@ -13,7 +13,7 @@
 	// ============================================================================
 
 	let actor = getContext('actor');
-	const state = createHeroicActionsTabState(actor);
+	const state = createHeroicActionsTabState(() => actor);
 </script>
 
 <section class="nimble-sheet__body nimble-sheet__body--player-character">

--- a/src/view/sheets/pages/PlayerCharacterHeroicActionsTab.svelte.ts
+++ b/src/view/sheets/pages/PlayerCharacterHeroicActionsTab.svelte.ts
@@ -1,4 +1,5 @@
 import { createSubscriber } from 'svelte/reactivity';
+import type { NimbleCharacter } from '../../../documents/actor/character.js';
 import GenericDialog from '../../../documents/dialogs/GenericDialog.svelte.js';
 import localize from '../../../utils/localize.js';
 import filterItems from '../../dataPreparationHelpers/filterItems.js';
@@ -57,7 +58,7 @@ export const HEROIC_ACTIONS: HeroicAction[] = [
 	},
 ];
 
-export function createHeroicActionsTabState(actor: Actor) {
+export function createHeroicActionsTabState(getActor: () => NimbleCharacter) {
 	// Top-level tab for switching between Actions and Reactions
 	let activeHeroicTab = $state<'actions' | 'reactions'>('actions');
 	let expandedPanel = $state('attack');
@@ -80,13 +81,15 @@ export function createHeroicActionsTabState(actor: Actor) {
 		];
 
 		const hookIds = hookNames.map((hookName) => ({
-			hookId: Hooks.on(hookName, () => update()),
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			hookId: Hooks.on(hookName as any, () => update()),
 			hookName,
 		}));
 
 		return () => {
 			hookIds.forEach(({ hookName, hookId }) => {
-				Hooks.off(hookName, hookId);
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				Hooks.off(hookName as any, hookId);
 			});
 		};
 	});
@@ -116,13 +119,13 @@ export function createHeroicActionsTabState(actor: Actor) {
 	function getCombatantInCombat(): Combatant | null {
 		const combat = getActiveCombatForCurrentScene();
 		if (!combat) return null;
-		return combat.combatants.find((entry) => entry.actorId === actor.id) ?? null;
+		return combat.combatants.find((entry) => entry.actorId === getActor().id) ?? null;
 	}
 
 	function getCombatant(): Combatant | null {
 		const combat = getActiveCombatForCurrentScene();
 		if (!combat?.started) return null;
-		return combat.combatants.find((entry) => entry.actorId === actor.id) ?? null;
+		return combat.combatants.find((entry) => entry.actorId === getActor().id) ?? null;
 	}
 
 	function isInActiveCombat(): boolean {
@@ -135,7 +138,8 @@ export function createHeroicActionsTabState(actor: Actor) {
 		const combatant = getCombatantInCombat();
 		if (!combatant) return { current: 0, max: 3 };
 
-		const actions = combatant.system?.actions?.base;
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const actions = (combatant as any).system?.actions?.base;
 		return {
 			current: actions?.current ?? 0,
 			max: actions?.max ?? 3,
@@ -145,7 +149,8 @@ export function createHeroicActionsTabState(actor: Actor) {
 	async function updateActionPips(newValue: number): Promise<void> {
 		const combatant = getCombatantInCombat();
 		if (!combatant) return;
-		await combatant.update({ 'system.actions.base.current': newValue });
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		await combatant.update({ 'system.actions.base.current': newValue } as any);
 	}
 
 	async function deductActionPips(count = 1): Promise<void> {
@@ -199,14 +204,14 @@ export function createHeroicActionsTabState(actor: Actor) {
 	// Spell Data (for hasSpells check)
 	// ============================================================================
 
-	const allSpells = $derived(filterItems(actor.reactive, ['spell'], ''));
+	const allSpells = $derived(filterItems(getActor().reactive, ['spell'], ''));
 	const hasSpells = $derived(allSpells.length > 0);
 
 	// ============================================================================
 	// Derived State
 	// ============================================================================
 
-	const flags = $derived(actor.reactive.flags.nimble);
+	const flags = $derived(getActor().reactive.flags.nimble);
 	const showEmbeddedDocumentImages = $derived(flags?.showEmbeddedDocumentImages ?? true);
 
 	function isActionDisabled(action: HeroicAction): boolean {

--- a/src/view/sheets/pages/PlayerCharacterHeroicActionsTab.svelte.ts
+++ b/src/view/sheets/pages/PlayerCharacterHeroicActionsTab.svelte.ts
@@ -1,0 +1,268 @@
+import { createSubscriber } from 'svelte/reactivity';
+import GenericDialog from '../../../documents/dialogs/GenericDialog.svelte.js';
+import localize from '../../../utils/localize.js';
+import filterItems from '../../dataPreparationHelpers/filterItems.js';
+import HeroicActionsHelpDialog from '../../dialogs/HeroicActionsHelpDialog.svelte';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface HeroicAction {
+	id: string;
+	icon: string;
+	labelKey: string;
+	descriptionKey: string;
+	type: string;
+	requiresCombat?: boolean;
+}
+
+interface ActionsData {
+	current: number;
+	max: number;
+}
+
+// ============================================================================
+// Action Definitions (Single source of truth for all heroic actions)
+// ============================================================================
+
+export const HEROIC_ACTIONS: HeroicAction[] = [
+	{
+		id: 'attack',
+		icon: 'fa-solid fa-sword',
+		labelKey: 'NIMBLE.ui.heroicActions.actions.attack.label',
+		descriptionKey: 'NIMBLE.ui.heroicActions.actions.attack.description',
+		type: 'panel',
+	},
+	{
+		id: 'spell',
+		icon: 'fa-solid fa-wand-sparkles',
+		labelKey: 'NIMBLE.ui.heroicActions.actions.spell.label',
+		descriptionKey: 'NIMBLE.ui.heroicActions.actions.spell.description',
+		type: 'panel',
+	},
+	{
+		id: 'move',
+		icon: 'fa-solid fa-person-running',
+		labelKey: 'NIMBLE.ui.heroicActions.actions.move.label',
+		descriptionKey: 'NIMBLE.ui.heroicActions.actions.move.description',
+		type: 'panel',
+	},
+	{
+		id: 'assess',
+		icon: 'fa-solid fa-eye',
+		labelKey: 'NIMBLE.ui.heroicActions.actions.assess.label',
+		descriptionKey: 'NIMBLE.ui.heroicActions.actions.assess.description',
+		type: 'panel',
+	},
+];
+
+export function createHeroicActionsTabState(actor: Actor) {
+	// Top-level tab for switching between Actions and Reactions
+	let activeHeroicTab = $state<'actions' | 'reactions'>('actions');
+	let expandedPanel = $state('attack');
+
+	// ============================================================================
+	// Combat State Management
+	// ============================================================================
+
+	const subscribeCombatState = createSubscriber((update) => {
+		const hookNames = [
+			'combatStart',
+			'createCombat',
+			'updateCombat',
+			'deleteCombat',
+			'createCombatant',
+			'updateCombatant',
+			'deleteCombatant',
+			'canvasInit',
+			'canvasReady',
+		];
+
+		const hookIds = hookNames.map((hookName) => ({
+			hookId: Hooks.on(hookName, () => update()),
+			hookName,
+		}));
+
+		return () => {
+			hookIds.forEach(({ hookName, hookId }) => {
+				Hooks.off(hookName, hookId);
+			});
+		};
+	});
+
+	function getActiveCombatForCurrentScene(): Combat | null {
+		const sceneId = canvas?.scene?.id;
+		if (!sceneId) return null;
+
+		const activeCombat = game.combat;
+		if (activeCombat?.active && activeCombat.scene?.id === sceneId) {
+			return activeCombat;
+		}
+
+		const activeByScene = game.combats?.contents?.find(
+			(combat) => combat?.active && combat.scene?.id === sceneId,
+		);
+		if (activeByScene) return activeByScene;
+
+		const viewedCombat = game.combats?.viewed ?? null;
+		if (viewedCombat?.active && viewedCombat.scene?.id === sceneId) {
+			return viewedCombat;
+		}
+
+		return null;
+	}
+
+	function getCombatantInCombat(): Combatant | null {
+		const combat = getActiveCombatForCurrentScene();
+		if (!combat) return null;
+		return combat.combatants.find((entry) => entry.actorId === actor.id) ?? null;
+	}
+
+	function getCombatant(): Combatant | null {
+		const combat = getActiveCombatForCurrentScene();
+		if (!combat?.started) return null;
+		return combat.combatants.find((entry) => entry.actorId === actor.id) ?? null;
+	}
+
+	function isInActiveCombat(): boolean {
+		const combatant = getCombatant();
+		if (!combatant) return false;
+		return combatant.initiative !== null;
+	}
+
+	function getActionsData(): ActionsData {
+		const combatant = getCombatantInCombat();
+		if (!combatant) return { current: 0, max: 3 };
+
+		const actions = combatant.system?.actions?.base;
+		return {
+			current: actions?.current ?? 0,
+			max: actions?.max ?? 3,
+		};
+	}
+
+	async function updateActionPips(newValue: number): Promise<void> {
+		const combatant = getCombatantInCombat();
+		if (!combatant) return;
+		await combatant.update({ 'system.actions.base.current': newValue });
+	}
+
+	async function deductActionPips(count = 1): Promise<void> {
+		const { current } = getActionsData();
+		if (current > 0) {
+			const newValue = Math.max(0, current - count);
+			await updateActionPips(newValue);
+		}
+	}
+
+	// Reactive combat state
+	const inCombat = $derived.by(() => {
+		subscribeCombatState();
+		return isInActiveCombat();
+	});
+
+	const actionsData = $derived.by(() => {
+		subscribeCombatState();
+		return getActionsData();
+	});
+
+	// ============================================================================
+	// Panel State & Action Handlers
+	// ============================================================================
+
+	function togglePanel(panelName: string): void {
+		if (expandedPanel === panelName) {
+			return;
+		}
+		expandedPanel = panelName;
+	}
+
+	function handleActionClick(action: HeroicAction): void {
+		switch (action.type) {
+			case 'panel':
+				togglePanel(action.id);
+				break;
+		}
+	}
+
+	function handleHelpDialog(): void {
+		GenericDialog.getOrCreate(
+			localize('NIMBLE.ui.heroicActions.help.dialogTitle'),
+			HeroicActionsHelpDialog,
+			{},
+			{ width: 480, uniqueId: 'heroic-actions-help' },
+		).render(true);
+	}
+
+	// ============================================================================
+	// Spell Data (for hasSpells check)
+	// ============================================================================
+
+	const allSpells = $derived(filterItems(actor.reactive, ['spell'], ''));
+	const hasSpells = $derived(allSpells.length > 0);
+
+	// ============================================================================
+	// Derived State
+	// ============================================================================
+
+	const flags = $derived(actor.reactive.flags.nimble);
+	const showEmbeddedDocumentImages = $derived(flags?.showEmbeddedDocumentImages ?? true);
+
+	function isActionDisabled(action: HeroicAction): boolean {
+		if (action.requiresCombat) {
+			return !inCombat || actionsData.current <= 0;
+		}
+		if (action.id === 'spell') {
+			return !hasSpells;
+		}
+		return false;
+	}
+
+	function getActionTooltip(action: HeroicAction): string {
+		const label = localize(action.labelKey);
+
+		if (action.requiresCombat) {
+			if (!inCombat) {
+				return `${label} (${localize('NIMBLE.ui.heroicActions.outsideCombat')})`;
+			}
+			if (actionsData.current <= 0) {
+				return `${label} (${localize('NIMBLE.ui.heroicActions.noActions')})`;
+			}
+		}
+		if (action.id === 'spell' && !hasSpells) {
+			return `${label} (${localize('NIMBLE.ui.heroicActions.noSpells')})`;
+		}
+		return label;
+	}
+
+	return {
+		get activeHeroicTab() {
+			return activeHeroicTab;
+		},
+		set activeHeroicTab(value: 'actions' | 'reactions') {
+			activeHeroicTab = value;
+		},
+		get expandedPanel() {
+			return expandedPanel;
+		},
+		get inCombat() {
+			return inCombat;
+		},
+		get actionsData() {
+			return actionsData;
+		},
+		get hasSpells() {
+			return hasSpells;
+		},
+		get showEmbeddedDocumentImages() {
+			return showEmbeddedDocumentImages;
+		},
+		HEROIC_ACTIONS,
+		deductActionPips,
+		handleActionClick,
+		handleHelpDialog,
+		isActionDisabled,
+		getActionTooltip,
+	};
+}

--- a/types/components/AssessActionDialog.d.ts
+++ b/types/components/AssessActionDialog.d.ts
@@ -1,0 +1,16 @@
+import type { NimbleCharacter } from '../../src/documents/actor/actor';
+
+export interface AssessActionDialogProps {
+	document: NimbleCharacter;
+	dialog: {
+		submit: (result: {
+			option: string;
+			skill: string;
+			isSuccess: boolean;
+			target?: string;
+		}) => void;
+		close: () => void;
+	};
+	deductActionPip: () => Promise<void>;
+	inCombat?: boolean;
+}

--- a/types/components/AssessActionPanel.d.ts
+++ b/types/components/AssessActionPanel.d.ts
@@ -1,0 +1,6 @@
+import type { NimbleCharacter } from '../../src/documents/actor/actor';
+
+export interface AssessActionPanelProps {
+	actor: NimbleCharacter;
+	onDeductAction?: () => Promise<void>;
+}

--- a/types/components/AttackActionPanel.d.ts
+++ b/types/components/AttackActionPanel.d.ts
@@ -1,0 +1,4 @@
+export interface AttackActionPanelProps {
+	onActivateItem?: (itemId: string) => Promise<void>;
+	showEmbeddedDocumentImages?: boolean;
+}

--- a/types/components/CastSpellActionPanel.d.ts
+++ b/types/components/CastSpellActionPanel.d.ts
@@ -1,0 +1,4 @@
+export interface CastSpellActionPanelProps {
+	onActivateItem?: (itemId: string) => Promise<void>;
+	showEmbeddedDocumentImages?: boolean;
+}

--- a/types/components/HeroicActionBox.d.ts
+++ b/types/components/HeroicActionBox.d.ts
@@ -1,0 +1,9 @@
+export interface HeroicActionBoxProps {
+	icon?: string;
+	label?: string;
+	description?: string;
+	tooltip?: string;
+	disabled?: boolean;
+	expanded?: boolean;
+	onclick?: () => void;
+}

--- a/types/components/MoveActionDialog.d.ts
+++ b/types/components/MoveActionDialog.d.ts
@@ -1,0 +1,11 @@
+import type { NimbleCharacter } from '../../src/documents/actor/actor';
+
+export interface MoveActionDialogProps {
+	document: NimbleCharacter;
+	dialog: {
+		submit: (result: { confirmed: boolean }) => void;
+		close: () => void;
+	};
+	deductActionPip: () => Promise<void>;
+	inCombat?: boolean;
+}

--- a/types/components/MoveActionPanel.d.ts
+++ b/types/components/MoveActionPanel.d.ts
@@ -1,0 +1,8 @@
+import type { NimbleCharacter } from '../../src/documents/actor/actor';
+
+export interface MoveActionPanelProps {
+	actor: NimbleCharacter;
+	inCombat?: boolean;
+	actionsRemaining?: number;
+	onDeductAction?: () => Promise<void>;
+}


### PR DESCRIPTION
## Summary
Adds a new "Heroic Actions" tab to the PC sheet providing a combat-focused interface for managing actions.

### Features
- **Four Action Types**:
  - **Attack**: Weapon selection with damage preview, expandable descriptions
  - **Cast a Spell**: Spell list with tier, mana cost, and effect info
  - **Move**: Movement speed display with confirmation
  - **Assess**: Three options (Ask Question, Create Opening, Anticipate Danger)

- **Combat Integration**:
  - Automatically deducts action pips when using actions
  - Supports dynamic action costs (e.g., 2-action spells)

- **UI/UX**:
  - Actions/Reactions tabs for future expansion
  - Help dialog with combat reference
  - Inline expandable descriptions for weapons/spells
  - Consistent header and padding styling
  - Dark mode support throughout

### Dependencies
> ⚠️ **Merge these PRs first:**
> - #426 - Unarmed Damage Rule System
> - #427 - Assess Action Chat Card

## Test plan
- [x] Open PC sheet and verify Heroic Actions tab is visible
- [x] Verify top-level tabs switch between Heroic Actions and Heroic Reactions
- [ ] Add character to combat and roll initiative - action tracking works
- [ ] Test Attack action: select weapon, verify unarmed strike works
- [ ] Test Cast a Spell: select spell, verify action cost handling
- [ ] Test Move action: verify movement display and chat message
- [ ] Test Assess action: select option and skill, verify roll and chat card
- [ ] Test Help dialog opens with combat reference
- [ ] Test dark mode styling