### PR TITLE
Style update to Interpose & Defend Buttons

### DIFF
--- a/src/view/sheets/components/DefendReactionPanel.svelte
+++ b/src/view/sheets/components/DefendReactionPanel.svelte
@@ -117,9 +117,10 @@
 		&--combined {
 			background: linear-gradient(
 				135deg,
-				var(--nimble-reaction-defend-primary) 0%,
-				var(--nimble-reaction-interpose-secondary) 50%,
-				var(--nimble-reaction-interpose-secondary) 100%
+				var(--nimble-reaction-interpose-secondary) 0%,
+				var(--nimble-reaction-interpose-secondary) 43%,
+				var(--nimble-reaction-defend-primary) 57%,
+				var(--nimble-reaction-defend-primary) 100%
 			);
 
 			&:hover:not(:disabled) {

--- a/src/view/sheets/components/InterposeReactionPanel.svelte
+++ b/src/view/sheets/components/InterposeReactionPanel.svelte
@@ -120,9 +120,10 @@
 		&--combined {
 			background: linear-gradient(
 				135deg,
-				var(--nimble-reaction-defend-primary) 0%,
-				var(--nimble-reaction-interpose-secondary) 50%,
-				var(--nimble-reaction-interpose-secondary) 100%
+				var(--nimble-reaction-interpose-secondary) 0%,
+				var(--nimble-reaction-interpose-secondary) 43%,
+				var(--nimble-reaction-defend-primary) 57%,
+				var(--nimble-reaction-defend-primary) 100%
 			);
 
 			&:hover:not(:disabled) {


### PR DESCRIPTION
Old:
<img width="340" height="45" alt="Screenshot_2026-03-17_143812" src="https://github.com/user-attachments/assets/3cd3efd5-bc45-486f-98f8-1af411a65249" />

New:
<img width="339" height="37" alt="Screenshot_2026-03-17_180303" src="https://github.com/user-attachments/assets/8804cb0c-16d9-4cc7-913d-c21dea413711" />

<img width="361" height="358" alt="Screenshot_2026-03-17_193318" src="https://github.com/user-attachments/assets/6a942a28-952e-45ad-b161-a477a1207622" />
<img width="359" height="360" alt="Screenshot_2026-03-17_193309" src="https://github.com/user-attachments/assets/e6acc105-aadd-466a-9fbf-8709d1833719" />

