### PR TITLE
fix: improve migration reliability

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -1440,6 +1440,17 @@
 				"couldNotOpenPanel": "Could not open group attack panel. See console for details."
 			}
 		},
+		"migration": {
+			"world": {
+				"starting": "Migrating world data to Nimble v{version}.",
+				"completed": "World migration complete.",
+				"completedWithErrors": "World migration completed with {count} error(s). Check the browser console (F12) for details."
+			},
+			"compendium": {
+				"starting": "Migrating compendium: {packName}...",
+				"finished": "Finished migrating compendium: {packName}."
+			}
+		},
 		"actorImport": {
 			"buttonLabel": "Import Actor",
 			"dialogTitle": "Import from Nimble Nexus",

--- a/src/hooks/ready.ts
+++ b/src/hooks/ready.ts
@@ -13,24 +13,26 @@ import registerMinionGroupTokenActions from './minionGroupTokenActions.js';
 let canvasConditionsPanelComponent: object | null = null;
 
 export default async function ready() {
-	// Run migrations if needed
-	const worldSchemaVersion = game.settings.get(
-		'nimble' as 'core',
-		'worldSchemaVersion' as 'rollMode',
-	) as unknown as number;
-	const latestSchemaVersion = MigrationRunnerBase.LATEST_SCHEMA_VERSION;
+	// Only the GM should run migrations (requires world-level write permissions)
+	if (game.user?.isGM) {
+		const worldSchemaVersion = game.settings.get(
+			'nimble' as 'core',
+			'worldSchemaVersion' as 'rollMode',
+		) as unknown as number;
+		const latestSchemaVersion = MigrationRunnerBase.LATEST_SCHEMA_VERSION;
 
-	if (worldSchemaVersion < latestSchemaVersion) {
-		console.log(
-			`Nimble | Migration needed: world schema version ${worldSchemaVersion} < latest schema version ${latestSchemaVersion}`,
-		);
-		const migrations = MigrationList.constructFromVersion(worldSchemaVersion);
-		const runner = new MigrationRunner(migrations);
-		await runner.runMigration();
-	} else {
-		console.log(
-			`Nimble | No migration needed: world schema version ${worldSchemaVersion} is up to date`,
-		);
+		if (worldSchemaVersion < latestSchemaVersion) {
+			console.log(
+				`Nimble | Migration needed: world schema version ${worldSchemaVersion} < latest schema version ${latestSchemaVersion}`,
+			);
+			const migrations = MigrationList.constructFromVersion(worldSchemaVersion);
+			const runner = new MigrationRunner(migrations);
+			await runner.runMigration();
+		} else {
+			console.log(
+				`Nimble | No migration needed: world schema version ${worldSchemaVersion} is up to date`,
+			);
+		}
 	}
 
 	game.nimble.conditions.configureStatusEffects();

--- a/src/migration/MigrationBase.ts
+++ b/src/migration/MigrationBase.ts
@@ -24,6 +24,10 @@ abstract class MigrationBase {
 	updateUser?(source: any): Promise<void>;
 
 	migrate?(): Promise<void>;
+
+	protected getSourceId(source: any): string | undefined {
+		return source._stats?.compendiumSource ?? source.flags?.core?.sourceId;
+	}
 }
 
 export { MigrationBase };

--- a/src/migration/MigrationRunner.ts
+++ b/src/migration/MigrationRunner.ts
@@ -14,6 +14,8 @@ interface CompendiumPack {
 }
 
 class MigrationRunner extends MigrationRunnerBase {
+	#migrationErrors: string[] = [];
+
 	override needsMigration(): boolean {
 		return super.needsMigration(
 			game.settings.get(
@@ -82,6 +84,7 @@ class MigrationRunner extends MigrationRunnerBase {
 					await documentClass.updateDocuments(updateGroup, { noHook: true, pack });
 				} catch (e) {
 					console.error(e);
+					this.#migrationErrors.push(`Batch update failed for ${pack ?? 'world'}: ${e}`);
 				} finally {
 					// TODO: Update progress bar
 					updateGroup.length = 0;
@@ -100,8 +103,8 @@ class MigrationRunner extends MigrationRunnerBase {
 			try {
 				await documentClass.updateDocuments(updateGroup, { noHook: true, pack });
 			} catch (e) {
-				// TODO: Update progress bar
 				console.warn(e);
+				this.#migrationErrors.push(`Batch update failed for ${pack ?? 'world'}: ${e}`);
 			}
 		}
 	}
@@ -157,7 +160,9 @@ class MigrationRunner extends MigrationRunnerBase {
 			} catch (error) {
 				// Output the error, since this means a migration threw it
 				if (error instanceof Error) {
-					console.error(`Error thrown while migrating ${actor.uuid}: ${error.message}`);
+					const message = `Error thrown while migrating ${actor.uuid}: ${error.message}`;
+					console.error(message);
+					this.#migrationErrors.push(message);
 				}
 				return null;
 			}
@@ -223,7 +228,9 @@ class MigrationRunner extends MigrationRunnerBase {
 				return this.getUpdatedItem(baseItem, migrations);
 			} catch (e) {
 				if (e instanceof Error) {
-					console.error(`Error thrown while migrating ${item.uuid}: ${e.message}`);
+					const message = `Error thrown while migrating ${item.uuid}: ${e.message}`;
+					console.error(message);
+					this.#migrationErrors.push(message);
 				}
 				return null;
 			}
@@ -296,7 +303,7 @@ class MigrationRunner extends MigrationRunnerBase {
 			const changes = foundry.utils.diffObject(table.toObject(), updatedMacro);
 
 			if (Object.keys(changes).length > 0) {
-				table.update(changes, { noHook: true });
+				await table.update(changes, { noHook: true });
 			}
 		} catch (error) {
 			console.warn(error);
@@ -468,14 +475,27 @@ class MigrationRunner extends MigrationRunnerBase {
 		}
 
 		for (const phase of migrationPhases) {
-			if (phase.length > 0) await this.runMigrations(phase);
+			if (phase.length > 0) {
+				await this.runMigrations(phase);
+				const lastVersion = phase[phase.length - 1].version;
+				await game.settings.set(
+					'nimble' as 'core',
+					'worldSchemaVersion' as 'rollMode',
+					lastVersion as unknown as foundry.CONST.DICE_ROLL_MODES,
+				);
+			}
 		}
 
-		await game.settings.set(
-			'nimble' as 'core',
-			'worldSchemaVersion' as 'rollMode',
-			migrationVersion.latest as unknown as foundry.CONST.DICE_ROLL_MODES,
-		);
+		if (this.#migrationErrors.length > 0) {
+			console.warn('Nimble | Migration errors:', this.#migrationErrors);
+			ui.notifications.warn(
+				localize('NIMBLE.migration.world.completedWithErrors', {
+					count: this.#migrationErrors.length.toString(),
+				}),
+			);
+		} else {
+			ui.notifications.info(localize('NIMBLE.migration.world.completed'));
+		}
 	}
 }
 

--- a/src/migration/migrations/Migration003OozelingConstructRules.ts
+++ b/src/migration/migrations/Migration003OozelingConstructRules.ts
@@ -35,7 +35,7 @@ class Migration003OozelingConstructRules extends MigrationBase {
 
 		// Check if this is the Oozeling/Construct ancestry by sourceId or name
 		const isOozelingConstruct =
-			source.flags?.core?.sourceId === OOZELING_CONSTRUCT_SOURCE_ID ||
+			this.getSourceId(source) === OOZELING_CONSTRUCT_SOURCE_ID ||
 			source.name === 'Oozeling/Construct';
 
 		if (!isOozelingConstruct) return;

--- a/src/migration/migrations/Migration006DwarfMaxHitDice.ts
+++ b/src/migration/migrations/Migration006DwarfMaxHitDice.ts
@@ -27,7 +27,7 @@ class Migration006DwarfMaxHitDice extends MigrationBase {
 		if (source.type !== 'ancestry') return;
 
 		// Check if this is the Dwarf ancestry by sourceId or name
-		const isDwarf = source.flags?.core?.sourceId === DWARF_SOURCE_ID || source.name === 'Dwarf';
+		const isDwarf = this.getSourceId(source) === DWARF_SOURCE_ID || source.name === 'Dwarf';
 
 		if (!isDwarf) return;
 

--- a/src/migration/migrations/Migration007WildOneHitDiceAdvantage.ts
+++ b/src/migration/migrations/Migration007WildOneHitDiceAdvantage.ts
@@ -26,8 +26,7 @@ class Migration007WildOneHitDiceAdvantage extends MigrationBase {
 		if (source.type !== 'background') return;
 
 		// Check if this is the Wild One background by sourceId or name
-		const isWildOne =
-			source.flags?.core?.sourceId === WILD_ONE_SOURCE_ID || source.name === 'Wild One';
+		const isWildOne = this.getSourceId(source) === WILD_ONE_SOURCE_ID || source.name === 'Wild One';
 
 		if (!isWildOne) return;
 

--- a/src/migration/migrations/Migration008FieldMedicHealingPotionBonus.ts
+++ b/src/migration/migrations/Migration008FieldMedicHealingPotionBonus.ts
@@ -28,7 +28,7 @@ class Migration008FieldMedicHealingPotionBonus extends MigrationBase {
 
 		// Check if this is the Field Medic feature by sourceId or name
 		const isFieldMedic =
-			source.flags?.core?.sourceId === FIELD_MEDIC_SOURCE_ID || source.name === 'Field Medic';
+			this.getSourceId(source) === FIELD_MEDIC_SOURCE_ID || source.name === 'Field Medic';
 
 		if (!isFieldMedic) return;
 

--- a/src/migration/migrations/Migration009HealingEffects.ts
+++ b/src/migration/migrations/Migration009HealingEffects.ts
@@ -59,7 +59,7 @@ class Migration009HealingEffects extends MigrationBase {
 		// Only process feature items
 		if (source.type !== 'feature') return;
 
-		const sourceId = source.flags?.core?.sourceId;
+		const sourceId = this.getSourceId(source);
 		const name = source.name;
 
 		// Handle Healing Salve

--- a/src/migration/migrations/Migration010SwiftFistsUnarmedDamage.ts
+++ b/src/migration/migrations/Migration010SwiftFistsUnarmedDamage.ts
@@ -29,7 +29,7 @@ class Migration010SwiftFistsUnarmedDamage extends MigrationBase {
 
 		// Check if this is the Swift Fists feature by sourceId
 		// Name-only matching is avoided to prevent false positives with homebrew items
-		const isSwiftFists = source.flags?.core?.sourceId === SWIFT_FISTS_SOURCE_ID;
+		const isSwiftFists = this.getSourceId(source) === SWIFT_FISTS_SOURCE_ID;
 
 		if (!isSwiftFists) return;
 

--- a/src/migration/migrations/Migration011SwiftFistsUnarmedProficiency.ts
+++ b/src/migration/migrations/Migration011SwiftFistsUnarmedProficiency.ts
@@ -30,7 +30,7 @@ class Migration011SwiftFistsUnarmedProficiency extends MigrationBase {
 	override async updateItem(source: any): Promise<void> {
 		// Handle feature items
 		if (source.type === 'feature') {
-			const sourceId = source.flags?.core?.sourceId;
+			const sourceId = this.getSourceId(source);
 
 			// Swift Fists - remove old rules
 			if (sourceId === SWIFT_FISTS_SOURCE_ID) {
@@ -77,7 +77,7 @@ class Migration011SwiftFistsUnarmedProficiency extends MigrationBase {
 
 		// Handle Zephyr class - add Unarmed Strike proficiency
 		if (source.type === 'class') {
-			const isZephyr = source.flags?.core?.sourceId === ZEPHYR_CLASS_SOURCE_ID;
+			const isZephyr = this.getSourceId(source) === ZEPHYR_CLASS_SOURCE_ID;
 
 			if (isZephyr) {
 				if (!source.system.weaponProficiencies) {

--- a/src/migration/migrations/Migration012ViciousExplosionDamage.ts
+++ b/src/migration/migrations/Migration012ViciousExplosionDamage.ts
@@ -34,7 +34,7 @@ class Migration012ViciousExplosionDamage extends MigrationBase {
 
 		// Check if item is a known vicious compendium item OR has the vicious property
 		// This handles both official items and player-created vicious items
-		const sourceId = source.flags?.core?.sourceId;
+		const sourceId = this.getSourceId(source);
 		const isKnownViciousItem = sourceId && VICIOUS_ITEM_SOURCE_IDS.has(sourceId);
 		const hasVicious = hasViciousProperty(source);
 


### PR DESCRIPTION
## Summary

After some investigation into why migrations can be flaky, found and fixed several issues in the migration infrastructure:

- **Source ID lookup hardening** — Migrations checked `flags.core.sourceId` to identify compendium-sourced items, but items granted via the GrantItem rule set `_stats.compendiumSource` instead. Added a shared `getSourceId()` helper to `MigrationBase` that checks both fields (matching `NimbleBaseItem.sourceId` logic), and updated Migration006-012 to use it. Current migrations mostly target drag-and-dropped features so this is mainly defensive, but it prevents silent skips if future migrations target granted equipment.

- **GM-only migration guard** — Migrations ran for every user including players, who can't write to world settings or update documents. Now scoped to GM only.

- **Per-phase version tracking** — `worldSchemaVersion` was only updated after *all* migration phases completed. If anything crashed mid-run, the next reload would re-run everything from scratch. Now updates after each phase.

- **Missing `await` on table update** — `table.update()` was fire-and-forget, so errors weren't caught and completion wasn't guaranteed.

- **Error visibility** — Failed documents were silently swallowed. Now tracks errors and shows a `ui.notifications.warn()` with the count, with full details logged to console.

- **Missing localization keys** — Migration notification strings (`NIMBLE.migration.world.starting`, etc.) weren't in `en.json`, so users saw raw key paths.

## Test plan

- [ ] Log in as a non-GM player with pending migrations — confirm no migration runs and no errors
- [ ] Reset `worldSchemaVersion` to 0 on a test world `game.settings.set('nimble', 'worldSchemaVersion', 0)`, reload, confirm all migrations run and complete with readable notifications
- [x] Confirm `pnpm check` passes