### PR TITLE
feat: add CI check for migration version consistency

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -78,3 +78,26 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - name: Check circular dependencies
         run: pnpm circular-deps
+
+  migration-version:
+    name: Migration Version Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v4
+      - name: Check migration count matches schema version
+        run: |
+          MIGRATION_COUNT=$(ls -1 src/migration/migrations/Migration*.ts 2>/dev/null | wc -l | tr -d ' ')
+          SCHEMA_VERSION=$(grep -E 'static LATEST_SCHEMA_VERSION\s*=' src/migration/MigrationRunnerBase.ts | grep -oE '[0-9]+')
+
+          echo "Migration files found: $MIGRATION_COUNT"
+          echo "LATEST_SCHEMA_VERSION: $SCHEMA_VERSION"
+
+          if [ "$MIGRATION_COUNT" != "$SCHEMA_VERSION" ]; then
+            echo ""
+            echo "ERROR: Migration count ($MIGRATION_COUNT) does not match LATEST_SCHEMA_VERSION ($SCHEMA_VERSION)"
+            echo "Please update LATEST_SCHEMA_VERSION in src/migration/MigrationRunnerBase.ts to $MIGRATION_COUNT"
+            exit 1
+          fi
+
+          echo "Migration version check passed!"

--- a/src/migration/MigrationRunnerBase.ts
+++ b/src/migration/MigrationRunnerBase.ts
@@ -9,7 +9,7 @@ interface CollectionDiff<T = any> {
 class MigrationRunnerBase {
 	migrations: MigrationBase[];
 
-	static LATEST_SCHEMA_VERSION = 7;
+	static LATEST_SCHEMA_VERSION = 10;
 
 	static RECOMMENDED_SAFE_VERSION = 0;
 


### PR DESCRIPTION
## Summary
- Adds a new GitHub Actions job (`migration-version`) that verifies the number of migration files matches `LATEST_SCHEMA_VERSION`
- Fixes existing mismatch: updated `LATEST_SCHEMA_VERSION` from 7 to 10 to match the 10 existing migration files

This prevents future situations where developers add migrations but forget to update the schema version constant.

## Test plan
- [ ] Verify the new `Migration Version Check` job appears in PR checks
- [ ] Verify the check passes with current migration count (10) matching schema version (10)