### PR TITLE
feat: drag heroic actions and reactions to macro bar

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -804,6 +804,26 @@
 				"enterCombat": "Enter combat to use actions",
 				"outsideCombat": "You are outside of combat",
 				"noActions": "You don't have any actions",
+				"confirmReaction": {
+					"title": "Use Reaction?",
+					"noActionsMessage": "You don't have any actions remaining.",
+					"spentMessage": "You've already used {reaction} this round.",
+					"bothMessage": "You don't have any actions remaining and you've already used {reaction} this round.",
+					"confirmQuestion": "Do you still want to use the {reaction} reaction?",
+					"confirm": "Use Reaction",
+					"cancel": "Cancel"
+				},
+				"confirmMove": {
+					"title": "Move?",
+					"noActionsMessage": "You've used all your actions this round.",
+					"confirmQuestion": "Do you still want to move?",
+					"confirm": "Move",
+					"cancel": "Cancel"
+				},
+				"confirmAttack": {
+					"confirmQuestion": "Do you still want to attack?",
+					"confirm": "Attack"
+				},
 				"noSpells": "You don't have any spells",
 				"endTurn": "End Turn",
 				"rollInitiative": "Roll Initiative",

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -824,6 +824,10 @@
 					"confirmQuestion": "Do you still want to attack?",
 					"confirm": "Attack"
 				},
+				"macroWarnings": {
+					"selectCharacterToken": "Select a character token to use this action",
+					"mustBeInCombat": "You must be in combat to use {action}"
+				},
 				"noSpells": "You don't have any spells",
 				"endTurn": "End Turn",
 				"rollInitiative": "Roll Initiative",

--- a/src/documents/combat/combat.svelte.test.ts
+++ b/src/documents/combat/combat.svelte.test.ts
@@ -2031,6 +2031,257 @@ describe('NimbleCombat', () => {
 		expect(combat.updateEmbeddedDocuments).not.toHaveBeenCalled();
 	});
 
+	it('allows force to override the no-actions heroic reaction blocker', async () => {
+		globals().game.user.isGM = false;
+		globals().game.user.role = 1;
+		const combatId = 'combat-sheet-force-no-actions';
+		const activeCharacter = createMockCombatant({
+			id: 'active-character',
+			type: 'character',
+			sort: 1,
+			isOwner: false,
+			initiative: 15,
+			actionsCurrent: 3,
+			actionsMax: 3,
+			actor: createCombatActorFixture({ hp: 8, woundsValue: 0, woundsMax: 6 }),
+			combatId,
+		});
+		const reactingCharacter = createMockCombatant({
+			id: 'reacting-character',
+			type: 'character',
+			sort: 2,
+			isOwner: true,
+			initiative: 12,
+			actionsCurrent: 0,
+			actionsMax: 3,
+			actor: createCombatActorFixture({
+				hp: 8,
+				woundsValue: 0,
+				woundsMax: 6,
+				isOwner: true,
+			}),
+			combatId,
+		});
+		const combat = new NimbleCombat({
+			id: combatId,
+			round: 1,
+			combatants: createCombatantsCollectionFixture([activeCharacter, reactingCharacter]),
+			turns: [activeCharacter, reactingCharacter],
+			turn: 0,
+			combatant: activeCharacter,
+		} as unknown as Combat.CreateData) as NimbleCombat & {
+			updateEmbeddedDocuments: ReturnType<typeof vi.fn>;
+		};
+
+		combat.updateEmbeddedDocuments = vi.fn().mockResolvedValue([]);
+
+		const changed = await combat.useHeroicReactions('reacting-character', ['help'], {
+			force: true,
+		});
+
+		expect(changed).toBe(true);
+		expect(combat.updateEmbeddedDocuments).toHaveBeenCalledWith('Combatant', [
+			{
+				_id: 'reacting-character',
+				'system.actions.base.current': 0,
+				'system.actions.heroic.helpAvailable': false,
+			},
+		]);
+	});
+
+	it('allows force to override the spent heroic reaction blocker', async () => {
+		globals().game.user.isGM = false;
+		globals().game.user.role = 1;
+		const combatId = 'combat-sheet-force-spent';
+		const activeCharacter = createMockCombatant({
+			id: 'active-character',
+			type: 'character',
+			sort: 1,
+			isOwner: false,
+			initiative: 15,
+			actionsCurrent: 3,
+			actionsMax: 3,
+			actor: createCombatActorFixture({ hp: 8, woundsValue: 0, woundsMax: 6 }),
+			combatId,
+		});
+		const reactingCharacter = createMockCombatant({
+			id: 'reacting-character',
+			type: 'character',
+			sort: 2,
+			isOwner: true,
+			initiative: 12,
+			actionsCurrent: 2,
+			actionsMax: 3,
+			actor: createCombatActorFixture({
+				hp: 8,
+				woundsValue: 0,
+				woundsMax: 6,
+				isOwner: true,
+			}),
+			combatId,
+		});
+		foundry.utils.setProperty(reactingCharacter, 'system.actions.heroic.helpAvailable', false);
+		const combat = new NimbleCombat({
+			id: combatId,
+			round: 1,
+			combatants: createCombatantsCollectionFixture([activeCharacter, reactingCharacter]),
+			turns: [activeCharacter, reactingCharacter],
+			turn: 0,
+			combatant: activeCharacter,
+		} as unknown as Combat.CreateData) as NimbleCombat & {
+			updateEmbeddedDocuments: ReturnType<typeof vi.fn>;
+		};
+
+		combat.updateEmbeddedDocuments = vi.fn().mockResolvedValue([]);
+
+		const changed = await combat.useHeroicReactions('reacting-character', ['help'], {
+			force: true,
+		});
+
+		expect(changed).toBe(true);
+		expect(combat.updateEmbeddedDocuments).toHaveBeenCalledWith('Combatant', [
+			{
+				_id: 'reacting-character',
+				'system.actions.base.current': 1,
+				'system.actions.heroic.helpAvailable': false,
+			},
+		]);
+	});
+
+	it('does not let force bypass the active-turn heroic reaction blocker', async () => {
+		globals().game.user.isGM = false;
+		globals().game.user.role = 1;
+		const combatId = 'combat-sheet-force-active-turn';
+		const reactingCharacter = createMockCombatant({
+			id: 'reacting-character',
+			type: 'character',
+			sort: 1,
+			isOwner: true,
+			initiative: 12,
+			actionsCurrent: 3,
+			actionsMax: 3,
+			actor: createCombatActorFixture({
+				hp: 8,
+				woundsValue: 0,
+				woundsMax: 6,
+				isOwner: true,
+			}),
+			combatId,
+		});
+		const combat = new NimbleCombat({
+			id: combatId,
+			round: 1,
+			combatants: createCombatantsCollectionFixture([reactingCharacter]),
+			turns: [reactingCharacter],
+			turn: 0,
+			combatant: reactingCharacter,
+		} as unknown as Combat.CreateData) as NimbleCombat & {
+			updateEmbeddedDocuments: ReturnType<typeof vi.fn>;
+		};
+
+		combat.updateEmbeddedDocuments = vi.fn().mockResolvedValue([]);
+
+		const changed = await combat.useHeroicReactions('reacting-character', ['defend'], {
+			force: true,
+		});
+
+		expect(changed).toBe(false);
+		expect(combat.updateEmbeddedDocuments).not.toHaveBeenCalled();
+	});
+
+	it('does not let force bypass the not-owner heroic reaction blocker', async () => {
+		globals().game.user.isGM = false;
+		globals().game.user.role = 1;
+		const combatId = 'combat-sheet-force-not-owner';
+		const activeCharacter = createMockCombatant({
+			id: 'active-character',
+			type: 'character',
+			sort: 1,
+			isOwner: false,
+			initiative: 15,
+			actionsCurrent: 3,
+			actionsMax: 3,
+			actor: createCombatActorFixture({ hp: 8, woundsValue: 0, woundsMax: 6 }),
+			combatId,
+		});
+		const reactingCharacter = createMockCombatant({
+			id: 'reacting-character',
+			type: 'character',
+			sort: 2,
+			isOwner: false,
+			initiative: 12,
+			actionsCurrent: 3,
+			actionsMax: 3,
+			actor: createCombatActorFixture({
+				hp: 8,
+				woundsValue: 0,
+				woundsMax: 6,
+				isOwner: false,
+			}),
+			combatId,
+		});
+		const combat = new NimbleCombat({
+			id: combatId,
+			round: 1,
+			combatants: createCombatantsCollectionFixture([activeCharacter, reactingCharacter]),
+			turns: [activeCharacter, reactingCharacter],
+			turn: 0,
+			combatant: activeCharacter,
+		} as unknown as Combat.CreateData) as NimbleCombat & {
+			updateEmbeddedDocuments: ReturnType<typeof vi.fn>;
+		};
+
+		combat.updateEmbeddedDocuments = vi.fn().mockResolvedValue([]);
+
+		const changed = await combat.useHeroicReactions('reacting-character', ['defend'], {
+			force: true,
+		});
+
+		expect(changed).toBe(false);
+		expect(combat.updateEmbeddedDocuments).not.toHaveBeenCalled();
+	});
+
+	it('does not let force bypass the outside-combat heroic reaction blocker', async () => {
+		globals().game.user.isGM = false;
+		globals().game.user.role = 1;
+		const combatId = 'combat-sheet-force-outside-combat';
+		const reactingCharacter = createMockCombatant({
+			id: 'reacting-character',
+			type: 'character',
+			sort: 1,
+			isOwner: true,
+			initiative: 12,
+			actionsCurrent: 3,
+			actionsMax: 3,
+			actor: createCombatActorFixture({
+				hp: 8,
+				woundsValue: 0,
+				woundsMax: 6,
+				isOwner: true,
+			}),
+			combatId,
+		});
+		const combat = new NimbleCombat({
+			id: combatId,
+			round: 0,
+			combatants: createCombatantsCollectionFixture([reactingCharacter]),
+			turns: [reactingCharacter],
+			turn: null,
+			combatant: null,
+		} as unknown as Combat.CreateData) as NimbleCombat & {
+			updateEmbeddedDocuments: ReturnType<typeof vi.fn>;
+		};
+
+		combat.updateEmbeddedDocuments = vi.fn().mockResolvedValue([]);
+
+		const changed = await combat.useHeroicReactions('reacting-character', ['defend'], {
+			force: true,
+		});
+
+		expect(changed).toBe(false);
+		expect(combat.updateEmbeddedDocuments).not.toHaveBeenCalled();
+	});
+
 	it('re-enables Defend without touching actor conditions', async () => {
 		const combatId = 'combat-defend-gm-reenable-clears-condition';
 		const activeCharacter = createMockCombatant({

--- a/src/documents/combat/combat.svelte.ts
+++ b/src/documents/combat/combat.svelte.ts
@@ -333,7 +333,7 @@ class NimbleCombat extends Combat {
 
 		const requestedTurnIdentity =
 			this.#pendingAtomicTurnIdentity &&
-				this.#findTurnIndexByIdentity(normalizedTurns, this.#pendingAtomicTurnIdentity) >= 0
+			this.#findTurnIndexByIdentity(normalizedTurns, this.#pendingAtomicTurnIdentity) >= 0
 				? this.#pendingAtomicTurnIdentity
 				: null;
 		const fallbackTurn = Number.isInteger(nextUpdateData.turn)
@@ -628,14 +628,14 @@ class NimbleCombat extends Combat {
 			sceneId == null
 				? []
 				: this.combatants
-					.filter(
-						(combatant) =>
-							combatant.initiative === null &&
-							combatant.type === 'character' &&
-							combatant.sceneId === sceneId,
-					)
-					.map((combatant) => combatant.id)
-					.filter((combatantId): combatantId is string => combatantId != null);
+						.filter(
+							(combatant) =>
+								combatant.initiative === null &&
+								combatant.type === 'character' &&
+								combatant.sceneId === sceneId,
+						)
+						.map((combatant) => combatant.id)
+						.filter((combatantId): combatantId is string => combatantId != null);
 
 		if (unrolledCharacterIds.length > 0) {
 			await this.rollInitiative(unrolledCharacterIds, { updateTurn: false });

--- a/src/documents/combat/combat.svelte.ts
+++ b/src/documents/combat/combat.svelte.ts
@@ -747,8 +747,11 @@ class NimbleCombat extends Combat {
 						reactionKeys,
 					});
 
-					// If not forced and can't use, return false
-					if (!options?.force && !usageState.canUse) return false;
+					const canForceUsage =
+						options?.force === true &&
+						(usageState.blockedReason === 'noActions' || usageState.blockedReason === 'spent');
+
+					if (!usageState.canUse && !canForceUsage) return false;
 
 					const reactionAvailabilityUpdate = {
 						_id: combatantId,

--- a/src/documents/combat/combat.svelte.ts
+++ b/src/documents/combat/combat.svelte.ts
@@ -333,7 +333,7 @@ class NimbleCombat extends Combat {
 
 		const requestedTurnIdentity =
 			this.#pendingAtomicTurnIdentity &&
-			this.#findTurnIndexByIdentity(normalizedTurns, this.#pendingAtomicTurnIdentity) >= 0
+				this.#findTurnIndexByIdentity(normalizedTurns, this.#pendingAtomicTurnIdentity) >= 0
 				? this.#pendingAtomicTurnIdentity
 				: null;
 		const fallbackTurn = Number.isInteger(nextUpdateData.turn)
@@ -628,14 +628,14 @@ class NimbleCombat extends Combat {
 			sceneId == null
 				? []
 				: this.combatants
-						.filter(
-							(combatant) =>
-								combatant.initiative === null &&
-								combatant.type === 'character' &&
-								combatant.sceneId === sceneId,
-						)
-						.map((combatant) => combatant.id)
-						.filter((combatantId): combatantId is string => combatantId != null);
+					.filter(
+						(combatant) =>
+							combatant.initiative === null &&
+							combatant.type === 'character' &&
+							combatant.sceneId === sceneId,
+					)
+					.map((combatant) => combatant.id)
+					.filter((combatantId): combatantId is string => combatantId != null);
 
 		if (unrolledCharacterIds.length > 0) {
 			await this.rollInitiative(unrolledCharacterIds, { updateTurn: false });
@@ -729,6 +729,7 @@ class NimbleCombat extends Combat {
 	async useHeroicReactions(
 		combatantId: string,
 		reactionKeys: HeroicReactionKey[],
+		options?: { force?: boolean },
 	): Promise<boolean> {
 		if (!combatantId || reactionKeys.length < 1) return false;
 
@@ -745,7 +746,9 @@ class NimbleCombat extends Combat {
 						combatant,
 						reactionKeys,
 					});
-					if (!usageState.canUse) return false;
+
+					// If not forced and can't use, return false
+					if (!options?.force && !usageState.canUse) return false;
 
 					const reactionAvailabilityUpdate = {
 						_id: combatantId,

--- a/src/game.ts
+++ b/src/game.ts
@@ -1,5 +1,5 @@
 import { NIMBLE } from './config.js';
-
+import AncestrySheet from './documents/sheets/AncestrySheet.svelte.js';
 // Sheets
 import BackgroundSheet from './documents/sheets/BackgroundSheet.svelte.js';
 import BoonSheet from './documents/sheets/BoonSheet.svelte.js';
@@ -8,20 +8,19 @@ import FeatureSheet from './documents/sheets/FeatureSheet.svelte.js';
 import MonsterFeatureSheet from './documents/sheets/MonsterFeatureSheet.svelte.js';
 import ObjectSheet from './documents/sheets/ObjectSheet.svelte.js';
 import PlayerCharacterSheet from './documents/sheets/PlayerCharacterSheet.svelte.js';
-import AncestrySheet from './documents/sheets/AncestrySheet.svelte.js';
 import SpellSheet from './documents/sheets/SpellSheet.svelte.js';
 import SubclassSheet from './documents/sheets/SubclassSheet.svelte.js';
 
 // Dialogs
 import NimbleNexusImportDialog from './import/nimbleNexus/NimbleNexusImportDialog.svelte.js';
-
+// Macros
+import { activateHeroicActionMacro } from './macros/activateHeroicActionMacro.ts';
+import { activateItemMacro } from './macros/activateItemMacro.ts';
+import { createHeroicActionMacro } from './macros/createHeroicActionMacro.ts';
+import { createMacro } from './macros/createMacro.ts';
 // Managers
 import { ConditionManager } from './managers/ConditionManager.js';
 import { ModifierManager } from './managers/ModifierManager.js';
-
-// Macros
-import { activateItemMacro } from './macros/activateItemMacro.ts';
-import { createMacro } from './macros/createMacro.ts';
 
 const managers = {
 	ConditionManager,
@@ -54,7 +53,9 @@ const NIMBLE_GAME = {
 		NimbleNexusImportDialog,
 	},
 	macros: {
+		activateHeroicActionMacro,
 		activateItemMacro,
+		createHeroicActionMacro,
 		createMacro,
 	},
 	managers,

--- a/src/hooks/hotBarDrop.test.ts
+++ b/src/hooks/hotBarDrop.test.ts
@@ -1,0 +1,56 @@
+import { hotbarDrop } from './hotBarDrop.js';
+
+describe('hotbarDrop', () => {
+	beforeEach(() => {
+		(
+			globalThis as unknown as {
+				game: {
+					nimble: {
+						macros: {
+							createMacro: ReturnType<typeof vi.fn>;
+							createHeroicActionMacro: ReturnType<typeof vi.fn>;
+						};
+					};
+				};
+			}
+		).game.nimble = {
+			macros: {
+				createMacro: vi.fn(),
+				createHeroicActionMacro: vi.fn(),
+			},
+		};
+	});
+
+	it('delegates item drops to createMacro and cancels the default handling', () => {
+		const data = { type: 'Item', uuid: 'Item.item-id' };
+
+		const result = hotbarDrop(null, data, 3);
+
+		expect(game.nimble.macros.createMacro).toHaveBeenCalledWith(data, 3);
+		expect(game.nimble.macros.createHeroicActionMacro).not.toHaveBeenCalled();
+		expect(result).toBe(false);
+	});
+
+	it('delegates heroic action drops to createHeroicActionMacro and cancels the default handling', () => {
+		const data = {
+			type: 'HeroicAction',
+			actionId: 'defend',
+			actionType: 'reaction',
+			name: 'Defend',
+		};
+
+		const result = hotbarDrop(null, data, 5);
+
+		expect(game.nimble.macros.createHeroicActionMacro).toHaveBeenCalledWith(data, 5);
+		expect(game.nimble.macros.createMacro).not.toHaveBeenCalled();
+		expect(result).toBe(false);
+	});
+
+	it('ignores unsupported drop payloads', () => {
+		const result = hotbarDrop(null, { type: 'Folder' }, 7);
+
+		expect(game.nimble.macros.createMacro).not.toHaveBeenCalled();
+		expect(game.nimble.macros.createHeroicActionMacro).not.toHaveBeenCalled();
+		expect(result).toBeUndefined();
+	});
+});

--- a/src/hooks/hotBarDrop.ts
+++ b/src/hooks/hotBarDrop.ts
@@ -3,4 +3,8 @@ export function hotbarDrop(_, data, slot) {
 		game.nimble.macros.createMacro(data, slot);
 		return false;
 	}
+	if (data.type === 'HeroicAction') {
+		game.nimble.macros.createHeroicActionMacro(data, slot);
+		return false;
+	}
 }

--- a/src/hooks/hotBarDrop.ts
+++ b/src/hooks/hotBarDrop.ts
@@ -1,10 +1,22 @@
-export function hotbarDrop(_, data, slot) {
-	if (data.type === 'Item') {
-		game.nimble.macros.createMacro(data, slot);
+interface HotbarDropData {
+	type?: string;
+	uuid?: string;
+	actionId?: string;
+	actionType?: 'action' | 'reaction';
+	name?: string;
+}
+
+export function hotbarDrop(_bar: unknown, data: unknown, slot: number): false | undefined {
+	const dropData = data as HotbarDropData;
+	if (dropData.type === 'Item') {
+		game.nimble.macros.createMacro(dropData as { uuid: string }, slot);
 		return false;
 	}
-	if (data.type === 'HeroicAction') {
-		game.nimble.macros.createHeroicActionMacro(data, slot);
+	if (dropData.type === 'HeroicAction') {
+		game.nimble.macros.createHeroicActionMacro(
+			dropData as { actionId: string; actionType: 'action' | 'reaction'; name: string },
+			slot,
+		);
 		return false;
 	}
 }

--- a/src/macros/activateHeroicActionMacro.test.ts
+++ b/src/macros/activateHeroicActionMacro.test.ts
@@ -1,0 +1,352 @@
+const {
+	damageRollMock,
+	getUnarmedDamageFormulaMock,
+	hasUnarmedProficiencyMock,
+	itemActivationConfigDialogMock,
+} = vi.hoisted(() => ({
+	damageRollMock: vi.fn(),
+	getUnarmedDamageFormulaMock: vi.fn(),
+	hasUnarmedProficiencyMock: vi.fn(),
+	itemActivationConfigDialogMock: vi.fn(),
+}));
+
+vi.mock('../dice/DamageRoll.js', () => ({
+	DamageRoll: damageRollMock,
+}));
+
+vi.mock('../documents/dialogs/ItemActivationConfigDialog.svelte.js', () => ({
+	default: itemActivationConfigDialogMock,
+}));
+
+vi.mock('../view/sheets/components/attackUtils.js', () => ({
+	getUnarmedDamageFormula: getUnarmedDamageFormulaMock,
+	hasUnarmedProficiency: hasUnarmedProficiencyMock,
+}));
+
+import { activateHeroicActionMacro } from './activateHeroicActionMacro.ts';
+
+function globals() {
+	return globalThis as unknown as {
+		canvas: unknown;
+		ChatMessage: {
+			create: ReturnType<typeof vi.fn>;
+			getSpeaker: ReturnType<typeof vi.fn>;
+		};
+		foundry: {
+			applications: {
+				api: {
+					DialogV2: {
+						confirm: ReturnType<typeof vi.fn>;
+					};
+				};
+			};
+		};
+		game: {
+			actors: unknown;
+			combat: unknown;
+			combats: unknown;
+			user: {
+				targets: Set<unknown>;
+			};
+		};
+		ui: {
+			notifications: {
+				warn: ReturnType<typeof vi.fn>;
+			};
+		};
+	};
+}
+
+type MacroTestActor = Actor & {
+	name: string;
+	type: string;
+	img: string;
+	permission: number;
+	reactive: {
+		system: {
+			attributes: {
+				armor: {
+					value: number;
+				};
+			};
+		};
+	};
+	sheet: {
+		render: ReturnType<typeof vi.fn>;
+		$state: Record<string, unknown>;
+	};
+};
+
+function setSpeakerActor(actor: Actor | null) {
+	globals().ChatMessage.create = vi.fn().mockResolvedValue({ id: 'chat-message-id' });
+	globals().ChatMessage.getSpeaker = vi.fn().mockReturnValue(actor ? { actor: actor.id } : {});
+	globals().game.actors = {
+		tokens: {},
+		get: vi.fn().mockReturnValue(actor),
+	};
+}
+
+function createCharacterActor(): MacroTestActor {
+	return {
+		id: 'character-macro-actor',
+		name: 'Heroic Tester',
+		type: 'character',
+		isOwner: true,
+		img: 'hero.webp',
+		permission: CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER,
+		system: {
+			attributes: {
+				movement: {
+					walk: 6,
+					fly: 0,
+					climb: 0,
+					swim: 0,
+					burrow: 0,
+				},
+			},
+		},
+		reactive: {
+			system: {
+				attributes: {
+					armor: {
+						value: 15,
+					},
+				},
+			},
+		},
+		sheet: {
+			render: vi.fn().mockResolvedValue(undefined),
+			$state: {},
+		},
+	} as unknown as MacroTestActor;
+}
+
+function createCombatant(actor: MacroTestActor, currentActions = 1) {
+	return {
+		id: 'combatant-heroic-macro',
+		actorId: actor.id,
+		actor,
+		initiative: 12,
+		system: {
+			actions: {
+				base: {
+					current: currentActions,
+				},
+				heroic: {
+					defendAvailable: true,
+					interposeAvailable: true,
+					helpAvailable: true,
+					opportunityAttackAvailable: true,
+				},
+			},
+		},
+		update: vi.fn().mockResolvedValue(undefined),
+	};
+}
+
+function setCurrentScene(sceneId: string) {
+	globals().canvas = {
+		scene: { id: sceneId },
+	};
+}
+
+function setActiveCombat(
+	combatant: ReturnType<typeof createCombatant>,
+	activeCombatant: Combatant,
+) {
+	const combat = {
+		scene: { id: 'scene-heroic-macro' },
+		active: true,
+		started: true,
+		round: 1,
+		combatant: activeCombatant,
+		combatants: [combatant, activeCombatant],
+	} as unknown as Combat;
+	globals().game.combat = combat;
+	globals().game.combats = {
+		contents: [combat],
+		viewed: combat,
+	};
+}
+
+describe('activateHeroicActionMacro', () => {
+	beforeEach(() => {
+		globals().ui.notifications.warn.mockReset();
+		globals().foundry.applications.api.DialogV2.confirm.mockReset();
+		globals().game.user.targets = new Set();
+		setCurrentScene('scene-heroic-macro');
+		globals().game.combat = null;
+		globals().game.combats = {
+			contents: [],
+			viewed: null,
+		};
+	});
+
+	it('warns when the current speaker does not resolve to a character actor', async () => {
+		setSpeakerActor({
+			id: 'npc-actor',
+			type: 'npc',
+		} as unknown as Actor);
+
+		await activateHeroicActionMacro('move', 'action');
+
+		expect(globals().ui.notifications.warn).toHaveBeenCalledWith(
+			game.i18n.localize('NIMBLE.ui.heroicActions.macroWarnings.selectCharacterToken'),
+		);
+	});
+
+	it('asks for confirmation before moving with no actions and stops when the user cancels', async () => {
+		const actor = createCharacterActor();
+		const combatant = createCombatant(actor, 0);
+		const activeCombatant = {
+			id: 'active-combatant',
+			actorId: 'other-actor',
+			initiative: 15,
+		} as Combatant;
+		setSpeakerActor(actor);
+		setActiveCombat(combatant, activeCombatant);
+		globals().foundry.applications.api.DialogV2.confirm.mockResolvedValue(false);
+
+		await activateHeroicActionMacro('move', 'action');
+
+		expect(globals().foundry.applications.api.DialogV2.confirm).toHaveBeenCalledTimes(1);
+		expect(combatant.update).not.toHaveBeenCalled();
+		expect(ChatMessage.create).not.toHaveBeenCalled();
+	});
+
+	it('moves after confirmation even when the actor has no actions remaining', async () => {
+		const actor = createCharacterActor();
+		const combatant = createCombatant(actor, 0);
+		const activeCombatant = {
+			id: 'active-combatant',
+			actorId: 'other-actor',
+			initiative: 15,
+		} as Combatant;
+		setSpeakerActor(actor);
+		setActiveCombat(combatant, activeCombatant);
+		globals().foundry.applications.api.DialogV2.confirm.mockResolvedValue(true);
+
+		await activateHeroicActionMacro('move', 'action');
+
+		expect(combatant.update).toHaveBeenCalledWith({
+			'system.actions.base.current': -1,
+		});
+		expect(ChatMessage.create).toHaveBeenCalledWith(
+			expect.objectContaining({
+				type: 'moveAction',
+				system: expect.objectContaining({
+					actorName: actor.name,
+					speed: 6,
+				}),
+			}),
+		);
+	});
+
+	it.each([
+		['defend', ['defend'], 'defend', [], 15],
+		['help', ['help'], 'help', ['Scene.scene.Token.target-one'], undefined],
+		['interpose', ['interpose'], 'interpose', ['Scene.scene.Token.target-one'], undefined],
+	] as const)(
+		'confirms and resolves the %s reaction directly from the hotbar',
+		async (actionId, reactionKeys, reactionType, targets, armorValue) => {
+			const actor = createCharacterActor();
+			const combatant = createCombatant(actor, 0);
+			const useHeroicReactions = vi.fn().mockResolvedValue(true);
+			const activeCombatant = {
+				id: 'active-combatant',
+				actorId: 'other-actor',
+				initiative: 15,
+			} as Combatant;
+			setSpeakerActor(actor);
+			setActiveCombat(
+				{
+					...combatant,
+					system: {
+						...combatant.system,
+						actions: {
+							...combatant.system.actions,
+							base: { current: 0 },
+						},
+					},
+				},
+				activeCombatant,
+			);
+			globals().game.combat = {
+				...(globals().game.combat as Combat),
+				useHeroicReactions,
+			};
+			globals().foundry.applications.api.DialogV2.confirm.mockResolvedValue(true);
+			globals().game.user.targets = new Set([
+				{
+					actor: { id: 'target-actor' },
+					document: { uuid: 'Scene.scene.Token.target-one' },
+				},
+			]);
+
+			await activateHeroicActionMacro(actionId, 'reaction');
+
+			expect(globals().foundry.applications.api.DialogV2.confirm).toHaveBeenCalledTimes(1);
+			expect(useHeroicReactions).toHaveBeenCalledWith(combatant.id, reactionKeys, {
+				force: true,
+			});
+			expect(ChatMessage.create).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: 'reaction',
+					system: expect.objectContaining({
+						reactionType,
+						targets,
+						...(armorValue === undefined ? {} : { armorValue }),
+					}),
+				}),
+			);
+		},
+	);
+
+	it('creates interpose before defend for the combined reaction macro', async () => {
+		const actor = createCharacterActor();
+		const combatant = createCombatant(actor, 2);
+		const useHeroicReactions = vi.fn().mockResolvedValue(true);
+		const activeCombatant = {
+			id: 'active-combatant',
+			actorId: 'other-actor',
+			initiative: 15,
+		} as Combatant;
+		setSpeakerActor(actor);
+		setActiveCombat(combatant, activeCombatant);
+		globals().game.combat = {
+			...(globals().game.combat as Combat),
+			useHeroicReactions,
+		};
+		globals().game.user.targets = new Set([
+			{
+				actor: { id: 'target-actor' },
+				document: { uuid: 'Scene.scene.Token.target-one' },
+			},
+		]);
+
+		await activateHeroicActionMacro('interposeAndDefend', 'reaction');
+
+		expect(useHeroicReactions).toHaveBeenCalledWith(
+			combatant.id,
+			['interpose', 'defend'],
+			undefined,
+		);
+		expect(ChatMessage.create).toHaveBeenCalledTimes(2);
+		expect(ChatMessage.create).toHaveBeenNthCalledWith(
+			1,
+			expect.objectContaining({
+				system: expect.objectContaining({
+					reactionType: 'interpose',
+				}),
+			}),
+		);
+		expect(ChatMessage.create).toHaveBeenNthCalledWith(
+			2,
+			expect.objectContaining({
+				system: expect.objectContaining({
+					reactionType: 'defend',
+				}),
+			}),
+		);
+	});
+});

--- a/src/macros/activateHeroicActionMacro.test.ts
+++ b/src/macros/activateHeroicActionMacro.test.ts
@@ -18,7 +18,7 @@ vi.mock('../documents/dialogs/ItemActivationConfigDialog.svelte.js', () => ({
 	default: itemActivationConfigDialogMock,
 }));
 
-vi.mock('../view/sheets/components/attackUtils.js', () => ({
+vi.mock('../utils/attackUtils.js', () => ({
 	getUnarmedDamageFormula: getUnarmedDamageFormulaMock,
 	hasUnarmedProficiency: hasUnarmedProficiencyMock,
 }));
@@ -229,7 +229,7 @@ describe('activateHeroicActionMacro', () => {
 		await activateHeroicActionMacro('move', 'action');
 
 		expect(combatant.update).toHaveBeenCalledWith({
-			'system.actions.base.current': -1,
+			'system.actions.base.current': 0,
 		});
 		expect(ChatMessage.create).toHaveBeenCalledWith(
 			expect.objectContaining({

--- a/src/macros/activateHeroicActionMacro.ts
+++ b/src/macros/activateHeroicActionMacro.ts
@@ -1,0 +1,221 @@
+import type { NimbleCharacter } from '../documents/actor/character.js';
+import { getActiveCombatForCurrentScene } from '../utils/combatState.js';
+import type { HeroicReactionKey } from '../utils/heroicActions.js';
+import { getMovementSpeeds } from '../utils/movementSpeeds.js';
+import { getTargetedTokens } from '../utils/targeting.js';
+
+type CombatWithHeroicReactionUse = Combat & {
+	useHeroicReactions?: (combatantId: string, reactionKeys: HeroicReactionKey[]) => Promise<boolean>;
+};
+
+/**
+ * The function called by macros created by dragging a heroic action/reaction to the macro hot bar.
+ *
+ * @param actionId - The id of the heroic action/reaction (e.g., 'attack', 'defend')
+ * @param actionType - Whether this is an 'action' or 'reaction'
+ */
+export async function activateHeroicActionMacro(
+	actionId: string,
+	actionType: 'action' | 'reaction',
+): Promise<void> {
+	const speaker = ChatMessage.getSpeaker();
+
+	let actor: Actor | undefined;
+	if (speaker.token) actor = game.actors.tokens[speaker.token as string];
+	if (!actor && speaker.actor) actor = game.actors.get(speaker.actor as string) ?? undefined;
+
+	if (!actor || actor.type !== 'character') {
+		ui.notifications.warn('Select a character token to use this action');
+		return;
+	}
+
+	// Handle move action directly without opening the sheet
+	if (actionId === 'move' && actionType === 'action') {
+		await executeMoveAction(actor as NimbleCharacter);
+		return;
+	}
+
+	// Handle defend reaction directly
+	if (actionId === 'defend' && actionType === 'reaction') {
+		await executeDefendReaction(actor as NimbleCharacter);
+		return;
+	}
+
+	// Handle interpose reaction directly
+	if (actionId === 'interpose' && actionType === 'reaction') {
+		await executeInterposeReaction(actor as NimbleCharacter);
+		return;
+	}
+
+	// Handle interpose & defend combo directly
+	if (actionId === 'interposeAndDefend' && actionType === 'reaction') {
+		await executeInterposeAndDefendReaction(actor as NimbleCharacter);
+		return;
+	}
+
+	// Open sheet and navigate to action panel
+	const sheet = actor.sheet as foundry.applications.sheets.ActorSheetV2 & {
+		$state: Record<string, unknown>;
+	};
+	await sheet.render(true);
+
+	// Set app state to navigate to the actions tab and expand correct panel
+	const appState = sheet.$state;
+	appState.activePrimaryTab = 'actions';
+	appState.heroicActionTarget = { actionId, actionType };
+}
+
+async function executeMoveAction(actor: NimbleCharacter): Promise<void> {
+	const combat = getActiveCombatForCurrentScene();
+	const combatant = combat?.combatants.find((c) => c.actorId === actor.id);
+	const inCombat = combatant?.initiative !== null;
+
+	if (!inCombat) {
+		ui.notifications.warn('You must be in combat to use the Move action');
+		return;
+	}
+
+	// Get current actions
+	// @ts-expect-error - combatant.system is not typed
+	const actions = combatant?.system?.actions?.base;
+	const actionsRemaining = actions?.current ?? 0;
+
+	if (actionsRemaining <= 0) {
+		ui.notifications.warn('No actions remaining');
+		return;
+	}
+
+	// Deduct action pip
+	await combatant!.update({ 'system.actions.base.current': actionsRemaining - 1 } as Record<
+		string,
+		unknown
+	>);
+
+	// Get movement speed
+	const movementSpeeds = getMovementSpeeds(actor);
+	const primarySpeed = movementSpeeds.find((s) => s.type === 'walk') ?? movementSpeeds[0];
+
+	// Create chat message
+	await ChatMessage.create({
+		author: game.user?.id,
+		speaker: ChatMessage.getSpeaker({ actor }),
+		type: 'moveAction',
+		system: {
+			actorName: actor.name,
+			speed: primarySpeed?.value ?? 0,
+		},
+	} as unknown as ChatMessage.CreateData);
+}
+
+async function executeDefendReaction(actor: NimbleCharacter): Promise<void> {
+	const combat = getActiveCombatForCurrentScene() as CombatWithHeroicReactionUse | null;
+	const combatant = combat?.combatants.find((c) => c.actorId === actor.id);
+	const combatantId = combatant?.id ?? combatant?._id ?? null;
+
+	if (!combat?.useHeroicReactions || !combatantId) {
+		ui.notifications.warn('You must be in combat to use the Defend reaction');
+		return;
+	}
+
+	const reactionUsed = await combat.useHeroicReactions(combatantId, ['defend']);
+	if (!reactionUsed) return;
+
+	const armorValue = actor.reactive.system.attributes.armor.value ?? 0;
+
+	await ChatMessage.create({
+		author: game.user?.id,
+		speaker: ChatMessage.getSpeaker({ actor }),
+		type: 'reaction',
+		system: {
+			actorName: actor.name,
+			actorType: actor.type,
+			image: actor.img,
+			permissions: actor.permission,
+			rollMode: 0,
+			reactionType: 'defend',
+			armorValue,
+			targets: [],
+		},
+	} as unknown as ChatMessage.CreateData);
+}
+
+async function executeInterposeReaction(actor: NimbleCharacter): Promise<void> {
+	const combat = getActiveCombatForCurrentScene() as CombatWithHeroicReactionUse | null;
+	const combatant = combat?.combatants.find((c) => c.actorId === actor.id);
+	const combatantId = combatant?.id ?? combatant?._id ?? null;
+
+	if (!combat?.useHeroicReactions || !combatantId) {
+		ui.notifications.warn('You must be in combat to use the Interpose reaction');
+		return;
+	}
+
+	const reactionUsed = await combat.useHeroicReactions(combatantId, ['interpose']);
+	if (!reactionUsed) return;
+
+	const targetUuids = getTargetedTokens(actor.id ?? '').map((t) => t.document.uuid);
+
+	await ChatMessage.create({
+		author: game.user?.id,
+		speaker: ChatMessage.getSpeaker({ actor }),
+		type: 'reaction',
+		system: {
+			actorName: actor.name,
+			actorType: actor.type,
+			image: actor.img,
+			permissions: actor.permission,
+			rollMode: 0,
+			reactionType: 'interpose',
+			targets: targetUuids,
+		},
+	} as unknown as ChatMessage.CreateData);
+}
+
+async function executeInterposeAndDefendReaction(actor: NimbleCharacter): Promise<void> {
+	const combat = getActiveCombatForCurrentScene() as CombatWithHeroicReactionUse | null;
+	const combatant = combat?.combatants.find((c) => c.actorId === actor.id);
+	const combatantId = combatant?.id ?? combatant?._id ?? null;
+
+	if (!combat?.useHeroicReactions || !combatantId) {
+		ui.notifications.warn('You must be in combat to use the Interpose & Defend reaction');
+		return;
+	}
+
+	const reactionUsed = await combat.useHeroicReactions(combatantId, ['interpose', 'defend']);
+	if (!reactionUsed) return;
+
+	const armorValue = actor.reactive.system.attributes.armor.value ?? 0;
+	const targetUuids = getTargetedTokens(actor.id ?? '').map((t) => t.document.uuid);
+
+	// Create Interpose message first
+	await ChatMessage.create({
+		author: game.user?.id,
+		speaker: ChatMessage.getSpeaker({ actor }),
+		type: 'reaction',
+		system: {
+			actorName: actor.name,
+			actorType: actor.type,
+			image: actor.img,
+			permissions: actor.permission,
+			rollMode: 0,
+			reactionType: 'interpose',
+			targets: targetUuids,
+		},
+	} as unknown as ChatMessage.CreateData);
+
+	// Then create Defend message
+	await ChatMessage.create({
+		author: game.user?.id,
+		speaker: ChatMessage.getSpeaker({ actor }),
+		type: 'reaction',
+		system: {
+			actorName: actor.name,
+			actorType: actor.type,
+			image: actor.img,
+			permissions: actor.permission,
+			rollMode: 0,
+			reactionType: 'defend',
+			armorValue,
+			targets: [],
+		},
+	} as unknown as ChatMessage.CreateData);
+}

--- a/src/macros/activateHeroicActionMacro.ts
+++ b/src/macros/activateHeroicActionMacro.ts
@@ -10,6 +10,7 @@ import {
 } from '../utils/heroicActions.js';
 import localize from '../utils/localize.js';
 import { getMovementSpeeds } from '../utils/movementSpeeds.js';
+import showReactionConfirmation from '../utils/showReactionConfirmation.js';
 import { getTargetedTokens } from '../utils/targeting.js';
 import {
 	getUnarmedDamageFormula,
@@ -125,7 +126,6 @@ async function checkReactionConfirmation(
 		return true;
 	}
 
-	const confirmReaction = 'NIMBLE.ui.heroicActions.confirmReaction';
 	const noActions =
 		usageState.blockedReason === 'noActions' ||
 		usageState.currentActions < usageState.requiredActions;
@@ -139,28 +139,12 @@ async function checkReactionConfirmation(
 	// Get the localized names of spent reactions
 	const spentReactionNames = spentReactions.map((key) => getHeroicReactionLabel(key)).join(' & ');
 
-	let message: string;
-	if (noActions && hasSpentReactions) {
-		message = localize(`${confirmReaction}.bothMessage`, { reaction: spentReactionNames });
-	} else if (noActions) {
-		message = localize(`${confirmReaction}.noActionsMessage`);
-	} else {
-		message = localize(`${confirmReaction}.spentMessage`, { reaction: spentReactionNames });
-	}
-
-	const confirmQuestion = localize(`${confirmReaction}.confirmQuestion`, {
-		reaction: reactionName,
+	return showReactionConfirmation({
+		reactionName,
+		spentReactionNames,
+		noActions,
+		hasSpentReactions,
 	});
-
-	const confirmed = await foundry.applications.api.DialogV2.confirm({
-		window: { title: localize(`${confirmReaction}.title`) },
-		content: `<p>${message}</p><p>${confirmQuestion}</p>`,
-		yes: { label: localize(`${confirmReaction}.confirm`) },
-		no: { label: localize(`${confirmReaction}.cancel`) },
-		rejectClose: false,
-	});
-
-	return confirmed === true;
 }
 
 async function executeMoveAction(actor: NimbleCharacter): Promise<void> {

--- a/src/macros/activateHeroicActionMacro.ts
+++ b/src/macros/activateHeroicActionMacro.ts
@@ -1,11 +1,27 @@
+import { DamageRoll } from '../dice/DamageRoll.js';
 import type { NimbleCharacter } from '../documents/actor/character.js';
+import ItemActivationConfigDialog from '../documents/dialogs/ItemActivationConfigDialog.svelte.js';
 import { getActiveCombatForCurrentScene } from '../utils/combatState.js';
-import type { HeroicReactionKey } from '../utils/heroicActions.js';
+import { getHeroicReactionUsageState } from '../utils/getHeroicReactionUsageState.js';
+import {
+	getHeroicReactionAvailability,
+	getHeroicReactionLabel,
+	type HeroicReactionKey,
+} from '../utils/heroicActions.js';
+import localize from '../utils/localize.js';
 import { getMovementSpeeds } from '../utils/movementSpeeds.js';
 import { getTargetedTokens } from '../utils/targeting.js';
+import {
+	getUnarmedDamageFormula,
+	hasUnarmedProficiency,
+} from '../view/sheets/components/attackUtils.js';
 
 type CombatWithHeroicReactionUse = Combat & {
-	useHeroicReactions?: (combatantId: string, reactionKeys: HeroicReactionKey[]) => Promise<boolean>;
+	useHeroicReactions?: (
+		combatantId: string,
+		reactionKeys: HeroicReactionKey[],
+		options?: { force?: boolean },
+	) => Promise<boolean>;
 };
 
 /**
@@ -35,6 +51,12 @@ export async function activateHeroicActionMacro(
 		return;
 	}
 
+	// Handle unarmed strike directly
+	if (actionId === 'unarmedStrike' && actionType === 'action') {
+		await executeUnarmedStrike(actor as NimbleCharacter);
+		return;
+	}
+
 	// Handle defend reaction directly
 	if (actionId === 'defend' && actionType === 'reaction') {
 		await executeDefendReaction(actor as NimbleCharacter);
@@ -53,6 +75,18 @@ export async function activateHeroicActionMacro(
 		return;
 	}
 
+	// Handle help reaction directly
+	if (actionId === 'help' && actionType === 'reaction') {
+		await executeHelpReaction(actor as NimbleCharacter);
+		return;
+	}
+
+	// Handle opportunity attack reaction directly
+	if (actionId === 'opportunity' && actionType === 'reaction') {
+		await executeOpportunityAttackReaction(actor as NimbleCharacter);
+		return;
+	}
+
 	// Open sheet and navigate to action panel
 	const sheet = actor.sheet as foundry.applications.sheets.ActorSheetV2 & {
 		$state: Record<string, unknown>;
@@ -63,6 +97,70 @@ export async function activateHeroicActionMacro(
 	const appState = sheet.$state;
 	appState.activePrimaryTab = 'actions';
 	appState.heroicActionTarget = { actionId, actionType };
+}
+
+/**
+ * Checks if a reaction requires confirmation due to missing actions or being spent.
+ * If confirmation is needed, shows a dialog and returns whether the user confirmed.
+ * Returns true if the reaction can proceed (either no issues or user confirmed).
+ */
+async function checkReactionConfirmation(
+	actor: NimbleCharacter,
+	reactionKeys: HeroicReactionKey[],
+	reactionName: string,
+): Promise<boolean> {
+	const combat = getActiveCombatForCurrentScene();
+	const combatant = combat?.combatants.find((c) => c.actorId === actor.id);
+
+	if (!combat || !combatant) return true;
+
+	const usageState = getHeroicReactionUsageState({
+		combat,
+		combatant,
+		reactionKeys,
+	});
+
+	// Only show confirmation for 'noActions' or 'spent' blocked reasons
+	if (usageState.blockedReason !== 'noActions' && usageState.blockedReason !== 'spent') {
+		return true;
+	}
+
+	const confirmReaction = 'NIMBLE.ui.heroicActions.confirmReaction';
+	const noActions =
+		usageState.blockedReason === 'noActions' ||
+		usageState.currentActions < usageState.requiredActions;
+
+	// Check which specific reactions are spent
+	const spentReactions = reactionKeys.filter(
+		(key) => !getHeroicReactionAvailability(combatant, key),
+	);
+	const hasSpentReactions = spentReactions.length > 0;
+
+	// Get the localized names of spent reactions
+	const spentReactionNames = spentReactions.map((key) => getHeroicReactionLabel(key)).join(' & ');
+
+	let message: string;
+	if (noActions && hasSpentReactions) {
+		message = localize(`${confirmReaction}.bothMessage`, { reaction: spentReactionNames });
+	} else if (noActions) {
+		message = localize(`${confirmReaction}.noActionsMessage`);
+	} else {
+		message = localize(`${confirmReaction}.spentMessage`, { reaction: spentReactionNames });
+	}
+
+	const confirmQuestion = localize(`${confirmReaction}.confirmQuestion`, {
+		reaction: reactionName,
+	});
+
+	const confirmed = await foundry.applications.api.DialogV2.confirm({
+		window: { title: localize(`${confirmReaction}.title`) },
+		content: `<p>${message}</p><p>${confirmQuestion}</p>`,
+		yes: { label: localize(`${confirmReaction}.confirm`) },
+		no: { label: localize(`${confirmReaction}.cancel`) },
+		rejectClose: false,
+	});
+
+	return confirmed === true;
 }
 
 async function executeMoveAction(actor: NimbleCharacter): Promise<void> {
@@ -81,15 +179,23 @@ async function executeMoveAction(actor: NimbleCharacter): Promise<void> {
 	const actionsRemaining = actions?.current ?? 0;
 
 	if (actionsRemaining <= 0) {
-		ui.notifications.warn('No actions remaining');
-		return;
+		// Show confirmation dialog
+		const confirmMove = 'NIMBLE.ui.heroicActions.confirmMove';
+		const confirmed = await foundry.applications.api.DialogV2.confirm({
+			window: { title: localize(`${confirmMove}.title`) },
+			content: `<p>${localize(`${confirmMove}.noActionsMessage`)}</p><p>${localize(`${confirmMove}.confirmQuestion`)}</p>`,
+			yes: { label: localize(`${confirmMove}.confirm`) },
+			no: { label: localize(`${confirmMove}.cancel`) },
+			rejectClose: false,
+		});
+
+		if (confirmed !== true) return;
 	}
 
-	// Deduct action pip
-	await combatant!.update({ 'system.actions.base.current': actionsRemaining - 1 } as Record<
-		string,
-		unknown
-	>);
+	// Deduct action pip (will go negative if forced)
+	await combatant!.update({
+		'system.actions.base.current': actionsRemaining - 1,
+	} as Record<string, unknown>);
 
 	// Get movement speed
 	const movementSpeeds = getMovementSpeeds(actor);
@@ -117,7 +223,11 @@ async function executeDefendReaction(actor: NimbleCharacter): Promise<void> {
 		return;
 	}
 
-	const reactionUsed = await combat.useHeroicReactions(combatantId, ['defend']);
+	const reactionName = localize('NIMBLE.ui.heroicActions.reactions.defend.label');
+	const confirmed = await checkReactionConfirmation(actor, ['defend'], reactionName);
+	if (!confirmed) return;
+
+	const reactionUsed = await combat.useHeroicReactions(combatantId, ['defend'], { force: true });
 	if (!reactionUsed) return;
 
 	const armorValue = actor.reactive.system.attributes.armor.value ?? 0;
@@ -149,7 +259,11 @@ async function executeInterposeReaction(actor: NimbleCharacter): Promise<void> {
 		return;
 	}
 
-	const reactionUsed = await combat.useHeroicReactions(combatantId, ['interpose']);
+	const reactionName = localize('NIMBLE.ui.heroicActions.reactions.interpose.label');
+	const confirmed = await checkReactionConfirmation(actor, ['interpose'], reactionName);
+	if (!confirmed) return;
+
+	const reactionUsed = await combat.useHeroicReactions(combatantId, ['interpose'], { force: true });
 	if (!reactionUsed) return;
 
 	const targetUuids = getTargetedTokens(actor.id ?? '').map((t) => t.document.uuid);
@@ -180,7 +294,13 @@ async function executeInterposeAndDefendReaction(actor: NimbleCharacter): Promis
 		return;
 	}
 
-	const reactionUsed = await combat.useHeroicReactions(combatantId, ['interpose', 'defend']);
+	const reactionName = localize('NIMBLE.ui.heroicActions.reactions.interposeAndDefend.confirm');
+	const confirmed = await checkReactionConfirmation(actor, ['interpose', 'defend'], reactionName);
+	if (!confirmed) return;
+
+	const reactionUsed = await combat.useHeroicReactions(combatantId, ['interpose', 'defend'], {
+		force: true,
+	});
 	if (!reactionUsed) return;
 
 	const armorValue = actor.reactive.system.attributes.armor.value ?? 0;
@@ -218,4 +338,197 @@ async function executeInterposeAndDefendReaction(actor: NimbleCharacter): Promis
 			targets: [],
 		},
 	} as unknown as ChatMessage.CreateData);
+}
+
+async function executeHelpReaction(actor: NimbleCharacter): Promise<void> {
+	const combat = getActiveCombatForCurrentScene() as CombatWithHeroicReactionUse | null;
+	const combatant = combat?.combatants.find((c) => c.actorId === actor.id);
+	const combatantId = combatant?.id ?? combatant?._id ?? null;
+
+	if (!combat?.useHeroicReactions || !combatantId) {
+		ui.notifications.warn('You must be in combat to use the Help reaction');
+		return;
+	}
+
+	const reactionName = localize('NIMBLE.ui.heroicActions.reactions.help.label');
+	const confirmed = await checkReactionConfirmation(actor, ['help'], reactionName);
+	if (!confirmed) return;
+
+	const reactionUsed = await combat.useHeroicReactions(combatantId, ['help'], { force: true });
+	if (!reactionUsed) return;
+
+	const targetUuids = getTargetedTokens(actor.id ?? '').map((t) => t.document.uuid);
+
+	await ChatMessage.create({
+		author: game.user?.id,
+		speaker: ChatMessage.getSpeaker({ actor }),
+		type: 'reaction',
+		system: {
+			actorName: actor.name,
+			actorType: actor.type,
+			image: actor.img,
+			permissions: actor.permission,
+			rollMode: 0,
+			reactionType: 'help',
+			targets: targetUuids,
+		},
+	} as unknown as ChatMessage.CreateData);
+}
+
+async function executeOpportunityAttackReaction(actor: NimbleCharacter): Promise<void> {
+	const combat = getActiveCombatForCurrentScene() as CombatWithHeroicReactionUse | null;
+	const combatant = combat?.combatants.find((c) => c.actorId === actor.id);
+	const combatantId = combatant?.id ?? combatant?._id ?? null;
+
+	if (!combat?.useHeroicReactions || !combatantId) {
+		ui.notifications.warn('You must be in combat to use the Opportunity Attack reaction');
+		return;
+	}
+
+	const reactionName = localize('NIMBLE.ui.heroicActions.reactions.opportunity.label');
+	const confirmed = await checkReactionConfirmation(actor, ['opportunityAttack'], reactionName);
+	if (!confirmed) return;
+
+	// For opportunity attack, we open the sheet to let the user choose a weapon
+	// since this requires more user interaction than the simple reactions
+	const sheet = actor.sheet as foundry.applications.sheets.ActorSheetV2 & {
+		$state: Record<string, unknown>;
+	};
+	await sheet.render(true);
+
+	const appState = sheet.$state;
+	appState.activePrimaryTab = 'actions';
+	appState.heroicActionTarget = { actionId: 'opportunity', actionType: 'reaction' };
+}
+
+async function executeUnarmedStrike(actor: NimbleCharacter): Promise<void> {
+	const combat = getActiveCombatForCurrentScene();
+	const combatant = combat?.combatants.find((c) => c.actorId === actor.id);
+	const inCombat = combatant?.initiative !== null;
+
+	// Get current actions if in combat
+	// @ts-expect-error - combatant.system is not typed
+	const actions = combatant?.system?.actions?.base;
+	const actionsRemaining = actions?.current ?? 0;
+
+	let rollFormula = getUnarmedDamageFormula(actor);
+	const canCrit = hasUnarmedProficiency(actor);
+
+	// Apply melee damage bonus (e.g., Reverberating Strikes)
+	const actorSystem = actor.system as {
+		meleeDamageBonus?: { value: number; damageType: string };
+	};
+	const meleeDamageBonus = actorSystem.meleeDamageBonus?.value ?? 0;
+	if (meleeDamageBonus > 0) {
+		rollFormula = `${rollFormula} + ${meleeDamageBonus}`;
+	}
+
+	const unarmedItem = {
+		name: localize('NIMBLE.ui.heroicActions.unarmedStrike'),
+		img: 'icons/skills/melee/unarmed-punch-fist.webp',
+		system: {
+			activation: {
+				effects: [
+					{
+						type: 'damage',
+						formula: rollFormula,
+						damageType: 'bludgeoning',
+						canCrit,
+						canMiss: true,
+					},
+				],
+			},
+		},
+	};
+
+	const dialog = new ItemActivationConfigDialog(
+		actor,
+		unarmedItem,
+		localize('NIMBLE.ui.heroicActions.unarmedStrike'),
+		{ rollMode: 0 },
+	);
+	await dialog.render(true);
+	const result = await dialog.promise;
+
+	if (!result) return;
+
+	const roll = new DamageRoll(rollFormula, actor.getRollData(), {
+		canCrit,
+		canMiss: true,
+		rollMode: result.rollMode ?? 0,
+		primaryDieValue: result.primaryDieValue ?? 0,
+		primaryDieModifier: Number(result.primaryDieModifier) || 0,
+		damageType: 'bludgeoning',
+		primaryDieAsDamage: true,
+	});
+
+	await roll.evaluate();
+
+	const rollData = roll.toJSON();
+
+	const evaluatedEffects = [
+		{
+			id: 'unarmed-damage',
+			type: 'damage',
+			formula: rollFormula,
+			damageType: 'bludgeoning',
+			canCrit,
+			canMiss: true,
+			roll: rollData,
+			parentNode: null,
+			parentContext: null,
+			on: {
+				hit: [
+					{
+						id: 'unarmed-damage-hit',
+						type: 'damageOutcome',
+						parentNode: 'unarmed-damage',
+						parentContext: 'hit',
+					},
+				],
+			},
+		},
+	];
+
+	const chatData = {
+		author: game.user?.id,
+		flavor: `${actor.name}: ${localize('NIMBLE.ui.heroicActions.unarmedStrike')}`,
+		speaker: ChatMessage.getSpeaker({ actor }),
+		style: CONST.CHAT_MESSAGE_STYLES.OTHER,
+		sound: CONFIG.sounds.dice,
+		rolls: [roll],
+		system: {
+			actorName: actor.name,
+			actorType: actor.type,
+			image: unarmedItem.img,
+			permissions: CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER,
+			rollMode: result.rollMode ?? 0,
+			name: localize('NIMBLE.ui.heroicActions.unarmedStrike'),
+			description: '',
+			featureType: 'feature',
+			class: '',
+			attackType: 'reach',
+			attackDistance: 1,
+			isCritical: roll.isCritical,
+			isMiss: roll.isMiss,
+			activation: {
+				effects: evaluatedEffects,
+				cost: { type: 'action', quantity: 1 },
+				duration: { type: 'none', quantity: 1 },
+				targets: { count: 1 },
+			},
+			targets: Array.from(game.user?.targets?.map((token) => token.document.uuid) ?? []),
+		},
+		type: 'feature',
+	};
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	await ChatMessage.create(chatData as any);
+
+	// Deduct action pip if in combat
+	if (inCombat && combatant) {
+		await combatant.update({
+			'system.actions.base.current': actionsRemaining - 1,
+		} as Record<string, unknown>);
+	}
 }

--- a/src/macros/activateHeroicActionMacro.ts
+++ b/src/macros/activateHeroicActionMacro.ts
@@ -25,6 +25,11 @@ type CombatWithHeroicReactionUse = Combat & {
 	) => Promise<boolean>;
 };
 
+type ReactionConfirmationResult = {
+	confirmed: boolean;
+	force: boolean;
+};
+
 /**
  * The function called by macros created by dragging a heroic action/reaction to the macro hot bar.
  *
@@ -109,11 +114,11 @@ async function checkReactionConfirmation(
 	actor: NimbleCharacter,
 	reactionKeys: HeroicReactionKey[],
 	reactionName: string,
-): Promise<boolean> {
+): Promise<ReactionConfirmationResult> {
 	const combat = getActiveCombatForCurrentScene();
 	const combatant = combat?.combatants.find((c) => c.actorId === actor.id);
 
-	if (!combat || !combatant) return true;
+	if (!combat || !combatant) return { confirmed: true, force: false };
 
 	const usageState = getHeroicReactionUsageState({
 		combat,
@@ -123,7 +128,7 @@ async function checkReactionConfirmation(
 
 	// Only show confirmation for 'noActions' or 'spent' blocked reasons
 	if (usageState.blockedReason !== 'noActions' && usageState.blockedReason !== 'spent') {
-		return true;
+		return { confirmed: true, force: false };
 	}
 
 	const noActions =
@@ -139,12 +144,15 @@ async function checkReactionConfirmation(
 	// Get the localized names of spent reactions
 	const spentReactionNames = spentReactions.map((key) => getHeroicReactionLabel(key)).join(' & ');
 
-	return showReactionConfirmation({
-		reactionName,
-		spentReactionNames,
-		noActions,
-		hasSpentReactions,
-	});
+	return {
+		confirmed: await showReactionConfirmation({
+			reactionName,
+			spentReactionNames,
+			noActions,
+			hasSpentReactions,
+		}),
+		force: true,
+	};
 }
 
 async function executeMoveAction(actor: NimbleCharacter): Promise<void> {
@@ -213,10 +221,14 @@ async function executeDefendReaction(actor: NimbleCharacter): Promise<void> {
 		);
 		return;
 	}
-	const confirmed = await checkReactionConfirmation(actor, ['defend'], reactionName);
+	const { confirmed, force } = await checkReactionConfirmation(actor, ['defend'], reactionName);
 	if (!confirmed) return;
 
-	const reactionUsed = await combat.useHeroicReactions(combatantId, ['defend'], { force: true });
+	const reactionUsed = await combat.useHeroicReactions(
+		combatantId,
+		['defend'],
+		force ? { force: true } : undefined,
+	);
 	if (!reactionUsed) return;
 
 	const armorValue = actor.reactive.system.attributes.armor.value ?? 0;
@@ -251,10 +263,14 @@ async function executeInterposeReaction(actor: NimbleCharacter): Promise<void> {
 		);
 		return;
 	}
-	const confirmed = await checkReactionConfirmation(actor, ['interpose'], reactionName);
+	const { confirmed, force } = await checkReactionConfirmation(actor, ['interpose'], reactionName);
 	if (!confirmed) return;
 
-	const reactionUsed = await combat.useHeroicReactions(combatantId, ['interpose'], { force: true });
+	const reactionUsed = await combat.useHeroicReactions(
+		combatantId,
+		['interpose'],
+		force ? { force: true } : undefined,
+	);
 	if (!reactionUsed) return;
 
 	const targetUuids = getTargetedTokens(actor.id ?? '').map((t) => t.document.uuid);
@@ -288,12 +304,18 @@ async function executeInterposeAndDefendReaction(actor: NimbleCharacter): Promis
 		);
 		return;
 	}
-	const confirmed = await checkReactionConfirmation(actor, ['interpose', 'defend'], reactionName);
+	const { confirmed, force } = await checkReactionConfirmation(
+		actor,
+		['interpose', 'defend'],
+		reactionName,
+	);
 	if (!confirmed) return;
 
-	const reactionUsed = await combat.useHeroicReactions(combatantId, ['interpose', 'defend'], {
-		force: true,
-	});
+	const reactionUsed = await combat.useHeroicReactions(
+		combatantId,
+		['interpose', 'defend'],
+		force ? { force: true } : undefined,
+	);
 	if (!reactionUsed) return;
 
 	const armorValue = actor.reactive.system.attributes.armor.value ?? 0;
@@ -346,10 +368,14 @@ async function executeHelpReaction(actor: NimbleCharacter): Promise<void> {
 		);
 		return;
 	}
-	const confirmed = await checkReactionConfirmation(actor, ['help'], reactionName);
+	const { confirmed, force } = await checkReactionConfirmation(actor, ['help'], reactionName);
 	if (!confirmed) return;
 
-	const reactionUsed = await combat.useHeroicReactions(combatantId, ['help'], { force: true });
+	const reactionUsed = await combat.useHeroicReactions(
+		combatantId,
+		['help'],
+		force ? { force: true } : undefined,
+	);
 	if (!reactionUsed) return;
 
 	const targetUuids = getTargetedTokens(actor.id ?? '').map((t) => t.document.uuid);
@@ -383,7 +409,11 @@ async function executeOpportunityAttackReaction(actor: NimbleCharacter): Promise
 		);
 		return;
 	}
-	const confirmed = await checkReactionConfirmation(actor, ['opportunityAttack'], reactionName);
+	const { confirmed, force } = await checkReactionConfirmation(
+		actor,
+		['opportunityAttack'],
+		reactionName,
+	);
 	if (!confirmed) return;
 
 	// For opportunity attack, we open the sheet to let the user choose a weapon
@@ -395,7 +425,7 @@ async function executeOpportunityAttackReaction(actor: NimbleCharacter): Promise
 
 	const appState = sheet.$state;
 	appState.activePrimaryTab = 'actions';
-	appState.heroicActionTarget = { actionId: 'opportunity', actionType: 'reaction' };
+	appState.heroicActionTarget = { actionId: 'opportunity', actionType: 'reaction', force };
 }
 
 async function executeUnarmedStrike(actor: NimbleCharacter): Promise<void> {

--- a/src/macros/activateHeroicActionMacro.ts
+++ b/src/macros/activateHeroicActionMacro.ts
@@ -41,7 +41,7 @@ export async function activateHeroicActionMacro(
 	if (!actor && speaker.actor) actor = game.actors.get(speaker.actor as string) ?? undefined;
 
 	if (!actor || actor.type !== 'character') {
-		ui.notifications.warn('Select a character token to use this action');
+		ui.notifications.warn(localize('NIMBLE.ui.heroicActions.macroWarnings.selectCharacterToken'));
 		return;
 	}
 
@@ -169,7 +169,10 @@ async function executeMoveAction(actor: NimbleCharacter): Promise<void> {
 	const inCombat = combatant?.initiative !== null;
 
 	if (!inCombat) {
-		ui.notifications.warn('You must be in combat to use the Move action');
+		const actionName = localize('NIMBLE.ui.heroicActions.actions.move.label');
+		ui.notifications.warn(
+			localize('NIMBLE.ui.heroicActions.macroWarnings.mustBeInCombat', { action: actionName }),
+		);
 		return;
 	}
 
@@ -218,12 +221,14 @@ async function executeDefendReaction(actor: NimbleCharacter): Promise<void> {
 	const combatant = combat?.combatants.find((c) => c.actorId === actor.id);
 	const combatantId = combatant?.id ?? combatant?._id ?? null;
 
+	const reactionName = localize('NIMBLE.ui.heroicActions.reactions.defend.label');
+
 	if (!combat?.useHeroicReactions || !combatantId) {
-		ui.notifications.warn('You must be in combat to use the Defend reaction');
+		ui.notifications.warn(
+			localize('NIMBLE.ui.heroicActions.macroWarnings.mustBeInCombat', { action: reactionName }),
+		);
 		return;
 	}
-
-	const reactionName = localize('NIMBLE.ui.heroicActions.reactions.defend.label');
 	const confirmed = await checkReactionConfirmation(actor, ['defend'], reactionName);
 	if (!confirmed) return;
 
@@ -254,12 +259,14 @@ async function executeInterposeReaction(actor: NimbleCharacter): Promise<void> {
 	const combatant = combat?.combatants.find((c) => c.actorId === actor.id);
 	const combatantId = combatant?.id ?? combatant?._id ?? null;
 
+	const reactionName = localize('NIMBLE.ui.heroicActions.reactions.interpose.label');
+
 	if (!combat?.useHeroicReactions || !combatantId) {
-		ui.notifications.warn('You must be in combat to use the Interpose reaction');
+		ui.notifications.warn(
+			localize('NIMBLE.ui.heroicActions.macroWarnings.mustBeInCombat', { action: reactionName }),
+		);
 		return;
 	}
-
-	const reactionName = localize('NIMBLE.ui.heroicActions.reactions.interpose.label');
 	const confirmed = await checkReactionConfirmation(actor, ['interpose'], reactionName);
 	if (!confirmed) return;
 
@@ -289,12 +296,14 @@ async function executeInterposeAndDefendReaction(actor: NimbleCharacter): Promis
 	const combatant = combat?.combatants.find((c) => c.actorId === actor.id);
 	const combatantId = combatant?.id ?? combatant?._id ?? null;
 
+	const reactionName = localize('NIMBLE.ui.heroicActions.reactions.interposeAndDefend.confirm');
+
 	if (!combat?.useHeroicReactions || !combatantId) {
-		ui.notifications.warn('You must be in combat to use the Interpose & Defend reaction');
+		ui.notifications.warn(
+			localize('NIMBLE.ui.heroicActions.macroWarnings.mustBeInCombat', { action: reactionName }),
+		);
 		return;
 	}
-
-	const reactionName = localize('NIMBLE.ui.heroicActions.reactions.interposeAndDefend.confirm');
 	const confirmed = await checkReactionConfirmation(actor, ['interpose', 'defend'], reactionName);
 	if (!confirmed) return;
 
@@ -345,12 +354,14 @@ async function executeHelpReaction(actor: NimbleCharacter): Promise<void> {
 	const combatant = combat?.combatants.find((c) => c.actorId === actor.id);
 	const combatantId = combatant?.id ?? combatant?._id ?? null;
 
+	const reactionName = localize('NIMBLE.ui.heroicActions.reactions.help.label');
+
 	if (!combat?.useHeroicReactions || !combatantId) {
-		ui.notifications.warn('You must be in combat to use the Help reaction');
+		ui.notifications.warn(
+			localize('NIMBLE.ui.heroicActions.macroWarnings.mustBeInCombat', { action: reactionName }),
+		);
 		return;
 	}
-
-	const reactionName = localize('NIMBLE.ui.heroicActions.reactions.help.label');
 	const confirmed = await checkReactionConfirmation(actor, ['help'], reactionName);
 	if (!confirmed) return;
 
@@ -380,12 +391,14 @@ async function executeOpportunityAttackReaction(actor: NimbleCharacter): Promise
 	const combatant = combat?.combatants.find((c) => c.actorId === actor.id);
 	const combatantId = combatant?.id ?? combatant?._id ?? null;
 
+	const reactionName = localize('NIMBLE.ui.heroicActions.reactions.opportunity.label');
+
 	if (!combat?.useHeroicReactions || !combatantId) {
-		ui.notifications.warn('You must be in combat to use the Opportunity Attack reaction');
+		ui.notifications.warn(
+			localize('NIMBLE.ui.heroicActions.macroWarnings.mustBeInCombat', { action: reactionName }),
+		);
 		return;
 	}
-
-	const reactionName = localize('NIMBLE.ui.heroicActions.reactions.opportunity.label');
 	const confirmed = await checkReactionConfirmation(actor, ['opportunityAttack'], reactionName);
 	if (!confirmed) return;
 

--- a/src/macros/activateHeroicActionMacro.ts
+++ b/src/macros/activateHeroicActionMacro.ts
@@ -60,27 +60,10 @@ export async function activateHeroicActionMacro(
 		return;
 	}
 
-	// Handle defend reaction directly
-	if (actionId === 'defend' && actionType === 'reaction') {
-		await executeDefendReaction(actor as NimbleCharacter);
-		return;
-	}
-
-	// Handle interpose reaction directly
-	if (actionId === 'interpose' && actionType === 'reaction') {
-		await executeInterposeReaction(actor as NimbleCharacter);
-		return;
-	}
-
-	// Handle interpose & defend combo directly
-	if (actionId === 'interposeAndDefend' && actionType === 'reaction') {
-		await executeInterposeAndDefendReaction(actor as NimbleCharacter);
-		return;
-	}
-
-	// Handle help reaction directly
-	if (actionId === 'help' && actionType === 'reaction') {
-		await executeHelpReaction(actor as NimbleCharacter);
+	// Handle chat-based reactions (defend, interpose, interposeAndDefend, help)
+	const reactionConfig = actionType === 'reaction' ? REACTION_CONFIGS[actionId] : undefined;
+	if (reactionConfig) {
+		await executeChatReaction(actor as NimbleCharacter, reactionConfig);
 		return;
 	}
 
@@ -263,55 +246,86 @@ async function executeMoveAction(actor: NimbleCharacter): Promise<void> {
 	} as unknown as ChatMessage.CreateData);
 }
 
-async function executeDefendReaction(actor: NimbleCharacter): Promise<void> {
-	const reactionName = localize('NIMBLE.ui.heroicActions.reactions.defend.label');
-	if (!(await resolveAndUseReaction(actor, ['defend'], reactionName))) return;
-
-	await ChatMessage.create(
-		buildReactionChatData(actor, 'defend', {
-			armorValue: actor.reactive.system.attributes.armor.value ?? 0,
-			targets: [],
-		}) as ChatMessage.CreateData,
-	);
+interface ReactionChatConfig {
+	reactionKeys: HeroicReactionKey[];
+	localizationKey: string;
+	messages: Array<{
+		type: string;
+		buildSystem: (actor: NimbleCharacter, targetUuids: string[]) => Record<string, unknown>;
+	}>;
 }
 
-async function executeInterposeReaction(actor: NimbleCharacter): Promise<void> {
-	const reactionName = localize('NIMBLE.ui.heroicActions.reactions.interpose.label');
-	if (!(await resolveAndUseReaction(actor, ['interpose'], reactionName))) return;
+const REACTION_CONFIGS: Record<string, ReactionChatConfig> = {
+	defend: {
+		reactionKeys: ['defend'],
+		localizationKey: 'NIMBLE.ui.heroicActions.reactions.defend.label',
+		messages: [
+			{
+				type: 'defend',
+				buildSystem: (actor) => ({
+					armorValue: actor.reactive.system.attributes.armor.value ?? 0,
+					targets: [],
+				}),
+			},
+		],
+	},
+	interpose: {
+		reactionKeys: ['interpose'],
+		localizationKey: 'NIMBLE.ui.heroicActions.reactions.interpose.label',
+		messages: [
+			{
+				type: 'interpose',
+				buildSystem: (_, targetUuids) => ({ targets: targetUuids }),
+			},
+		],
+	},
+	interposeAndDefend: {
+		reactionKeys: ['interpose', 'defend'],
+		localizationKey: 'NIMBLE.ui.heroicActions.reactions.interposeAndDefend.confirm',
+		messages: [
+			{
+				type: 'interpose',
+				buildSystem: (_, targetUuids) => ({ targets: targetUuids }),
+			},
+			{
+				type: 'defend',
+				buildSystem: (actor) => ({
+					armorValue: actor.reactive.system.attributes.armor.value ?? 0,
+					targets: [],
+				}),
+			},
+		],
+	},
+	help: {
+		reactionKeys: ['help'],
+		localizationKey: 'NIMBLE.ui.heroicActions.reactions.help.label',
+		messages: [
+			{
+				type: 'help',
+				buildSystem: (_, targetUuids) => ({ targets: targetUuids }),
+			},
+		],
+	},
+};
+
+async function executeChatReaction(
+	actor: NimbleCharacter,
+	config: ReactionChatConfig,
+): Promise<void> {
+	const reactionName = localize(config.localizationKey);
+	if (!(await resolveAndUseReaction(actor, config.reactionKeys, reactionName))) return;
 
 	const targetUuids = getTargetedTokens(actor.id ?? '').map((t) => t.document.uuid);
-	await ChatMessage.create(
-		buildReactionChatData(actor, 'interpose', { targets: targetUuids }) as ChatMessage.CreateData,
-	);
-}
 
-async function executeInterposeAndDefendReaction(actor: NimbleCharacter): Promise<void> {
-	const reactionName = localize('NIMBLE.ui.heroicActions.reactions.interposeAndDefend.confirm');
-	if (!(await resolveAndUseReaction(actor, ['interpose', 'defend'], reactionName))) return;
-
-	const targetUuids = getTargetedTokens(actor.id ?? '').map((t) => t.document.uuid);
-
-	await ChatMessage.create(
-		buildReactionChatData(actor, 'interpose', {
-			targets: targetUuids,
-		}) as ChatMessage.CreateData,
-	);
-	await ChatMessage.create(
-		buildReactionChatData(actor, 'defend', {
-			armorValue: actor.reactive.system.attributes.armor.value ?? 0,
-			targets: [],
-		}) as ChatMessage.CreateData,
-	);
-}
-
-async function executeHelpReaction(actor: NimbleCharacter): Promise<void> {
-	const reactionName = localize('NIMBLE.ui.heroicActions.reactions.help.label');
-	if (!(await resolveAndUseReaction(actor, ['help'], reactionName))) return;
-
-	const targetUuids = getTargetedTokens(actor.id ?? '').map((t) => t.document.uuid);
-	await ChatMessage.create(
-		buildReactionChatData(actor, 'help', { targets: targetUuids }) as ChatMessage.CreateData,
-	);
+	for (const msg of config.messages) {
+		await ChatMessage.create(
+			buildReactionChatData(
+				actor,
+				msg.type,
+				msg.buildSystem(actor, targetUuids),
+			) as ChatMessage.CreateData,
+		);
+	}
 }
 
 async function executeOpportunityAttackReaction(actor: NimbleCharacter): Promise<void> {

--- a/src/macros/activateHeroicActionMacro.ts
+++ b/src/macros/activateHeroicActionMacro.ts
@@ -1,6 +1,7 @@
 import { DamageRoll } from '../dice/DamageRoll.js';
 import type { NimbleCharacter } from '../documents/actor/character.js';
 import ItemActivationConfigDialog from '../documents/dialogs/ItemActivationConfigDialog.svelte.js';
+import { getUnarmedDamageFormula, hasUnarmedProficiency } from '../utils/attackUtils.js';
 import { getActiveCombatForCurrentScene } from '../utils/combatState.js';
 import { getHeroicReactionUsageState } from '../utils/getHeroicReactionUsageState.js';
 import {
@@ -12,10 +13,6 @@ import localize from '../utils/localize.js';
 import { getMovementSpeeds } from '../utils/movementSpeeds.js';
 import showReactionConfirmation from '../utils/showReactionConfirmation.js';
 import { getTargetedTokens } from '../utils/targeting.js';
-import {
-	getUnarmedDamageFormula,
-	hasUnarmedProficiency,
-} from '../view/sheets/components/attackUtils.js';
 
 type CombatWithHeroicReactionUse = Combat & {
 	useHeroicReactions?: (
@@ -155,10 +152,68 @@ async function checkReactionConfirmation(
 	};
 }
 
+/**
+ * Resolves combat state, confirms the reaction with the user if needed,
+ * and uses the heroic reaction. Returns { force } on success, or null if
+ * the reaction should not proceed.
+ */
+async function resolveAndUseReaction(
+	actor: NimbleCharacter,
+	reactionKeys: HeroicReactionKey[],
+	reactionName: string,
+): Promise<{ force: boolean } | null> {
+	const combat = getActiveCombatForCurrentScene() as CombatWithHeroicReactionUse | null;
+	const combatant = combat?.combatants.find((c) => c.actorId === actor.id);
+	const combatantId = combatant?.id ?? combatant?._id ?? null;
+
+	if (!combat?.useHeroicReactions || !combatantId) {
+		ui.notifications.warn(
+			localize('NIMBLE.ui.heroicActions.macroWarnings.mustBeInCombat', { action: reactionName }),
+		);
+		return null;
+	}
+
+	const { confirmed, force } = await checkReactionConfirmation(actor, reactionKeys, reactionName);
+	if (!confirmed) return null;
+
+	const reactionUsed = await combat.useHeroicReactions(
+		combatantId,
+		reactionKeys,
+		force ? { force: true } : undefined,
+	);
+	if (!reactionUsed) return null;
+
+	return { force };
+}
+
+/**
+ * Builds the common chat message data for a reaction.
+ */
+function buildReactionChatData(
+	actor: NimbleCharacter,
+	reactionType: string,
+	system: Record<string, unknown>,
+): unknown {
+	return {
+		author: game.user?.id,
+		speaker: ChatMessage.getSpeaker({ actor }),
+		type: 'reaction',
+		system: {
+			actorName: actor.name,
+			actorType: actor.type,
+			image: actor.img,
+			permissions: actor.permission,
+			rollMode: 0,
+			reactionType,
+			...system,
+		},
+	};
+}
+
 async function executeMoveAction(actor: NimbleCharacter): Promise<void> {
 	const combat = getActiveCombatForCurrentScene();
 	const combatant = combat?.combatants.find((c) => c.actorId === actor.id);
-	const inCombat = combatant?.initiative !== null;
+	const inCombat = !!combatant && combatant.initiative !== null;
 
 	if (!inCombat) {
 		const actionName = localize('NIMBLE.ui.heroicActions.actions.move.label');
@@ -170,7 +225,7 @@ async function executeMoveAction(actor: NimbleCharacter): Promise<void> {
 
 	// Get current actions
 	// @ts-expect-error - combatant.system is not typed
-	const actions = combatant?.system?.actions?.base;
+	const actions = combatant.system?.actions?.base;
 	const actionsRemaining = actions?.current ?? 0;
 
 	if (actionsRemaining <= 0) {
@@ -187,9 +242,9 @@ async function executeMoveAction(actor: NimbleCharacter): Promise<void> {
 		if (confirmed !== true) return;
 	}
 
-	// Deduct action pip (will go negative if forced)
-	await combatant!.update({
-		'system.actions.base.current': actionsRemaining - 1,
+	// Deduct action pip (clamp at 0)
+	await combatant.update({
+		'system.actions.base.current': Math.max(0, actionsRemaining - 1),
 	} as Record<string, unknown>);
 
 	// Get movement speed
@@ -209,212 +264,60 @@ async function executeMoveAction(actor: NimbleCharacter): Promise<void> {
 }
 
 async function executeDefendReaction(actor: NimbleCharacter): Promise<void> {
-	const combat = getActiveCombatForCurrentScene() as CombatWithHeroicReactionUse | null;
-	const combatant = combat?.combatants.find((c) => c.actorId === actor.id);
-	const combatantId = combatant?.id ?? combatant?._id ?? null;
-
 	const reactionName = localize('NIMBLE.ui.heroicActions.reactions.defend.label');
+	if (!(await resolveAndUseReaction(actor, ['defend'], reactionName))) return;
 
-	if (!combat?.useHeroicReactions || !combatantId) {
-		ui.notifications.warn(
-			localize('NIMBLE.ui.heroicActions.macroWarnings.mustBeInCombat', { action: reactionName }),
-		);
-		return;
-	}
-	const { confirmed, force } = await checkReactionConfirmation(actor, ['defend'], reactionName);
-	if (!confirmed) return;
-
-	const reactionUsed = await combat.useHeroicReactions(
-		combatantId,
-		['defend'],
-		force ? { force: true } : undefined,
-	);
-	if (!reactionUsed) return;
-
-	const armorValue = actor.reactive.system.attributes.armor.value ?? 0;
-
-	await ChatMessage.create({
-		author: game.user?.id,
-		speaker: ChatMessage.getSpeaker({ actor }),
-		type: 'reaction',
-		system: {
-			actorName: actor.name,
-			actorType: actor.type,
-			image: actor.img,
-			permissions: actor.permission,
-			rollMode: 0,
-			reactionType: 'defend',
-			armorValue,
+	await ChatMessage.create(
+		buildReactionChatData(actor, 'defend', {
+			armorValue: actor.reactive.system.attributes.armor.value ?? 0,
 			targets: [],
-		},
-	} as unknown as ChatMessage.CreateData);
+		}) as ChatMessage.CreateData,
+	);
 }
 
 async function executeInterposeReaction(actor: NimbleCharacter): Promise<void> {
-	const combat = getActiveCombatForCurrentScene() as CombatWithHeroicReactionUse | null;
-	const combatant = combat?.combatants.find((c) => c.actorId === actor.id);
-	const combatantId = combatant?.id ?? combatant?._id ?? null;
-
 	const reactionName = localize('NIMBLE.ui.heroicActions.reactions.interpose.label');
-
-	if (!combat?.useHeroicReactions || !combatantId) {
-		ui.notifications.warn(
-			localize('NIMBLE.ui.heroicActions.macroWarnings.mustBeInCombat', { action: reactionName }),
-		);
-		return;
-	}
-	const { confirmed, force } = await checkReactionConfirmation(actor, ['interpose'], reactionName);
-	if (!confirmed) return;
-
-	const reactionUsed = await combat.useHeroicReactions(
-		combatantId,
-		['interpose'],
-		force ? { force: true } : undefined,
-	);
-	if (!reactionUsed) return;
+	if (!(await resolveAndUseReaction(actor, ['interpose'], reactionName))) return;
 
 	const targetUuids = getTargetedTokens(actor.id ?? '').map((t) => t.document.uuid);
-
-	await ChatMessage.create({
-		author: game.user?.id,
-		speaker: ChatMessage.getSpeaker({ actor }),
-		type: 'reaction',
-		system: {
-			actorName: actor.name,
-			actorType: actor.type,
-			image: actor.img,
-			permissions: actor.permission,
-			rollMode: 0,
-			reactionType: 'interpose',
-			targets: targetUuids,
-		},
-	} as unknown as ChatMessage.CreateData);
+	await ChatMessage.create(
+		buildReactionChatData(actor, 'interpose', { targets: targetUuids }) as ChatMessage.CreateData,
+	);
 }
 
 async function executeInterposeAndDefendReaction(actor: NimbleCharacter): Promise<void> {
-	const combat = getActiveCombatForCurrentScene() as CombatWithHeroicReactionUse | null;
-	const combatant = combat?.combatants.find((c) => c.actorId === actor.id);
-	const combatantId = combatant?.id ?? combatant?._id ?? null;
-
 	const reactionName = localize('NIMBLE.ui.heroicActions.reactions.interposeAndDefend.confirm');
+	if (!(await resolveAndUseReaction(actor, ['interpose', 'defend'], reactionName))) return;
 
-	if (!combat?.useHeroicReactions || !combatantId) {
-		ui.notifications.warn(
-			localize('NIMBLE.ui.heroicActions.macroWarnings.mustBeInCombat', { action: reactionName }),
-		);
-		return;
-	}
-	const { confirmed, force } = await checkReactionConfirmation(
-		actor,
-		['interpose', 'defend'],
-		reactionName,
-	);
-	if (!confirmed) return;
-
-	const reactionUsed = await combat.useHeroicReactions(
-		combatantId,
-		['interpose', 'defend'],
-		force ? { force: true } : undefined,
-	);
-	if (!reactionUsed) return;
-
-	const armorValue = actor.reactive.system.attributes.armor.value ?? 0;
 	const targetUuids = getTargetedTokens(actor.id ?? '').map((t) => t.document.uuid);
 
-	// Create Interpose message first
-	await ChatMessage.create({
-		author: game.user?.id,
-		speaker: ChatMessage.getSpeaker({ actor }),
-		type: 'reaction',
-		system: {
-			actorName: actor.name,
-			actorType: actor.type,
-			image: actor.img,
-			permissions: actor.permission,
-			rollMode: 0,
-			reactionType: 'interpose',
+	await ChatMessage.create(
+		buildReactionChatData(actor, 'interpose', {
 			targets: targetUuids,
-		},
-	} as unknown as ChatMessage.CreateData);
-
-	// Then create Defend message
-	await ChatMessage.create({
-		author: game.user?.id,
-		speaker: ChatMessage.getSpeaker({ actor }),
-		type: 'reaction',
-		system: {
-			actorName: actor.name,
-			actorType: actor.type,
-			image: actor.img,
-			permissions: actor.permission,
-			rollMode: 0,
-			reactionType: 'defend',
-			armorValue,
+		}) as ChatMessage.CreateData,
+	);
+	await ChatMessage.create(
+		buildReactionChatData(actor, 'defend', {
+			armorValue: actor.reactive.system.attributes.armor.value ?? 0,
 			targets: [],
-		},
-	} as unknown as ChatMessage.CreateData);
+		}) as ChatMessage.CreateData,
+	);
 }
 
 async function executeHelpReaction(actor: NimbleCharacter): Promise<void> {
-	const combat = getActiveCombatForCurrentScene() as CombatWithHeroicReactionUse | null;
-	const combatant = combat?.combatants.find((c) => c.actorId === actor.id);
-	const combatantId = combatant?.id ?? combatant?._id ?? null;
-
 	const reactionName = localize('NIMBLE.ui.heroicActions.reactions.help.label');
-
-	if (!combat?.useHeroicReactions || !combatantId) {
-		ui.notifications.warn(
-			localize('NIMBLE.ui.heroicActions.macroWarnings.mustBeInCombat', { action: reactionName }),
-		);
-		return;
-	}
-	const { confirmed, force } = await checkReactionConfirmation(actor, ['help'], reactionName);
-	if (!confirmed) return;
-
-	const reactionUsed = await combat.useHeroicReactions(
-		combatantId,
-		['help'],
-		force ? { force: true } : undefined,
-	);
-	if (!reactionUsed) return;
+	if (!(await resolveAndUseReaction(actor, ['help'], reactionName))) return;
 
 	const targetUuids = getTargetedTokens(actor.id ?? '').map((t) => t.document.uuid);
-
-	await ChatMessage.create({
-		author: game.user?.id,
-		speaker: ChatMessage.getSpeaker({ actor }),
-		type: 'reaction',
-		system: {
-			actorName: actor.name,
-			actorType: actor.type,
-			image: actor.img,
-			permissions: actor.permission,
-			rollMode: 0,
-			reactionType: 'help',
-			targets: targetUuids,
-		},
-	} as unknown as ChatMessage.CreateData);
+	await ChatMessage.create(
+		buildReactionChatData(actor, 'help', { targets: targetUuids }) as ChatMessage.CreateData,
+	);
 }
 
 async function executeOpportunityAttackReaction(actor: NimbleCharacter): Promise<void> {
-	const combat = getActiveCombatForCurrentScene() as CombatWithHeroicReactionUse | null;
-	const combatant = combat?.combatants.find((c) => c.actorId === actor.id);
-	const combatantId = combatant?.id ?? combatant?._id ?? null;
-
 	const reactionName = localize('NIMBLE.ui.heroicActions.reactions.opportunity.label');
-
-	if (!combat?.useHeroicReactions || !combatantId) {
-		ui.notifications.warn(
-			localize('NIMBLE.ui.heroicActions.macroWarnings.mustBeInCombat', { action: reactionName }),
-		);
-		return;
-	}
-	const { confirmed, force } = await checkReactionConfirmation(
-		actor,
-		['opportunityAttack'],
-		reactionName,
-	);
-	if (!confirmed) return;
+	const result = await resolveAndUseReaction(actor, ['opportunityAttack'], reactionName);
+	if (!result) return;
 
 	// For opportunity attack, we open the sheet to let the user choose a weapon
 	// since this requires more user interaction than the simple reactions
@@ -425,13 +328,17 @@ async function executeOpportunityAttackReaction(actor: NimbleCharacter): Promise
 
 	const appState = sheet.$state;
 	appState.activePrimaryTab = 'actions';
-	appState.heroicActionTarget = { actionId: 'opportunity', actionType: 'reaction', force };
+	appState.heroicActionTarget = {
+		actionId: 'opportunity',
+		actionType: 'reaction',
+		force: result.force,
+	};
 }
 
 async function executeUnarmedStrike(actor: NimbleCharacter): Promise<void> {
 	const combat = getActiveCombatForCurrentScene();
 	const combatant = combat?.combatants.find((c) => c.actorId === actor.id);
-	const inCombat = combatant?.initiative !== null;
+	const inCombat = !!combatant && combatant.initiative !== null;
 
 	// Get current actions if in combat
 	// @ts-expect-error - combatant.system is not typed
@@ -517,6 +424,8 @@ async function executeUnarmedStrike(actor: NimbleCharacter): Promise<void> {
 		},
 	];
 
+	const targetUuids = getTargetedTokens(actor.id ?? '').map((t) => t.document.uuid);
+
 	const chatData = {
 		author: game.user?.id,
 		flavor: `${actor.name}: ${localize('NIMBLE.ui.heroicActions.unarmedStrike')}`,
@@ -544,7 +453,7 @@ async function executeUnarmedStrike(actor: NimbleCharacter): Promise<void> {
 				duration: { type: 'none', quantity: 1 },
 				targets: { count: 1 },
 			},
-			targets: Array.from(game.user?.targets?.map((token) => token.document.uuid) ?? []),
+			targets: targetUuids,
 		},
 		type: 'feature',
 	};
@@ -555,7 +464,7 @@ async function executeUnarmedStrike(actor: NimbleCharacter): Promise<void> {
 	// Deduct action pip if in combat
 	if (inCombat && combatant) {
 		await combatant.update({
-			'system.actions.base.current': actionsRemaining - 1,
+			'system.actions.base.current': Math.max(0, actionsRemaining - 1),
 		} as Record<string, unknown>);
 	}
 }

--- a/src/macros/activateItemMacro.test.ts
+++ b/src/macros/activateItemMacro.test.ts
@@ -1,0 +1,181 @@
+import { activateItemMacro } from './activateItemMacro.ts';
+
+function globals() {
+	return globalThis as unknown as {
+		canvas: unknown;
+		ChatMessage: {
+			getSpeaker: ReturnType<typeof vi.fn>;
+		};
+		game: {
+			actors: unknown;
+			combat: unknown;
+			combats: unknown;
+		};
+		ui: {
+			notifications: {
+				warn: ReturnType<typeof vi.fn>;
+			};
+		};
+	};
+}
+
+type TestActor = Actor & {
+	name: string;
+	items: Array<{
+		name: string;
+		system?: Record<string, unknown>;
+		activate: ReturnType<typeof vi.fn>;
+	}>;
+};
+
+function setSpeakerActor(actor: TestActor) {
+	globals().ChatMessage.getSpeaker = vi.fn().mockReturnValue({ actor: actor.id });
+	globals().game.actors = {
+		tokens: {},
+		get: vi.fn().mockReturnValue(actor),
+	};
+}
+
+function createItem({
+	name = 'Longsword',
+	cost = { type: 'action', quantity: 1 },
+	activationResult = { ok: true },
+}: {
+	name?: string;
+	cost?: { type: string; quantity: number } | null;
+	activationResult?: unknown;
+}) {
+	return {
+		name,
+		system: cost
+			? {
+					activation: {
+						cost,
+					},
+				}
+			: {},
+		activate: vi.fn().mockResolvedValue(activationResult),
+	};
+}
+
+function createActor(item: ReturnType<typeof createItem>): TestActor {
+	return {
+		id: 'actor-item-macro',
+		name: 'Macro User',
+		items: [item],
+	} as unknown as TestActor;
+}
+
+function createCombatant(currentActions: number, initiative: number | null = 12) {
+	return {
+		id: 'combatant-item-macro',
+		actorId: 'actor-item-macro',
+		initiative,
+		system: {
+			actions: {
+				base: {
+					current: currentActions,
+				},
+			},
+		},
+		update: vi.fn().mockResolvedValue(undefined),
+	};
+}
+
+function setCurrentScene(sceneId: string) {
+	globals().canvas = {
+		scene: { id: sceneId },
+	};
+}
+
+function setActiveCombat(combatant: ReturnType<typeof createCombatant> | null) {
+	const combat =
+		combatant == null
+			? null
+			: {
+					scene: { id: 'scene-item-macro' },
+					active: true,
+					combatants: [combatant],
+				};
+	globals().game.combat = combat;
+	globals().game.combats = {
+		contents: combat ? [combat as unknown as Combat] : [],
+		viewed: combat as unknown as Combat | null,
+	};
+}
+
+describe('activateItemMacro', () => {
+	beforeEach(() => {
+		globals().ui.notifications.warn.mockReset();
+		setCurrentScene('scene-item-macro');
+		setActiveCombat(null);
+	});
+
+	it('deducts action pips after a successful action-cost activation and clamps at zero', async () => {
+		const item = createItem({
+			cost: { type: 'action', quantity: 2 },
+		});
+		const actor = createActor(item);
+		const combatant = createCombatant(1);
+		setSpeakerActor(actor);
+		setActiveCombat(combatant);
+
+		await activateItemMacro('Longsword');
+
+		expect(item.activate).toHaveBeenCalled();
+		expect(combatant.update).toHaveBeenCalledWith({
+			'system.actions.base.current': 0,
+		});
+	});
+
+	it('does not deduct action pips when the activation fails', async () => {
+		const item = createItem({
+			activationResult: false,
+		});
+		const actor = createActor(item);
+		const combatant = createCombatant(2);
+		setSpeakerActor(actor);
+		setActiveCombat(combatant);
+
+		await activateItemMacro('Longsword');
+
+		expect(combatant.update).not.toHaveBeenCalled();
+	});
+
+	it('does not deduct action pips for non-action activation costs', async () => {
+		const item = createItem({
+			cost: { type: 'reaction', quantity: 1 },
+		});
+		const actor = createActor(item);
+		const combatant = createCombatant(2);
+		setSpeakerActor(actor);
+		setActiveCombat(combatant);
+
+		await activateItemMacro('Longsword');
+
+		expect(combatant.update).not.toHaveBeenCalled();
+	});
+
+	it('does not deduct action pips when there is no active combat', async () => {
+		const item = createItem({});
+		const actor = createActor(item);
+		setSpeakerActor(actor);
+		setActiveCombat(null);
+
+		await activateItemMacro('Longsword');
+
+		expect(item.activate).toHaveBeenCalled();
+	});
+
+	it('does not deduct action pips when the actor is not currently in initiative order', async () => {
+		const item = createItem({});
+		const actor = createActor(item);
+		const combatant = createCombatant(2, null);
+		setSpeakerActor(actor);
+		setActiveCombat(combatant);
+
+		await activateItemMacro('Longsword');
+
+		expect(combatant.update).not.toHaveBeenCalled();
+	});
+});

--- a/src/macros/activateItemMacro.ts
+++ b/src/macros/activateItemMacro.ts
@@ -1,10 +1,23 @@
+import { getActiveCombatForCurrentScene } from '../utils/combatState.js';
+
+interface ActivationCost {
+	type: string;
+	quantity: number;
+}
+
+interface ItemActivationSystem {
+	activation?: {
+		cost?: ActivationCost;
+	};
+}
+
 /**
  * The function called by macros created by dragging an item to the macro hot bar.
  *
  * @param {string} itemName  The name of the owned item to be activated.
  * @returns {Promise}
  */
-export function activateItemMacro(itemName: string) {
+export async function activateItemMacro(itemName: string) {
 	const speaker = ChatMessage.getSpeaker();
 
 	let actor: Actor | undefined;
@@ -22,6 +35,35 @@ export function activateItemMacro(itemName: string) {
 		return ui.notifications.warn(`Your controlled Actor does not have an item named ${itemName}`);
 	}
 
-	const item = items[0] as object as { activate(): Promise<void> };
-	return item.activate();
+	const item = items[0] as Item & { activate(): Promise<unknown> };
+	const result = await item.activate();
+
+	// If activation was successful and item has an action cost, deduct action pips
+	if (result) {
+		const itemSystem = item.system as unknown as ItemActivationSystem;
+		const activationCost = itemSystem?.activation?.cost;
+		if (activationCost?.type === 'action') {
+			await deductActionPips(actor!, activationCost.quantity ?? 1);
+		}
+	}
+
+	return result;
+}
+
+/**
+ * Deducts action pips from the actor's combatant in the current combat.
+ */
+async function deductActionPips(actor: Actor, count: number): Promise<void> {
+	const combat = getActiveCombatForCurrentScene();
+	if (!combat) return;
+
+	const combatant = combat.combatants.find((c) => c.actorId === actor.id);
+	if (!combatant || combatant.initiative === null) return;
+
+	// @ts-expect-error - combatant.system is not typed
+	const currentActions = combatant.system?.actions?.base?.current ?? 0;
+	if (currentActions > 0) {
+		const newValue = Math.max(0, currentActions - count);
+		await combatant.update({ 'system.actions.base.current': newValue } as Record<string, unknown>);
+	}
 }

--- a/src/macros/createHeroicActionMacro.test.ts
+++ b/src/macros/createHeroicActionMacro.test.ts
@@ -1,0 +1,115 @@
+import { createHeroicActionMacro } from './createHeroicActionMacro.ts';
+
+function globals() {
+	return globalThis as unknown as {
+		game: {
+			macros: Macro[];
+			user: {
+				id: string;
+				assignHotbarMacro: ReturnType<typeof vi.fn>;
+			};
+		};
+		Macro: {
+			create: ReturnType<typeof vi.fn>;
+		};
+	};
+}
+
+describe('createHeroicActionMacro', () => {
+	beforeEach(() => {
+		globals().game.macros = [];
+		globals().game.user.id = 'test-user-id';
+		globals().game.user.assignHotbarMacro = vi.fn().mockResolvedValue(undefined);
+		globals().Macro = {
+			create: vi.fn(),
+		};
+	});
+
+	it('creates a new heroic action macro with the expected command, icon, and flags', async () => {
+		const macro = {
+			id: 'macro-defend',
+			name: 'Defend',
+		} as unknown as Macro;
+		globals().Macro.create.mockResolvedValue(macro);
+
+		await createHeroicActionMacro(
+			{
+				actionId: 'defend',
+				actionType: 'reaction',
+				name: 'Defend',
+			},
+			4,
+		);
+
+		expect(globals().Macro.create).toHaveBeenCalledWith(
+			expect.objectContaining({
+				name: 'Defend',
+				type: 'script',
+				scope: 'actor',
+				img: 'icons/svg/shield.svg',
+				command: 'game.nimble.macros.activateHeroicActionMacro("defend", "reaction")',
+				flags: {
+					nimble: {
+						heroicActionMacro: true,
+						actionId: 'defend',
+						actionType: 'reaction',
+					},
+				},
+			}),
+		);
+		expect(globals().game.user.assignHotbarMacro).toHaveBeenCalledWith(macro, 4);
+	});
+
+	it('reuses an existing owned macro with the same command', async () => {
+		const macro = {
+			id: 'macro-help',
+			command: 'game.nimble.macros.activateHeroicActionMacro("help", "reaction")',
+			ownership: {
+				[globals().game.user.id]: CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER,
+			},
+			img: 'icons/svg/upgrade.svg',
+			isOwner: true,
+			update: vi.fn(),
+		} as unknown as Macro;
+		globals().game.macros = [macro];
+
+		await createHeroicActionMacro(
+			{
+				actionId: 'help',
+				actionType: 'reaction',
+				name: 'Help',
+			},
+			2,
+		);
+
+		expect(globals().Macro.create).not.toHaveBeenCalled();
+		expect(globals().game.user.assignHotbarMacro).toHaveBeenCalledWith(macro, 2);
+	});
+
+	it('repairs the icon for an existing owned macro before assigning it', async () => {
+		const update = vi.fn().mockResolvedValue(undefined);
+		const macro = {
+			id: 'macro-opportunity',
+			command: 'game.nimble.macros.activateHeroicActionMacro("opportunity", "reaction")',
+			ownership: {
+				default: CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER,
+			},
+			img: 'systems/nimble/assets/icons/d20.svg',
+			isOwner: true,
+			update,
+		} as unknown as Macro;
+		globals().game.macros = [macro];
+
+		await createHeroicActionMacro(
+			{
+				actionId: 'opportunity',
+				actionType: 'reaction',
+				name: 'Opportunity Attack',
+			},
+			8,
+		);
+
+		expect(update).toHaveBeenCalledWith({ img: 'icons/svg/target.svg' });
+		expect(globals().game.user.assignHotbarMacro).toHaveBeenCalledWith(macro, 8);
+	});
+});

--- a/src/macros/createHeroicActionMacro.ts
+++ b/src/macros/createHeroicActionMacro.ts
@@ -26,7 +26,9 @@ export async function createHeroicActionMacro(data: HeroicActionMacroData, slot:
 
 	let macro: Macro | undefined = game.macros.find((m) => {
 		const sameCommand = m.command === command;
-		const perms = m.ownership?.default === 3 || m.ownership?.[game.user!.id] === 3;
+		const perms =
+			m.ownership?.default === CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER ||
+			m.ownership?.[game.user!.id] === CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER;
 
 		return sameCommand && perms;
 	});

--- a/src/macros/createHeroicActionMacro.ts
+++ b/src/macros/createHeroicActionMacro.ts
@@ -13,7 +13,7 @@ function getActionIcon(actionId: string): string {
 		defend: 'icons/svg/shield.svg',
 		interpose: 'icons/svg/angel.svg',
 		opportunity: 'icons/svg/target.svg',
-		help: 'icons/svg/hand.svg',
+		help: 'icons/svg/upgrade.svg',
 		interposeAndDefend: 'icons/svg/combat.svg',
 		unarmedStrike: 'icons/skills/melee/unarmed-punch-fist.webp',
 	};

--- a/src/macros/createHeroicActionMacro.ts
+++ b/src/macros/createHeroicActionMacro.ts
@@ -1,0 +1,57 @@
+interface HeroicActionMacroData {
+	actionId: string;
+	actionType: 'action' | 'reaction';
+	name: string;
+}
+
+function getActionIcon(actionId: string): string {
+	const iconMap: Record<string, string> = {
+		attack: 'icons/svg/sword.svg',
+		spell: 'icons/svg/lightning.svg',
+		move: 'icons/svg/wingfoot.svg',
+		assess: 'icons/svg/eye.svg',
+		defend: 'icons/svg/shield.svg',
+		interpose: 'icons/svg/angel.svg',
+		opportunity: 'icons/svg/target.svg',
+		help: 'icons/svg/upgrade.svg',
+		interposeAndDefend: 'icons/svg/combat.svg',
+	};
+	return iconMap[actionId] ?? 'systems/nimble/assets/icons/d20.svg';
+}
+
+export async function createHeroicActionMacro(data: HeroicActionMacroData, slot: number) {
+	const command = `game.nimble.macros.activateHeroicActionMacro("${data.actionId}", "${data.actionType}")`;
+	const expectedIcon = getActionIcon(data.actionId);
+
+	let macro: Macro | undefined = game.macros.find((m) => {
+		const sameCommand = m.command === command;
+		const perms = m.ownership?.default === 3 || m.ownership?.[game.user!.id] === 3;
+
+		return sameCommand && perms;
+	});
+
+	if (!macro) {
+		macro =
+			(await Macro.create({
+				name: data.name,
+				type: 'script',
+				scope: 'actor',
+				img: expectedIcon,
+				command: command,
+				flags: {
+					nimble: {
+						heroicActionMacro: true,
+						actionId: data.actionId,
+						actionType: data.actionType,
+					},
+				} as Macro.CreateData['flags'],
+			})) ?? undefined;
+	} else if (macro.img !== expectedIcon && macro.isOwner) {
+		// Update icon if it changed (e.g., was previously broken)
+		await macro.update({ img: expectedIcon });
+	}
+
+	if (macro) {
+		await game.user!.assignHotbarMacro(macro, slot);
+	}
+}

--- a/src/macros/createHeroicActionMacro.ts
+++ b/src/macros/createHeroicActionMacro.ts
@@ -13,8 +13,9 @@ function getActionIcon(actionId: string): string {
 		defend: 'icons/svg/shield.svg',
 		interpose: 'icons/svg/angel.svg',
 		opportunity: 'icons/svg/target.svg',
-		help: 'icons/svg/upgrade.svg',
+		help: 'icons/svg/hand.svg',
 		interposeAndDefend: 'icons/svg/combat.svg',
+		unarmedStrike: 'icons/skills/melee/unarmed-punch-fist.webp',
 	};
 	return iconMap[actionId] ?? 'systems/nimble/assets/icons/d20.svg';
 }

--- a/src/migration/migrations/Migration011SwiftFistsUnarmedProficiency.ts
+++ b/src/migration/migrations/Migration011SwiftFistsUnarmedProficiency.ts
@@ -1,4 +1,4 @@
-import { UNARMED_STRIKE_PROFICIENCY } from '../../view/sheets/components/attackUtils.js';
+import { UNARMED_STRIKE_PROFICIENCY } from '../../utils/attackUtils.js';
 import { MigrationBase } from '../MigrationBase.js';
 
 const SWIFT_FISTS_SOURCE_ID = 'Compendium.nimble.class-features.Item.kHJVcWe64VhHsOFu';

--- a/src/utils/assessOptions.ts
+++ b/src/utils/assessOptions.ts
@@ -39,7 +39,7 @@ export const assessOptions: AssessOption[] = [
 		descriptionKey: 'NIMBLE.ui.heroicActions.assess.createOpening.description',
 		successKey: 'NIMBLE.ui.heroicActions.assess.createOpening.success',
 		failureKey: 'NIMBLE.ui.heroicActions.assess.createOpening.failure',
-		requiresTarget: true,
+		requiresTarget: false,
 	},
 	{
 		id: 'anticipate-danger',

--- a/src/utils/attackUtils.ts
+++ b/src/utils/attackUtils.ts
@@ -1,4 +1,4 @@
-import type { NimbleCharacter } from '../../../documents/actor/character.js';
+import type { NimbleCharacter } from '../documents/actor/character.js';
 
 /** Default unarmed: 1d4 + STR damage, but cannot crit without proficiency (e.g., Swift Fists) */
 export const DEFAULT_UNARMED_DAMAGE = '1d4 + @abilities.strength.mod';

--- a/src/utils/showReactionConfirmation.ts
+++ b/src/utils/showReactionConfirmation.ts
@@ -1,0 +1,44 @@
+import localize from './localize.js';
+
+interface ReactionConfirmationOptions {
+	reactionName: string;
+	spentReactionNames: string;
+	noActions: boolean;
+	hasSpentReactions: boolean;
+}
+
+/**
+ * Shows a confirmation dialog when a reaction is being used but the character
+ * has no actions remaining or has already spent the reaction this round.
+ *
+ * @returns true if the user confirmed, false otherwise
+ */
+export default async function showReactionConfirmation(
+	options: ReactionConfirmationOptions,
+): Promise<boolean> {
+	const { reactionName, spentReactionNames, noActions, hasSpentReactions } = options;
+	const confirmReaction = 'NIMBLE.ui.heroicActions.confirmReaction';
+
+	let message: string;
+	if (noActions && hasSpentReactions) {
+		message = localize(`${confirmReaction}.bothMessage`, { reaction: spentReactionNames });
+	} else if (noActions) {
+		message = localize(`${confirmReaction}.noActionsMessage`);
+	} else {
+		message = localize(`${confirmReaction}.spentMessage`, { reaction: spentReactionNames });
+	}
+
+	const confirmQuestion = localize(`${confirmReaction}.confirmQuestion`, {
+		reaction: reactionName,
+	});
+
+	const confirmed = await foundry.applications.api.DialogV2.confirm({
+		window: { title: localize(`${confirmReaction}.title`) },
+		content: `<p>${message}</p><p>${confirmQuestion}</p>`,
+		yes: { label: localize(`${confirmReaction}.confirm`) },
+		no: { label: localize(`${confirmReaction}.cancel`) },
+		rejectClose: false,
+	});
+
+	return confirmed === true;
+}

--- a/src/view/sheets/components/AttackActionPanel.svelte
+++ b/src/view/sheets/components/AttackActionPanel.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import { getContext } from 'svelte';
 	import localize from '../../../utils/localize.js';
 	import { createAttackPanelState } from './AttackActionPanel.svelte.ts';
@@ -15,6 +15,17 @@
 		() => actor,
 		() => onActivateItem,
 	);
+
+	function handleUnarmedStrikeDragStart(event: DragEvent) {
+		if (!event.dataTransfer) return;
+		const dragData = {
+			type: 'HeroicAction',
+			actionId: 'unarmedStrike',
+			actionType: 'action',
+			name: localize('NIMBLE.ui.heroicActions.unarmedStrike'),
+		};
+		event.dataTransfer.setData('text/plain', JSON.stringify(dragData));
+	}
 </script>
 
 <section class="attack-panel">
@@ -38,6 +49,7 @@
 					properties={[localize('NIMBLE.npcSheet.melee')]}
 					showImage={false}
 					onclick={state.handleUnarmedStrike}
+					ondragstart={handleUnarmedStrikeDragStart}
 				/>
 			{/if}
 

--- a/src/view/sheets/components/AttackActionPanel.svelte.ts
+++ b/src/view/sheets/components/AttackActionPanel.svelte.ts
@@ -2,10 +2,10 @@ import { DamageRoll } from '../../../dice/DamageRoll.js';
 import type { NimbleCharacter } from '../../../documents/actor/character.js';
 import ItemActivationConfigDialog from '../../../documents/dialogs/ItemActivationConfigDialog.svelte.js';
 import { getPrimaryDamageFormulaFromActivationEffects } from '../../../utils/activationEffects.js';
+import { getUnarmedDamageFormula, hasUnarmedProficiency } from '../../../utils/attackUtils.js';
 import { evaluateFormula as evalFormula } from '../../../utils/evaluateFormula.js';
 import localize from '../../../utils/localize.js';
 import sortItems from '../../../utils/sortItems.js';
-import { getUnarmedDamageFormula, hasUnarmedProficiency } from './attackUtils.js';
 
 /** System data for weapon items */
 interface WeaponSystemData {

--- a/src/view/sheets/components/CastSpellActionPanel.svelte
+++ b/src/view/sheets/components/CastSpellActionPanel.svelte
@@ -42,12 +42,13 @@
 					{@const isExpanded = state.expandedDescriptions.has(spell._id)}
 					{@const spellEffects = state.getSpellEffects(spell)}
 
-					<li class="spell-card" class:spell-card--expanded={isExpanded} data-item-id={spell._id}>
+					<li class="spell-card" class:spell-card--expanded={isExpanded}>
 						<div
 							class="spell-card__row"
 							role="button"
 							tabindex="0"
 							draggable="true"
+							data-item-id={spell._id}
 							ondragstart={(event) => sheet._onDragStart(event)}
 							onclick={() => state.handleSpellClick(spell._id)}
 							onkeydown={(e) => state.handleKeydown(e, () => state.handleSpellClick(spell._id))}

--- a/src/view/sheets/components/DefendReactionPanel.svelte
+++ b/src/view/sheets/components/DefendReactionPanel.svelte
@@ -26,6 +26,17 @@
 	const isDisabled = $derived(reactionDisabled);
 	const canInterposeAndDefend = $derived(!combinedReactionDisabled);
 	const { getTargetName, handleDefend, handleInterposeAndDefend } = state;
+
+	function handleInterposeAndDefendDragStart(event: DragEvent) {
+		if (!event.dataTransfer) return;
+		const dragData = {
+			type: 'HeroicAction',
+			actionId: 'interposeAndDefend',
+			actionType: 'reaction',
+			name: localize('NIMBLE.ui.heroicActions.reactions.interposeAndDefend.confirm'),
+		};
+		event.dataTransfer.setData('text/plain', JSON.stringify(dragData));
+	}
 </script>
 
 <section class="reaction-panel">
@@ -63,6 +74,8 @@
 		<button
 			class="reaction-panel__button reaction-panel__button--combined"
 			disabled={!canInterposeAndDefend}
+			draggable="true"
+			ondragstart={handleInterposeAndDefendDragStart}
 			onclick={handleInterposeAndDefend}
 		>
 			<i class="fa-solid fa-people-arrows"></i>

--- a/src/view/sheets/components/DefendReactionPanel.svelte
+++ b/src/view/sheets/components/DefendReactionPanel.svelte
@@ -8,6 +8,9 @@
 		actor,
 		reactionDisabled = true,
 		combinedReactionDisabled = true,
+		defendSpent = false,
+		interposeSpent = false,
+		noActions = false,
 		onUseReaction = async () => false,
 		onUseCombinedReaction = async () => false,
 	}: ReactionPanelProps = $props();
@@ -15,6 +18,9 @@
 	const state = createDefendPanelState(
 		() => actor,
 		() => reactionDisabled,
+		() => defendSpent,
+		() => interposeSpent,
+		() => noActions,
 		() => onUseReaction,
 		() => combinedReactionDisabled,
 		() => onUseCombinedReaction,
@@ -23,9 +29,18 @@
 	const availableTargets = $derived(state.availableTargets);
 	const selectedTarget = $derived(state.selectedTarget);
 	const armorValue = $derived(state.armorValue);
-	const isDisabled = $derived(reactionDisabled);
-	const canInterposeAndDefend = $derived(!combinedReactionDisabled);
 	const { getTargetName, handleDefend, handleInterposeAndDefend } = state;
+
+	function handleDefendDragStart(event: DragEvent) {
+		if (!event.dataTransfer) return;
+		const dragData = {
+			type: 'HeroicAction',
+			actionId: 'defend',
+			actionType: 'reaction',
+			name: localize('NIMBLE.ui.heroicActions.reactions.defend.label'),
+		};
+		event.dataTransfer.setData('text/plain', JSON.stringify(dragData));
+	}
 
 	function handleInterposeAndDefendDragStart(event: DragEvent) {
 		if (!event.dataTransfer) return;
@@ -65,7 +80,12 @@
 		})}
 	</p>
 
-	<button class="reaction-panel__button" disabled={isDisabled} onclick={handleDefend}>
+	<button
+		class="reaction-panel__button"
+		draggable="true"
+		ondragstart={handleDefendDragStart}
+		onclick={handleDefend}
+	>
 		<i class="fa-solid fa-shield"></i>
 		{localize('NIMBLE.ui.heroicActions.reactions.defend.confirm')}
 	</button>
@@ -73,7 +93,6 @@
 	<div class="reaction-panel__combined-section">
 		<button
 			class="reaction-panel__button reaction-panel__button--combined"
-			disabled={!canInterposeAndDefend}
 			draggable="true"
 			ondragstart={handleInterposeAndDefendDragStart}
 			onclick={handleInterposeAndDefend}

--- a/src/view/sheets/components/DefendReactionPanel.svelte
+++ b/src/view/sheets/components/DefendReactionPanel.svelte
@@ -15,16 +15,16 @@
 		onUseCombinedReaction = async () => false,
 	}: ReactionPanelProps = $props();
 
-	const state = createDefendPanelState(
-		() => actor,
-		() => reactionDisabled,
-		() => defendSpent,
-		() => interposeSpent,
-		() => noActions,
-		() => onUseReaction,
-		() => combinedReactionDisabled,
-		() => onUseCombinedReaction,
-	);
+	const state = createDefendPanelState({
+		getActor: () => actor,
+		getReactionDisabled: () => reactionDisabled,
+		getDefendSpent: () => defendSpent,
+		getInterposeSpent: () => interposeSpent,
+		getNoActions: () => noActions,
+		getOnUseReaction: () => onUseReaction,
+		getCombinedReactionDisabled: () => combinedReactionDisabled,
+		getOnUseCombinedReaction: () => onUseCombinedReaction,
+	});
 
 	const availableTargets = $derived(state.availableTargets);
 	const selectedTarget = $derived(state.selectedTarget);

--- a/src/view/sheets/components/DefendReactionPanel.svelte.ts
+++ b/src/view/sheets/components/DefendReactionPanel.svelte.ts
@@ -1,5 +1,6 @@
 import type { NimbleCharacter } from '../../../documents/actor/character.js';
 import localize from '../../../utils/localize.js';
+import showReactionConfirmation from '../../../utils/showReactionConfirmation.js';
 import { getTargetedTokens, getTargetName } from '../../../utils/targeting.js';
 
 export function createDefendPanelState(
@@ -32,38 +33,6 @@ export function createDefendPanelState(
 		return () => Hooks.off('targetToken', hookId);
 	});
 
-	async function showReactionConfirmation(
-		reactionName: string,
-		spentReactionNames: string,
-		noActions: boolean,
-		hasSpentReactions: boolean,
-	): Promise<boolean> {
-		const confirmReaction = 'NIMBLE.ui.heroicActions.confirmReaction';
-
-		let message: string;
-		if (noActions && hasSpentReactions) {
-			message = localize(`${confirmReaction}.bothMessage`, { reaction: spentReactionNames });
-		} else if (noActions) {
-			message = localize(`${confirmReaction}.noActionsMessage`);
-		} else {
-			message = localize(`${confirmReaction}.spentMessage`, { reaction: spentReactionNames });
-		}
-
-		const confirmQuestion = localize(`${confirmReaction}.confirmQuestion`, {
-			reaction: reactionName,
-		});
-
-		const confirmed = await foundry.applications.api.DialogV2.confirm({
-			window: { title: localize(`${confirmReaction}.title`) },
-			content: `<p>${message}</p><p>${confirmQuestion}</p>`,
-			yes: { label: localize(`${confirmReaction}.confirm`) },
-			no: { label: localize(`${confirmReaction}.cancel`) },
-			rejectClose: false,
-		});
-
-		return confirmed === true;
-	}
-
 	async function handleDefend(): Promise<void> {
 		const isDisabled = getReactionDisabled();
 
@@ -72,12 +41,12 @@ export function createDefendPanelState(
 			const noActions = getNoActions();
 			const reactionName = localize('NIMBLE.ui.heroicActions.reactions.defend.label');
 
-			const confirmed = await showReactionConfirmation(
+			const confirmed = await showReactionConfirmation({
 				reactionName,
-				reactionName,
+				spentReactionNames: reactionName,
 				noActions,
-				defendSpent,
-			);
+				hasSpentReactions: defendSpent,
+			});
 			if (!confirmed) return;
 
 			const reactionUsed = await getOnUseReaction()({ force: true });
@@ -124,12 +93,12 @@ export function createDefendPanelState(
 				spentReactions.push(localize('NIMBLE.ui.heroicActions.reactionLabels.defend'));
 			const spentReactionNames = spentReactions.join(' & ');
 
-			const confirmed = await showReactionConfirmation(
+			const confirmed = await showReactionConfirmation({
 				reactionName,
 				spentReactionNames,
 				noActions,
-				spentReactions.length > 0,
-			);
+				hasSpentReactions: spentReactions.length > 0,
+			});
 			if (!confirmed) return;
 
 			const reactionUsed = await getOnUseCombinedReaction()({ force: true });

--- a/src/view/sheets/components/DefendReactionPanel.svelte.ts
+++ b/src/view/sheets/components/DefendReactionPanel.svelte.ts
@@ -1,12 +1,16 @@
 import type { NimbleCharacter } from '../../../documents/actor/character.js';
+import localize from '../../../utils/localize.js';
 import { getTargetedTokens, getTargetName } from '../../../utils/targeting.js';
 
 export function createDefendPanelState(
 	getActor: () => NimbleCharacter,
 	getReactionDisabled: () => boolean,
-	getOnUseReaction: () => () => Promise<boolean>,
+	getDefendSpent: () => boolean,
+	getInterposeSpent: () => boolean,
+	getNoActions: () => boolean,
+	getOnUseReaction: () => (options?: { force?: boolean }) => Promise<boolean>,
 	getCombinedReactionDisabled: () => boolean,
-	getOnUseCombinedReaction: () => () => Promise<boolean>,
+	getOnUseCombinedReaction: () => (options?: { force?: boolean }) => Promise<boolean>,
 ) {
 	// Targeting state
 	let targetingVersion = $state(0);
@@ -28,11 +32,60 @@ export function createDefendPanelState(
 		return () => Hooks.off('targetToken', hookId);
 	});
 
-	async function handleDefend(): Promise<void> {
-		if (getReactionDisabled()) return;
+	async function showReactionConfirmation(
+		reactionName: string,
+		spentReactionNames: string,
+		noActions: boolean,
+		hasSpentReactions: boolean,
+	): Promise<boolean> {
+		const confirmReaction = 'NIMBLE.ui.heroicActions.confirmReaction';
 
-		const reactionUsed = await getOnUseReaction()();
-		if (!reactionUsed) return;
+		let message: string;
+		if (noActions && hasSpentReactions) {
+			message = localize(`${confirmReaction}.bothMessage`, { reaction: spentReactionNames });
+		} else if (noActions) {
+			message = localize(`${confirmReaction}.noActionsMessage`);
+		} else {
+			message = localize(`${confirmReaction}.spentMessage`, { reaction: spentReactionNames });
+		}
+
+		const confirmQuestion = localize(`${confirmReaction}.confirmQuestion`, {
+			reaction: reactionName,
+		});
+
+		const confirmed = await foundry.applications.api.DialogV2.confirm({
+			window: { title: localize(`${confirmReaction}.title`) },
+			content: `<p>${message}</p><p>${confirmQuestion}</p>`,
+			yes: { label: localize(`${confirmReaction}.confirm`) },
+			no: { label: localize(`${confirmReaction}.cancel`) },
+			rejectClose: false,
+		});
+
+		return confirmed === true;
+	}
+
+	async function handleDefend(): Promise<void> {
+		const isDisabled = getReactionDisabled();
+
+		if (isDisabled) {
+			const defendSpent = getDefendSpent();
+			const noActions = getNoActions();
+			const reactionName = localize('NIMBLE.ui.heroicActions.reactions.defend.label');
+
+			const confirmed = await showReactionConfirmation(
+				reactionName,
+				reactionName,
+				noActions,
+				defendSpent,
+			);
+			if (!confirmed) return;
+
+			const reactionUsed = await getOnUseReaction()({ force: true });
+			if (!reactionUsed) return;
+		} else {
+			const reactionUsed = await getOnUseReaction()();
+			if (!reactionUsed) return;
+		}
 
 		const actor = getActor();
 		const currentArmorValue = actor.reactive.system.attributes.armor.value ?? 0;
@@ -55,10 +108,36 @@ export function createDefendPanelState(
 	}
 
 	async function handleInterposeAndDefend(): Promise<void> {
-		if (getCombinedReactionDisabled()) return;
+		const isDisabled = getCombinedReactionDisabled();
 
-		const reactionUsed = await getOnUseCombinedReaction()();
-		if (!reactionUsed) return;
+		if (isDisabled) {
+			const defendSpent = getDefendSpent();
+			const interposeSpent = getInterposeSpent();
+			const noActions = getNoActions();
+			const reactionName = localize('NIMBLE.ui.heroicActions.reactions.interposeAndDefend.confirm');
+
+			// Build spent reactions string
+			const spentReactions: string[] = [];
+			if (interposeSpent)
+				spentReactions.push(localize('NIMBLE.ui.heroicActions.reactionLabels.interpose'));
+			if (defendSpent)
+				spentReactions.push(localize('NIMBLE.ui.heroicActions.reactionLabels.defend'));
+			const spentReactionNames = spentReactions.join(' & ');
+
+			const confirmed = await showReactionConfirmation(
+				reactionName,
+				spentReactionNames,
+				noActions,
+				spentReactions.length > 0,
+			);
+			if (!confirmed) return;
+
+			const reactionUsed = await getOnUseCombinedReaction()({ force: true });
+			if (!reactionUsed) return;
+		} else {
+			const reactionUsed = await getOnUseCombinedReaction()();
+			if (!reactionUsed) return;
+		}
 
 		const actor = getActor();
 		const currentArmorValue = actor.reactive.system.attributes.armor.value ?? 0;

--- a/src/view/sheets/components/DefendReactionPanel.svelte.ts
+++ b/src/view/sheets/components/DefendReactionPanel.svelte.ts
@@ -1,18 +1,12 @@
-import type { NimbleCharacter } from '../../../documents/actor/character.js';
+import type { ReactionPanelStateOptions } from '../../../../types/components/ReactionPanel.d.ts';
 import localize from '../../../utils/localize.js';
 import showReactionConfirmation from '../../../utils/showReactionConfirmation.js';
 import { getTargetedTokens, getTargetName } from '../../../utils/targeting.js';
+import handleInterposeAndDefend from './handleInterposeAndDefend.js';
 
-export function createDefendPanelState(
-	getActor: () => NimbleCharacter,
-	getReactionDisabled: () => boolean,
-	getDefendSpent: () => boolean,
-	getInterposeSpent: () => boolean,
-	getNoActions: () => boolean,
-	getOnUseReaction: () => (options?: { force?: boolean }) => Promise<boolean>,
-	getCombinedReactionDisabled: () => boolean,
-	getOnUseCombinedReaction: () => (options?: { force?: boolean }) => Promise<boolean>,
-) {
+export function createDefendPanelState(options: ReactionPanelStateOptions) {
+	const { getActor, getReactionDisabled, getDefendSpent, getNoActions, getOnUseReaction } = options;
+
 	// Targeting state
 	let targetingVersion = $state(0);
 
@@ -76,76 +70,6 @@ export function createDefendPanelState(
 		await ChatMessage.create(chatData as unknown as ChatMessage.CreateData);
 	}
 
-	async function handleInterposeAndDefend(): Promise<void> {
-		const isDisabled = getCombinedReactionDisabled();
-
-		if (isDisabled) {
-			const defendSpent = getDefendSpent();
-			const interposeSpent = getInterposeSpent();
-			const noActions = getNoActions();
-			const reactionName = localize('NIMBLE.ui.heroicActions.reactions.interposeAndDefend.confirm');
-
-			// Build spent reactions string
-			const spentReactions: string[] = [];
-			if (interposeSpent)
-				spentReactions.push(localize('NIMBLE.ui.heroicActions.reactionLabels.interpose'));
-			if (defendSpent)
-				spentReactions.push(localize('NIMBLE.ui.heroicActions.reactionLabels.defend'));
-			const spentReactionNames = spentReactions.join(' & ');
-
-			const confirmed = await showReactionConfirmation({
-				reactionName,
-				spentReactionNames,
-				noActions,
-				hasSpentReactions: spentReactions.length > 0,
-			});
-			if (!confirmed) return;
-
-			const reactionUsed = await getOnUseCombinedReaction()({ force: true });
-			if (!reactionUsed) return;
-		} else {
-			const reactionUsed = await getOnUseCombinedReaction()();
-			if (!reactionUsed) return;
-		}
-
-		const actor = getActor();
-		const currentArmorValue = actor.reactive.system.attributes.armor.value ?? 0;
-		const targetUuids = getTargetedTokens(actor.id ?? '').map((t) => t.document.uuid);
-
-		// Create Interpose message first (stepping in front of ally)
-		await ChatMessage.create({
-			author: game.user?.id,
-			speaker: ChatMessage.getSpeaker({ actor }),
-			type: 'reaction',
-			system: {
-				actorName: actor.name,
-				actorType: actor.type,
-				image: actor.img,
-				permissions: actor.permission,
-				rollMode: 0,
-				reactionType: 'interpose',
-				targets: targetUuids,
-			},
-		} as unknown as ChatMessage.CreateData);
-
-		// Then create Defend message (reducing damage taken)
-		await ChatMessage.create({
-			author: game.user?.id,
-			speaker: ChatMessage.getSpeaker({ actor }),
-			type: 'reaction',
-			system: {
-				actorName: actor.name,
-				actorType: actor.type,
-				image: actor.img,
-				permissions: actor.permission,
-				rollMode: 0,
-				reactionType: 'defend',
-				armorValue: currentArmorValue,
-				targets: [],
-			},
-		} as unknown as ChatMessage.CreateData);
-	}
-
 	return {
 		get availableTargets() {
 			return availableTargets;
@@ -158,6 +82,6 @@ export function createDefendPanelState(
 		},
 		getTargetName,
 		handleDefend,
-		handleInterposeAndDefend,
+		handleInterposeAndDefend: () => handleInterposeAndDefend(options),
 	};
 }

--- a/src/view/sheets/components/HelpReactionPanel.svelte
+++ b/src/view/sheets/components/HelpReactionPanel.svelte
@@ -7,19 +7,33 @@
 	let {
 		actor,
 		reactionDisabled = true,
+		helpSpent = false,
+		noActions = false,
 		onUseReaction = async () => false,
 	}: ReactionPanelProps = $props();
 
 	const state = createHelpPanelState(
 		() => actor,
 		() => reactionDisabled,
+		() => helpSpent,
+		() => noActions,
 		() => onUseReaction,
 	);
 
 	const availableTargets = $derived(state.availableTargets);
 	const selectedTarget = $derived(state.selectedTarget);
-	const isDisabled = $derived(reactionDisabled);
 	const { getTargetName, handleHelp } = state;
+
+	function handleHelpDragStart(event: DragEvent) {
+		if (!event.dataTransfer) return;
+		const dragData = {
+			type: 'HeroicAction',
+			actionId: 'help',
+			actionType: 'reaction',
+			name: localize('NIMBLE.ui.heroicActions.reactions.help.label'),
+		};
+		event.dataTransfer.setData('text/plain', JSON.stringify(dragData));
+	}
 </script>
 
 <section class="reaction-panel">
@@ -62,7 +76,12 @@
 		{localize('NIMBLE.ui.heroicActions.reactions.help.tip')}
 	</p>
 
-	<button class="reaction-panel__button" disabled={isDisabled} onclick={handleHelp}>
+	<button
+		class="reaction-panel__button"
+		draggable="true"
+		ondragstart={handleHelpDragStart}
+		onclick={handleHelp}
+	>
 		<i class="fa-solid fa-handshake-angle"></i>
 		{localize('NIMBLE.ui.heroicActions.reactions.help.confirm')}
 	</button>

--- a/src/view/sheets/components/HelpReactionPanel.svelte.ts
+++ b/src/view/sheets/components/HelpReactionPanel.svelte.ts
@@ -1,10 +1,13 @@
 import type { NimbleCharacter } from '../../../documents/actor/character.js';
+import localize from '../../../utils/localize.js';
 import { getTargetedTokens, getTargetName } from '../../../utils/targeting.js';
 
 export function createHelpPanelState(
 	getActor: () => NimbleCharacter,
 	getReactionDisabled: () => boolean,
-	getOnUseReaction: () => () => Promise<boolean>,
+	getHelpSpent: () => boolean,
+	getNoActions: () => boolean,
+	getOnUseReaction: () => (options?: { force?: boolean }) => Promise<boolean>,
 ) {
 	// Targeting state
 	let targetingVersion = $state(0);
@@ -24,11 +27,60 @@ export function createHelpPanelState(
 		return () => Hooks.off('targetToken', hookId);
 	});
 
-	async function handleHelp(): Promise<void> {
-		if (getReactionDisabled()) return;
+	async function showReactionConfirmation(
+		reactionName: string,
+		spentReactionNames: string,
+		noActions: boolean,
+		hasSpentReactions: boolean,
+	): Promise<boolean> {
+		const confirmReaction = 'NIMBLE.ui.heroicActions.confirmReaction';
 
-		const reactionUsed = await getOnUseReaction()();
-		if (!reactionUsed) return;
+		let message: string;
+		if (noActions && hasSpentReactions) {
+			message = localize(`${confirmReaction}.bothMessage`, { reaction: spentReactionNames });
+		} else if (noActions) {
+			message = localize(`${confirmReaction}.noActionsMessage`);
+		} else {
+			message = localize(`${confirmReaction}.spentMessage`, { reaction: spentReactionNames });
+		}
+
+		const confirmQuestion = localize(`${confirmReaction}.confirmQuestion`, {
+			reaction: reactionName,
+		});
+
+		const confirmed = await foundry.applications.api.DialogV2.confirm({
+			window: { title: localize(`${confirmReaction}.title`) },
+			content: `<p>${message}</p><p>${confirmQuestion}</p>`,
+			yes: { label: localize(`${confirmReaction}.confirm`) },
+			no: { label: localize(`${confirmReaction}.cancel`) },
+			rejectClose: false,
+		});
+
+		return confirmed === true;
+	}
+
+	async function handleHelp(): Promise<void> {
+		const isDisabled = getReactionDisabled();
+
+		if (isDisabled) {
+			const helpSpent = getHelpSpent();
+			const noActions = getNoActions();
+			const reactionName = localize('NIMBLE.ui.heroicActions.reactions.help.label');
+
+			const confirmed = await showReactionConfirmation(
+				reactionName,
+				reactionName,
+				noActions,
+				helpSpent,
+			);
+			if (!confirmed) return;
+
+			const reactionUsed = await getOnUseReaction()({ force: true });
+			if (!reactionUsed) return;
+		} else {
+			const reactionUsed = await getOnUseReaction()();
+			if (!reactionUsed) return;
+		}
 
 		const actor = getActor();
 		const targetUuids = availableTargets.map((t) => t.document.uuid);

--- a/src/view/sheets/components/HelpReactionPanel.svelte.ts
+++ b/src/view/sheets/components/HelpReactionPanel.svelte.ts
@@ -1,5 +1,6 @@
 import type { NimbleCharacter } from '../../../documents/actor/character.js';
 import localize from '../../../utils/localize.js';
+import showReactionConfirmation from '../../../utils/showReactionConfirmation.js';
 import { getTargetedTokens, getTargetName } from '../../../utils/targeting.js';
 
 export function createHelpPanelState(
@@ -27,38 +28,6 @@ export function createHelpPanelState(
 		return () => Hooks.off('targetToken', hookId);
 	});
 
-	async function showReactionConfirmation(
-		reactionName: string,
-		spentReactionNames: string,
-		noActions: boolean,
-		hasSpentReactions: boolean,
-	): Promise<boolean> {
-		const confirmReaction = 'NIMBLE.ui.heroicActions.confirmReaction';
-
-		let message: string;
-		if (noActions && hasSpentReactions) {
-			message = localize(`${confirmReaction}.bothMessage`, { reaction: spentReactionNames });
-		} else if (noActions) {
-			message = localize(`${confirmReaction}.noActionsMessage`);
-		} else {
-			message = localize(`${confirmReaction}.spentMessage`, { reaction: spentReactionNames });
-		}
-
-		const confirmQuestion = localize(`${confirmReaction}.confirmQuestion`, {
-			reaction: reactionName,
-		});
-
-		const confirmed = await foundry.applications.api.DialogV2.confirm({
-			window: { title: localize(`${confirmReaction}.title`) },
-			content: `<p>${message}</p><p>${confirmQuestion}</p>`,
-			yes: { label: localize(`${confirmReaction}.confirm`) },
-			no: { label: localize(`${confirmReaction}.cancel`) },
-			rejectClose: false,
-		});
-
-		return confirmed === true;
-	}
-
 	async function handleHelp(): Promise<void> {
 		const isDisabled = getReactionDisabled();
 
@@ -67,12 +36,12 @@ export function createHelpPanelState(
 			const noActions = getNoActions();
 			const reactionName = localize('NIMBLE.ui.heroicActions.reactions.help.label');
 
-			const confirmed = await showReactionConfirmation(
+			const confirmed = await showReactionConfirmation({
 				reactionName,
-				reactionName,
+				spentReactionNames: reactionName,
 				noActions,
-				helpSpent,
-			);
+				hasSpentReactions: helpSpent,
+			});
 			if (!confirmed) return;
 
 			const reactionUsed = await getOnUseReaction()({ force: true });

--- a/src/view/sheets/components/InterposeReactionPanel.svelte
+++ b/src/view/sheets/components/InterposeReactionPanel.svelte
@@ -25,6 +25,17 @@
 	const isDisabled = $derived(reactionDisabled);
 	const canInterposeAndDefend = $derived(!combinedReactionDisabled);
 	const { getTargetName, handleInterpose, handleInterposeAndDefend } = state;
+
+	function handleInterposeAndDefendDragStart(event: DragEvent) {
+		if (!event.dataTransfer) return;
+		const dragData = {
+			type: 'HeroicAction',
+			actionId: 'interposeAndDefend',
+			actionType: 'reaction',
+			name: localize('NIMBLE.ui.heroicActions.reactions.interposeAndDefend.confirm'),
+		};
+		event.dataTransfer.setData('text/plain', JSON.stringify(dragData));
+	}
 </script>
 
 <section class="reaction-panel">
@@ -71,6 +82,8 @@
 		<button
 			class="reaction-panel__button reaction-panel__button--combined"
 			disabled={!canInterposeAndDefend}
+			draggable="true"
+			ondragstart={handleInterposeAndDefendDragStart}
 			onclick={handleInterposeAndDefend}
 		>
 			<i class="fa-solid fa-people-arrows"></i>

--- a/src/view/sheets/components/InterposeReactionPanel.svelte
+++ b/src/view/sheets/components/InterposeReactionPanel.svelte
@@ -8,6 +8,9 @@
 		actor,
 		reactionDisabled = true,
 		combinedReactionDisabled = true,
+		defendSpent = false,
+		interposeSpent = false,
+		noActions = false,
 		onUseReaction = async () => false,
 		onUseCombinedReaction = async () => false,
 	}: ReactionPanelProps = $props();
@@ -15,6 +18,9 @@
 	const state = createInterposePanelState(
 		() => actor,
 		() => reactionDisabled,
+		() => defendSpent,
+		() => interposeSpent,
+		() => noActions,
 		() => onUseReaction,
 		() => combinedReactionDisabled,
 		() => onUseCombinedReaction,
@@ -22,9 +28,18 @@
 
 	const availableTargets = $derived(state.availableTargets);
 	const selectedTarget = $derived(state.selectedTarget);
-	const isDisabled = $derived(reactionDisabled);
-	const canInterposeAndDefend = $derived(!combinedReactionDisabled);
 	const { getTargetName, handleInterpose, handleInterposeAndDefend } = state;
+
+	function handleInterposeDragStart(event: DragEvent) {
+		if (!event.dataTransfer) return;
+		const dragData = {
+			type: 'HeroicAction',
+			actionId: 'interpose',
+			actionType: 'reaction',
+			name: localize('NIMBLE.ui.heroicActions.reactions.interpose.label'),
+		};
+		event.dataTransfer.setData('text/plain', JSON.stringify(dragData));
+	}
 
 	function handleInterposeAndDefendDragStart(event: DragEvent) {
 		if (!event.dataTransfer) return;
@@ -74,14 +89,18 @@
 	/>
 
 	<div class="reaction-panel__button-group">
-		<button class="reaction-panel__button" disabled={isDisabled} onclick={handleInterpose}>
+		<button
+			class="reaction-panel__button"
+			draggable="true"
+			ondragstart={handleInterposeDragStart}
+			onclick={handleInterpose}
+		>
 			<i class="fa-solid fa-people-arrows"></i>
 			{localize('NIMBLE.ui.heroicActions.reactions.interpose.confirm')}
 		</button>
 
 		<button
 			class="reaction-panel__button reaction-panel__button--combined"
-			disabled={!canInterposeAndDefend}
 			draggable="true"
 			ondragstart={handleInterposeAndDefendDragStart}
 			onclick={handleInterposeAndDefend}

--- a/src/view/sheets/components/InterposeReactionPanel.svelte
+++ b/src/view/sheets/components/InterposeReactionPanel.svelte
@@ -15,16 +15,16 @@
 		onUseCombinedReaction = async () => false,
 	}: ReactionPanelProps = $props();
 
-	const state = createInterposePanelState(
-		() => actor,
-		() => reactionDisabled,
-		() => defendSpent,
-		() => interposeSpent,
-		() => noActions,
-		() => onUseReaction,
-		() => combinedReactionDisabled,
-		() => onUseCombinedReaction,
-	);
+	const state = createInterposePanelState({
+		getActor: () => actor,
+		getReactionDisabled: () => reactionDisabled,
+		getDefendSpent: () => defendSpent,
+		getInterposeSpent: () => interposeSpent,
+		getNoActions: () => noActions,
+		getOnUseReaction: () => onUseReaction,
+		getCombinedReactionDisabled: () => combinedReactionDisabled,
+		getOnUseCombinedReaction: () => onUseCombinedReaction,
+	});
 
 	const availableTargets = $derived(state.availableTargets);
 	const selectedTarget = $derived(state.selectedTarget);

--- a/src/view/sheets/components/InterposeReactionPanel.svelte.ts
+++ b/src/view/sheets/components/InterposeReactionPanel.svelte.ts
@@ -1,18 +1,13 @@
-import type { NimbleCharacter } from '../../../documents/actor/character.js';
+import type { ReactionPanelStateOptions } from '../../../../types/components/ReactionPanel.d.ts';
 import localize from '../../../utils/localize.js';
 import showReactionConfirmation from '../../../utils/showReactionConfirmation.js';
 import { getTargetedTokens, getTargetName } from '../../../utils/targeting.js';
+import handleInterposeAndDefend from './handleInterposeAndDefend.js';
 
-export function createInterposePanelState(
-	getActor: () => NimbleCharacter,
-	getReactionDisabled: () => boolean,
-	getDefendSpent: () => boolean,
-	getInterposeSpent: () => boolean,
-	getNoActions: () => boolean,
-	getOnUseReaction: () => (options?: { force?: boolean }) => Promise<boolean>,
-	getCombinedReactionDisabled: () => boolean,
-	getOnUseCombinedReaction: () => (options?: { force?: boolean }) => Promise<boolean>,
-) {
+export function createInterposePanelState(options: ReactionPanelStateOptions) {
+	const { getActor, getReactionDisabled, getInterposeSpent, getNoActions, getOnUseReaction } =
+		options;
+
 	// Targeting state
 	let targetingVersion = $state(0);
 
@@ -76,76 +71,6 @@ export function createInterposePanelState(
 		await ChatMessage.create(chatData as unknown as ChatMessage.CreateData);
 	}
 
-	async function handleInterposeAndDefend(): Promise<void> {
-		const isDisabled = getCombinedReactionDisabled();
-
-		if (isDisabled) {
-			const defendSpent = getDefendSpent();
-			const interposeSpent = getInterposeSpent();
-			const noActions = getNoActions();
-			const reactionName = localize('NIMBLE.ui.heroicActions.reactions.interposeAndDefend.confirm');
-
-			// Build spent reactions string
-			const spentReactions: string[] = [];
-			if (interposeSpent)
-				spentReactions.push(localize('NIMBLE.ui.heroicActions.reactionLabels.interpose'));
-			if (defendSpent)
-				spentReactions.push(localize('NIMBLE.ui.heroicActions.reactionLabels.defend'));
-			const spentReactionNames = spentReactions.join(' & ');
-
-			const confirmed = await showReactionConfirmation({
-				reactionName,
-				spentReactionNames,
-				noActions,
-				hasSpentReactions: spentReactions.length > 0,
-			});
-			if (!confirmed) return;
-
-			const reactionUsed = await getOnUseCombinedReaction()({ force: true });
-			if (!reactionUsed) return;
-		} else {
-			const reactionUsed = await getOnUseCombinedReaction()();
-			if (!reactionUsed) return;
-		}
-
-		const actor = getActor();
-		const currentArmorValue = actor.reactive.system.attributes.armor.value ?? 0;
-		const targetUuids = getTargetedTokens(actor.id ?? '').map((t) => t.document.uuid);
-
-		// Create Interpose message first (stepping in front of ally)
-		await ChatMessage.create({
-			author: game.user?.id,
-			speaker: ChatMessage.getSpeaker({ actor }),
-			type: 'reaction',
-			system: {
-				actorName: actor.name,
-				actorType: actor.type,
-				image: actor.img,
-				permissions: actor.permission,
-				rollMode: 0,
-				reactionType: 'interpose',
-				targets: targetUuids,
-			},
-		} as unknown as ChatMessage.CreateData);
-
-		// Then create Defend message (reducing damage taken)
-		await ChatMessage.create({
-			author: game.user?.id,
-			speaker: ChatMessage.getSpeaker({ actor }),
-			type: 'reaction',
-			system: {
-				actorName: actor.name,
-				actorType: actor.type,
-				image: actor.img,
-				permissions: actor.permission,
-				rollMode: 0,
-				reactionType: 'defend',
-				armorValue: currentArmorValue,
-				targets: [],
-			},
-		} as unknown as ChatMessage.CreateData);
-	}
-
 	return {
 		get availableTargets() {
 			return availableTargets;
@@ -158,6 +83,6 @@ export function createInterposePanelState(
 		},
 		getTargetName,
 		handleInterpose,
-		handleInterposeAndDefend,
+		handleInterposeAndDefend: () => handleInterposeAndDefend(options),
 	};
 }

--- a/src/view/sheets/components/InterposeReactionPanel.svelte.ts
+++ b/src/view/sheets/components/InterposeReactionPanel.svelte.ts
@@ -1,12 +1,16 @@
 import type { NimbleCharacter } from '../../../documents/actor/character.js';
+import localize from '../../../utils/localize.js';
 import { getTargetedTokens, getTargetName } from '../../../utils/targeting.js';
 
 export function createInterposePanelState(
 	getActor: () => NimbleCharacter,
 	getReactionDisabled: () => boolean,
-	getOnUseReaction: () => () => Promise<boolean>,
+	getDefendSpent: () => boolean,
+	getInterposeSpent: () => boolean,
+	getNoActions: () => boolean,
+	getOnUseReaction: () => (options?: { force?: boolean }) => Promise<boolean>,
 	getCombinedReactionDisabled: () => boolean,
-	getOnUseCombinedReaction: () => () => Promise<boolean>,
+	getOnUseCombinedReaction: () => (options?: { force?: boolean }) => Promise<boolean>,
 ) {
 	// Targeting state
 	let targetingVersion = $state(0);
@@ -28,11 +32,60 @@ export function createInterposePanelState(
 		return () => Hooks.off('targetToken', hookId);
 	});
 
-	async function handleInterpose(): Promise<void> {
-		if (getReactionDisabled()) return;
+	async function showReactionConfirmation(
+		reactionName: string,
+		spentReactionNames: string,
+		noActions: boolean,
+		hasSpentReactions: boolean,
+	): Promise<boolean> {
+		const confirmReaction = 'NIMBLE.ui.heroicActions.confirmReaction';
 
-		const reactionUsed = await getOnUseReaction()();
-		if (!reactionUsed) return;
+		let message: string;
+		if (noActions && hasSpentReactions) {
+			message = localize(`${confirmReaction}.bothMessage`, { reaction: spentReactionNames });
+		} else if (noActions) {
+			message = localize(`${confirmReaction}.noActionsMessage`);
+		} else {
+			message = localize(`${confirmReaction}.spentMessage`, { reaction: spentReactionNames });
+		}
+
+		const confirmQuestion = localize(`${confirmReaction}.confirmQuestion`, {
+			reaction: reactionName,
+		});
+
+		const confirmed = await foundry.applications.api.DialogV2.confirm({
+			window: { title: localize(`${confirmReaction}.title`) },
+			content: `<p>${message}</p><p>${confirmQuestion}</p>`,
+			yes: { label: localize(`${confirmReaction}.confirm`) },
+			no: { label: localize(`${confirmReaction}.cancel`) },
+			rejectClose: false,
+		});
+
+		return confirmed === true;
+	}
+
+	async function handleInterpose(): Promise<void> {
+		const isDisabled = getReactionDisabled();
+
+		if (isDisabled) {
+			const interposeSpent = getInterposeSpent();
+			const noActions = getNoActions();
+			const reactionName = localize('NIMBLE.ui.heroicActions.reactions.interpose.label');
+
+			const confirmed = await showReactionConfirmation(
+				reactionName,
+				reactionName,
+				noActions,
+				interposeSpent,
+			);
+			if (!confirmed) return;
+
+			const reactionUsed = await getOnUseReaction()({ force: true });
+			if (!reactionUsed) return;
+		} else {
+			const reactionUsed = await getOnUseReaction()();
+			if (!reactionUsed) return;
+		}
 
 		const actor = getActor();
 		const targetUuids = getTargetedTokens(actor.id ?? '').map((t) => t.document.uuid);
@@ -55,10 +108,36 @@ export function createInterposePanelState(
 	}
 
 	async function handleInterposeAndDefend(): Promise<void> {
-		if (getCombinedReactionDisabled()) return;
+		const isDisabled = getCombinedReactionDisabled();
 
-		const reactionUsed = await getOnUseCombinedReaction()();
-		if (!reactionUsed) return;
+		if (isDisabled) {
+			const defendSpent = getDefendSpent();
+			const interposeSpent = getInterposeSpent();
+			const noActions = getNoActions();
+			const reactionName = localize('NIMBLE.ui.heroicActions.reactions.interposeAndDefend.confirm');
+
+			// Build spent reactions string
+			const spentReactions: string[] = [];
+			if (interposeSpent)
+				spentReactions.push(localize('NIMBLE.ui.heroicActions.reactionLabels.interpose'));
+			if (defendSpent)
+				spentReactions.push(localize('NIMBLE.ui.heroicActions.reactionLabels.defend'));
+			const spentReactionNames = spentReactions.join(' & ');
+
+			const confirmed = await showReactionConfirmation(
+				reactionName,
+				spentReactionNames,
+				noActions,
+				spentReactions.length > 0,
+			);
+			if (!confirmed) return;
+
+			const reactionUsed = await getOnUseCombinedReaction()({ force: true });
+			if (!reactionUsed) return;
+		} else {
+			const reactionUsed = await getOnUseCombinedReaction()();
+			if (!reactionUsed) return;
+		}
 
 		const actor = getActor();
 		const currentArmorValue = actor.reactive.system.attributes.armor.value ?? 0;

--- a/src/view/sheets/components/InterposeReactionPanel.svelte.ts
+++ b/src/view/sheets/components/InterposeReactionPanel.svelte.ts
@@ -1,5 +1,6 @@
 import type { NimbleCharacter } from '../../../documents/actor/character.js';
 import localize from '../../../utils/localize.js';
+import showReactionConfirmation from '../../../utils/showReactionConfirmation.js';
 import { getTargetedTokens, getTargetName } from '../../../utils/targeting.js';
 
 export function createInterposePanelState(
@@ -32,38 +33,6 @@ export function createInterposePanelState(
 		return () => Hooks.off('targetToken', hookId);
 	});
 
-	async function showReactionConfirmation(
-		reactionName: string,
-		spentReactionNames: string,
-		noActions: boolean,
-		hasSpentReactions: boolean,
-	): Promise<boolean> {
-		const confirmReaction = 'NIMBLE.ui.heroicActions.confirmReaction';
-
-		let message: string;
-		if (noActions && hasSpentReactions) {
-			message = localize(`${confirmReaction}.bothMessage`, { reaction: spentReactionNames });
-		} else if (noActions) {
-			message = localize(`${confirmReaction}.noActionsMessage`);
-		} else {
-			message = localize(`${confirmReaction}.spentMessage`, { reaction: spentReactionNames });
-		}
-
-		const confirmQuestion = localize(`${confirmReaction}.confirmQuestion`, {
-			reaction: reactionName,
-		});
-
-		const confirmed = await foundry.applications.api.DialogV2.confirm({
-			window: { title: localize(`${confirmReaction}.title`) },
-			content: `<p>${message}</p><p>${confirmQuestion}</p>`,
-			yes: { label: localize(`${confirmReaction}.confirm`) },
-			no: { label: localize(`${confirmReaction}.cancel`) },
-			rejectClose: false,
-		});
-
-		return confirmed === true;
-	}
-
 	async function handleInterpose(): Promise<void> {
 		const isDisabled = getReactionDisabled();
 
@@ -72,12 +41,12 @@ export function createInterposePanelState(
 			const noActions = getNoActions();
 			const reactionName = localize('NIMBLE.ui.heroicActions.reactions.interpose.label');
 
-			const confirmed = await showReactionConfirmation(
+			const confirmed = await showReactionConfirmation({
 				reactionName,
-				reactionName,
+				spentReactionNames: reactionName,
 				noActions,
-				interposeSpent,
-			);
+				hasSpentReactions: interposeSpent,
+			});
 			if (!confirmed) return;
 
 			const reactionUsed = await getOnUseReaction()({ force: true });
@@ -124,12 +93,12 @@ export function createInterposePanelState(
 				spentReactions.push(localize('NIMBLE.ui.heroicActions.reactionLabels.defend'));
 			const spentReactionNames = spentReactions.join(' & ');
 
-			const confirmed = await showReactionConfirmation(
+			const confirmed = await showReactionConfirmation({
 				reactionName,
 				spentReactionNames,
 				noActions,
-				spentReactions.length > 0,
-			);
+				hasSpentReactions: spentReactions.length > 0,
+			});
 			if (!confirmed) return;
 
 			const reactionUsed = await getOnUseCombinedReaction()({ force: true });

--- a/src/view/sheets/components/MoveActionPanel.svelte
+++ b/src/view/sheets/components/MoveActionPanel.svelte
@@ -13,8 +13,33 @@
 	let movementSpeeds = $derived(getMovementSpeeds(actor));
 	let primarySpeed = $derived(movementSpeeds.find((s) => s.type === 'walk') ?? movementSpeeds[0]);
 
+	function handleMoveDragStart(event: DragEvent) {
+		if (!event.dataTransfer) return;
+		const dragData = {
+			type: 'HeroicAction',
+			actionId: 'move',
+			actionType: 'action',
+			name: localize('NIMBLE.ui.heroicActions.actions.move.label'),
+		};
+		event.dataTransfer.setData('text/plain', JSON.stringify(dragData));
+	}
+
 	async function handleMove() {
-		if (!inCombat || actionsRemaining <= 0) return;
+		if (!inCombat) return;
+
+		// Show confirmation dialog if no actions remaining
+		if (actionsRemaining <= 0) {
+			const confirmMove = 'NIMBLE.ui.heroicActions.confirmMove';
+			const confirmed = await foundry.applications.api.DialogV2.confirm({
+				window: { title: localize(`${confirmMove}.title`) },
+				content: `<p>${localize(`${confirmMove}.noActionsMessage`)}</p><p>${localize(`${confirmMove}.confirmQuestion`)}</p>`,
+				yes: { label: localize(`${confirmMove}.confirm`) },
+				no: { label: localize(`${confirmMove}.cancel`) },
+				rejectClose: false,
+			});
+
+			if (confirmed !== true) return;
+		}
 
 		await onDeductAction();
 
@@ -77,7 +102,9 @@
 
 	<button
 		class="action-card__button"
-		disabled={!inCombat || actionsRemaining <= 0}
+		disabled={!inCombat}
+		draggable="true"
+		ondragstart={handleMoveDragStart}
 		onclick={handleMove}
 	>
 		<i class="fa-solid fa-person-running"></i>

--- a/src/view/sheets/components/OpportunityAttackPanel.svelte
+++ b/src/view/sheets/components/OpportunityAttackPanel.svelte
@@ -14,6 +14,8 @@
 		opportunitySpent = false,
 		noActions = false,
 		onUseReaction = async () => false,
+		forceNextReactionUse = false,
+		onConsumeForcedReactionUse = () => {},
 		showEmbeddedDocumentImages = true,
 	}: OpportunityAttackPanelProps = $props();
 
@@ -23,6 +25,8 @@
 		() => opportunitySpent,
 		() => noActions,
 		() => onUseReaction,
+		() => forceNextReactionUse,
+		() => onConsumeForcedReactionUse,
 	);
 
 	const meleeWeapons = $derived(state.meleeWeapons);

--- a/src/view/sheets/components/OpportunityAttackPanel.svelte
+++ b/src/view/sheets/components/OpportunityAttackPanel.svelte
@@ -11,6 +11,8 @@
 	let {
 		actor,
 		reactionDisabled = true,
+		opportunitySpent = false,
+		noActions = false,
 		onUseReaction = async () => false,
 		showEmbeddedDocumentImages = true,
 	}: OpportunityAttackPanelProps = $props();
@@ -18,6 +20,8 @@
 	const state = createOpportunityAttackPanelState(
 		() => actor,
 		() => reactionDisabled,
+		() => opportunitySpent,
+		() => noActions,
 		() => onUseReaction,
 	);
 
@@ -25,7 +29,6 @@
 	const showUnarmedStrike = $derived(state.showUnarmedStrike);
 	const availableTargets = $derived(state.availableTargets);
 	const selectedTarget = $derived(state.selectedTarget);
-	const isDisabled = $derived(reactionDisabled);
 	const {
 		sortItems,
 		getWeaponDamage,
@@ -35,6 +38,17 @@
 		handleUnarmedStrike,
 		handleItemClick,
 	} = state;
+
+	function handleUnarmedStrikeDragStart(event: DragEvent) {
+		if (!event.dataTransfer) return;
+		const dragData = {
+			type: 'HeroicAction',
+			actionId: 'unarmedStrike',
+			actionType: 'action',
+			name: localize('NIMBLE.ui.heroicActions.unarmedStrike'),
+		};
+		event.dataTransfer.setData('text/plain', JSON.stringify(dragData));
+	}
 </script>
 
 <section class="reaction-panel">
@@ -79,9 +93,9 @@
 				icon="fa-solid fa-hand-fist"
 				damage={getUnarmedDamageDisplay()}
 				properties={[localize('NIMBLE.npcSheet.melee')]}
-				disabled={isDisabled}
 				showImage={false}
 				onclick={() => handleUnarmedStrike()}
+				ondragstart={handleUnarmedStrikeDragStart}
 			/>
 		{/if}
 
@@ -91,7 +105,6 @@
 				image={item.reactive.img}
 				damage={getWeaponDamage(item)}
 				properties={getWeaponProperties(item)}
-				disabled={isDisabled}
 				showImage={showEmbeddedDocumentImages}
 				itemId={item._id}
 				onclick={() => handleItemClick(item._id)}

--- a/src/view/sheets/components/OpportunityAttackPanel.svelte.ts
+++ b/src/view/sheets/components/OpportunityAttackPanel.svelte.ts
@@ -4,6 +4,7 @@ import ItemActivationConfigDialog from '../../../documents/dialogs/ItemActivatio
 import { getPrimaryDamageFormulaFromActivationEffects } from '../../../utils/activationEffects.js';
 import { evaluateFormula as evalFormula } from '../../../utils/evaluateFormula.js';
 import localize from '../../../utils/localize.js';
+import showReactionConfirmation from '../../../utils/showReactionConfirmation.js';
 import sortItems from '../../../utils/sortItems.js';
 import { getTargetedTokens, getTargetName } from '../../../utils/targeting.js';
 import { getUnarmedDamageFormula, hasUnarmedProficiency } from './attackUtils.js';
@@ -114,38 +115,6 @@ export function createOpportunityAttackPanelState(
 		}
 	}
 
-	async function showReactionConfirmation(
-		reactionName: string,
-		spentReactionNames: string,
-		noActions: boolean,
-		hasSpentReactions: boolean,
-	): Promise<boolean> {
-		const confirmReaction = 'NIMBLE.ui.heroicActions.confirmReaction';
-
-		let message: string;
-		if (noActions && hasSpentReactions) {
-			message = localize(`${confirmReaction}.bothMessage`, { reaction: spentReactionNames });
-		} else if (noActions) {
-			message = localize(`${confirmReaction}.noActionsMessage`);
-		} else {
-			message = localize(`${confirmReaction}.spentMessage`, { reaction: spentReactionNames });
-		}
-
-		const confirmQuestion = localize(`${confirmReaction}.confirmQuestion`, {
-			reaction: reactionName,
-		});
-
-		const confirmed = await foundry.applications.api.DialogV2.confirm({
-			window: { title: localize(`${confirmReaction}.title`) },
-			content: `<p>${message}</p><p>${confirmQuestion}</p>`,
-			yes: { label: localize(`${confirmReaction}.confirm`) },
-			no: { label: localize(`${confirmReaction}.cancel`) },
-			rejectClose: false,
-		});
-
-		return confirmed === true;
-	}
-
 	async function checkAndConfirmReaction(): Promise<{ confirmed: boolean; force: boolean }> {
 		const isDisabled = getReactionDisabled();
 
@@ -154,12 +123,12 @@ export function createOpportunityAttackPanelState(
 			const noActions = getNoActions();
 			const reactionName = localize('NIMBLE.ui.heroicActions.reactions.opportunity.label');
 
-			const confirmed = await showReactionConfirmation(
+			const confirmed = await showReactionConfirmation({
 				reactionName,
-				reactionName,
+				spentReactionNames: reactionName,
 				noActions,
-				opportunitySpent,
-			);
+				hasSpentReactions: opportunitySpent,
+			});
 			return { confirmed, force: true };
 		}
 

--- a/src/view/sheets/components/OpportunityAttackPanel.svelte.ts
+++ b/src/view/sheets/components/OpportunityAttackPanel.svelte.ts
@@ -2,12 +2,12 @@ import { DamageRoll } from '../../../dice/DamageRoll.js';
 import type { NimbleCharacter } from '../../../documents/actor/character.js';
 import ItemActivationConfigDialog from '../../../documents/dialogs/ItemActivationConfigDialog.svelte.js';
 import { getPrimaryDamageFormulaFromActivationEffects } from '../../../utils/activationEffects.js';
+import { getUnarmedDamageFormula, hasUnarmedProficiency } from '../../../utils/attackUtils.js';
 import { evaluateFormula as evalFormula } from '../../../utils/evaluateFormula.js';
 import localize from '../../../utils/localize.js';
 import showReactionConfirmation from '../../../utils/showReactionConfirmation.js';
 import sortItems from '../../../utils/sortItems.js';
 import { getTargetedTokens, getTargetName } from '../../../utils/targeting.js';
-import { getUnarmedDamageFormula, hasUnarmedProficiency } from './attackUtils.js';
 
 interface WeaponSystemData {
 	objectType: string;

--- a/src/view/sheets/components/OpportunityAttackPanel.svelte.ts
+++ b/src/view/sheets/components/OpportunityAttackPanel.svelte.ts
@@ -29,6 +29,8 @@ export function createOpportunityAttackPanelState(
 	getOpportunitySpent: () => boolean,
 	getNoActions: () => boolean,
 	getOnUseReaction: () => (options?: { force?: boolean }) => Promise<boolean>,
+	getForceNextReactionUse: () => boolean,
+	getOnConsumeForcedReactionUse: () => () => void,
 ) {
 	const { weaponProperties } = CONFIG.NIMBLE;
 
@@ -116,6 +118,10 @@ export function createOpportunityAttackPanelState(
 	}
 
 	async function checkAndConfirmReaction(): Promise<{ confirmed: boolean; force: boolean }> {
+		if (getForceNextReactionUse()) {
+			return { confirmed: true, force: true };
+		}
+
 		const isDisabled = getReactionDisabled();
 
 		if (isDisabled) {
@@ -182,6 +188,10 @@ export function createOpportunityAttackPanelState(
 
 		const reactionUsed = await getOnUseReaction()(force ? { force: true } : undefined);
 		if (!reactionUsed) return;
+
+		if (force) {
+			getOnConsumeForcedReactionUse()();
+		}
 
 		const roll = new DamageRoll(rollFormula, getActor().getRollData(), {
 			canCrit,
@@ -276,6 +286,10 @@ export function createOpportunityAttackPanelState(
 			// Item activation owns its own dialog flow, so consume the reaction only after success.
 			const reactionUsed = await getOnUseReaction()(force ? { force: true } : undefined);
 			if (!reactionUsed) return null;
+
+			if (force) {
+				getOnConsumeForcedReactionUse()();
+			}
 		}
 
 		return result;

--- a/src/view/sheets/components/OpportunityAttackPanel.svelte.ts
+++ b/src/view/sheets/components/OpportunityAttackPanel.svelte.ts
@@ -25,7 +25,9 @@ interface WeaponSystemData {
 export function createOpportunityAttackPanelState(
 	getActor: () => NimbleCharacter,
 	getReactionDisabled: () => boolean,
-	getOnUseReaction: () => () => Promise<boolean>,
+	getOpportunitySpent: () => boolean,
+	getNoActions: () => boolean,
+	getOnUseReaction: () => (options?: { force?: boolean }) => Promise<boolean>,
 ) {
 	const { weaponProperties } = CONFIG.NIMBLE;
 
@@ -112,6 +114,58 @@ export function createOpportunityAttackPanelState(
 		}
 	}
 
+	async function showReactionConfirmation(
+		reactionName: string,
+		spentReactionNames: string,
+		noActions: boolean,
+		hasSpentReactions: boolean,
+	): Promise<boolean> {
+		const confirmReaction = 'NIMBLE.ui.heroicActions.confirmReaction';
+
+		let message: string;
+		if (noActions && hasSpentReactions) {
+			message = localize(`${confirmReaction}.bothMessage`, { reaction: spentReactionNames });
+		} else if (noActions) {
+			message = localize(`${confirmReaction}.noActionsMessage`);
+		} else {
+			message = localize(`${confirmReaction}.spentMessage`, { reaction: spentReactionNames });
+		}
+
+		const confirmQuestion = localize(`${confirmReaction}.confirmQuestion`, {
+			reaction: reactionName,
+		});
+
+		const confirmed = await foundry.applications.api.DialogV2.confirm({
+			window: { title: localize(`${confirmReaction}.title`) },
+			content: `<p>${message}</p><p>${confirmQuestion}</p>`,
+			yes: { label: localize(`${confirmReaction}.confirm`) },
+			no: { label: localize(`${confirmReaction}.cancel`) },
+			rejectClose: false,
+		});
+
+		return confirmed === true;
+	}
+
+	async function checkAndConfirmReaction(): Promise<{ confirmed: boolean; force: boolean }> {
+		const isDisabled = getReactionDisabled();
+
+		if (isDisabled) {
+			const opportunitySpent = getOpportunitySpent();
+			const noActions = getNoActions();
+			const reactionName = localize('NIMBLE.ui.heroicActions.reactions.opportunity.label');
+
+			const confirmed = await showReactionConfirmation(
+				reactionName,
+				reactionName,
+				noActions,
+				opportunitySpent,
+			);
+			return { confirmed, force: true };
+		}
+
+		return { confirmed: true, force: false };
+	}
+
 	// ============================================================================
 	// Unarmed Strike
 	// ============================================================================
@@ -121,7 +175,9 @@ export function createOpportunityAttackPanelState(
 	}
 
 	async function handleUnarmedStrike(): Promise<void> {
-		if (getReactionDisabled()) return;
+		// Check if we need confirmation before proceeding
+		const { confirmed, force } = await checkAndConfirmReaction();
+		if (!confirmed) return;
 
 		const rollFormula = getUnarmedDamageFormula(getActor());
 		const canCrit = hasUnarmedProficiency(getActor()); // Only characters proficient with unarmed (e.g., Zephyr with Swift Fists) can crit
@@ -155,7 +211,7 @@ export function createOpportunityAttackPanelState(
 
 		if (!result) return;
 
-		const reactionUsed = await getOnUseReaction()();
+		const reactionUsed = await getOnUseReaction()(force ? { force: true } : undefined);
 		if (!reactionUsed) return;
 
 		const roll = new DamageRoll(rollFormula, getActor().getRollData(), {
@@ -240,14 +296,16 @@ export function createOpportunityAttackPanelState(
 	}
 
 	async function handleItemClick(itemId: string): Promise<unknown> {
-		if (getReactionDisabled()) return null;
+		// Check if we need confirmation before proceeding
+		const { confirmed, force } = await checkAndConfirmReaction();
+		if (!confirmed) return null;
 
 		const item = getActor().items.get(itemId);
 		const result = await getActor().activateItem(itemId, { rollMode: -1 }); // Disadvantage
 
 		if (result && item) {
 			// Item activation owns its own dialog flow, so consume the reaction only after success.
-			const reactionUsed = await getOnUseReaction()();
+			const reactionUsed = await getOnUseReaction()(force ? { force: true } : undefined);
 			if (!reactionUsed) return null;
 		}
 

--- a/src/view/sheets/components/ReactionPanels.test.ts
+++ b/src/view/sheets/components/ReactionPanels.test.ts
@@ -1,0 +1,302 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import type { Component } from 'svelte';
+
+type RenderComponent = Component<Record<string, unknown>>;
+
+const DefendReactionPanel = (await import('./DefendReactionPanel.svelte')) as unknown as {
+	default: RenderComponent;
+};
+const HelpReactionPanel = (await import('./HelpReactionPanel.svelte')) as unknown as {
+	default: RenderComponent;
+};
+const InterposeReactionPanel = (await import('./InterposeReactionPanel.svelte')) as unknown as {
+	default: RenderComponent;
+};
+const OpportunityAttackPanel = (await import('./OpportunityAttackPanel.svelte')) as unknown as {
+	default: RenderComponent;
+};
+
+type TargetToken = {
+	actor?: { id: string; name?: string };
+	document: { uuid: string; texture?: { src?: string } };
+	name?: string;
+};
+
+type ReactionActor = {
+	id: string;
+	name: string;
+	type: string;
+	img: string;
+	system: {
+		unarmedDamage: string;
+	};
+	permission: number;
+	reactive: {
+		system: {
+			attributes: {
+				armor: {
+					value: number;
+				};
+			};
+		};
+		items?: Item[];
+	};
+	items?: {
+		get: ReturnType<typeof vi.fn>;
+	};
+	activateItem?: ReturnType<typeof vi.fn>;
+};
+
+function createReactionActor(): ReactionActor {
+	return {
+		id: 'reaction-panel-actor',
+		name: 'Shield Bearer',
+		type: 'character',
+		img: 'shield-bearer.webp',
+		system: {
+			unarmedDamage: '1d4',
+		},
+		permission: CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER,
+		reactive: {
+			system: {
+				attributes: {
+					armor: {
+						value: 14,
+					},
+				},
+			},
+		},
+	};
+}
+
+function createOpportunityActor() {
+	const weapon = {
+		_id: 'weapon-opportunity',
+		id: 'weapon-opportunity',
+		sort: 1,
+		type: 'object',
+		reactive: {
+			name: 'Spear',
+			img: 'spear.webp',
+		},
+		system: {
+			objectType: 'weapon',
+			activation: {
+				effects: [
+					{
+						type: 'damage',
+						formula: '1d6',
+					},
+				],
+			},
+			properties: {
+				selected: ['reach'],
+				reach: {
+					max: 2,
+				},
+			},
+		},
+	} as unknown as Item;
+
+	const actor = createReactionActor();
+	return {
+		...actor,
+		reactive: {
+			...actor.reactive,
+			items: [weapon],
+		},
+		items: {
+			get: vi.fn().mockReturnValue(weapon),
+		},
+		activateItem: vi.fn().mockResolvedValue({ ok: true }),
+	};
+}
+
+function setTargets(targets: TargetToken[]) {
+	(
+		globalThis as unknown as {
+			game: {
+				user: {
+					targets: Set<TargetToken>;
+				};
+			};
+		}
+	).game.user.targets = new Set(targets);
+}
+
+function confirmDialog() {
+	return foundry.applications.api.DialogV2.confirm as unknown as ReturnType<typeof vi.fn>;
+}
+
+describe('reaction panel confirmation wrappers', () => {
+	beforeEach(() => {
+		confirmDialog().mockReset();
+		(
+			globalThis as unknown as {
+				ChatMessage: {
+					create: ReturnType<typeof vi.fn>;
+					getSpeaker: ReturnType<typeof vi.fn>;
+				};
+			}
+		).ChatMessage.create = vi.fn().mockResolvedValue({ id: 'chat-message-id' });
+		(
+			globalThis as unknown as {
+				ChatMessage: {
+					create: ReturnType<typeof vi.fn>;
+					getSpeaker: ReturnType<typeof vi.fn>;
+				};
+			}
+		).ChatMessage.getSpeaker = vi.fn().mockReturnValue({ actor: 'reaction-panel-actor' });
+
+		setTargets([]);
+	});
+
+	it('stops the help reaction when the confirmation dialog is cancelled', async () => {
+		const onUseReaction = vi.fn().mockResolvedValue(true);
+		confirmDialog().mockResolvedValue(false);
+
+		render(HelpReactionPanel.default, {
+			props: {
+				actor: createReactionActor(),
+				reactionDisabled: true,
+				helpSpent: true,
+				noActions: false,
+				onUseReaction,
+			},
+		});
+
+		await fireEvent.click(
+			screen.getByRole('button', {
+				name: game.i18n.localize('NIMBLE.ui.heroicActions.reactions.help.confirm'),
+			}),
+		);
+
+		expect(confirmDialog()).toHaveBeenCalledTimes(1);
+		expect(onUseReaction).not.toHaveBeenCalled();
+		expect(ChatMessage.create).not.toHaveBeenCalled();
+	});
+
+	it('passes force=true after the help confirmation succeeds', async () => {
+		const onUseReaction = vi.fn().mockResolvedValue(true);
+		confirmDialog().mockResolvedValue(true);
+
+		render(HelpReactionPanel.default, {
+			props: {
+				actor: createReactionActor(),
+				reactionDisabled: true,
+				helpSpent: false,
+				noActions: true,
+				onUseReaction,
+			},
+		});
+
+		await fireEvent.click(
+			screen.getByRole('button', {
+				name: game.i18n.localize('NIMBLE.ui.heroicActions.reactions.help.confirm'),
+			}),
+		);
+
+		expect(onUseReaction).toHaveBeenCalledWith({ force: true });
+		expect(ChatMessage.create).toHaveBeenCalledTimes(1);
+	});
+
+	it('builds the combined interpose/defend spent label before confirming', async () => {
+		confirmDialog().mockResolvedValue(false);
+
+		render(InterposeReactionPanel.default, {
+			props: {
+				actor: createReactionActor(),
+				reactionDisabled: false,
+				combinedReactionDisabled: true,
+				defendSpent: true,
+				interposeSpent: true,
+				noActions: false,
+				onUseReaction: vi.fn().mockResolvedValue(true),
+				onUseCombinedReaction: vi.fn().mockResolvedValue(true),
+			},
+		});
+
+		await fireEvent.click(screen.getByRole('button', { name: /Interpose & Defend/ }));
+
+		expect(confirmDialog()).toHaveBeenCalledWith(
+			expect.objectContaining({
+				content: expect.stringContaining(
+					game.i18n.localize('NIMBLE.ui.heroicActions.reactionLabels.interpose'),
+				),
+			}),
+		);
+		expect(confirmDialog()).toHaveBeenCalledWith(
+			expect.objectContaining({
+				content: expect.stringContaining(
+					game.i18n.localize('NIMBLE.ui.heroicActions.reactionLabels.defend'),
+				),
+			}),
+		);
+	});
+
+	it('passes force=true for the combined defend path after confirmation', async () => {
+		const onUseCombinedReaction = vi.fn().mockResolvedValue(true);
+		confirmDialog().mockResolvedValue(true);
+
+		render(DefendReactionPanel.default, {
+			props: {
+				actor: createReactionActor(),
+				reactionDisabled: false,
+				combinedReactionDisabled: true,
+				defendSpent: true,
+				interposeSpent: false,
+				noActions: true,
+				onUseReaction: vi.fn().mockResolvedValue(true),
+				onUseCombinedReaction,
+			},
+		});
+
+		await fireEvent.click(screen.getByRole('button', { name: /Interpose & Defend/ }));
+
+		expect(onUseCombinedReaction).toHaveBeenCalledWith({ force: true });
+		await waitFor(() => expect(ChatMessage.create).toHaveBeenCalledTimes(2));
+	});
+
+	it('does not activate an opportunity attack weapon when the confirmation dialog is cancelled', async () => {
+		const actor = createOpportunityActor();
+		confirmDialog().mockResolvedValue(false);
+
+		render(OpportunityAttackPanel.default, {
+			props: {
+				actor,
+				reactionDisabled: true,
+				opportunitySpent: true,
+				noActions: false,
+				onUseReaction: vi.fn().mockResolvedValue(true),
+				showEmbeddedDocumentImages: false,
+			},
+		});
+
+		await fireEvent.click(screen.getByRole('button', { name: /spear/i }));
+
+		expect(confirmDialog()).toHaveBeenCalledTimes(1);
+		expect(actor.activateItem).not.toHaveBeenCalled();
+	});
+
+	it('passes force=true for opportunity attacks after confirmation succeeds', async () => {
+		const actor = createOpportunityActor();
+		const onUseReaction = vi.fn().mockResolvedValue(true);
+		confirmDialog().mockResolvedValue(true);
+
+		render(OpportunityAttackPanel.default, {
+			props: {
+				actor,
+				reactionDisabled: true,
+				opportunitySpent: false,
+				noActions: true,
+				onUseReaction,
+				showEmbeddedDocumentImages: false,
+			},
+		});
+
+		await fireEvent.click(screen.getByRole('button', { name: /spear/i }));
+
+		expect(actor.activateItem).toHaveBeenCalledWith('weapon-opportunity', { rollMode: -1 });
+		await waitFor(() => expect(onUseReaction).toHaveBeenCalledWith({ force: true }));
+	});
+});

--- a/src/view/sheets/components/WeaponCard.svelte
+++ b/src/view/sheets/components/WeaponCard.svelte
@@ -23,13 +23,13 @@
 	class="weapon-card"
 	class:weapon-card--expanded={isExpanded}
 	class:weapon-card--disabled={disabled}
-	data-item-id={itemId}
 >
 	<div
 		class="weapon-card__row"
 		role="button"
 		tabindex={disabled ? -1 : 0}
 		draggable={ondragstart ? 'true' : 'false'}
+		data-item-id={itemId}
 		{ondragstart}
 		onclick={disabled ? null : onclick}
 		onkeydown={(e) => {

--- a/src/view/sheets/components/handleInterposeAndDefend.ts
+++ b/src/view/sheets/components/handleInterposeAndDefend.ts
@@ -1,0 +1,89 @@
+import type { ReactionPanelStateOptions } from '../../../../types/components/ReactionPanel.d.ts';
+import localize from '../../../utils/localize.js';
+import showReactionConfirmation from '../../../utils/showReactionConfirmation.js';
+import { getTargetedTokens } from '../../../utils/targeting.js';
+
+export default async function handleInterposeAndDefend(
+	options: Pick<
+		ReactionPanelStateOptions,
+		| 'getActor'
+		| 'getDefendSpent'
+		| 'getInterposeSpent'
+		| 'getNoActions'
+		| 'getCombinedReactionDisabled'
+		| 'getOnUseCombinedReaction'
+	>,
+): Promise<void> {
+	const {
+		getActor,
+		getDefendSpent,
+		getInterposeSpent,
+		getNoActions,
+		getCombinedReactionDisabled,
+		getOnUseCombinedReaction,
+	} = options;
+
+	const isDisabled = getCombinedReactionDisabled();
+
+	if (isDisabled) {
+		const defendSpent = getDefendSpent();
+		const interposeSpent = getInterposeSpent();
+		const noActions = getNoActions();
+		const reactionName = localize('NIMBLE.ui.heroicActions.reactions.interposeAndDefend.confirm');
+
+		const spentReactions: string[] = [];
+		if (interposeSpent)
+			spentReactions.push(localize('NIMBLE.ui.heroicActions.reactionLabels.interpose'));
+		if (defendSpent) spentReactions.push(localize('NIMBLE.ui.heroicActions.reactionLabels.defend'));
+		const spentReactionNames = spentReactions.join(' & ');
+
+		const confirmed = await showReactionConfirmation({
+			reactionName,
+			spentReactionNames,
+			noActions,
+			hasSpentReactions: spentReactions.length > 0,
+		});
+		if (!confirmed) return;
+
+		const reactionUsed = await getOnUseCombinedReaction()({ force: true });
+		if (!reactionUsed) return;
+	} else {
+		const reactionUsed = await getOnUseCombinedReaction()();
+		if (!reactionUsed) return;
+	}
+
+	const actor = getActor();
+	const currentArmorValue = actor.reactive.system.attributes.armor.value ?? 0;
+	const targetUuids = getTargetedTokens(actor.id ?? '').map((t) => t.document.uuid);
+
+	await ChatMessage.create({
+		author: game.user?.id,
+		speaker: ChatMessage.getSpeaker({ actor }),
+		type: 'reaction',
+		system: {
+			actorName: actor.name,
+			actorType: actor.type,
+			image: actor.img,
+			permissions: actor.permission,
+			rollMode: 0,
+			reactionType: 'interpose',
+			targets: targetUuids,
+		},
+	} as unknown as ChatMessage.CreateData);
+
+	await ChatMessage.create({
+		author: game.user?.id,
+		speaker: ChatMessage.getSpeaker({ actor }),
+		type: 'reaction',
+		system: {
+			actorName: actor.name,
+			actorType: actor.type,
+			image: actor.img,
+			permissions: actor.permission,
+			rollMode: 0,
+			reactionType: 'defend',
+			armorValue: currentArmorValue,
+			targets: [],
+		},
+	} as unknown as ChatMessage.CreateData);
+}

--- a/src/view/sheets/pages/PlayerCharacterHeroicActionsTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterHeroicActionsTab.svelte
@@ -193,8 +193,11 @@
 			{actor}
 			reactionDisabled={!state.canUseReaction('defend')}
 			combinedReactionDisabled={!state.canUseInterposeAndDefendCombo}
-			onUseReaction={() => state.useReaction('defend')}
-			onUseCombinedReaction={() => state.useReactionCombo(['interpose', 'defend'])}
+			defendSpent={!state.isReactionAvailable('defend')}
+			interposeSpent={!state.isReactionAvailable('interpose')}
+			noActions={state.actionsData.current <= 0}
+			onUseReaction={(options) => state.useReaction('defend', options)}
+			onUseCombinedReaction={(options) => state.useReactionCombo(['interpose', 'defend'], options)}
 		/>
 	{/if}
 
@@ -203,8 +206,11 @@
 			{actor}
 			reactionDisabled={!state.canUseReaction('interpose')}
 			combinedReactionDisabled={!state.canUseInterposeAndDefendCombo}
-			onUseReaction={() => state.useReaction('interpose')}
-			onUseCombinedReaction={() => state.useReactionCombo(['interpose', 'defend'])}
+			defendSpent={!state.isReactionAvailable('defend')}
+			interposeSpent={!state.isReactionAvailable('interpose')}
+			noActions={state.actionsData.current <= 0}
+			onUseReaction={(options) => state.useReaction('interpose', options)}
+			onUseCombinedReaction={(options) => state.useReactionCombo(['interpose', 'defend'], options)}
 		/>
 	{/if}
 
@@ -212,7 +218,9 @@
 		<OpportunityAttackPanel
 			{actor}
 			reactionDisabled={!state.canUseReaction('opportunityAttack')}
-			onUseReaction={() => state.useReaction('opportunityAttack')}
+			opportunitySpent={!state.isReactionAvailable('opportunityAttack')}
+			noActions={state.actionsData.current <= 0}
+			onUseReaction={(options) => state.useReaction('opportunityAttack', options)}
 			showEmbeddedDocumentImages={state.showEmbeddedDocumentImages}
 		/>
 	{/if}
@@ -221,7 +229,9 @@
 		<HelpReactionPanel
 			{actor}
 			reactionDisabled={!state.canUseReaction('help')}
-			onUseReaction={() => state.useReaction('help')}
+			helpSpent={!state.isReactionAvailable('help')}
+			noActions={state.actionsData.current <= 0}
+			onUseReaction={(options) => state.useReaction('help', options)}
 		/>
 	{/if}
 </section>

--- a/src/view/sheets/pages/PlayerCharacterHeroicActionsTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterHeroicActionsTab.svelte
@@ -20,6 +20,7 @@
 	interface HeroicActionTarget {
 		actionId: string;
 		actionType: 'action' | 'reaction';
+		force?: boolean;
 	}
 
 	interface SheetState {
@@ -28,7 +29,8 @@
 
 	let actor = getContext('actor');
 	const sheetState = getContext<SheetState>('sheetState');
-	const state = createHeroicActionsTabState(() => actor);
+	const heroicState = createHeroicActionsTabState(() => actor);
+	let forceNextOpportunityReactionUse = $state(false);
 
 	// React to heroicActionTarget from macro activation
 	$effect(() => {
@@ -36,13 +38,14 @@
 		if (!target) return;
 
 		if (target.actionType === 'action') {
-			state.activeHeroicTab = 'actions';
-			state.expandedPanel = target.actionId;
+			heroicState.activeHeroicTab = 'actions';
+			heroicState.expandedPanel = target.actionId;
 		} else if (target.actionType === 'reaction') {
-			state.activeHeroicTab = 'reactions';
+			heroicState.activeHeroicTab = 'reactions';
 			// Handle interposeAndDefend combo by navigating to defend panel
 			const panelId = target.actionId === 'interposeAndDefend' ? 'defend' : target.actionId;
-			state.expandedReactionPanel = panelId;
+			heroicState.expandedReactionPanel = panelId;
+			forceNextOpportunityReactionUse = target.actionId === 'opportunity' && target.force === true;
 		}
 
 		// Clear the target after handling
@@ -76,17 +79,17 @@
 			<div class="heroic-tab-header__tabs">
 				<button
 					class="heroic-tab-header__tab"
-					class:heroic-tab-header__tab--active={state.activeHeroicTab === 'actions'}
+					class:heroic-tab-header__tab--active={heroicState.activeHeroicTab === 'actions'}
 					type="button"
-					onclick={() => (state.activeHeroicTab = 'actions')}
+					onclick={() => (heroicState.activeHeroicTab = 'actions')}
 				>
 					{localize('NIMBLE.ui.heroicActions.title')}
 				</button>
 				<button
 					class="heroic-tab-header__tab"
-					class:heroic-tab-header__tab--active={state.activeHeroicTab === 'reactions'}
+					class:heroic-tab-header__tab--active={heroicState.activeHeroicTab === 'reactions'}
 					type="button"
-					onclick={() => (state.activeHeroicTab = 'reactions')}
+					onclick={() => (heroicState.activeHeroicTab = 'reactions')}
 				>
 					{localize('NIMBLE.ui.heroicActions.reactionsTitle')}
 				</button>
@@ -98,27 +101,27 @@
 				type="button"
 				aria-label={localize('NIMBLE.ui.heroicActions.help.tooltip')}
 				data-tooltip={localize('NIMBLE.ui.heroicActions.help.tooltip')}
-				onclick={state.handleHelpDialog}
+				onclick={heroicState.handleHelpDialog}
 			>
 				<i class="fa-solid fa-circle-question"></i>
 			</button>
 		</header>
 
-		{#if state.activeHeroicTab === 'actions'}
+		{#if heroicState.activeHeroicTab === 'actions'}
 			<div class="heroic-actions-tabs">
-				{#each state.HEROIC_ACTIONS as action (action.id)}
+				{#each heroicState.HEROIC_ACTIONS as action (action.id)}
 					<button
 						class="heroic-action-tab"
-						class:heroic-action-tab--active={state.expandedPanel === action.id}
-						class:heroic-action-tab--disabled={state.isActionDisabled(action)}
+						class:heroic-action-tab--active={heroicState.expandedPanel === action.id}
+						class:heroic-action-tab--disabled={heroicState.isActionDisabled(action)}
 						type="button"
 						aria-label={localize(action.labelKey)}
-						data-tooltip={state.getActionTooltip(action)}
-						disabled={state.isActionDisabled(action)}
+						data-tooltip={heroicState.getActionTooltip(action)}
+						disabled={heroicState.isActionDisabled(action)}
 						draggable="true"
 						ondragstart={(event) =>
 							handleActionDragStart(event, action.id, 'action', action.labelKey)}
-						onclick={() => state.handleActionClick(action)}
+						onclick={() => heroicState.handleActionClick(action)}
 					>
 						<i class={action.icon}></i>
 						<span class="heroic-action-tab__indicator"></span>
@@ -127,23 +130,25 @@
 			</div>
 		{/if}
 
-		{#if state.activeHeroicTab === 'reactions'}
+		{#if heroicState.activeHeroicTab === 'reactions'}
 			<div class="heroic-actions-tabs">
-				{#each state.HEROIC_REACTIONS as reaction (reaction.id)}
+				{#each heroicState.HEROIC_REACTIONS as reaction (reaction.id)}
 					<button
 						class="heroic-action-tab"
-						class:heroic-action-tab--active={state.expandedReactionPanel === reaction.id}
-						class:heroic-action-tab--available={state.isReactionAvailable(reaction.reactionKey)}
-						class:heroic-action-tab--spent={!state.isReactionAvailable(reaction.reactionKey)}
-						class:heroic-action-tab--disabled={!state.canUseReaction(reaction.reactionKey)}
+						class:heroic-action-tab--active={heroicState.expandedReactionPanel === reaction.id}
+						class:heroic-action-tab--available={heroicState.isReactionAvailable(
+							reaction.reactionKey,
+						)}
+						class:heroic-action-tab--spent={!heroicState.isReactionAvailable(reaction.reactionKey)}
+						class:heroic-action-tab--disabled={!heroicState.canUseReaction(reaction.reactionKey)}
 						type="button"
 						aria-label={localize(reaction.labelKey)}
-						aria-disabled={!state.canUseReaction(reaction.reactionKey)}
-						data-tooltip={state.getReactionTooltip(reaction)}
+						aria-disabled={!heroicState.canUseReaction(reaction.reactionKey)}
+						data-tooltip={heroicState.getReactionTooltip(reaction)}
 						draggable="true"
 						ondragstart={(event) =>
 							handleActionDragStart(event, reaction.id, 'reaction', reaction.labelKey)}
-						onclick={() => state.handleReactionClick(reaction)}
+						onclick={() => heroicState.handleReactionClick(reaction)}
 					>
 						<i class={reaction.icon}></i>
 						<span class="heroic-action-tab__indicator"></span>
@@ -153,85 +158,91 @@
 		{/if}
 	</section>
 
-	{#if state.activeHeroicTab === 'actions' && state.expandedPanel === 'attack'}
+	{#if heroicState.activeHeroicTab === 'actions' && heroicState.expandedPanel === 'attack'}
 		<AttackActionPanel
-			showEmbeddedDocumentImages={state.showEmbeddedDocumentImages}
+			showEmbeddedDocumentImages={heroicState.showEmbeddedDocumentImages}
 			onActivateItem={async (cost) => {
-				if (state.inCombat && state.actionsData.current > 0) {
-					await state.deductActionPips(cost);
+				if (heroicState.inCombat && heroicState.actionsData.current > 0) {
+					await heroicState.deductActionPips(cost);
 				}
 			}}
 		/>
 	{/if}
 
-	{#if state.activeHeroicTab === 'actions' && state.expandedPanel === 'spell'}
+	{#if heroicState.activeHeroicTab === 'actions' && heroicState.expandedPanel === 'spell'}
 		<CastSpellActionPanel
-			showEmbeddedDocumentImages={state.showEmbeddedDocumentImages}
+			showEmbeddedDocumentImages={heroicState.showEmbeddedDocumentImages}
 			onActivateItem={async (cost) => {
-				if (state.inCombat && state.actionsData.current > 0) {
-					await state.deductActionPips(cost);
+				if (heroicState.inCombat && heroicState.actionsData.current > 0) {
+					await heroicState.deductActionPips(cost);
 				}
 			}}
 		/>
 	{/if}
 
-	{#if state.activeHeroicTab === 'actions' && state.expandedPanel === 'move'}
+	{#if heroicState.activeHeroicTab === 'actions' && heroicState.expandedPanel === 'move'}
 		<MoveActionPanel
 			{actor}
-			inCombat={state.inCombat}
-			actionsRemaining={state.actionsData.current}
-			onDeductAction={() => state.deductActionPips(1)}
+			inCombat={heroicState.inCombat}
+			actionsRemaining={heroicState.actionsData.current}
+			onDeductAction={() => heroicState.deductActionPips(1)}
 		/>
 	{/if}
 
-	{#if state.activeHeroicTab === 'actions' && state.expandedPanel === 'assess'}
-		<AssessActionPanel {actor} onDeductAction={() => state.deductActionPips(1)} />
+	{#if heroicState.activeHeroicTab === 'actions' && heroicState.expandedPanel === 'assess'}
+		<AssessActionPanel {actor} onDeductAction={() => heroicState.deductActionPips(1)} />
 	{/if}
 
-	{#if state.activeHeroicTab === 'reactions' && state.expandedReactionPanel === 'defend'}
+	{#if heroicState.activeHeroicTab === 'reactions' && heroicState.expandedReactionPanel === 'defend'}
 		<DefendReactionPanel
 			{actor}
-			reactionDisabled={!state.canUseReaction('defend')}
-			combinedReactionDisabled={!state.canUseInterposeAndDefendCombo}
-			defendSpent={!state.isReactionAvailable('defend')}
-			interposeSpent={!state.isReactionAvailable('interpose')}
-			noActions={state.actionsData.current <= 0}
-			onUseReaction={(options) => state.useReaction('defend', options)}
-			onUseCombinedReaction={(options) => state.useReactionCombo(['interpose', 'defend'], options)}
+			reactionDisabled={!heroicState.canUseReaction('defend')}
+			combinedReactionDisabled={!heroicState.canUseInterposeAndDefendCombo}
+			defendSpent={!heroicState.isReactionAvailable('defend')}
+			interposeSpent={!heroicState.isReactionAvailable('interpose')}
+			noActions={heroicState.actionsData.current <= 0}
+			onUseReaction={(options) => heroicState.useReaction('defend', options)}
+			onUseCombinedReaction={(options) =>
+				heroicState.useReactionCombo(['interpose', 'defend'], options)}
 		/>
 	{/if}
 
-	{#if state.activeHeroicTab === 'reactions' && state.expandedReactionPanel === 'interpose'}
+	{#if heroicState.activeHeroicTab === 'reactions' && heroicState.expandedReactionPanel === 'interpose'}
 		<InterposeReactionPanel
 			{actor}
-			reactionDisabled={!state.canUseReaction('interpose')}
-			combinedReactionDisabled={!state.canUseInterposeAndDefendCombo}
-			defendSpent={!state.isReactionAvailable('defend')}
-			interposeSpent={!state.isReactionAvailable('interpose')}
-			noActions={state.actionsData.current <= 0}
-			onUseReaction={(options) => state.useReaction('interpose', options)}
-			onUseCombinedReaction={(options) => state.useReactionCombo(['interpose', 'defend'], options)}
+			reactionDisabled={!heroicState.canUseReaction('interpose')}
+			combinedReactionDisabled={!heroicState.canUseInterposeAndDefendCombo}
+			defendSpent={!heroicState.isReactionAvailable('defend')}
+			interposeSpent={!heroicState.isReactionAvailable('interpose')}
+			noActions={heroicState.actionsData.current <= 0}
+			onUseReaction={(options) => heroicState.useReaction('interpose', options)}
+			onUseCombinedReaction={(options) =>
+				heroicState.useReactionCombo(['interpose', 'defend'], options)}
 		/>
 	{/if}
 
-	{#if state.activeHeroicTab === 'reactions' && state.expandedReactionPanel === 'opportunity'}
+	{#if heroicState.activeHeroicTab === 'reactions' && heroicState.expandedReactionPanel === 'opportunity'}
 		<OpportunityAttackPanel
 			{actor}
-			reactionDisabled={!state.canUseReaction('opportunityAttack')}
-			opportunitySpent={!state.isReactionAvailable('opportunityAttack')}
-			noActions={state.actionsData.current <= 0}
-			onUseReaction={(options) => state.useReaction('opportunityAttack', options)}
-			showEmbeddedDocumentImages={state.showEmbeddedDocumentImages}
+			reactionDisabled={!heroicState.canUseReaction('opportunityAttack')}
+			opportunitySpent={!heroicState.isReactionAvailable('opportunityAttack')}
+			noActions={heroicState.actionsData.current <= 0}
+			onUseReaction={(options) => heroicState.useReaction('opportunityAttack', options)}
+			forceNextReactionUse={forceNextOpportunityReactionUse}
+			onConsumeForcedReactionUse={() => {
+				forceNextOpportunityReactionUse = false;
+			}}
+			showEmbeddedDocumentImages={heroicState.showEmbeddedDocumentImages}
 		/>
 	{/if}
 
-	{#if state.activeHeroicTab === 'reactions' && state.expandedReactionPanel === 'help'}
+	{#if heroicState.activeHeroicTab === 'reactions' && heroicState.expandedReactionPanel === 'help'}
 		<HelpReactionPanel
 			{actor}
-			reactionDisabled={!state.canUseReaction('help')}
-			helpSpent={!state.isReactionAvailable('help')}
-			noActions={state.actionsData.current <= 0}
-			onUseReaction={(options) => state.useReaction('help', options)}
+			reactionDisabled={!heroicState.canUseReaction('help')}
+			helpSpent={!heroicState.isReactionAvailable('help')}
+			noActions={heroicState.actionsData.current <= 0}
+			onUseReaction={(options) => heroicState.useReaction('help', options)}
 		/>
 	{/if}
 </section>

--- a/src/view/sheets/pages/PlayerCharacterHeroicActionsTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterHeroicActionsTab.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { getContext } from 'svelte';
+	import { getContext, untrack } from 'svelte';
 	import localize from '../../../utils/localize.js';
 	import { createHeroicActionsTabState } from './PlayerCharacterHeroicActionsTab.svelte.js';
 
@@ -17,8 +17,57 @@
 	// Context & State
 	// ============================================================================
 
+	interface HeroicActionTarget {
+		actionId: string;
+		actionType: 'action' | 'reaction';
+	}
+
+	interface SheetState {
+		heroicActionTarget?: HeroicActionTarget | null;
+	}
+
 	let actor = getContext('actor');
+	const sheetState = getContext<SheetState>('sheetState');
 	const state = createHeroicActionsTabState(() => actor);
+
+	// React to heroicActionTarget from macro activation
+	$effect(() => {
+		const target = sheetState?.heroicActionTarget;
+		if (!target) return;
+
+		if (target.actionType === 'action') {
+			state.activeHeroicTab = 'actions';
+			state.expandedPanel = target.actionId;
+		} else if (target.actionType === 'reaction') {
+			state.activeHeroicTab = 'reactions';
+			// Handle interposeAndDefend combo by navigating to defend panel
+			const panelId = target.actionId === 'interposeAndDefend' ? 'defend' : target.actionId;
+			state.expandedReactionPanel = panelId;
+		}
+
+		// Clear the target after handling
+		untrack(() => {
+			if (sheetState) {
+				sheetState.heroicActionTarget = null;
+			}
+		});
+	});
+
+	function handleActionDragStart(
+		event: DragEvent,
+		actionId: string,
+		actionType: 'action' | 'reaction',
+		labelKey: string,
+	) {
+		if (!event.dataTransfer) return;
+		const dragData = {
+			type: 'HeroicAction',
+			actionId,
+			actionType,
+			name: localize(labelKey),
+		};
+		event.dataTransfer.setData('text/plain', JSON.stringify(dragData));
+	}
 </script>
 
 <section class="nimble-sheet__body nimble-sheet__body--player-character">
@@ -66,6 +115,9 @@
 						aria-label={localize(action.labelKey)}
 						data-tooltip={state.getActionTooltip(action)}
 						disabled={state.isActionDisabled(action)}
+						draggable="true"
+						ondragstart={(event) =>
+							handleActionDragStart(event, action.id, 'action', action.labelKey)}
 						onclick={() => state.handleActionClick(action)}
 					>
 						<i class={action.icon}></i>
@@ -88,6 +140,9 @@
 						aria-label={localize(reaction.labelKey)}
 						aria-disabled={!state.canUseReaction(reaction.reactionKey)}
 						data-tooltip={state.getReactionTooltip(reaction)}
+						draggable="true"
+						ondragstart={(event) =>
+							handleActionDragStart(event, reaction.id, 'reaction', reaction.labelKey)}
 						onclick={() => state.handleReactionClick(reaction)}
 					>
 						<i class={reaction.icon}></i>

--- a/src/view/sheets/pages/PlayerCharacterHeroicActionsTab.svelte.ts
+++ b/src/view/sheets/pages/PlayerCharacterHeroicActionsTab.svelte.ts
@@ -114,7 +114,11 @@ type HeroicReactionId = (typeof HEROIC_REACTIONS)[number]['id'];
 type ReactionUsageStateMap = Record<HeroicReactionId, HeroicReactionUsageState>;
 
 type CombatWithHeroicReactionUse = Combat & {
-	useHeroicReactions?: (combatantId: string, reactionKeys: HeroicReactionKey[]) => Promise<boolean>;
+	useHeroicReactions?: (
+		combatantId: string,
+		reactionKeys: HeroicReactionKey[],
+		options?: { force?: boolean },
+	) => Promise<boolean>;
 };
 
 export function createHeroicActionsTabState(getActor: () => NimbleCharacter) {
@@ -271,16 +275,22 @@ export function createHeroicActionsTabState(getActor: () => NimbleCharacter) {
 		return getReactionUsageState(reaction).canUse;
 	}
 
-	async function useReaction(reactionKey: HeroicReactionKey): Promise<boolean> {
-		return useReactionCombo([reactionKey]);
+	async function useReaction(
+		reactionKey: HeroicReactionKey,
+		options?: { force?: boolean },
+	): Promise<boolean> {
+		return useReactionCombo([reactionKey], options);
 	}
 
-	async function useReactionCombo(reactionKeys: HeroicReactionKey[]): Promise<boolean> {
+	async function useReactionCombo(
+		reactionKeys: HeroicReactionKey[],
+		options?: { force?: boolean },
+	): Promise<boolean> {
 		const combat = getCombat();
 		const combatant = getCombatant();
 		const combatantId = combatant?.id ?? combatant?._id ?? null;
 		if (!combat?.useHeroicReactions || !combatantId) return false;
-		return combat.useHeroicReactions(combatantId, reactionKeys);
+		return combat.useHeroicReactions(combatantId, reactionKeys, options);
 	}
 
 	function handleHelpDialog(): void {

--- a/src/view/sheets/pages/PlayerCharacterHeroicActionsTab.svelte.ts
+++ b/src/view/sheets/pages/PlayerCharacterHeroicActionsTab.svelte.ts
@@ -359,8 +359,14 @@ export function createHeroicActionsTabState(getActor: () => NimbleCharacter) {
 		get expandedPanel() {
 			return expandedPanel;
 		},
+		set expandedPanel(value: string) {
+			expandedPanel = value;
+		},
 		get expandedReactionPanel() {
 			return expandedReactionPanel;
+		},
+		set expandedReactionPanel(value: string) {
+			expandedReactionPanel = value;
 		},
 		get inCombat() {
 			return inCombat;

--- a/src/view/sheets/pages/PlayerCharacterHeroicActionsTab.test.ts
+++ b/src/view/sheets/pages/PlayerCharacterHeroicActionsTab.test.ts
@@ -20,7 +20,7 @@ vi.mock('../../../documents/dialogs/ItemActivationConfigDialog.svelte.js', () =>
 	default: itemActivationConfigDialogMock,
 }));
 
-vi.mock('../components/attackUtils.js', () => ({
+vi.mock('../../../utils/attackUtils.js', () => ({
 	getUnarmedDamageFormula: getUnarmedDamageFormulaMock,
 	hasUnarmedProficiency: hasUnarmedProficiencyMock,
 }));

--- a/src/view/sheets/pages/PlayerCharacterHeroicActionsTab.test.ts
+++ b/src/view/sheets/pages/PlayerCharacterHeroicActionsTab.test.ts
@@ -1,0 +1,210 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+
+const {
+	damageRollMock,
+	getUnarmedDamageFormulaMock,
+	hasUnarmedProficiencyMock,
+	itemActivationConfigDialogMock,
+} = vi.hoisted(() => ({
+	damageRollMock: vi.fn(),
+	getUnarmedDamageFormulaMock: vi.fn(),
+	hasUnarmedProficiencyMock: vi.fn(),
+	itemActivationConfigDialogMock: vi.fn(),
+}));
+
+vi.mock('../../../dice/DamageRoll.js', () => ({
+	DamageRoll: damageRollMock,
+}));
+
+vi.mock('../../../documents/dialogs/ItemActivationConfigDialog.svelte.js', () => ({
+	default: itemActivationConfigDialogMock,
+}));
+
+vi.mock('../components/attackUtils.js', () => ({
+	getUnarmedDamageFormula: getUnarmedDamageFormulaMock,
+	hasUnarmedProficiency: hasUnarmedProficiencyMock,
+}));
+
+import { activateHeroicActionMacro } from '../../../macros/activateHeroicActionMacro.ts';
+import PlayerCharacterHeroicActionsTabTestHarness from './PlayerCharacterHeroicActionsTab.testHarness.svelte';
+
+function globals() {
+	return globalThis as unknown as {
+		canvas: unknown;
+		ChatMessage: {
+			getSpeaker: ReturnType<typeof vi.fn>;
+		};
+		foundry: {
+			applications: {
+				api: {
+					DialogV2: {
+						confirm: ReturnType<typeof vi.fn>;
+					};
+				};
+			};
+		};
+		game: {
+			actors: unknown;
+			combat: unknown;
+			combats: unknown;
+			user: {
+				isGM?: boolean;
+				targets: Set<unknown>;
+			};
+		};
+	};
+}
+
+function createOpportunityActor(sheetState: Record<string, unknown>) {
+	const weapon = {
+		_id: 'weapon-opportunity',
+		id: 'weapon-opportunity',
+		sort: 1,
+		type: 'object',
+		reactive: {
+			name: 'Spear',
+			img: 'spear.webp',
+		},
+		system: {
+			objectType: 'weapon',
+			activation: {
+				effects: [
+					{
+						type: 'damage',
+						formula: '1d6',
+					},
+				],
+			},
+			properties: {
+				selected: ['reach'],
+				reach: {
+					max: 2,
+				},
+			},
+		},
+	} as unknown as Item;
+
+	return {
+		id: 'heroic-actions-tab-actor',
+		name: 'Opportunity Tester',
+		type: 'character',
+		isOwner: true,
+		img: 'opportunity.webp',
+		system: {
+			unarmedDamage: '1d4',
+		},
+		permission: CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER,
+		reactive: {
+			flags: {
+				nimble: {
+					showEmbeddedDocumentImages: false,
+				},
+			},
+			system: {
+				attributes: {
+					armor: {
+						value: 13,
+					},
+				},
+			},
+			items: [weapon],
+		},
+		items: {
+			get: vi.fn().mockReturnValue(weapon),
+		},
+		activateItem: vi.fn().mockResolvedValue({ ok: true }),
+		sheet: {
+			render: vi.fn().mockResolvedValue(undefined),
+			$state: sheetState,
+		},
+	} as const;
+}
+
+describe('PlayerCharacterHeroicActionsTab opportunity macro handoff', () => {
+	beforeEach(() => {
+		globals().foundry.applications.api.DialogV2.confirm.mockReset();
+		globals().foundry.applications.api.DialogV2.confirm.mockResolvedValue(true);
+		globals().ChatMessage.getSpeaker = vi.fn();
+		globals().game.user = {
+			...game.user,
+			isGM: false,
+			targets: new Set(),
+		};
+	});
+
+	it('opens the opportunity panel from the macro and uses the next weapon click without prompting twice', async () => {
+		const sheetState: Record<string, unknown> = {};
+		const actor = createOpportunityActor(sheetState);
+		const application = { _onDragStart: vi.fn() };
+		const useHeroicReactions = vi.fn().mockResolvedValue(true);
+		const reactingCombatant = {
+			id: 'combatant-opportunity',
+			actorId: actor.id,
+			actor,
+			type: 'character',
+			initiative: 12,
+			system: {
+				actions: {
+					base: {
+						current: 0,
+					},
+					heroic: {
+						opportunityAttackAvailable: true,
+					},
+				},
+			},
+		};
+		const activeCombatant = {
+			id: 'active-combatant',
+			actorId: 'other-actor',
+			initiative: 20,
+		};
+
+		globals().game.actors = {
+			tokens: {},
+			get: vi.fn().mockReturnValue(actor),
+		};
+		globals().ChatMessage.getSpeaker.mockReturnValue({ actor: actor.id });
+		globals().canvas = {
+			scene: { id: 'scene-opportunity' },
+		};
+		globals().game.combat = {
+			scene: { id: 'scene-opportunity' },
+			active: true,
+			started: true,
+			round: 1,
+			combatant: activeCombatant,
+			useHeroicReactions,
+			combatants: [reactingCombatant, activeCombatant],
+		};
+		globals().game.combats = {
+			contents: [globals().game.combat as Combat],
+			viewed: globals().game.combat as Combat,
+		};
+
+		await activateHeroicActionMacro('opportunity', 'reaction');
+
+		expect(globals().foundry.applications.api.DialogV2.confirm).toHaveBeenCalledTimes(1);
+
+		render(PlayerCharacterHeroicActionsTabTestHarness, {
+			actor,
+			application,
+			sheetState,
+		});
+
+		await waitFor(() => expect(screen.getByRole('button', { name: /spear/i })).toBeInTheDocument());
+		await fireEvent.click(screen.getByRole('button', { name: /spear/i }));
+
+		expect(actor.activateItem).toHaveBeenCalledWith('weapon-opportunity', { rollMode: -1 });
+		await waitFor(() =>
+			expect(useHeroicReactions).toHaveBeenCalledWith(
+				'combatant-opportunity',
+				['opportunityAttack'],
+				{
+					force: true,
+				},
+			),
+		);
+		expect(globals().foundry.applications.api.DialogV2.confirm).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/view/sheets/pages/PlayerCharacterHeroicActionsTab.testHarness.svelte
+++ b/src/view/sheets/pages/PlayerCharacterHeroicActionsTab.testHarness.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import { setContext, untrack } from 'svelte';
+	import PlayerCharacterHeroicActionsTab from './PlayerCharacterHeroicActionsTab.svelte';
+
+	let { actor, application, sheetState } = $props();
+
+	setContext(
+		'actor',
+		untrack(() => actor),
+	);
+	setContext(
+		'application',
+		untrack(() => application),
+	);
+	setContext(
+		'sheetState',
+		untrack(() => sheetState),
+	);
+</script>
+
+<PlayerCharacterHeroicActionsTab />

--- a/types/components/ReactionPanel.d.ts
+++ b/types/components/ReactionPanel.d.ts
@@ -1,5 +1,16 @@
 import type { NimbleCharacter } from '../../src/documents/actor/actor';
 
+export interface ReactionPanelStateOptions {
+	getActor: () => NimbleCharacter;
+	getReactionDisabled: () => boolean;
+	getDefendSpent: () => boolean;
+	getInterposeSpent: () => boolean;
+	getNoActions: () => boolean;
+	getOnUseReaction: () => (options?: { force?: boolean }) => Promise<boolean>;
+	getCombinedReactionDisabled: () => boolean;
+	getOnUseCombinedReaction: () => (options?: { force?: boolean }) => Promise<boolean>;
+}
+
 export interface ReactionPanelProps {
 	actor: NimbleCharacter;
 	reactionDisabled?: boolean;

--- a/types/components/ReactionPanel.d.ts
+++ b/types/components/ReactionPanel.d.ts
@@ -15,4 +15,6 @@ export interface ReactionPanelProps {
 
 export interface OpportunityAttackPanelProps extends ReactionPanelProps {
 	showEmbeddedDocumentImages?: boolean;
+	forceNextReactionUse?: boolean;
+	onConsumeForcedReactionUse?: () => void;
 }

--- a/types/components/ReactionPanel.d.ts
+++ b/types/components/ReactionPanel.d.ts
@@ -4,8 +4,13 @@ export interface ReactionPanelProps {
 	actor: NimbleCharacter;
 	reactionDisabled?: boolean;
 	combinedReactionDisabled?: boolean;
-	onUseReaction?: () => Promise<boolean>;
-	onUseCombinedReaction?: () => Promise<boolean>;
+	defendSpent?: boolean;
+	interposeSpent?: boolean;
+	helpSpent?: boolean;
+	opportunitySpent?: boolean;
+	noActions?: boolean;
+	onUseReaction?: (options?: { force?: boolean }) => Promise<boolean>;
+	onUseCombinedReaction?: (options?: { force?: boolean }) => Promise<boolean>;
 }
 
 export interface OpportunityAttackPanelProps extends ReactionPanelProps {


### PR DESCRIPTION
<img width="1044" height="534" alt="Screenshot 2026-03-21 at 8 53 52 PM" src="https://github.com/user-attachments/assets/fa8759c8-3645-4fd3-86a0-ae7cea0e14a4" />
<img width="886" height="480" alt="Screenshot 2026-03-21 at 8 53 44 PM" src="https://github.com/user-attachments/assets/fb01309f-9e49-4525-bb81-bd7f900aa31b" />

## Summary

- Enable dragging heroic actions and reactions from the character sheet's Actions tab to the macro bar
- Draggable action/reaction buttons:
  - **Action tab buttons**: Attack, Spell, Move, Assess
  - **Reaction tab buttons**: Defend, Interpose, Opportunity Attack, Help, Interpose & Defend
  - **Individual buttons**: Move (Confirm Move), Unarmed Strike, Help, Defend, Interpose
- Actions that execute directly from macro without opening a panel:
  - **Move**: deducts action pip and posts chat message
  - **Unarmed Strike**: opens roll dialog, executes attack, deducts action pip
  - **Defend**: uses defend reaction and posts chat message
  - **Interpose**: uses interpose reaction and posts chat message
  - **Interpose & Defend**: uses both reactions and posts both messages
  - **Help**: uses help reaction and posts chat message
- Confirmation dialogs when using reactions without available actions or when reaction is already spent
- Other actions open the character sheet to the appropriate panel for further user interaction

Fixes #465

## Test plan

- [x] Open a character sheet and go to the Actions tab
- [x] Drag an action tab (Attack, Spell, Move, Assess) to the macro bar - verify icon appears
- [x] Select a character token and click the macro - verify behavior:
  - Attack/Spell/Assess: opens sheet to correct panel
  - Move: posts move message and deducts action (in combat)
- [x] Drag the "Confirm Move" button to macro bar and test it works
- [x] Drag the "Unarmed Strike" card to macro bar and verify it rolls attack
- [x] Drag reaction tabs (Defend, Interpose, Opportunity Attack, Help) to macro bar
- [x] Drag individual reaction buttons (Defend, Interpose, Help) to macro bar
- [ ] Test reactions execute directly when clicked (in combat)
- [x] Test confirmation dialog appears when no actions remaining or reaction already spent
- [x] Test the Interpose & Defend combo button in the Defend/Interpose panels
- [ ] Run `pnpm check` to verify no lint/type/test errors