### PR TITLE
docs: add PR guidelines and Discord link to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,6 +149,28 @@ The system integrates deeply with FoundryVTT through:
 - Test your changes in FoundryVTT
 - Update documentation as needed
 
+### Community & Communication
+
+**Join our Discord server before contributing:** [Nimble FoundryVTT System](https://discord.gg/WRf5hBqM)
+
+We encourage all contributors to join the Discord and discuss changes before submitting large or architectural PRs. This helps ensure alignment with project direction and prevents wasted effort.
+
+### Pull Request Guidelines
+
+**PRs that will be rejected:**
+
+- **Overly large PRs without prior discussion** - If your PR touches many files or introduces significant new functionality, please discuss it on Discord first. Breaking changes into smaller, reviewable PRs is preferred.
+- **Complex infrastructure changes** - PRs introducing Docker setups, Playwright automation, CI/CD changes, or other infrastructure without prior team consultation will be closed.
+- **AI-generated bulk changes** - Large PRs that appear to be AI-generated without human review or curation are difficult to review and will be rejected. This includes bulk additions of configuration files, automated testing suites, or agent-style setups.
+- **Security risks** - PRs containing potential security vulnerabilities, including prompt injection risks in configuration files, will not be merged.
+
+**Best practices:**
+
+- Keep PRs focused and reasonably sized
+- Provide clear descriptions of what your PR does and why
+- If using AI tools to assist with code, review and understand all changes before submitting
+- For significant features or architectural changes, open an issue or discuss on Discord first
+
 ## 📦 Deployment
 
 1. Build the system: `pnpm build`


### PR DESCRIPTION
## Summary

- Add Community & Communication section with Discord server link
- Add Pull Request Guidelines section covering what types of PRs will be rejected:
  - Overly large PRs without prior discussion
  - Complex infrastructure changes (Docker, Playwright, CI/CD) without consultation
  - AI-generated bulk changes that are difficult to review
  - Security risks including prompt injection vulnerabilities
- Add best practices for contributors

## Context

This addresses the need to document our contribution expectations following PRs #436 and #437 which were closed due to being too large and complex to review without prior discussion.

## Test plan

- [ ] Verify markdown renders correctly on GitHub