### PR TITLE
feat: repurpose combat sidebar button to toggle combat

### DIFF
--- a/src/hooks/combatSidebarToggle.ts
+++ b/src/hooks/combatSidebarToggle.ts
@@ -1,0 +1,90 @@
+import localize from '../utils/localize.js';
+
+/**
+ * Check if the current user has permission to toggle combat (GM or Assistant role).
+ */
+function canUserToggleCombat(): boolean {
+	const user = game.user;
+	if (!user) return false;
+	if (user.isGM) return true;
+	const assistantRoleValue = Number(CONST.USER_ROLES?.ASSISTANT ?? 3);
+	return (user.role ?? 0) >= assistantRoleValue;
+}
+
+/**
+ * Handle click on combat sidebar button - toggles combat for current scene.
+ */
+async function handleCombatToggleClick(event: Event): Promise<void> {
+	event.preventDefault();
+	event.stopPropagation();
+	event.stopImmediatePropagation();
+
+	const scene = canvas.scene;
+	if (!scene) {
+		ui.notifications?.warn('No active scene to create combat for.');
+		return;
+	}
+
+	// Check if there's already a combat for this scene
+	const existingCombat = game.combats?.contents.find((combat) => combat.scene?.id === scene.id);
+
+	if (existingCombat) {
+		const hasCombatants = existingCombat.combatants.size > 0;
+		const hasStarted = (existingCombat.round ?? 0) > 0;
+
+		// Confirm before ending combat if there are combatants or combat has started
+		if (hasCombatants || hasStarted) {
+			const confirmed = await foundry.applications.api.DialogV2.confirm({
+				window: { title: localize('NIMBLE.combatControls.endCombatTitle') },
+				content: `<p>${localize('NIMBLE.combatControls.endCombatContent')}</p>`,
+				yes: { label: localize('NIMBLE.combatControls.endCombat') },
+				no: { label: localize('NIMBLE.combatControls.continueCombat') },
+				rejectClose: false,
+				modal: true,
+			});
+
+			if (confirmed === true) {
+				await existingCombat.delete();
+			}
+		} else {
+			// No combatants and not started, delete without confirmation
+			await existingCombat.delete();
+		}
+	} else {
+		// Create a new combat for the current scene
+		await Combat.create({ scene: scene.id });
+	}
+}
+
+/**
+ * Block right-click context menu on combat sidebar button.
+ */
+function handleCombatContextMenu(event: Event): void {
+	event.preventDefault();
+	event.stopPropagation();
+	event.stopImmediatePropagation();
+}
+
+/**
+ * Register combat sidebar toggle functionality.
+ * Intercepts the combat sidebar button to toggle combat instead of opening the native tracker.
+ */
+export default function registerCombatSidebarToggle(): void {
+	// Enable combat toggle visibility for GM/Assistant users via CSS
+	if (canUserToggleCombat()) {
+		document.body.classList.add('nimble-combat-toggle-enabled');
+	}
+
+	// Find the combat sidebar button
+	const combatSidebarButton = document.querySelector<HTMLElement>(
+		'#sidebar-tabs [data-tab="combat"]',
+	);
+
+	if (!combatSidebarButton) return;
+
+	// Intercept left-click to toggle combat
+	combatSidebarButton.addEventListener('click', handleCombatToggleClick, { capture: true });
+
+	// Block right-click context menu (native Foundry multi-encounter menu)
+	combatSidebarButton.addEventListener('contextmenu', handleCombatContextMenu, { capture: true });
+}

--- a/src/hooks/ready.ts
+++ b/src/hooks/ready.ts
@@ -64,4 +64,56 @@ export default async function ready() {
 	const combatTrackerConfig = game.settings.get('core', 'combatTrackerConfig') ?? {};
 	combatTrackerConfig.skipDefeated ??= true;
 	game.settings.set('core', 'combatTrackerConfig', combatTrackerConfig);
+
+	// Intercept the combat sidebar button to toggle combat for the scene
+	const combatSidebarButton = document.querySelector<HTMLElement>(
+		'#sidebar-tabs [data-tab="combat"]',
+	);
+	if (combatSidebarButton) {
+		combatSidebarButton.addEventListener(
+			'click',
+			async (event) => {
+				event.preventDefault();
+				event.stopPropagation();
+				event.stopImmediatePropagation();
+
+				const scene = canvas.scene;
+				if (!scene) {
+					ui.notifications?.warn('No active scene to create combat for.');
+					return;
+				}
+
+				// Check if there's already a combat for this scene
+				const existingCombat = game.combats?.contents.find(
+					(combat) => combat.scene?.id === scene.id,
+				);
+
+				if (existingCombat) {
+					// If combat hasn't started yet, just delete it
+					if ((existingCombat.round ?? 0) === 0) {
+						await existingCombat.delete();
+						return;
+					}
+
+					// If combat has started, show confirmation dialog
+					const confirmed = await foundry.applications.api.DialogV2.confirm({
+						window: { title: 'End Combat' },
+						content: '<p>End this combat encounter?</p>',
+						yes: { label: 'End Combat' },
+						no: { label: 'Continue Combat' },
+						rejectClose: false,
+						modal: true,
+					});
+
+					if (confirmed === true) {
+						await existingCombat.delete();
+					}
+				} else {
+					// Create a new combat for the current scene
+					await Combat.create({ scene: scene.id });
+				}
+			},
+			{ capture: true },
+		);
+	}
 }

--- a/src/hooks/ready.ts
+++ b/src/hooks/ready.ts
@@ -74,17 +74,16 @@ export default async function ready() {
 	combatTrackerConfig.skipDefeated ??= true;
 	game.settings.set('core', 'combatTrackerConfig', combatTrackerConfig);
 
+	// Enable combat toggle visibility for GM/Assistant users via CSS
+	if (canUserToggleCombat()) {
+		document.body.classList.add('nimble-combat-toggle-enabled');
+	}
+
 	// Intercept the combat sidebar button to toggle combat for the scene
 	const combatSidebarButton = document.querySelector<HTMLElement>(
 		'#sidebar-tabs [data-tab="combat"]',
 	);
 	if (combatSidebarButton) {
-		// Hide the button for users who can't toggle combat
-		if (!canUserToggleCombat()) {
-			combatSidebarButton.style.display = 'none';
-			return;
-		}
-
 		combatSidebarButton.addEventListener(
 			'click',
 			async (event) => {

--- a/src/hooks/ready.ts
+++ b/src/hooks/ready.ts
@@ -4,10 +4,19 @@ import { MigrationList } from '../migration/MigrationList.js';
 import { MigrationRunner } from '../migration/MigrationRunner.js';
 import { MigrationRunnerBase } from '../migration/MigrationRunnerBase.js';
 import { registerCombatTurnSocketListener } from '../utils/combatTurnActions.js';
+import localize from '../utils/localize.js';
 import CanvasConditionsPanel from '../view/ui/CanvasConditionsPanel.svelte';
 import CtTopTracker from '../view/ui/CtTopTracker.svelte';
 import combatStateGuards from './combatStateGuards.js';
 import registerMinionGroupTokenActions from './minionGroupTokenActions.js';
+
+function canUserToggleCombat(): boolean {
+	const user = game.user;
+	if (!user) return false;
+	if (user.isGM) return true;
+	const assistantRoleValue = Number(CONST.USER_ROLES?.ASSISTANT ?? 3);
+	return (user.role ?? 0) >= assistantRoleValue;
+}
 
 let canvasConditionsPanelComponent: object | null = null;
 
@@ -77,6 +86,10 @@ export default async function ready() {
 				event.stopPropagation();
 				event.stopImmediatePropagation();
 
+				if (!canUserToggleCombat()) {
+					return;
+				}
+
 				const scene = canvas.scene;
 				if (!scene) {
 					ui.notifications?.warn('No active scene to create combat for.');
@@ -89,23 +102,25 @@ export default async function ready() {
 				);
 
 				if (existingCombat) {
-					// If combat hasn't started yet, just delete it
-					if ((existingCombat.round ?? 0) === 0) {
-						await existingCombat.delete();
-						return;
-					}
+					const hasCombatants = existingCombat.combatants.size > 0;
+					const hasStarted = (existingCombat.round ?? 0) > 0;
 
-					// If combat has started, show confirmation dialog
-					const confirmed = await foundry.applications.api.DialogV2.confirm({
-						window: { title: 'End Combat' },
-						content: '<p>End this combat encounter?</p>',
-						yes: { label: 'End Combat' },
-						no: { label: 'Continue Combat' },
-						rejectClose: false,
-						modal: true,
-					});
+					// Confirm before ending combat if there are combatants or combat has started
+					if (hasCombatants || hasStarted) {
+						const confirmed = await foundry.applications.api.DialogV2.confirm({
+							window: { title: localize('NIMBLE.combatControls.endCombatTitle') },
+							content: `<p>${localize('NIMBLE.combatControls.endCombatContent')}</p>`,
+							yes: { label: localize('NIMBLE.combatControls.endCombat') },
+							no: { label: localize('NIMBLE.combatControls.continueCombat') },
+							rejectClose: false,
+							modal: true,
+						});
 
-					if (confirmed === true) {
+						if (confirmed === true) {
+							await existingCombat.delete();
+						}
+					} else {
+						// No combatants and not started, delete without confirmation
 						await existingCombat.delete();
 					}
 				} else {

--- a/src/hooks/ready.ts
+++ b/src/hooks/ready.ts
@@ -79,16 +79,18 @@ export default async function ready() {
 		'#sidebar-tabs [data-tab="combat"]',
 	);
 	if (combatSidebarButton) {
+		// Hide the button for users who can't toggle combat
+		if (!canUserToggleCombat()) {
+			combatSidebarButton.style.display = 'none';
+			return;
+		}
+
 		combatSidebarButton.addEventListener(
 			'click',
 			async (event) => {
 				event.preventDefault();
 				event.stopPropagation();
 				event.stopImmediatePropagation();
-
-				if (!canUserToggleCombat()) {
-					return;
-				}
 
 				const scene = canvas.scene;
 				if (!scene) {

--- a/src/hooks/ready.ts
+++ b/src/hooks/ready.ts
@@ -4,19 +4,11 @@ import { MigrationList } from '../migration/MigrationList.js';
 import { MigrationRunner } from '../migration/MigrationRunner.js';
 import { MigrationRunnerBase } from '../migration/MigrationRunnerBase.js';
 import { registerCombatTurnSocketListener } from '../utils/combatTurnActions.js';
-import localize from '../utils/localize.js';
 import CanvasConditionsPanel from '../view/ui/CanvasConditionsPanel.svelte';
 import CtTopTracker from '../view/ui/CtTopTracker.svelte';
+import registerCombatSidebarToggle from './combatSidebarToggle.js';
 import combatStateGuards from './combatStateGuards.js';
 import registerMinionGroupTokenActions from './minionGroupTokenActions.js';
-
-function canUserToggleCombat(): boolean {
-	const user = game.user;
-	if (!user) return false;
-	if (user.isGM) return true;
-	const assistantRoleValue = Number(CONST.USER_ROLES?.ASSISTANT ?? 3);
-	return (user.role ?? 0) >= assistantRoleValue;
-}
 
 let canvasConditionsPanelComponent: object | null = null;
 
@@ -74,62 +66,5 @@ export default async function ready() {
 	combatTrackerConfig.skipDefeated ??= true;
 	game.settings.set('core', 'combatTrackerConfig', combatTrackerConfig);
 
-	// Enable combat toggle visibility for GM/Assistant users via CSS
-	if (canUserToggleCombat()) {
-		document.body.classList.add('nimble-combat-toggle-enabled');
-	}
-
-	// Intercept the combat sidebar button to toggle combat for the scene
-	const combatSidebarButton = document.querySelector<HTMLElement>(
-		'#sidebar-tabs [data-tab="combat"]',
-	);
-	if (combatSidebarButton) {
-		combatSidebarButton.addEventListener(
-			'click',
-			async (event) => {
-				event.preventDefault();
-				event.stopPropagation();
-				event.stopImmediatePropagation();
-
-				const scene = canvas.scene;
-				if (!scene) {
-					ui.notifications?.warn('No active scene to create combat for.');
-					return;
-				}
-
-				// Check if there's already a combat for this scene
-				const existingCombat = game.combats?.contents.find(
-					(combat) => combat.scene?.id === scene.id,
-				);
-
-				if (existingCombat) {
-					const hasCombatants = existingCombat.combatants.size > 0;
-					const hasStarted = (existingCombat.round ?? 0) > 0;
-
-					// Confirm before ending combat if there are combatants or combat has started
-					if (hasCombatants || hasStarted) {
-						const confirmed = await foundry.applications.api.DialogV2.confirm({
-							window: { title: localize('NIMBLE.combatControls.endCombatTitle') },
-							content: `<p>${localize('NIMBLE.combatControls.endCombatContent')}</p>`,
-							yes: { label: localize('NIMBLE.combatControls.endCombat') },
-							no: { label: localize('NIMBLE.combatControls.continueCombat') },
-							rejectClose: false,
-							modal: true,
-						});
-
-						if (confirmed === true) {
-							await existingCombat.delete();
-						}
-					} else {
-						// No combatants and not started, delete without confirmation
-						await existingCombat.delete();
-					}
-				} else {
-					// Create a new combat for the current scene
-					await Combat.create({ scene: scene.id });
-				}
-			},
-			{ capture: true },
-		);
-	}
+	registerCombatSidebarToggle();
 }

--- a/src/scss/vendor/foundry/_initiative.scss
+++ b/src/scss/vendor/foundry/_initiative.scss
@@ -11,3 +11,12 @@
 #sidebar:has([data-tab="combat"].active) #chat:is(.sidebar-tab) {
   display: block !important;
 }
+
+// Hide combat sidebar button by default, show only for GM/Assistant GM
+#sidebar-tabs li:has([data-tab="combat"]) {
+  display: none;
+
+  .nimble-combat-toggle-enabled & {
+    display: revert;
+  }
+}

--- a/src/scss/vendor/foundry/_initiative.scss
+++ b/src/scss/vendor/foundry/_initiative.scss
@@ -2,6 +2,12 @@
   display: none;
 }
 
-#sidebar li:has(> [data-tab="combat"]) {
-  display: none;
+// Hide the combat sidebar panel content - we use our custom combat tracker instead
+#combat:is(.sidebar-tab) {
+  display: none !important;
+}
+
+// When combat tab is active, show chat tab content instead
+#sidebar:has([data-tab="combat"].active) #chat:is(.sidebar-tab) {
+  display: block !important;
 }


### PR DESCRIPTION
https://github.com/user-attachments/assets/c705ef6b-afda-424d-b0c3-f379c9f5ba91

## Summary
- Repurposes the combat sidebar button to toggle combat for the current scene
- Clicking creates a new combat if none exists, or ends existing combat
- Shows confirmation dialog before ending started combat (round > 0)
- Hides Foundry's combat sidebar panel (we use custom Combat Tracker)
- Shows the combat button in sidebar (was previously hidden)

## Test plan
- [ ] Click combat sidebar button with no combat - should create combat and show custom tracker
- [ ] Click combat sidebar button with unstarted combat (round 0) - should delete combat
- [ ] Click combat sidebar button with started combat - should show confirmation dialog
- [ ] Confirm "End Combat" - should delete combat
- [ ] Confirm "Continue Combat" - should keep combat active