### PR TITLE
fix: apply temp healing to temp HP instead of regular HP

### DIFF
--- a/src/documents/actor/base.svelte.ts
+++ b/src/documents/actor/base.svelte.ts
@@ -260,7 +260,7 @@ class NimbleBaseActor<ActorType extends SystemActorTypes = SystemActorTypes> ext
 		const { value, max, temp } = systemData.attributes.hp;
 		const healingAmount = Math.floor(healing);
 
-		if (healingType === 'temporaryHealing') {
+		if (healingType === 'tempHealing') {
 			if (healingAmount <= temp) {
 				ui.notifications.warn('Temporary hit points were not granted to {this.name}. ', {
 					localize: true,

--- a/src/documents/chatMessage.ts
+++ b/src/documents/chatMessage.ts
@@ -374,7 +374,7 @@ class NimbleChatMessage extends ChatMessage {
 
 			const updates: Record<string, unknown> = {};
 
-			if (healingRecord.healingType === 'temporaryHealing') {
+			if (healingRecord.healingType === 'tempHealing') {
 				// Revert temp HP
 				updates['system.attributes.hp.temp'] = targetRecord.previousTempHp;
 			} else {

--- a/src/view/chat/components/HealingNode.svelte
+++ b/src/view/chat/components/HealingNode.svelte
@@ -76,7 +76,11 @@
 						<div class="healing-applied__targets">
 							{#each healingRecord.targets as target}
 								<span class="healing-applied__target">
-									{target.tokenName}: {target.previousHp} → {target.newHp} HP
+									{#if healingRecord.healingType === 'tempHealing'}
+										{target.tokenName}: {target.previousTempHp} → {target.newTempHp} Temp HP
+									{:else}
+										{target.tokenName}: {target.previousHp} → {target.newHp} HP
+									{/if}
 								</span>
 							{/each}
 						</div>

--- a/types/effectTree.d.ts
+++ b/types/effectTree.d.ts
@@ -54,7 +54,7 @@ export type DamageOutcomeNode = {
 export type HealingNode = {
 	id: string;
 	type: 'healing';
-	healingType: 'healing' | 'temporaryHealing';
+	healingType: 'healing' | 'tempHealing';
 	formula: string;
 	parentContext: string | null;
 	parentNode: string | null;


### PR DESCRIPTION
## Summary
- Fixed healing type check to use `tempHealing` instead of `temporaryHealing` to match config, UI, and compendium data
- Updated chat card to display temp HP changes (e.g., `0 → 4 Temp HP`) for temp healing effects

## Test plan
- [x] Cast Frost Shield on a target
- [x] Apply the temp healing from the chat card
- [x] Verify temp HP increases (not regular HP)
- [x] Verify chat card shows temp HP values in the applied message

Closes #442