### PR TITLE
fix: make action dice discrete and show tooltips to the right

### DIFF
--- a/src/view/sheets/components/ActionTracker.svelte
+++ b/src/view/sheets/components/ActionTracker.svelte
@@ -27,6 +27,7 @@
 					type="button"
 					aria-label={localize('NIMBLE.ui.heroicActions.rollInitiative')}
 					data-tooltip={localize('NIMBLE.ui.heroicActions.rollInitiative')}
+					data-tooltip-direction="RIGHT"
 					onclick={state.rollInitiative}
 				>
 					<i class="fa-solid fa-dice-d20"></i>
@@ -46,6 +47,7 @@
 							type="button"
 							aria-label={state.getPipAriaLabel(i, isAvailable)}
 							data-tooltip={state.getPipTooltip(isAvailable)}
+							data-tooltip-direction="RIGHT"
 							onclick={() => state.handlePipClick(i)}
 						>
 							<i class="fa-solid {diceIcon}"></i>
@@ -61,6 +63,7 @@
 						type="button"
 						aria-label={localize('NIMBLE.ui.heroicActions.endTurn')}
 						data-tooltip={localize('NIMBLE.ui.heroicActions.endTurn')}
+						data-tooltip-direction="RIGHT"
 						onclick={state.endTurn}
 					>
 						<i class="fa-solid fa-forward-step"></i>

--- a/src/view/sheets/components/ActionTracker.svelte.ts
+++ b/src/view/sheets/components/ActionTracker.svelte.ts
@@ -163,12 +163,16 @@ export function createActionTrackerState(getActor: () => NimbleCharacter) {
 	function handlePipClick(index: number): void {
 		if (!hasInitiative) return;
 
-		const pipNumber = index + 1;
+		const isAvailable = index < actionsData.current;
 
-		if (pipNumber <= actionsData.current) {
-			updateActionPips(index);
+		if (isAvailable) {
+			// Spend one action
+			const newValue = Math.max(actionsData.current - 1, 0);
+			updateActionPips(newValue);
 		} else {
-			updateActionPips(pipNumber);
+			// Restore one action
+			const newValue = Math.min(actionsData.current + 1, actionsData.max);
+			updateActionPips(newValue);
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Each action pip click now spends/restores exactly **one** action instead of setting actions to the clicked pip's index
- Fixes unintuitive behavior where clicking pip 1 would consume all actions at once
- Tooltips now appear to the right of the action tracker buttons instead of below

Fixes #482

## Test plan
- [x] Enter combat with a character and roll initiative
- [x] Verify clicking any available (green) pip decrements actions by 1
- [x] Verify clicking any spent (gray) pip increments actions by 1
- [x] Verify tooltips appear to the right of the action tracker buttons
- [ ] Test with boons/items that grant more than 3 actions (system already supports this)

Closes #482