### PR TITLE
feat: add setting to enable/disable Combat System panel

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -1334,6 +1334,10 @@
 			"autoExpandRolls": {
 				"name": "Auto-Expand Rolls",
 				"hint": "When enabled, dice roll details are shown inline below each roll in chat messages, without needing to hover."
+			},
+			"ncswEnabled": {
+				"name": "Enable Combat System",
+				"hint": "Show the Combat System panel during combat. Helps GMs quickly target heroes and roll attacks for minions, monsters, and legendary monsters."
 			}
 		},
 		"combatTrackerSettings": {

--- a/src/hooks/minionGroupTokenActions.ts
+++ b/src/hooks/minionGroupTokenActions.ts
@@ -1,6 +1,8 @@
 import {
+	getNcswEnabled,
 	getPersistedNcswSidebarViewMode,
 	isNcswSidebarViewModeSettingRegistered,
+	NCSW_ENABLED_SETTING_CHANGED_EVENT_NAME,
 	type NcswSidebarViewMode,
 	setPersistedNcswSidebarViewMode,
 } from '../settings/ncswSettings.js';
@@ -8,12 +10,12 @@ import {
 	flattenActivationEffects,
 	getUnsupportedActivationEffectTypes,
 } from '../utils/activationEffects.js';
+import { getCombatantImage } from '../utils/combatantImage.js';
 import {
 	consumeCombatantAction,
 	getCombatantCurrentActions,
 	maybeAdvanceTurnForCombatant,
 } from '../utils/combatTurnActions.js';
-import { getCombatantImage } from '../utils/combatantImage.js';
 import { isCombatantDead } from '../utils/isCombatantDead.js';
 import {
 	createMinionGroupAttackSelectionState,
@@ -222,6 +224,10 @@ function isNcswSidebarModeActive(): boolean {
 export function getNcswSidebarViewMode(): NcswSidebarViewMode {
 	ensureNcswSidebarViewModeInitialized();
 	return ncswSidebarViewMode;
+}
+
+export function hideNcswPanel(): void {
+	hideGroupAttackPanel();
 }
 
 export function setNcswSidebarViewMode(mode: NcswSidebarViewMode): void {
@@ -1091,6 +1097,12 @@ function bindActionSelectDescriptionPopover(options: {
 function getGroupAttackPanelElement(): HTMLDivElement {
 	if (minionGroupAttackPanelElement && document.body.contains(minionGroupAttackPanelElement)) {
 		return minionGroupAttackPanelElement;
+	}
+
+	const existingElement = document.getElementById(NCSW_PANEL_ID) as HTMLDivElement | null;
+	if (existingElement) {
+		minionGroupAttackPanelElement = existingElement;
+		return existingElement;
 	}
 
 	const element = document.createElement('div');
@@ -2242,6 +2254,7 @@ async function executeNonMinionAttackRoll(
 
 function canUseNcswPanel(context: SelectionContext): boolean {
 	return (
+		getNcswEnabled() &&
 		Boolean(game.user?.isGM) &&
 		Boolean(canvas?.ready) &&
 		isNcswCombatStateEnabled(context.combat) &&
@@ -2411,6 +2424,7 @@ function resolveNcswSceneToggleOrder(tools: SceneControlToolLike[]): number {
 }
 
 function isNcswSceneToggleVisible(): boolean {
+	if (!getNcswEnabled()) return false;
 	const combat = getCombatForNcswSceneToggleVisibility();
 	return Boolean(game.user?.isGM) && isNcswCombatStateEnabled(combat);
 }
@@ -2981,6 +2995,11 @@ export default function registerMinionGroupTokenActions(): void {
 		}
 	};
 	window.addEventListener('resize', windowResizeHandler);
+
+	window.addEventListener(NCSW_ENABLED_SETTING_CHANGED_EVENT_NAME, () => {
+		hideGroupAttackPanel();
+		scheduleSceneControlsRefresh('ncsw-setting-disabled');
+	});
 
 	const refreshActionBarAndSceneControls = (source: string): void => {
 		scheduleActionBarRefresh(source);

--- a/src/settings/ncswSettings.ts
+++ b/src/settings/ncswSettings.ts
@@ -1,6 +1,9 @@
 export const NCSW_SIDEBAR_VIEW_MODE_SETTING_KEY = 'ncswSidebarViewMode';
+export const NCSW_ENABLED_SETTING_KEY = 'ncswEnabled';
+export const NCSW_ENABLED_SETTING_CHANGED_EVENT_NAME = 'nimble:ncsw-enabled-changed';
 
 const NCSW_SIDEBAR_VIEW_MODE_VALUES = ['combatTracker', 'ncs'] as const;
+const DEFAULT_NCSW_ENABLED_SETTING = true;
 export type NcswSidebarViewMode = (typeof NCSW_SIDEBAR_VIEW_MODE_VALUES)[number];
 const DEFAULT_NCSW_SIDEBAR_VIEW_MODE = 'ncs';
 const NCSW_SIDEBAR_VIEW_MODE_SET = new Set<NcswSidebarViewMode>(NCSW_SIDEBAR_VIEW_MODE_VALUES);
@@ -27,6 +30,24 @@ export function registerNcswSettings(): void {
 			default: DEFAULT_NCSW_SIDEBAR_VIEW_MODE,
 		} as unknown as Parameters<typeof game.settings.register>[2],
 	);
+
+	game.settings.register(
+		'nimble' as 'core',
+		NCSW_ENABLED_SETTING_KEY as 'rollMode',
+		{
+			name: 'NIMBLE.settings.ncswEnabled.name',
+			hint: 'NIMBLE.settings.ncswEnabled.hint',
+			scope: 'client',
+			config: true,
+			type: Boolean,
+			default: DEFAULT_NCSW_ENABLED_SETTING,
+			onChange: (enabled) => {
+				if (!enabled) {
+					window.dispatchEvent(new CustomEvent(NCSW_ENABLED_SETTING_CHANGED_EVENT_NAME));
+				}
+			},
+		} as unknown as Parameters<typeof game.settings.register>[2],
+	);
 }
 
 export function isNcswSidebarViewModeSettingRegistered(): boolean {
@@ -50,4 +71,14 @@ export async function setPersistedNcswSidebarViewMode(mode: NcswSidebarViewMode)
 		NCSW_SIDEBAR_VIEW_MODE_SETTING_KEY as 'rollMode',
 		normalizeNcswSidebarViewMode(mode) as never,
 	);
+}
+
+export function isNcswEnabledSettingRegistered(): boolean {
+	const settings = game.settings?.settings as { has: (key: string) => boolean } | undefined;
+	return settings?.has(`nimble.${NCSW_ENABLED_SETTING_KEY}`) ?? false;
+}
+
+export function getNcswEnabled(): boolean {
+	if (!isNcswEnabledSettingRegistered()) return true;
+	return Boolean(game.settings.get('nimble' as 'core', NCSW_ENABLED_SETTING_KEY as 'rollMode'));
 }


### PR DESCRIPTION

Fixes duplicate Combat System dialogues

<img width="1768" height="955" alt="Screenshot 2026-03-18 at 7 55 54 AM" src="https://github.com/user-attachments/assets/9baa6414-9f5a-4071-b414-96ae70d8ca1a" />

Implements system settings to hide the combat system for those who don't want to use it.

<img width="1286" height="909" alt="Screenshot 2026-03-18 at 8 03 08 AM" src="https://github.com/user-attachments/assets/66b39791-1c44-4acf-a455-58bf5a72c31e" />

<img width="523" height="117" alt="Screenshot 2026-03-18 at 8 03 26 AM" src="https://github.com/user-attachments/assets/57f38b9d-a473-47b6-a314-d941366bbbac" />


## Summary
- Adds a new client setting "Enable Combat System" in system settings
- When disabled, the Combat System panel (NCSW) won't appear when selecting tokens during combat
- The scene control toggle button is also hidden when disabled
- Panel immediately closes when the setting is toggled off
- Fixes duplicate panels appearing when navigating away and back by checking for existing DOM element by ID

## Test plan
- [ ] Open system settings, verify "Enable Combat System" setting appears
- [ ] Disable the setting, verify the Combat System panel no longer appears when selecting tokens in combat
- [ ] Verify the crosshairs toggle button in scene controls is hidden when disabled
- [ ] If panel is open, toggle setting off - verify it closes immediately
- [ ] Navigate away from window and back, verify no duplicate panels appear