### PR TITLE
fix(ui): replace `__img` border with `::after` overlay divider

### DIFF
--- a/src/scss/components/_document-card.scss
+++ b/src/scss/components/_document-card.scss
@@ -195,13 +195,28 @@
     display: contents;
   }
 
-  &__img {
-    grid-area: img;
-    flex-shrink: 0;
-    height: var(--nimble-card-image-height, 2rem);
+	&__img-wrapper {
+		grid-area: img;
+		position: relative;
+		flex-shrink: 0;
+		margin-inline-end: 0.5rem;
+		height: var(--nimble-card-image-height, 2rem);
     width: var(--nimble-card-image-width, 2rem);
+
+		&::after {
+			content: '';
+			position: absolute;
+			inset: 0;
+			right: -1px;
+			border-right: 1px solid var(--nimble-card-border-color);
+			pointer-events: none;
+			z-index: 1;
+		}
+	}
+
+  &__img {
+    flex-shrink: 0;
     border: 0;
-    border-right: 1px solid var(--nimble-card-border-color);
     border-radius: 0;
     background-color: rgba(0, 0, 0, 0.7);
     aspect-ratio: 1 / 1;
@@ -284,11 +299,6 @@
       outline: none !important;
       outline-color: transparent !important;
       box-shadow: none !important;
-    }
-
-    .nimble-document-card__img {
-      flex-shrink: 0;
-      margin-inline-end: 0.5rem;
     }
 
     .nimble-document-card__indicator {

--- a/src/view/components/ActorConditionsList.svelte
+++ b/src/view/components/ActorConditionsList.svelte
@@ -289,11 +289,13 @@
 				<ul class="nimble-item-list">
 					{#each passiveEffects as effect}
 						<li class="nimble-document-card nimble-document-card--no-meta">
-							<img
-								class="nimble-document-card__img"
-								src={effect.img}
-								alt={effect.name ?? effect.id}
-							/>
+							<div class="nimble-document-card__img-wrapper">
+								<img
+									class="nimble-document-card__img"
+									src={effect.img}
+									alt={effect.name ?? effect.id}
+								/>
+							</div>
 							<h4 class="nimble-document-card__name nimble-heading" data-heading-variant="item">
 								{effect.name ?? effect.id}
 							</h4>

--- a/src/view/sheets/pages/NPCCoreTab.svelte
+++ b/src/view/sheets/pages/NPCCoreTab.svelte
@@ -846,7 +846,9 @@
 					onclick={() => actor.activateItem(item.reactive._id)}
 				>
 					{#if showEmbeddedDocumentImages}
-						<img class="nimble-document-card__img" src={item.reactive.img} alt="" />
+						<div class="nimble-document-card__img-wrapper">
+							<img class="nimble-document-card__img" src={item.reactive.img} alt="" />
+						</div>
 					{/if}
 
 					<span class="nimble-document-card__indicator">
@@ -1014,7 +1016,9 @@
 					onclick={() => actor.activateItem(item.reactive._id)}
 				>
 					{#if showEmbeddedDocumentImages}
-						<img class="nimble-document-card__img" src={item.reactive.img} alt="" />
+						<div class="nimble-document-card__img-wrapper">
+							<img class="nimble-document-card__img" src={item.reactive.img} alt="" />
+						</div>
 					{/if}
 
 					<span class="nimble-document-card__indicator">

--- a/src/view/sheets/pages/PlayerCharacterFeaturesTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterFeaturesTab.svelte
@@ -199,11 +199,13 @@
 					>
 						<header class="u-semantic-only">
 							{#if showEmbeddedDocumentImages}
-								<img
-									class="nimble-document-card__img"
-									src={item.reactive.img}
-									alt={item.reactive.name}
-								/>
+								<div class="nimble-document-card__img-wrapper">
+									<img
+										class="nimble-document-card__img"
+										src={item.reactive.img}
+										alt={item.reactive.name}
+									/>
+								</div>
 							{/if}
 
 							<h4 class="nimble-document-card__name nimble-heading" data-heading-variant="item">
@@ -255,11 +257,13 @@
 									onclick={() => actor.activateItem(subclass._id)}
 								>
 									{#if showEmbeddedDocumentImages}
-										<img
-											class="nimble-document-card__img"
-											src={subclass.reactive.img}
-											alt={subclass.reactive.name}
-										/>
+										<div class="nimble-document-card__img-wrapper">
+											<img
+												class="nimble-document-card__img"
+												src={subclass.reactive.img}
+												alt={subclass.reactive.name}
+											/>
+										</div>
 									{/if}
 
 									<h4 class="nimble-document-card__name nimble-heading" data-heading-variant="item">

--- a/src/view/sheets/pages/PlayerCharacterInventoryTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterInventoryTab.svelte
@@ -205,11 +205,13 @@
 					>
 						<header class="u-semantic-only">
 							{#if showEmbeddedDocumentImages}
-								<img
-									class="nimble-document-card__img"
-									src={item.reactive.img}
-									alt={item.reactive.name}
-								/>
+								<div class="nimble-document-card__img-wrapper">
+									<img
+										class="nimble-document-card__img"
+										src={item.reactive.img}
+										alt={item.reactive.name}
+									/>
+								</div>
 							{/if}
 
 							<h4 class="nimble-document-card__name nimble-heading" data-heading-variant="item">

--- a/src/view/sheets/pages/PlayerCharacterSpellsTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterSpellsTab.svelte
@@ -254,11 +254,13 @@
 						onclick={() => actor.activateItem(spell._id)}
 					>
 						{#if showEmbeddedDocumentImages}
-							<img
-								class="nimble-document-card__img"
-								src={spell.reactive.img}
-								alt={spell.reactive.name}
-							/>
+							<div class="nimble-document-card__img-wrapper">
+								<img
+									class="nimble-document-card__img"
+									src={spell.reactive.img}
+									alt={spell.reactive.name}
+								/>
+							</div>
 						{/if}
 
 						<header class="u-semantic-only">


### PR DESCRIPTION
### **Description**
The right-side divider on document card images was implemented as `border-right` directly on the `<img>` element. This caused the image to render at 31×32px instead of 32×32px, which made `object-fit: cover` resample the image onto an uneven dimensions, resulting in a visibly pixelated image.

This PR wraps the `<img>` in a `__img-wrapper` div and moves the divider to a `::after` pseudo-element positioned outside the image box, so the image always renders at its intended square dimensions.

### **Changes:**
- Added `__img-wrapper` with `::after` overlay divider
- Removed `border-right` from `__img`
- Updated all card usages across inventory, features, spells, NPC, and conditions list tabs