### PR TITLE
chore(i18n): register Spanish and French translation files

### DIFF
--- a/public/system.json
+++ b/public/system.json
@@ -37,6 +37,16 @@
 			"lang": "en",
 			"name": "English",
 			"path": "lang/en.json"
+		},
+		{
+			"lang": "es",
+			"name": "Español",
+			"path": "lang/es.json"
+		},
+		{
+			"lang": "fr",
+			"name": "Français",
+			"path": "lang/fr.json"
 		}
 	],
 	"grid": {


### PR DESCRIPTION
## Summary
- Register `es.json` and `fr.json` in `system.json` languages array
- Enables Foundry VTT to load Spanish and French translations when users select those languages

## Test plan
- [ ] Set Foundry language to Spanish, verify Nimble UI strings appear in Spanish
- [ ] Set Foundry language to French, verify Nimble UI strings appear in French