### PR TITLE
Secret Spells Compendium

### DIFF
--- a/packs/ids.json
+++ b/packs/ids.json
@@ -1026,18 +1026,6 @@
 				"vengeance": "C0TMU6el43PzVsp0",
 				"warding-bond": "iL26UVOBVgarmeFH"
 			},
-			"secret": {
-				"cryotomb": "gDg4NlUQHWqbu9tV",
-				"greater-windform": "21OMcsYYwn5C7CLR",
-				"hearth-and-home": "Mkw21dquWBdFBG9Y",
-				"lesser-windform": "eX8CJssX3F2vqFi1",
-				"memory-veil": "PeLuUpKawDLOPHhv",
-				"radiant-bond": "pGCVd6N7Ed0AeEBE",
-				"revive": "iFCKExxkdI48bWxH",
-				"sparkfetch": "GXxJYF05KxMKG4bM",
-				"speak-with-dead": "JQPywIEOHDp0dPYS",
-				"teleport": "np6pQWIzyOomWi7B"
-			},
 			"utility": {
 				"beautify": "Bl4w343YQKXukTyg",
 				"bond-of-peace": "iTCGTLVJpvcqdhl0",
@@ -1069,6 +1057,32 @@
 				"thousand-cuts": "UZCSfngNtbXATH3B",
 				"updraft": "rxzdEK621oVYuWQ8",
 				"vicious-mockery": "kTJSEElZSzeOMXBO"
+			}
+		}
+	},
+	"secretSpells": {
+		"core": {
+			"fire": {
+				"hearth-and-home": "Mkw21dquWBdFBG9Y"
+			},
+			"ice": {
+				"cryotomb": "gDg4NlUQHWqbu9tV"
+			},
+			"lightning": {
+				"sparkfetch": "GXxJYF05KxMKG4bM",
+				"teleport": "np6pQWIzyOomWi7B"
+			},
+			"necrotic": {
+				"memory-veil": "PeLuUpKawDLOPHhv",
+				"speak-with-dead": "JQPywIEOHDp0dPYS"
+			},
+			"radiant": {
+				"radiant-bond": "pGCVd6N7Ed0AeEBE",
+				"revive": "iFCKExxkdI48bWxH"
+			},
+			"wind": {
+				"greater-windform": "21OMcsYYwn5C7CLR",
+				"lesser-windform": "eX8CJssX3F2vqFi1"
 			}
 		}
 	},

--- a/packs/secretSpells/core/fire/hearth-and-home.json
+++ b/packs/secretSpells/core/fire/hearth-and-home.json
@@ -1,8 +1,8 @@
 {
 	"folder": null,
-	"name": "Sparkfetch",
+	"name": "Hearth & Home",
 	"type": "spell",
-	"img": "icons/magic/lightning/fist-unarmed-strike-blue.webp",
+	"img": "icons/environment/settlement/house-farmland-small.webp",
 	"system": {
 		"macro": "",
 		"identifier": "",
@@ -11,14 +11,14 @@
 			"acquireTargetsFromTemplate": false,
 			"cost": {
 				"details": "",
-				"quantity": 1,
-				"type": "none",
+				"quantity": 10,
+				"type": "minute",
 				"isReaction": false
 			},
 			"duration": {
 				"details": "",
 				"quantity": 1,
-				"type": "none"
+				"type": "hour"
 			},
 			"effects": [],
 			"showDescription": true,
@@ -34,7 +34,7 @@
 			}
 		},
 		"description": {
-			"baseEffect": "<p>Loudly teleport a tiny, unheld metal item you can see to yourself.</p>",
+			"baseEffect": "<p><strong>Casting time 10 minutes.</strong> </p><p>Conjure a welcoming inn, complete with sturdy wooden tables, plush chairs, and a soft rug underfoot. At its heart burns a cozy fire in a fireplace, filling the space with warmth and light. The inn lasts for 12 hours and vanishes without a trace afterward.</p>",
 			"higherLevelEffect": "",
 			"upcastEffect": ""
 		},
@@ -47,10 +47,12 @@
 				"min": 1,
 				"max": null
 			},
-			"selected": []
+			"selected": [
+				"secretSpell"
+			]
 		},
-		"school": "lightning",
-		"tier": 0
+		"school": "fire",
+		"tier": 3
 	},
 	"effects": [],
 	"flags": {},
@@ -59,8 +61,8 @@
 		"systemId": "nimble",
 		"systemVersion": "0.2.0",
 		"createdTime": 1757106811491,
-		"modifiedTime": 1762397595368,
+		"modifiedTime": 1762397186698,
 		"lastModifiedBy": "zvcmZ9cAKxekqF5X"
 	},
-	"_id": "GXxJYF05KxMKG4bM"
+	"_id": "Mkw21dquWBdFBG9Y"
 }

--- a/packs/secretSpells/core/ice/cryotomb.json
+++ b/packs/secretSpells/core/ice/cryotomb.json
@@ -69,7 +69,8 @@
 				"max": null
 			},
 			"selected": [
-				"range"
+				"range",
+				"secretSpell"
 			]
 		},
 		"school": "ice",

--- a/packs/secretSpells/core/lightning/sparkfetch.json
+++ b/packs/secretSpells/core/lightning/sparkfetch.json
@@ -1,8 +1,8 @@
 {
 	"folder": null,
-	"name": "Radiant Bond",
+	"name": "Sparkfetch",
 	"type": "spell",
-	"img": "icons/magic/holy/meditation-chi-focus-blue.webp",
+	"img": "icons/magic/lightning/fist-unarmed-strike-blue.webp",
 	"system": {
 		"macro": "",
 		"identifier": "",
@@ -11,14 +11,14 @@
 			"acquireTargetsFromTemplate": false,
 			"cost": {
 				"details": "",
-				"quantity": 10,
+				"quantity": 1,
 				"type": "none",
 				"isReaction": false
 			},
 			"duration": {
 				"details": "",
 				"quantity": 1,
-				"type": "minute"
+				"type": "none"
 			},
 			"effects": [],
 			"showDescription": true,
@@ -34,7 +34,7 @@
 			}
 		},
 		"description": {
-			"baseEffect": "<p><strong>Concentration: up to 10 minutes.</strong></p><p>Telepathically communicate across any distance with a creature that holds a gift you have freely given.</p>",
+			"baseEffect": "<p>Loudly teleport a tiny, unheld metal item you can see to yourself.</p>",
 			"higherLevelEffect": "",
 			"upcastEffect": ""
 		},
@@ -48,11 +48,11 @@
 				"max": null
 			},
 			"selected": [
-				"concentration"
+				"secretSpell"
 			]
 		},
-		"school": "radiant",
-		"tier": 3
+		"school": "lightning",
+		"tier": 0
 	},
 	"effects": [],
 	"flags": {},
@@ -61,8 +61,8 @@
 		"systemId": "nimble",
 		"systemVersion": "0.2.0",
 		"createdTime": 1757106811491,
-		"modifiedTime": 1762397466256,
+		"modifiedTime": 1762397595368,
 		"lastModifiedBy": "zvcmZ9cAKxekqF5X"
 	},
-	"_id": "pGCVd6N7Ed0AeEBE"
+	"_id": "GXxJYF05KxMKG4bM"
 }

--- a/packs/secretSpells/core/lightning/teleport.json
+++ b/packs/secretSpells/core/lightning/teleport.json
@@ -1,8 +1,8 @@
 {
 	"folder": null,
-	"name": "Greater Windform",
+	"name": "Teleport",
 	"type": "spell",
-	"img": "icons/magic/air/wind-tornado-funnel-blue.webp",
+	"img": "icons/skills/movement/feet-winged-boots-glowing-yellow.webp",
 	"system": {
 		"macro": "",
 		"identifier": "",
@@ -11,27 +11,19 @@
 			"acquireTargetsFromTemplate": false,
 			"cost": {
 				"details": "",
-				"quantity": 1,
-				"type": "none",
+				"quantity": 10,
+				"type": "minute",
 				"isReaction": false
 			},
 			"duration": {
 				"details": "",
 				"quantity": 1,
-				"type": "minute"
+				"type": "none"
 			},
-			"effects": [
-				{
-					"id": "z7U64ITrBXdEXOo5",
-					"type": "condition",
-					"condition": "invisible",
-					"parentContext": null,
-					"parentNode": null
-				}
-			],
+			"effects": [],
 			"showDescription": true,
 			"targets": {
-				"count": 1,
+				"count": 10,
 				"restrictions": ""
 			},
 			"template": {
@@ -42,7 +34,7 @@
 			}
 		},
 		"description": {
-			"baseEffect": "<p><strong>Concentration: up to 10 minutes.</strong></p><p> Gain invisibility, a flying speed, and the ability to slip through any space that wind can pass through.</p>",
+			"baseEffect": "<p><strong>Casting time: 10 minutes</strong> </p><p>You and up to 10 willing creatures within 2 spaces are instantly teleported to a place of your choice that you have visited before.</p>",
 			"higherLevelEffect": "",
 			"upcastEffect": ""
 		},
@@ -53,14 +45,15 @@
 			},
 			"reach": {
 				"min": 1,
-				"max": null
+				"max": 2
 			},
 			"selected": [
-				"concentration"
+				"reach",
+				"secretSpell"
 			]
 		},
-		"school": "wind",
-		"tier": 5
+		"school": "lightning",
+		"tier": 6
 	},
 	"effects": [],
 	"flags": {},
@@ -69,8 +62,8 @@
 		"systemId": "nimble",
 		"systemVersion": "0.2.0",
 		"createdTime": 1757106811491,
-		"modifiedTime": 1762397126428,
+		"modifiedTime": 1762397678429,
 		"lastModifiedBy": "zvcmZ9cAKxekqF5X"
 	},
-	"_id": "21OMcsYYwn5C7CLR"
+	"_id": "np6pQWIzyOomWi7B"
 }

--- a/packs/secretSpells/core/necrotic/memory-veil.json
+++ b/packs/secretSpells/core/necrotic/memory-veil.json
@@ -66,7 +66,8 @@
 				"max": null
 			},
 			"selected": [
-				"concentration"
+				"concentration",
+				"secretSpell"
 			]
 		},
 		"school": "necrotic",

--- a/packs/secretSpells/core/necrotic/speak-with-dead.json
+++ b/packs/secretSpells/core/necrotic/speak-with-dead.json
@@ -1,8 +1,8 @@
 {
 	"folder": null,
-	"name": "Teleport",
+	"name": "Speak With Dead",
 	"type": "spell",
-	"img": "icons/skills/movement/feet-winged-boots-glowing-yellow.webp",
+	"img": "icons/magic/death/hand-dirt-undead-zombie.webp",
 	"system": {
 		"macro": "",
 		"identifier": "",
@@ -12,7 +12,7 @@
 			"cost": {
 				"details": "",
 				"quantity": 10,
-				"type": "minute",
+				"type": "none",
 				"isReaction": false
 			},
 			"duration": {
@@ -23,7 +23,7 @@
 			"effects": [],
 			"showDescription": true,
 			"targets": {
-				"count": 10,
+				"count": 1,
 				"restrictions": ""
 			},
 			"template": {
@@ -34,7 +34,7 @@
 			}
 		},
 		"description": {
-			"baseEffect": "<p><strong>Casting time: 10 minutes</strong> </p><p>You and up to 10 willing creatures within 2 spaces are instantly teleported to a place of your choice that you have visited before.</p>",
+			"baseEffect": "<p>Temporarily animate a corpse, allowing it to answer up to 3 questions before returning to rest. The corpse must answer, but it isn't required to be truthful if it dislikes the questioner or the questions.</p>",
 			"higherLevelEffect": "",
 			"upcastEffect": ""
 		},
@@ -45,14 +45,14 @@
 			},
 			"reach": {
 				"min": 1,
-				"max": 2
+				"max": null
 			},
 			"selected": [
-				"reach"
+				"secretSpell"
 			]
 		},
-		"school": "lightning",
-		"tier": 6
+		"school": "necrotic",
+		"tier": 4
 	},
 	"effects": [],
 	"flags": {},
@@ -61,8 +61,8 @@
 		"systemId": "nimble",
 		"systemVersion": "0.2.0",
 		"createdTime": 1757106811491,
-		"modifiedTime": 1762397678429,
+		"modifiedTime": 1762397632511,
 		"lastModifiedBy": "zvcmZ9cAKxekqF5X"
 	},
-	"_id": "np6pQWIzyOomWi7B"
+	"_id": "JQPywIEOHDp0dPYS"
 }

--- a/packs/secretSpells/core/radiant/radiant-bond.json
+++ b/packs/secretSpells/core/radiant/radiant-bond.json
@@ -1,8 +1,8 @@
 {
 	"folder": null,
-	"name": "Speak With Dead",
+	"name": "Radiant Bond",
 	"type": "spell",
-	"img": "icons/magic/death/hand-dirt-undead-zombie.webp",
+	"img": "icons/magic/holy/meditation-chi-focus-blue.webp",
 	"system": {
 		"macro": "",
 		"identifier": "",
@@ -18,7 +18,7 @@
 			"duration": {
 				"details": "",
 				"quantity": 1,
-				"type": "none"
+				"type": "minute"
 			},
 			"effects": [],
 			"showDescription": true,
@@ -34,7 +34,7 @@
 			}
 		},
 		"description": {
-			"baseEffect": "<p>Temporarily animate a corpse, allowing it to answer up to 3 questions before returning to rest. The corpse must answer, but it isn't required to be truthful if it dislikes the questioner or the questions.</p>",
+			"baseEffect": "<p><strong>Concentration: up to 10 minutes.</strong></p><p>Telepathically communicate across any distance with a creature that holds a gift you have freely given.</p>",
 			"higherLevelEffect": "",
 			"upcastEffect": ""
 		},
@@ -47,10 +47,13 @@
 				"min": 1,
 				"max": null
 			},
-			"selected": []
+			"selected": [
+				"concentration",
+				"secretSpell"
+			]
 		},
-		"school": "necrotic",
-		"tier": 4
+		"school": "radiant",
+		"tier": 3
 	},
 	"effects": [],
 	"flags": {},
@@ -59,8 +62,8 @@
 		"systemId": "nimble",
 		"systemVersion": "0.2.0",
 		"createdTime": 1757106811491,
-		"modifiedTime": 1762397632511,
+		"modifiedTime": 1762397466256,
 		"lastModifiedBy": "zvcmZ9cAKxekqF5X"
 	},
-	"_id": "JQPywIEOHDp0dPYS"
+	"_id": "pGCVd6N7Ed0AeEBE"
 }

--- a/packs/secretSpells/core/radiant/revive.json
+++ b/packs/secretSpells/core/radiant/revive.json
@@ -1,8 +1,8 @@
 {
 	"folder": null,
-	"name": "Hearth & Home",
+	"name": "Revive",
 	"type": "spell",
-	"img": "icons/environment/settlement/house-farmland-small.webp",
+	"img": "icons/magic/life/heart-cross-strong-flame-purple-orange.webp",
 	"system": {
 		"macro": "",
 		"identifier": "",
@@ -11,14 +11,14 @@
 			"acquireTargetsFromTemplate": false,
 			"cost": {
 				"details": "",
-				"quantity": 10,
-				"type": "minute",
+				"quantity": 1,
+				"type": "hour",
 				"isReaction": false
 			},
 			"duration": {
 				"details": "",
 				"quantity": 1,
-				"type": "hour"
+				"type": "none"
 			},
 			"effects": [],
 			"showDescription": true,
@@ -34,7 +34,7 @@
 			}
 		},
 		"description": {
-			"baseEffect": "<p><strong>Casting time 10 minutes.</strong> </p><p>Conjure a welcoming inn, complete with sturdy wooden tables, plush chairs, and a soft rug underfoot. At its heart burns a cozy fire in a fireplace, filling the space with warmth and light. The inn lasts for 12 hours and vanishes without a trace afterward.</p>",
+			"baseEffect": "<p><strong>Casting time: 1 hour</strong></p><p>Bring a dead creature back to life, provided they've been dead no more than 10 days and have not been revived by this spell before. Attempting to revive a creature already brought back with this spell risks raising a mindless, zombified husk instead.</p>",
 			"higherLevelEffect": "",
 			"upcastEffect": ""
 		},
@@ -47,9 +47,11 @@
 				"min": 1,
 				"max": null
 			},
-			"selected": []
+			"selected": [
+				"secretSpell"
+			]
 		},
-		"school": "fire",
+		"school": "radiant",
 		"tier": 3
 	},
 	"effects": [],
@@ -59,8 +61,8 @@
 		"systemId": "nimble",
 		"systemVersion": "0.2.0",
 		"createdTime": 1757106811491,
-		"modifiedTime": 1762397186698,
+		"modifiedTime": 1762397545040,
 		"lastModifiedBy": "zvcmZ9cAKxekqF5X"
 	},
-	"_id": "Mkw21dquWBdFBG9Y"
+	"_id": "iFCKExxkdI48bWxH"
 }

--- a/packs/secretSpells/core/wind/greater-windform.json
+++ b/packs/secretSpells/core/wind/greater-windform.json
@@ -1,8 +1,8 @@
 {
 	"folder": null,
-	"name": "Lesser Windform",
+	"name": "Greater Windform",
 	"type": "spell",
-	"img": "icons/magic/air/weather-wind-gust.webp",
+	"img": "icons/magic/air/wind-tornado-funnel-blue.webp",
 	"system": {
 		"macro": "",
 		"identifier": "",
@@ -21,13 +21,6 @@
 				"type": "minute"
 			},
 			"effects": [
-				{
-					"id": "zZYtdX6Z0KjLKpK3",
-					"type": "condition",
-					"condition": "blinded",
-					"parentContext": null,
-					"parentNode": null
-				},
 				{
 					"id": "z7U64ITrBXdEXOo5",
 					"type": "condition",
@@ -49,7 +42,7 @@
 			}
 		},
 		"description": {
-			"baseEffect": "<p><strong>Concentration: up to 10 minutes</strong>. </p><p>You are invisible and blinded for the duration of the spell.</p>",
+			"baseEffect": "<p><strong>Concentration: up to 10 minutes.</strong></p><p> Gain invisibility, a flying speed, and the ability to slip through any space that wind can pass through.</p>",
 			"higherLevelEffect": "",
 			"upcastEffect": ""
 		},
@@ -63,11 +56,12 @@
 				"max": null
 			},
 			"selected": [
-				"concentration"
+				"concentration",
+				"secretSpell"
 			]
 		},
 		"school": "wind",
-		"tier": 0
+		"tier": 5
 	},
 	"effects": [],
 	"flags": {},
@@ -76,8 +70,8 @@
 		"systemId": "nimble",
 		"systemVersion": "0.2.0",
 		"createdTime": 1757106811491,
-		"modifiedTime": 1762397253681,
+		"modifiedTime": 1762397126428,
 		"lastModifiedBy": "zvcmZ9cAKxekqF5X"
 	},
-	"_id": "eX8CJssX3F2vqFi1"
+	"_id": "21OMcsYYwn5C7CLR"
 }

--- a/packs/secretSpells/core/wind/lesser-windform.json
+++ b/packs/secretSpells/core/wind/lesser-windform.json
@@ -1,8 +1,8 @@
 {
 	"folder": null,
-	"name": "Revive",
+	"name": "Lesser Windform",
 	"type": "spell",
-	"img": "icons/magic/life/heart-cross-strong-flame-purple-orange.webp",
+	"img": "icons/magic/air/weather-wind-gust.webp",
 	"system": {
 		"macro": "",
 		"identifier": "",
@@ -12,15 +12,30 @@
 			"cost": {
 				"details": "",
 				"quantity": 1,
-				"type": "hour",
+				"type": "none",
 				"isReaction": false
 			},
 			"duration": {
 				"details": "",
 				"quantity": 1,
-				"type": "none"
+				"type": "minute"
 			},
-			"effects": [],
+			"effects": [
+				{
+					"id": "zZYtdX6Z0KjLKpK3",
+					"type": "condition",
+					"condition": "blinded",
+					"parentContext": null,
+					"parentNode": null
+				},
+				{
+					"id": "z7U64ITrBXdEXOo5",
+					"type": "condition",
+					"condition": "invisible",
+					"parentContext": null,
+					"parentNode": null
+				}
+			],
 			"showDescription": true,
 			"targets": {
 				"count": 1,
@@ -34,7 +49,7 @@
 			}
 		},
 		"description": {
-			"baseEffect": "<p><strong>Casting time: 1 hour</strong></p><p>Bring a dead creature back to life, provided they've been dead no more than 10 days and have not been revived by this spell before. Attempting to revive a creature already brought back with this spell risks raising a mindless, zombified husk instead.</p>",
+			"baseEffect": "<p><strong>Concentration: up to 10 minutes</strong>. </p><p>You are invisible and blinded for the duration of the spell.</p>",
 			"higherLevelEffect": "",
 			"upcastEffect": ""
 		},
@@ -47,10 +62,13 @@
 				"min": 1,
 				"max": null
 			},
-			"selected": []
+			"selected": [
+				"concentration",
+				"secretSpell"
+			]
 		},
-		"school": "radiant",
-		"tier": 3
+		"school": "wind",
+		"tier": 0
 	},
 	"effects": [],
 	"flags": {},
@@ -59,8 +77,8 @@
 		"systemId": "nimble",
 		"systemVersion": "0.2.0",
 		"createdTime": 1757106811491,
-		"modifiedTime": 1762397545040,
+		"modifiedTime": 1762397253681,
 		"lastModifiedBy": "zvcmZ9cAKxekqF5X"
 	},
-	"_id": "iFCKExxkdI48bWxH"
+	"_id": "eX8CJssX3F2vqFi1"
 }

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -510,6 +510,7 @@
 			"reach": "Reach",
 			"range": "Range",
 			"load": "Load",
+			"secretSpell": "Secret Spell",
 			"thrown": "Thrown",
 			"twoHanded": "2-Handed",
 			"utilitySpell": "Utility",

--- a/public/system.json
+++ b/public/system.json
@@ -187,6 +187,13 @@
 			"system": "nimble"
 		},
 		{
+			"name": "nimble-secret-spells",
+			"label": "Nimble Secret Spells",
+			"path": "packs/secretSpells.db",
+			"type": "Item",
+			"system": "nimble"
+		},
+		{
 			"name": "nimble-subclasses",
 			"label": "Nimble Subclasses",
 			"path": "packs/subclasses.db",

--- a/src/config.ts
+++ b/src/config.ts
@@ -529,6 +529,7 @@ const spellUpcastDialog = {
 const spellProperties = {
 	...genericProperties,
 	concentration: 'NIMBLE.properties.concentration',
+	secretSpell: 'NIMBLE.properties.secretSpell',
 	utilitySpell: 'NIMBLE.properties.utilitySpell',
 };
 

--- a/src/hooks/compendiumSpellsFilter.test.ts
+++ b/src/hooks/compendiumSpellsFilter.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { mapTierForCompendiumDisplay } from './compendiumSpellsFilter.js';
+import {
+	isSupportedSpellCompendium,
+	mapTierForCompendiumDisplay,
+} from './compendiumSpellsFilter.js';
 
 describe('mapTierForCompendiumDisplay', () => {
 	it('maps utility spells to display tier 0', () => {
@@ -25,5 +28,17 @@ describe('mapTierForCompendiumDisplay', () => {
 	it('falls back to cantrip display tier for invalid non-utility values', () => {
 		expect(mapTierForCompendiumDisplay(undefined, ['range'])).toBe(1);
 		expect(mapTierForCompendiumDisplay('not-a-number', ['range'])).toBe(1);
+	});
+});
+
+describe('isSupportedSpellCompendium', () => {
+	it('supports both public spell compendia', () => {
+		expect(isSupportedSpellCompendium('nimble.nimble-spells')).toBe(true);
+		expect(isSupportedSpellCompendium('nimble.nimble-secret-spells')).toBe(true);
+	});
+
+	it('rejects non-spell compendia', () => {
+		expect(isSupportedSpellCompendium('nimble.nimble-items')).toBe(false);
+		expect(isSupportedSpellCompendium(undefined)).toBe(false);
 	});
 });

--- a/src/hooks/compendiumSpellsFilter.ts
+++ b/src/hooks/compendiumSpellsFilter.ts
@@ -1,9 +1,14 @@
 /**
- * Spell School Icon Filter for Nimble Spells Compendium
- * Adds clickable icon buttons to filter spells by school and sorts by tier with group headers
+ * Spell school filters for Nimble spell compendia.
+ * Adds clickable icon buttons and groups spells by tier and school.
  */
 
-const GLOBAL_NIMBLE_SPELLS_COLLECTION = 'nimble.nimble-spells';
+const SPELL_COMPENDIUM_COLLECTIONS = [
+	'nimble.nimble-spells',
+	'nimble.nimble-secret-spells',
+] as const;
+const DEFAULT_SPELL_COMPENDIUM_COLLECTION = SPELL_COMPENDIUM_COLLECTIONS[0];
+const SPELL_COMPENDIUM_COLLECTION_SET = new Set<string>(SPELL_COMPENDIUM_COLLECTIONS);
 
 const SCHOOL_KEYS = [
 	'fire',
@@ -66,6 +71,12 @@ type CompendiumFilterState = {
 
 const compendiumStateByApp = new WeakMap<object, CompendiumFilterState>();
 
+export function isSupportedSpellCompendium(
+	collectionId: string | null | undefined,
+): collectionId is string {
+	return typeof collectionId === 'string' && SPELL_COMPENDIUM_COLLECTION_SET.has(collectionId);
+}
+
 function createCompendiumFilterState(): CompendiumFilterState {
 	return {
 		activeSchoolFilter: '',
@@ -87,6 +98,90 @@ function getCompendiumFilterState(app: any): CompendiumFilterState {
 		compendiumStateByApp.set(app, state);
 	}
 	return state;
+}
+
+function resolveCompendiumCollectionId(app: any, collection?: any): string | null {
+	const collectionId =
+		app?.collection?.metadata?.id ||
+		app?.collection?.id ||
+		collection?.metadata?.id ||
+		collection?.id ||
+		app?.pack ||
+		collection?.collection ||
+		null;
+
+	return typeof collectionId === 'string' ? collectionId : null;
+}
+
+function getCompendiumCollectionAttr(collectionId: string): string {
+	return (
+		collectionId.split('.').pop() ||
+		DEFAULT_SPELL_COMPENDIUM_COLLECTION.split('.').pop() ||
+		'nimble-spells'
+	);
+}
+
+function getSpellCompendiumElement(app: any, collectionId: string): HTMLElement | null {
+	if (app?.element) {
+		return app.element;
+	}
+
+	if (typeof document === 'undefined') {
+		return null;
+	}
+
+	const collectionAttr = getCompendiumCollectionAttr(collectionId);
+	return (document.querySelector(`.compendium[data-collection="${collectionAttr}"]`) ||
+		document.querySelector(`.compendium[data-pack="${collectionAttr}"]`) ||
+		document.querySelector(
+			`.directory[data-collection="${collectionAttr}"]`,
+		)) as HTMLElement | null;
+}
+
+function getSpellPack(pack: any, collectionId: string): any {
+	return pack || game.packs.get(collectionId) || null;
+}
+
+async function loadSpellIndex(pack: any, collectionId: string): Promise<any[]> {
+	const resolvedPack = getSpellPack(pack, collectionId);
+	if (!resolvedPack) {
+		return [];
+	}
+
+	let index: any[] = [];
+
+	if (typeof resolvedPack.getIndex === 'function') {
+		const indexData = await resolvedPack.getIndex({
+			fields: ['system.school', 'system.tier', 'system.properties.selected', 'name'],
+		});
+		if (indexData && indexData.size > 0) {
+			index = Array.from(indexData);
+		} else if (resolvedPack.index && resolvedPack.index.size > 0) {
+			index = Array.from(resolvedPack.index);
+		}
+	}
+
+	if (index.length === 0 && typeof resolvedPack.getDocuments === 'function') {
+		const docs = await resolvedPack.getDocuments();
+		index = docs.map((doc: any) => ({
+			_id: doc.id,
+			name: doc.name || '',
+			system: {
+				school: doc.system?.school || '',
+				tier: doc.system?.tier ?? 0,
+				properties: { selected: doc.system?.properties?.selected || [] },
+			},
+		}));
+	}
+
+	if (index.length === 0) {
+		const gamePack = game.packs.get(collectionId);
+		if ((gamePack?.index?.size ?? 0) > 0) {
+			index = Array.from(gamePack!.index);
+		}
+	}
+
+	return index;
 }
 
 function ensureSchoolFilterStyles(): void {
@@ -492,6 +587,7 @@ function setupClearFiltersButton(
 	app: any,
 	collection: any,
 	state: CompendiumFilterState,
+	collectionId: string,
 ): void {
 	const searchInput = header.querySelector(SEARCH_INPUT_SELECTOR) as HTMLInputElement | null;
 	let clearButton = header.querySelector(
@@ -530,7 +626,7 @@ function setupClearFiltersButton(
 			}
 		}
 
-		applyFilter('', app?.collection || collection, app, collection, state);
+		applyFilter('', app?.collection || collection, app, collection, state, collectionId);
 	};
 
 	if (!clearButton.dataset.nimbleClearFiltersBound) {
@@ -593,77 +689,33 @@ async function applyFilter(
 	app: any,
 	collection: any,
 	state: CompendiumFilterState,
+	collectionId: string,
 ): Promise<void> {
-	const TARGET_COLLECTION = GLOBAL_NIMBLE_SPELLS_COLLECTION;
-
 	try {
 		if (state.isApplyingFilter) {
 			return;
 		}
 		state.isApplyingFilter = true;
 
-		// Get the pack from packFromApp
-		const pack = packFromApp || collection;
+		const pack = getSpellPack(packFromApp || collection, collectionId);
 		if (!pack) {
 			console.warn('Nimble: Unable to find pack for filtering');
 			return;
 		}
 
-		// Load index with fallback chain
 		let index: any[] = [];
 		try {
-			// Try primary method
-			if (typeof pack.getIndex === 'function') {
-				const indexData = await pack.getIndex({
-					fields: ['system.school', 'system.tier', 'system.properties.selected', 'name'],
-				});
-				if (indexData && indexData.size > 0) {
-					index = Array.from(indexData);
-				} else if (pack.index && pack.index.size > 0) {
-					// Fallback 1: use pack.index directly
-					index = Array.from(pack.index);
-				}
-			}
-
-			// Fallback 2: get documents directly
-			if (index.length === 0 && typeof pack.getDocuments === 'function') {
-				const docs = await pack.getDocuments();
-				index = docs.map((doc: any) => ({
-					_id: doc.id,
-					name: doc.name || '',
-					system: {
-						school: doc.system?.school || '',
-						tier: doc.system?.tier ?? 0,
-						properties: { selected: doc.system?.properties?.selected || [] },
-					},
-				}));
-			}
-
-			// Fallback 3: use game.packs
-			if (index.length === 0) {
-				const gamePack = game.packs.get(TARGET_COLLECTION);
-				if ((gamePack?.index?.size ?? 0) > 0) {
-					index = Array.from(gamePack!.index);
-				}
-			}
+			index = await loadSpellIndex(pack, collectionId);
 		} catch (error) {
 			console.warn('Nimble: Error loading pack index:', error);
 			return;
 		}
-
-		// Get the compendium element with multiple selector fallbacks
-		let compendiumElement: HTMLElement | null = null;
-		const collectionAttr = TARGET_COLLECTION.split('.').pop() || 'nimble-spells';
-
-		if (app?.element) {
-			compendiumElement = app.element;
-		} else if (typeof document !== 'undefined') {
-			compendiumElement =
-				document.querySelector(`.compendium[data-collection="${collectionAttr}"]`) ||
-				document.querySelector(`.compendium[data-pack="${collectionAttr}"]`) ||
-				document.querySelector(`.directory[data-collection="${collectionAttr}"]`);
+		if (index.length === 0) {
+			console.warn('Nimble: Unable to load pack index for filtering');
+			return;
 		}
 
+		const compendiumElement = getSpellCompendiumElement(app, collectionId);
 		if (!compendiumElement) {
 			console.warn('Nimble: Unable to find compendium element for filtering');
 			return;
@@ -905,55 +957,27 @@ function initializeSchoolButtons(
 	app: any,
 	collection: any,
 	state: CompendiumFilterState,
+	collectionId: string,
 ): void {
 	async function loadAndRenderButtons() {
-		const TARGET_COLLECTION = GLOBAL_NIMBLE_SPELLS_COLLECTION;
-
 		try {
 			ensureSchoolFilterStyles();
 
-			// Extract CompendiumCollection from app or use directly
-			const pack = app?.collection || collection;
+			const pack = getSpellPack(app?.collection || collection, collectionId);
 			if (!pack) {
 				console.warn('Nimble: Unable to find collection for button initialization');
 				return;
 			}
 
-			// Load pack index
 			let index: any[] = [];
 			try {
-				if (typeof pack.getIndex === 'function') {
-					const indexData = await pack.getIndex({
-						fields: ['system.school', 'system.tier', 'system.properties.selected', 'name'],
-					});
-					if (indexData && indexData.size > 0) {
-						index = Array.from(indexData);
-					} else if (pack.index && pack.index.size > 0) {
-						index = Array.from(pack.index);
-					}
-				}
-
-				if (index.length === 0 && typeof pack.getDocuments === 'function') {
-					const docs = await pack.getDocuments();
-					index = docs.map((doc: any) => ({
-						_id: doc.id,
-						name: doc.name || '',
-						system: {
-							school: doc.system?.school || '',
-							tier: doc.system?.tier ?? 0,
-							properties: { selected: doc.system?.properties?.selected || [] },
-						},
-					}));
-				}
-
-				if (index.length === 0) {
-					const gamePack = game.packs.get(TARGET_COLLECTION);
-					if ((gamePack?.index?.size ?? 0) > 0) {
-						index = Array.from(gamePack!.index);
-					}
-				}
+				index = await loadSpellIndex(pack, collectionId);
 			} catch (error) {
 				console.warn('Nimble: Error loading index for button initialization:', error);
+				return;
+			}
+			if (index.length === 0) {
+				console.warn('Nimble: Unable to load index for button initialization');
 				return;
 			}
 
@@ -1001,7 +1025,7 @@ function initializeSchoolButtons(
 				e.preventDefault();
 				e.stopPropagation();
 				state.activeSchoolFilter = '';
-				applyFilter('', pack, app, collection, state);
+				applyFilter('', pack, app, collection, state, collectionId);
 				// Update active state
 				btnGroup.querySelectorAll('.header-button.nimble-spell-school').forEach((btn) => {
 					btn.classList.remove('active');
@@ -1025,7 +1049,7 @@ function initializeSchoolButtons(
 						e.preventDefault();
 						e.stopPropagation();
 						state.activeSchoolFilter = school;
-						applyFilter(school, pack, app, collection, state);
+						applyFilter(school, pack, app, collection, state, collectionId);
 						// Update active state
 						btnGroup.querySelectorAll('.header-button.nimble-spell-school').forEach((b) => {
 							b.classList.remove('active');
@@ -1050,50 +1074,22 @@ async function addIconsToAllSpells(
 	app: any,
 	collection: any,
 	state: CompendiumFilterState,
+	collectionId: string,
 ): Promise<void> {
-	const TARGET_COLLECTION = GLOBAL_NIMBLE_SPELLS_COLLECTION;
-
 	try {
-		const pack = app?.collection || collection;
+		const pack = getSpellPack(app?.collection || collection, collectionId);
 		if (!pack) {
 			return;
 		}
 
-		// Load pack index
 		let index: any[] = [];
 		try {
-			if (typeof pack.getIndex === 'function') {
-				const indexData = await pack.getIndex({
-					fields: ['system.school', 'system.tier', 'system.properties.selected', 'name'],
-				});
-				if (indexData && indexData.size > 0) {
-					index = Array.from(indexData);
-				} else if (pack.index && pack.index.size > 0) {
-					index = Array.from(pack.index);
-				}
-			}
-
-			if (index.length === 0 && typeof pack.getDocuments === 'function') {
-				const docs = await pack.getDocuments();
-				index = docs.map((doc: any) => ({
-					_id: doc.id,
-					name: doc.name || '',
-					system: {
-						school: doc.system?.school || '',
-						tier: doc.system?.tier ?? 0,
-						properties: { selected: doc.system?.properties?.selected || [] },
-					},
-				}));
-			}
-
-			if (index.length === 0) {
-				const gamePack = game.packs.get(TARGET_COLLECTION);
-				if ((gamePack?.index?.size ?? 0) > 0) {
-					index = Array.from(gamePack!.index);
-				}
-			}
+			index = await loadSpellIndex(pack, collectionId);
 		} catch (error) {
 			console.warn('Nimble: Error loading index for icon render:', error);
+			return;
+		}
+		if (index.length === 0) {
 			return;
 		}
 
@@ -1116,19 +1112,7 @@ async function addIconsToAllSpells(
 		state.cachedSpellDataById = dataById;
 		state.cachedSpellNameById = nameById;
 
-		// Find compendium element
-		let compendiumElement: HTMLElement | null = null;
-		const collectionAttr = TARGET_COLLECTION.split('.').pop() || 'nimble-spells';
-
-		if (app?.element) {
-			compendiumElement = app.element;
-		} else if (typeof document !== 'undefined') {
-			compendiumElement =
-				document.querySelector(`.compendium[data-collection="${collectionAttr}"]`) ||
-				document.querySelector(`.compendium[data-pack="${collectionAttr}"]`) ||
-				document.querySelector(`.directory[data-collection="${collectionAttr}"]`);
-		}
-
+		const compendiumElement = getSpellCompendiumElement(app, collectionId);
 		if (!compendiumElement) {
 			return;
 		}
@@ -1163,23 +1147,19 @@ async function addIconsToAllSpells(
  * Register the renderCompendium hook to add filter buttons
  */
 export default function registerCompendiumSpellsFilter(): void {
-	const TARGET_COLLECTION = GLOBAL_NIMBLE_SPELLS_COLLECTION;
-
 	Hooks.on('renderCompendium', (app: any, html: any) => {
 		try {
-			// Handle both string collection and CompendiumCollection object
-			let collectionId = app?.collection?.metadata?.id || app?.collection?.id || app?.pack;
-
-			// Additional fallback for collection resolution
+			let collectionId = resolveCompendiumCollectionId(app);
 			if (!collectionId && app?.document?.pack) {
 				collectionId = app.document.pack;
 			}
 
-			if (collectionId !== TARGET_COLLECTION) {
+			if (!isSupportedSpellCompendium(collectionId)) {
 				return;
 			}
 			const state = getCompendiumFilterState(app);
 			ensureSchoolFilterStyles();
+			const compendiumElement = getSpellCompendiumElement(app, collectionId);
 
 			// Find header element
 			const header =
@@ -1197,20 +1177,20 @@ export default function registerCompendiumSpellsFilter(): void {
 			}
 
 			// Initialize the buttons
-			initializeSchoolButtons(header, app, app?.collection, state);
-			setupClearFiltersButton(header, app, app?.collection, state);
+			initializeSchoolButtons(header, app, app?.collection, state, collectionId);
+			setupClearFiltersButton(header, app, app?.collection, state, collectionId);
 
 			// Add school icons to the initial list (no filtering)
-			addIconsToAllSpells(app, app?.collection, state);
+			addIconsToAllSpells(app, app?.collection, state, collectionId);
 
-			applySchoolFilterClass(app?.element || null, state.activeSchoolFilter);
+			applySchoolFilterClass(compendiumElement, state.activeSchoolFilter);
 
 			const searchInput = html?.querySelector?.(SEARCH_INPUT_SELECTOR) as HTMLInputElement | null;
 			if (searchInput && !searchInput.dataset.nimbleSpellSearchBound) {
 				searchInput.dataset.nimbleSpellSearchBound = '1';
 				const applyActiveSchoolClass = () => {
-					applySchoolFilterClass(app?.element || null, state.activeSchoolFilter);
-					applyCachedMetadataToListItems(app?.element || null, state.cachedSpellDataById);
+					applySchoolFilterClass(compendiumElement, state.activeSchoolFilter);
+					applyCachedMetadataToListItems(compendiumElement, state.cachedSpellDataById);
 				};
 
 				searchInput.addEventListener(
@@ -1222,13 +1202,20 @@ export default function registerCompendiumSpellsFilter(): void {
 						applyActiveSchoolClass();
 						const term = searchInput.value || '';
 						if (!term.trim()) {
-							applyFilter(state.activeSchoolFilter, app?.collection, app, app?.collection, state);
+							applyFilter(
+								state.activeSchoolFilter,
+								app?.collection,
+								app,
+								app?.collection,
+								state,
+								collectionId,
+							);
 							return;
 						}
 						html?.querySelectorAll?.(SPELL_HEADER_SELECTOR).forEach((header: Element) => {
 							header.remove();
 						});
-						applySearchFilter(app?.element || null, term, state.cachedSpellNameById);
+						applySearchFilter(compendiumElement, term, state.cachedSpellNameById);
 					},
 					true,
 				);
@@ -1241,7 +1228,7 @@ export default function registerCompendiumSpellsFilter(): void {
 			if (listContainer && !(listContainer as HTMLElement).dataset.nimbleSpellObserver) {
 				(listContainer as HTMLElement).dataset.nimbleSpellObserver = '1';
 				const observer = new MutationObserver(() => {
-					scheduleMetadataRefresh(app?.element || null, state);
+					scheduleMetadataRefresh(compendiumElement, state);
 				});
 				observer.observe(listContainer, { childList: true, subtree: true });
 			}

--- a/src/models/item/SpellDataModel.ts
+++ b/src/models/item/SpellDataModel.ts
@@ -15,7 +15,7 @@ const schema = () => ({
 			required: true,
 			nullable: false,
 			initial: [],
-			options: ['concentration', 'range', 'reach', 'utilitySpell'],
+			options: ['concentration', 'range', 'reach', 'secretSpell', 'utilitySpell'],
 		}),
 	}),
 	school: new fields.StringField({ required: true, initial: '', nullable: false }),

--- a/src/utils/secretSpellsPack.test.ts
+++ b/src/utils/secretSpellsPack.test.ts
@@ -1,0 +1,63 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { globSync } from 'glob';
+import { describe, expect, it } from 'vitest';
+
+type SpellSource = {
+	name: string;
+	system: {
+		properties: {
+			selected: string[];
+		};
+	};
+};
+
+const SECRET_SPELL_NAMES = [
+	'Cryotomb',
+	'Greater Windform',
+	'Hearth & Home',
+	'Lesser Windform',
+	'Memory Veil',
+	'Radiant Bond',
+	'Revive',
+	'Sparkfetch',
+	'Speak With Dead',
+	'Teleport',
+].sort();
+
+function readSpellSource(relativeFilePath: string): SpellSource {
+	return JSON.parse(
+		readFileSync(path.resolve(process.cwd(), relativeFilePath), 'utf-8'),
+	) as SpellSource;
+}
+
+describe('secret spell pack organization', () => {
+	it('stores the expected secret spells only in the dedicated secret spell pack', () => {
+		const secretSpellFiles = globSync('packs/secretSpells/**/*.json').sort();
+		const mainSpellFiles = globSync('packs/spells/**/*.json').sort();
+		const legacySecretSpellFiles = globSync('packs/spells/core/secret/**/*.json');
+
+		const secretSpellNames = secretSpellFiles.map((file) => readSpellSource(file).name).sort();
+		const mainSpellNames = new Set(mainSpellFiles.map((file) => readSpellSource(file).name));
+
+		expect(secretSpellNames).toEqual(SECRET_SPELL_NAMES);
+		expect(legacySecretSpellFiles).toHaveLength(0);
+
+		for (const spellName of SECRET_SPELL_NAMES) {
+			expect(mainSpellNames.has(spellName)).toBe(false);
+		}
+	});
+
+	it('marks every secret spell with the secretSpell property and keeps that property out of the main spell pack', () => {
+		const secretSpellFiles = globSync('packs/secretSpells/**/*.json').sort();
+		const mainSpellFiles = globSync('packs/spells/**/*.json').sort();
+
+		for (const file of secretSpellFiles) {
+			expect(readSpellSource(file).system.properties.selected).toContain('secretSpell');
+		}
+
+		for (const file of mainSpellFiles) {
+			expect(readSpellSource(file).system.properties.selected).not.toContain('secretSpell');
+		}
+	});
+});


### PR DESCRIPTION
### PR Summary
-   Adds secretSpell as a formal spell property and wires it into config and localization.
-   Registers a new Nimble Secret Spells compendium in the system manifest.
-   Moves the 10 secret spells out of the main spells pack into a dedicated secretSpells pack, preserving their IDs in packs/ids.json.
-   Updates the spell compendium filter/sorting hook so the same button bar, grouping, and list formatting work for both Nimble Spells and Nimble Secret Spells.
-   Adds regression coverage for both supported spell compendia and for secret-spell pack segregation.

<img width="309" height="189" alt="Screenshot 2026-03-14 114518" src="https://github.com/user-attachments/assets/f8658252-da08-418e-87b6-101597b1887f" />

<img width="367" height="735" alt="Screenshot 2026-03-14 112721" src="https://github.com/user-attachments/assets/2d3bc948-974b-4c96-acfa-310f62ecdc45" />
<img width="364" height="1175" alt="Screenshot 2026-03-14 112728" src="https://github.com/user-attachments/assets/039862b8-4b27-4e05-aed4-811f1b25a1b5" />
<img width="375" height="500" alt="Screenshot 2026-03-14 112739" src="https://github.com/user-attachments/assets/f3224246-b089-4f7e-9a85-150dc3c5bbce" />
