### PR TITLE
fix: only show red/green dice styling on Primary Die

### DIFF
--- a/src/view/dataPreparationHelpers/rollTooltips/prepareRollTooltipDiceResults.ts
+++ b/src/view/dataPreparationHelpers/rollTooltips/prepareRollTooltipDiceResults.ts
@@ -1,4 +1,6 @@
-export default function prepareRollTooltipDiceResults({ faces, results }) {
+export default function prepareRollTooltipDiceResults({ faces, flavor, results }) {
+	const isPrimaryDie = flavor === 'Primary Die';
+
 	return results.reduce((acc, { rerolled, discarded, result }) => {
 		const isCritical = (faces === 20 && result === 20) || result === faces;
 
@@ -8,8 +10,8 @@ export default function prepareRollTooltipDiceResults({ faces, results }) {
 		let classes = `nimble-die nimble-die--${faces}`;
 
 		if (isDiscarded) classes += ' nimble-die--discarded';
-		else if (isFumble) classes += ' nimble-die--min';
-		else if (isCritical) classes += ' nimble-die--max';
+		else if (isPrimaryDie && isFumble) classes += ' nimble-die--min';
+		else if (isPrimaryDie && isCritical) classes += ' nimble-die--max';
 
 		return `${acc}<li class="${classes}">${result}</li>`;
 	}, '');


### PR DESCRIPTION
## Summary
- Red (fumble) and green (critical) dice styling now only applies to dice with the "Primary Die" flavor
- Damage dice display with normal styling regardless of their roll result

Fixes #364

## Test plan
- [x] Roll an attack that hits - primary die should show normal styling
- [x] Roll an attack that misses (primary die shows 1) - primary die should be red
- [x] Roll an attack with damage dice - damage dice should never show red/green styling regardless of result
- [x] Roll a critical hit (primary die shows max) - primary die should be green