### PR TITLE
Fix: Apply NPC Armor rules in combat damage application

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -77,6 +77,7 @@
 			"boon": "Boon"
 		},
 		"chat": {
+			"applyDamage": "Apply Damage",
 			"applyHealing": "Apply Healing",
 			"healing": "Healing",
 			"healingApplied": "Healing Applied",
@@ -84,6 +85,7 @@
 			"undo": "Undo",
 			"noTargetsSelected": "No targets selected",
 			"noDamageToApply": "No damage to apply.",
+			"targetSkippedZeroDamage": "Ignored {tokenName} because the result is 0.",
 			"healingAlreadyApplied": "Healing has already been applied",
 			"healingUndone": "Healing has been undone",
 			"noHealingRecord": "No healing record found to undo"

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -83,6 +83,7 @@
 			"undoHealing": "Undo Healing",
 			"undo": "Undo",
 			"noTargetsSelected": "No targets selected",
+			"noDamageToApply": "No damage to apply.",
 			"healingAlreadyApplied": "Healing has already been applied",
 			"healingUndone": "Healing has been undone",
 			"noHealingRecord": "No healing record found to undo"

--- a/src/documents/chatMessage.test.ts
+++ b/src/documents/chatMessage.test.ts
@@ -338,6 +338,31 @@ describe('NimbleChatMessage.applyDamage', () => {
 		expect(globals().ui.notifications.info).toHaveBeenCalledWith('No damage to apply.');
 	});
 
+	it('shows no-damage feedback when total damage is 0 or negative', async () => {
+		const actor = {
+			system: {
+				attributes: {
+					hp: {
+						value: 10,
+						temp: 2,
+						max: 10,
+					},
+				},
+			},
+			update: vi.fn().mockResolvedValue(undefined),
+		};
+
+		globals().fromUuidSync.mockReturnValue({ actor });
+
+		const message = createActivationMessage();
+		await message.applyDamage(0, { outcome: 'fullDamage' });
+		await message.applyDamage(-4, { outcome: 'fullDamage' });
+
+		expect(globals().fromUuidSync).not.toHaveBeenCalled();
+		expect(actor.update).not.toHaveBeenCalled();
+		expect(globals().ui.notifications.info).toHaveBeenCalledWith('No damage to apply.');
+	});
+
 	it('warns when there are no targets', async () => {
 		const message = createActivationMessage([]);
 		await message.applyDamage(4, { outcome: 'fullDamage' });

--- a/src/documents/chatMessage.test.ts
+++ b/src/documents/chatMessage.test.ts
@@ -34,6 +34,43 @@ function createActivationMessage(targets: string[] = ['Scene.scene.Token.token']
 	} as unknown as ChatMessage.CreateData);
 }
 
+function createSerializedDamageRoll(params: {
+	diceResults: number[];
+	flatBonus?: number;
+	isCritical?: boolean;
+	excludedPrimaryDieValue?: number;
+}) {
+	const flatBonus = params.flatBonus ?? 0;
+	const diceTotal = params.diceResults.reduce((sum, result) => sum + result, 0);
+	const total = diceTotal + flatBonus;
+
+	const terms: Record<string, unknown>[] = [
+		{
+			number: params.diceResults.length || 1,
+			faces: 6,
+			results: params.diceResults.map((result) => ({
+				result,
+				active: true,
+				discarded: false,
+			})),
+		},
+	];
+
+	if (flatBonus !== 0) {
+		terms.push({ operator: '+' });
+		terms.push({ number: flatBonus });
+	}
+
+	return {
+		class: 'DamageRoll',
+		formula: `${params.diceResults.length || 1}d6${flatBonus ? ` + ${flatBonus}` : ''}`,
+		total,
+		isCritical: params.isCritical ?? false,
+		excludedPrimaryDieValue: params.excludedPrimaryDieValue ?? 0,
+		terms,
+	};
+}
+
 describe('NimbleChatMessage.applyHealing', () => {
 	beforeEach(() => {
 		globals().fromUuidSync = vi.fn();
@@ -327,5 +364,234 @@ describe('NimbleChatMessage.applyDamage', () => {
 		await message.applyDamage(4, { outcome: 'fullDamage' });
 
 		expect(actor.update).not.toHaveBeenCalled();
+	});
+
+	it('applies medium armor by using dice-only damage on non-critical hits', async () => {
+		const actor = {
+			system: {
+				attributes: {
+					armor: 'medium',
+					hp: {
+						value: 10,
+						temp: 0,
+						max: 10,
+					},
+				},
+			},
+			update: vi.fn().mockResolvedValue(undefined),
+		};
+
+		globals().fromUuidSync.mockReturnValue({ actor });
+
+		const roll = createSerializedDamageRoll({
+			diceResults: [6],
+			flatBonus: 2,
+			isCritical: false,
+		});
+
+		const message = createActivationMessage();
+		await message.applyDamage(8, { outcome: 'fullDamage', roll });
+
+		expect(actor.update).toHaveBeenCalledWith({
+			'system.attributes.hp.value': 4,
+		});
+	});
+
+	it('applies heavy armor by halving dice-only damage and rounding up on non-critical hits', async () => {
+		const actor = {
+			system: {
+				attributes: {
+					armor: 'heavy',
+					hp: {
+						value: 10,
+						temp: 0,
+						max: 10,
+					},
+				},
+			},
+			update: vi.fn().mockResolvedValue(undefined),
+		};
+
+		globals().fromUuidSync.mockReturnValue({ actor });
+
+		const roll = createSerializedDamageRoll({
+			diceResults: [5],
+			flatBonus: 5,
+			isCritical: false,
+		});
+
+		const message = createActivationMessage();
+		await message.applyDamage(10, { outcome: 'fullDamage', roll });
+
+		expect(actor.update).toHaveBeenCalledWith({
+			'system.attributes.hp.value': 7,
+		});
+	});
+
+	it('stacks heavy armor reduction with halfDamage outcome', async () => {
+		const actor = {
+			system: {
+				attributes: {
+					armor: 'heavy',
+					hp: {
+						value: 10,
+						temp: 0,
+						max: 10,
+					},
+				},
+			},
+			update: vi.fn().mockResolvedValue(undefined),
+		};
+
+		globals().fromUuidSync.mockReturnValue({ actor });
+
+		const roll = createSerializedDamageRoll({
+			diceResults: [5],
+			flatBonus: 5,
+			isCritical: false,
+		});
+
+		const message = createActivationMessage();
+		await message.applyDamage(5, { outcome: 'halfDamage', roll });
+
+		expect(actor.update).toHaveBeenCalledWith({
+			'system.attributes.hp.value': 8,
+		});
+	});
+
+	it('applies full damage to armored targets on critical hits', async () => {
+		const actor = {
+			system: {
+				attributes: {
+					armor: 'heavy',
+					hp: {
+						value: 10,
+						temp: 0,
+						max: 10,
+					},
+				},
+			},
+			update: vi.fn().mockResolvedValue(undefined),
+		};
+
+		globals().fromUuidSync.mockReturnValue({ actor });
+
+		const roll = createSerializedDamageRoll({
+			diceResults: [5],
+			flatBonus: 5,
+			isCritical: true,
+		});
+
+		const message = createActivationMessage();
+		await message.applyDamage(10, { outcome: 'fullDamage', roll });
+
+		expect(actor.update).toHaveBeenCalledWith({
+			'system.attributes.hp.value': 0,
+		});
+	});
+
+	it('applies halfDamage to critical hits but still ignores armor reduction', async () => {
+		const actor = {
+			system: {
+				attributes: {
+					armor: 'heavy',
+					hp: {
+						value: 10,
+						temp: 0,
+						max: 10,
+					},
+				},
+			},
+			update: vi.fn().mockResolvedValue(undefined),
+		};
+
+		globals().fromUuidSync.mockReturnValue({ actor });
+
+		const roll = createSerializedDamageRoll({
+			diceResults: [5],
+			flatBonus: 5,
+			isCritical: true,
+		});
+
+		const message = createActivationMessage();
+		await message.applyDamage(5, { outcome: 'halfDamage', roll });
+
+		expect(actor.update).toHaveBeenCalledWith({
+			'system.attributes.hp.value': 5,
+		});
+	});
+
+	it('bypasses armor rules when ignoreArmor is enabled', async () => {
+		const actor = {
+			system: {
+				attributes: {
+					armor: 'heavy',
+					hp: {
+						value: 10,
+						temp: 0,
+						max: 10,
+					},
+				},
+			},
+			update: vi.fn().mockResolvedValue(undefined),
+		};
+
+		globals().fromUuidSync.mockReturnValue({ actor });
+
+		const roll = createSerializedDamageRoll({
+			diceResults: [5],
+			flatBonus: 5,
+			isCritical: false,
+		});
+
+		const message = createActivationMessage();
+		await message.applyDamage(10, {
+			outcome: 'fullDamage',
+			roll,
+			ignoreArmor: true,
+		});
+
+		expect(actor.update).toHaveBeenCalledWith({
+			'system.attributes.hp.value': 0,
+		});
+	});
+
+	it('applies armor reduction per roll when only some grouped rolls are critical', async () => {
+		const actor = {
+			system: {
+				attributes: {
+					armor: 'heavy',
+					hp: {
+						value: 20,
+						temp: 0,
+						max: 20,
+					},
+				},
+			},
+			update: vi.fn().mockResolvedValue(undefined),
+		};
+
+		globals().fromUuidSync.mockReturnValue({ actor });
+
+		const nonCriticalRoll = createSerializedDamageRoll({
+			diceResults: [4],
+			flatBonus: 2,
+			isCritical: false,
+		});
+		const criticalRoll = createSerializedDamageRoll({
+			diceResults: [6],
+			flatBonus: 3,
+			isCritical: true,
+		});
+
+		const message = createActivationMessage();
+		await message.applyDamage(15, {
+			outcome: 'fullDamage',
+			rolls: [nonCriticalRoll, criticalRoll],
+		});
+
+		expect(actor.update).toHaveBeenCalledWith({
+			'system.attributes.hp.value': 9,
+		});
 	});
 });

--- a/src/documents/chatMessage.test.ts
+++ b/src/documents/chatMessage.test.ts
@@ -57,13 +57,16 @@ function createSerializedDamageRoll(params: {
 	];
 
 	if (flatBonus !== 0) {
-		terms.push({ operator: '+' });
-		terms.push({ number: flatBonus });
+		terms.push({ operator: flatBonus < 0 ? '-' : '+' });
+		terms.push({ number: Math.abs(flatBonus) });
 	}
+
+	const flatBonusFormulaSegment =
+		flatBonus === 0 ? '' : ` ${flatBonus < 0 ? '-' : '+'} ${Math.abs(flatBonus)}`;
 
 	return {
 		class: 'DamageRoll',
-		formula: `${params.diceResults.length || 1}d6${flatBonus ? ` + ${flatBonus}` : ''}`,
+		formula: `${params.diceResults.length || 1}d6${flatBonusFormulaSegment}`,
 		total,
 		isCritical: params.isCritical ?? false,
 		excludedPrimaryDieValue: params.excludedPrimaryDieValue ?? 0,
@@ -397,6 +400,114 @@ describe('NimbleChatMessage.applyDamage', () => {
 		});
 	});
 
+	it('applies medium armor with halfDamage outcome using halved dice-only damage', async () => {
+		const actor = {
+			system: {
+				attributes: {
+					armor: 'medium',
+					hp: {
+						value: 10,
+						temp: 0,
+						max: 10,
+					},
+				},
+			},
+			update: vi.fn().mockResolvedValue(undefined),
+		};
+
+		globals().fromUuidSync.mockReturnValue({ actor });
+
+		const roll = createSerializedDamageRoll({
+			diceResults: [5],
+			flatBonus: 5,
+			isCritical: false,
+		});
+
+		const message = createActivationMessage();
+		await message.applyDamage(5, { outcome: 'halfDamage', roll });
+
+		expect(actor.update).toHaveBeenCalledWith({
+			'system.attributes.hp.value': 7,
+		});
+	});
+
+	it('applies negative modifiers after medium armor dice-only calculation', async () => {
+		const actor = {
+			system: {
+				attributes: {
+					armor: 'medium',
+					hp: {
+						value: 10,
+						temp: 0,
+						max: 10,
+					},
+				},
+			},
+			update: vi.fn().mockResolvedValue(undefined),
+		};
+
+		globals().fromUuidSync.mockReturnValue({ actor });
+
+		const roll = createSerializedDamageRoll({
+			diceResults: [4],
+			flatBonus: -1,
+			isCritical: false,
+		});
+
+		const message = createActivationMessage();
+		await message.applyDamage(3, { outcome: 'fullDamage', roll });
+
+		expect(actor.update).toHaveBeenCalledWith({
+			'system.attributes.hp.value': 7,
+		});
+	});
+
+	it('applies all negative modifiers and ignores positive modifiers for medium armor', async () => {
+		const actor = {
+			system: {
+				attributes: {
+					armor: 'medium',
+					hp: {
+						value: 10,
+						temp: 0,
+						max: 10,
+					},
+				},
+			},
+			update: vi.fn().mockResolvedValue(undefined),
+		};
+
+		globals().fromUuidSync.mockReturnValue({ actor });
+
+		const roll = {
+			class: 'DamageRoll',
+			formula: '1d6 + 2 - 1 - 2',
+			total: 5,
+			isCritical: false,
+			excludedPrimaryDieValue: 0,
+			terms: [
+				{
+					number: 1,
+					faces: 6,
+					results: [{ result: 6, active: true, discarded: false }],
+				},
+				{ operator: '+' },
+				{ number: 2 },
+				{ operator: '-' },
+				{ number: 1 },
+				{ operator: '-' },
+				{ number: 2 },
+			],
+		};
+
+		const message = createActivationMessage();
+		await message.applyDamage(5, { outcome: 'fullDamage', roll });
+
+		expect(actor.update).toHaveBeenCalledWith({
+			'system.attributes.hp.value': 7,
+		});
+	});
+
 	it('applies heavy armor by halving dice-only damage and rounding up on non-critical hits', async () => {
 		const actor = {
 			system: {
@@ -426,6 +537,214 @@ describe('NimbleChatMessage.applyDamage', () => {
 		expect(actor.update).toHaveBeenCalledWith({
 			'system.attributes.hp.value': 7,
 		});
+	});
+
+	it('includes situational dice modifiers (e.g. +2d8) in heavy armor dice-only reduction', async () => {
+		const actor = {
+			system: {
+				attributes: {
+					armor: 'heavy',
+					hp: {
+						value: 10,
+						temp: 0,
+						max: 10,
+					},
+				},
+			},
+			update: vi.fn().mockResolvedValue(undefined),
+		};
+
+		globals().fromUuidSync.mockReturnValue({ actor });
+
+		const roll = {
+			class: 'DamageRoll',
+			formula: '1d6 + 2d8 + 3',
+			total: 17,
+			isCritical: false,
+			excludedPrimaryDieValue: 0,
+			terms: [
+				{
+					number: 1,
+					faces: 6,
+					results: [{ result: 4, active: true, discarded: false }],
+				},
+				{ operator: '+' },
+				{
+					number: 2,
+					faces: 8,
+					results: [
+						{ result: 5, active: true, discarded: false },
+						{ result: 5, active: true, discarded: false },
+					],
+				},
+				{ operator: '+' },
+				{ number: 3 },
+			],
+		};
+
+		const message = createActivationMessage();
+		await message.applyDamage(17, { outcome: 'fullDamage', roll });
+
+		expect(actor.update).toHaveBeenCalledWith({
+			'system.attributes.hp.value': 3,
+		});
+	});
+
+	it('applies negative modifiers after heavy armor reduction', async () => {
+		const actor = {
+			system: {
+				attributes: {
+					armor: 'heavy',
+					hp: {
+						value: 10,
+						temp: 0,
+						max: 10,
+					},
+				},
+			},
+			update: vi.fn().mockResolvedValue(undefined),
+		};
+
+		globals().fromUuidSync.mockReturnValue({ actor });
+
+		const roll = createSerializedDamageRoll({
+			diceResults: [4],
+			flatBonus: -1,
+			isCritical: false,
+		});
+
+		const message = createActivationMessage();
+		await message.applyDamage(3, { outcome: 'fullDamage', roll });
+
+		expect(actor.update).toHaveBeenCalledWith({
+			'system.attributes.hp.value': 9,
+		});
+	});
+
+	it('applies heavy armor fallback reduction when no roll metadata is provided', async () => {
+		const actor = {
+			system: {
+				attributes: {
+					armor: 'heavy',
+					hp: {
+						value: 10,
+						temp: 0,
+						max: 10,
+					},
+				},
+			},
+			update: vi.fn().mockResolvedValue(undefined),
+		};
+
+		globals().fromUuidSync.mockReturnValue({ actor });
+
+		const message = createActivationMessage();
+		await message.applyDamage(9, { outcome: 'fullDamage' });
+
+		expect(actor.update).toHaveBeenCalledWith({
+			'system.attributes.hp.value': 5,
+		});
+	});
+
+	it('shows no-damage feedback when all targets are reduced to 0 damage by armor', async () => {
+		const ironGuard = {
+			system: {
+				attributes: {
+					armor: 'heavy',
+					hp: {
+						value: 10,
+						temp: 0,
+						max: 10,
+					},
+				},
+			},
+			update: vi.fn().mockResolvedValue(undefined),
+		};
+		const stoneSentinel = {
+			system: {
+				attributes: {
+					armor: 'heavy',
+					hp: {
+						value: 10,
+						temp: 0,
+						max: 10,
+					},
+				},
+			},
+			update: vi.fn().mockResolvedValue(undefined),
+		};
+
+		globals().fromUuidSync.mockImplementation((uuid: string) => {
+			if (uuid === 'Scene.scene.Token.alpha') return { actor: ironGuard, name: 'Iron Guard' };
+			if (uuid === 'Scene.scene.Token.beta')
+				return { actor: stoneSentinel, name: 'Stone Sentinel' };
+			return null;
+		});
+
+		const roll = createSerializedDamageRoll({
+			diceResults: [2],
+			flatBonus: -1,
+			isCritical: false,
+		});
+
+		const message = createActivationMessage(['Scene.scene.Token.alpha', 'Scene.scene.Token.beta']);
+		await message.applyDamage(1, { outcome: 'fullDamage', roll });
+
+		expect(ironGuard.update).not.toHaveBeenCalled();
+		expect(stoneSentinel.update).not.toHaveBeenCalled();
+		expect(globals().ui.notifications.info).toHaveBeenCalledWith('No damage to apply.');
+	});
+
+	it('notifies the GM when a target is skipped because adjusted damage is 0', async () => {
+		const ironGuard = {
+			system: {
+				attributes: {
+					armor: 'heavy',
+					hp: {
+						value: 10,
+						temp: 0,
+						max: 10,
+					},
+				},
+			},
+			update: vi.fn().mockResolvedValue(undefined),
+		};
+		const scout = {
+			system: {
+				attributes: {
+					armor: 'medium',
+					hp: {
+						value: 10,
+						temp: 0,
+						max: 10,
+					},
+				},
+			},
+			update: vi.fn().mockResolvedValue(undefined),
+		};
+
+		globals().fromUuidSync.mockImplementation((uuid: string) => {
+			if (uuid === 'Scene.scene.Token.alpha') return { actor: ironGuard, name: 'Iron Guard' };
+			if (uuid === 'Scene.scene.Token.beta') return { actor: scout, name: 'Scout' };
+			return null;
+		});
+
+		const roll = createSerializedDamageRoll({
+			diceResults: [2],
+			flatBonus: -1,
+			isCritical: false,
+		});
+
+		const message = createActivationMessage(['Scene.scene.Token.alpha', 'Scene.scene.Token.beta']);
+		await message.applyDamage(1, { outcome: 'fullDamage', roll });
+
+		expect(ironGuard.update).not.toHaveBeenCalled();
+		expect(scout.update).toHaveBeenCalledWith({
+			'system.attributes.hp.value': 9,
+		});
+		expect(globals().ui.notifications.info).toHaveBeenCalledWith(
+			'Ignored Iron Guard because the result is 0.',
+		);
 	});
 
 	it('stacks heavy armor reduction with halfDamage outcome', async () => {

--- a/src/documents/chatMessage.ts
+++ b/src/documents/chatMessage.ts
@@ -2,6 +2,7 @@ export type SystemChatMessageTypes = Exclude<foundry.documents.BaseChatMessage.S
 
 import { createSubscriber } from 'svelte/reactivity';
 import type { DamageOutcomeNode, EffectNode } from '#types/effectTree.js';
+import localize from '#utils/localize.ts';
 import { getRelevantNodes } from '#view/dataPreparationHelpers/effectTree/getRelevantNodes.ts';
 import type { DamageRoll } from '../dice/DamageRoll.js';
 
@@ -47,6 +48,19 @@ type DamageApplyOptions = {
 	isCritical?: boolean;
 };
 
+interface DamageApplicationTarget {
+	actor: Actor.Implementation;
+	currentHp: number;
+	currentTemp: number;
+	adjustedDamage: number;
+}
+
+interface DamageApplicationPlan {
+	hasTargets: boolean;
+	applicableTargets: DamageApplicationTarget[];
+	zeroDamageTargetNames: string[];
+}
+
 function getActorArmorType(actor: Actor.Implementation): 'none' | 'medium' | 'heavy' {
 	const armor = foundry.utils.getProperty(actor, 'system.attributes.armor');
 	if (armor === 'medium' || armor === 'heavy') return armor;
@@ -75,15 +89,6 @@ function getDiceDamageTotal(serializedRoll: DamageRoll.SerializedData): number |
 	if (!Array.isArray(serializedRoll.terms)) return null;
 
 	for (const term of serializedRoll.terms) {
-		if (term instanceof foundry.dice.terms.Die) {
-			hasDiceTerm = true;
-			for (const result of term.results) {
-				if (result.active === false || result.discarded === true) continue;
-				diceDamage += result.result;
-			}
-			continue;
-		}
-
 		const serializedTerm = term as { faces?: unknown; results?: unknown };
 		const faces = Number(serializedTerm.faces);
 		if (!Number.isFinite(faces) || faces <= 0) continue;
@@ -115,7 +120,42 @@ function getDiceDamageTotal(serializedRoll: DamageRoll.SerializedData): number |
 	return Math.max(0, Math.floor(diceDamage));
 }
 
-function resolveArmorAdjustedDamage(params: {
+function getNegativeModifierTotal(serializedRoll: DamageRoll.SerializedData): number {
+	if (!Array.isArray(serializedRoll.terms)) return 0;
+
+	let negativeModifierTotal = 0;
+	let pendingOperator: '+' | '-' = '+';
+
+	for (const term of serializedRoll.terms) {
+		const serializedTerm = term as { operator?: unknown; number?: unknown; faces?: unknown };
+
+		if (serializedTerm.operator === '+' || serializedTerm.operator === '-') {
+			pendingOperator = serializedTerm.operator;
+			continue;
+		}
+
+		const faces = Number(serializedTerm.faces);
+		if (Number.isFinite(faces) && faces > 0) {
+			pendingOperator = '+';
+			continue;
+		}
+
+		const numericValue = Number(serializedTerm.number);
+		if (!Number.isFinite(numericValue)) {
+			pendingOperator = '+';
+			continue;
+		}
+
+		let signedModifier = numericValue;
+		if (pendingOperator === '-') signedModifier = -signedModifier;
+		if (signedModifier < 0) negativeModifierTotal += signedModifier;
+		pendingOperator = '+';
+	}
+
+	return Math.floor(negativeModifierTotal);
+}
+
+function calculateArmorAdjustedDamage(params: {
 	actor: Actor.Implementation;
 	damage: number;
 	options?: DamageApplyOptions;
@@ -153,13 +193,66 @@ function resolveArmorAdjustedDamage(params: {
 		}
 
 		const diceDamage = getDiceDamageTotal(serializedRoll) ?? rollTotal;
+		const negativeModifierTotal = getNegativeModifierTotal(serializedRoll);
 		let adjustedDamage = diceDamage;
 		if (applyOutcomeHalfDamage) adjustedDamage = Math.ceil(adjustedDamage * 0.5);
 		if (applyHeavyArmor) adjustedDamage = Math.ceil(adjustedDamage * 0.5);
+		adjustedDamage += negativeModifierTotal;
 		totalAdjustedDamage += adjustedDamage;
 	}
 
 	return Math.max(0, Math.floor(totalAdjustedDamage));
+}
+
+function buildDamageApplicationPlan(params: {
+	targets: string[];
+	damage: number;
+	options?: DamageApplyOptions;
+}): DamageApplicationPlan {
+	const applicableTargets: DamageApplicationTarget[] = [];
+	const zeroDamageTargetNames = new Set<string>();
+
+	for (const uuid of params.targets) {
+		const tokenDocument = fromUuidSync(uuid) as TokenDocument | null;
+		const actor = tokenDocument?.actor as Actor.Implementation | null;
+		if (!actor) continue;
+
+		const hpData = foundry.utils.getProperty(actor, 'system.attributes.hp') as
+			| {
+					value?: number;
+					temp?: number;
+			  }
+			| undefined;
+		const currentHp = hpData?.value;
+		if (typeof currentHp !== 'number' || Number.isNaN(currentHp)) continue;
+
+		const currentTemp = typeof hpData?.temp === 'number' ? hpData.temp : 0;
+		const adjustedDamage = calculateArmorAdjustedDamage({
+			actor,
+			damage: params.damage,
+			options: params.options,
+		});
+
+		if (!Number.isFinite(adjustedDamage) || adjustedDamage <= 0) {
+			zeroDamageTargetNames.add(
+				tokenDocument?.name || actor.name || localize('NIMBLE.ui.heroicActions.unknown'),
+			);
+			continue;
+		}
+
+		applicableTargets.push({
+			actor,
+			currentHp,
+			currentTemp,
+			adjustedDamage,
+		});
+	}
+
+	return {
+		hasTargets: params.targets.length > 0,
+		applicableTargets,
+		zeroDamageTargetNames: [...zeroDamageTargetNames],
+	};
 }
 
 class NimbleChatMessage extends ChatMessage {
@@ -355,7 +448,7 @@ class NimbleChatMessage extends ChatMessage {
 		if (!game.user?.isGM) return;
 
 		if (options?.outcome === 'noDamage') {
-			ui.notifications?.info(game.i18n.localize('NIMBLE.chat.noDamageToApply'));
+			ui.notifications?.info(localize('NIMBLE.chat.noDamageToApply'));
 			return;
 		}
 
@@ -364,43 +457,52 @@ class NimbleChatMessage extends ChatMessage {
 
 		const systemData = this.system as ActivationCardSystemData;
 		const targets = systemData.targets || [];
-
-		if (!targets.length) {
-			ui.notifications?.warn(game.i18n.localize('NIMBLE.chat.noTargetsSelected'));
+		const damageApplicationPlan = buildDamageApplicationPlan({ targets, damage, options });
+		if (!damageApplicationPlan.hasTargets) {
+			ui.notifications?.warn(localize('NIMBLE.chat.noTargetsSelected'));
 			return;
 		}
 
-		for (const uuid of targets) {
-			const tokenDocument = fromUuidSync(uuid) as TokenDocument | null;
-			const actor = tokenDocument?.actor as Actor.Implementation | null;
-			if (!actor) continue;
+		if (damageApplicationPlan.applicableTargets.length < 1) {
+			ui.notifications?.info(localize('NIMBLE.chat.noDamageToApply'));
+			return;
+		}
 
-			const hpData = foundry.utils.getProperty(actor, 'system.attributes.hp') as
-				| {
-						value?: number;
-						temp?: number;
-				  }
-				| undefined;
-			const currentHp = hpData?.value;
-			if (typeof currentHp !== 'number' || Number.isNaN(currentHp)) continue;
-
-			const adjustedDamage = resolveArmorAdjustedDamage({ actor, damage, options });
-			if (!Number.isFinite(adjustedDamage) || adjustedDamage <= 0) continue;
-
-			const currentTemp = typeof hpData?.temp === 'number' ? hpData.temp : 0;
-			const absorbedByTemp = Math.min(currentTemp, adjustedDamage);
-			const nextTemp = currentTemp - absorbedByTemp;
-			const remainingDamage = adjustedDamage - absorbedByTemp;
-			const nextHp = Math.max(currentHp - remainingDamage, 0);
+		for (const target of damageApplicationPlan.applicableTargets) {
+			const absorbedByTemp = Math.min(target.currentTemp, target.adjustedDamage);
+			const nextTemp = target.currentTemp - absorbedByTemp;
+			const remainingDamage = target.adjustedDamage - absorbedByTemp;
+			const nextHp = Math.max(target.currentHp - remainingDamage, 0);
 
 			const updates: Record<string, unknown> = {};
-			if (nextTemp !== currentTemp) updates['system.attributes.hp.temp'] = nextTemp;
-			if (nextHp !== currentHp) updates['system.attributes.hp.value'] = nextHp;
+			if (nextTemp !== target.currentTemp) updates['system.attributes.hp.temp'] = nextTemp;
+			if (nextHp !== target.currentHp) updates['system.attributes.hp.value'] = nextHp;
 
 			if (Object.keys(updates).length > 0) {
-				await actor.update(updates as Actor.UpdateData);
+				await target.actor.update(updates as Actor.UpdateData);
 			}
 		}
+
+		for (const tokenName of damageApplicationPlan.zeroDamageTargetNames) {
+			ui.notifications?.info(
+				localize('NIMBLE.chat.targetSkippedZeroDamage', {
+					tokenName,
+				}),
+			);
+		}
+	}
+
+	canApplyDamage(value: number, options?: DamageApplyOptions): boolean {
+		if (!this.isActivationCard()) return false;
+		if (options?.outcome === 'noDamage') return false;
+
+		const damage = Math.floor(Math.abs(Number(value)));
+		if (!Number.isFinite(damage) || damage <= 0) return false;
+
+		const targets = (this.system as ActivationCardSystemData).targets || [];
+		const damageApplicationPlan = buildDamageApplicationPlan({ targets, damage, options });
+		if (!damageApplicationPlan.hasTargets) return true;
+		return damageApplicationPlan.applicableTargets.length > 0;
 	}
 
 	async applyHealing(value: number, healingType?: string, effectId?: string): Promise<void> {
@@ -460,7 +562,7 @@ class NimbleChatMessage extends ChatMessage {
 
 			healingRecord.targets.push({
 				uuid,
-				tokenName: tokenDocument?.name || 'Unknown',
+				tokenName: tokenDocument?.name || localize('NIMBLE.ui.heroicActions.unknown'),
 				previousHp,
 				previousTempHp,
 				newHp,

--- a/src/documents/chatMessage.ts
+++ b/src/documents/chatMessage.ts
@@ -1,8 +1,9 @@
 export type SystemChatMessageTypes = Exclude<foundry.documents.BaseChatMessage.SubType, 'base'>;
 
 import { createSubscriber } from 'svelte/reactivity';
-import type { EffectNode } from '#types/effectTree.js';
+import type { DamageOutcomeNode, EffectNode } from '#types/effectTree.js';
 import { getRelevantNodes } from '#view/dataPreparationHelpers/effectTree/getRelevantNodes.ts';
+import type { DamageRoll } from '../dice/DamageRoll.js';
 
 /** Types for activation cards that have targets and effects */
 type ActivationCardTypes = 'feature' | 'minionGroupAttack' | 'object' | 'reaction' | 'spell';
@@ -34,6 +35,131 @@ interface ActivationCardSystemData {
 	};
 	appliedHealing?: Record<string, AppliedHealingRecord>;
 	[key: string]: unknown;
+}
+
+type DamageApplyOutcome = DamageOutcomeNode['outcome'] | 'noDamage';
+
+type DamageApplyOptions = {
+	ignoreArmor?: boolean;
+	outcome?: DamageApplyOutcome;
+	roll?: DamageRoll.SerializedData | null;
+	rolls?: Array<DamageRoll.SerializedData | null | undefined>;
+	isCritical?: boolean;
+};
+
+function getActorArmorType(actor: Actor.Implementation): 'none' | 'medium' | 'heavy' {
+	const armor = foundry.utils.getProperty(actor, 'system.attributes.armor');
+	if (armor === 'medium' || armor === 'heavy') return armor;
+	return 'none';
+}
+
+function getDamageRollTotal(serializedRoll: DamageRoll.SerializedData): number {
+	const total = Number(serializedRoll.total ?? 0);
+	if (!Number.isFinite(total) || total <= 0) return 0;
+	return Math.floor(total);
+}
+
+function getSerializedDamageRolls(
+	options: DamageApplyOptions | undefined,
+): DamageRoll.SerializedData[] {
+	const serializedRolls =
+		options?.rolls?.filter((roll): roll is DamageRoll.SerializedData => roll != null) ?? [];
+	if (options?.roll) serializedRolls.push(options.roll);
+	return serializedRolls;
+}
+
+function getDiceDamageTotal(serializedRoll: DamageRoll.SerializedData): number | null {
+	let diceDamage = 0;
+	let hasDiceTerm = false;
+
+	if (!Array.isArray(serializedRoll.terms)) return null;
+
+	for (const term of serializedRoll.terms) {
+		if (term instanceof foundry.dice.terms.Die) {
+			hasDiceTerm = true;
+			for (const result of term.results) {
+				if (result.active === false || result.discarded === true) continue;
+				diceDamage += result.result;
+			}
+			continue;
+		}
+
+		const serializedTerm = term as { faces?: unknown; results?: unknown };
+		const faces = Number(serializedTerm.faces);
+		if (!Number.isFinite(faces) || faces <= 0) continue;
+
+		hasDiceTerm = true;
+
+		if (!Array.isArray(serializedTerm.results)) continue;
+		for (const result of serializedTerm.results) {
+			const serializedResult = result as {
+				result?: unknown;
+				active?: unknown;
+				discarded?: unknown;
+			};
+			if (serializedResult.active === false || serializedResult.discarded === true) continue;
+
+			const resultValue = Number(serializedResult.result);
+			if (!Number.isFinite(resultValue)) continue;
+			diceDamage += resultValue;
+		}
+	}
+
+	if (!hasDiceTerm) return null;
+
+	const excludedPrimaryDieValue = Number(serializedRoll.excludedPrimaryDieValue ?? 0);
+	if (Number.isFinite(excludedPrimaryDieValue) && excludedPrimaryDieValue > 0) {
+		diceDamage -= excludedPrimaryDieValue;
+	}
+
+	return Math.max(0, Math.floor(diceDamage));
+}
+
+function resolveArmorAdjustedDamage(params: {
+	actor: Actor.Implementation;
+	damage: number;
+	options?: DamageApplyOptions;
+}): number {
+	const armorType = getActorArmorType(params.actor);
+	if (armorType === 'none') return params.damage;
+
+	const damageOptions = params.options;
+	if (damageOptions?.ignoreArmor === true) return params.damage;
+	const serializedRolls = getSerializedDamageRolls(damageOptions);
+	const applyOutcomeHalfDamage = damageOptions?.outcome === 'halfDamage';
+	const applyHeavyArmor = armorType === 'heavy';
+
+	if (serializedRolls.length < 1) {
+		if (damageOptions?.isCritical === true) {
+			if (applyOutcomeHalfDamage) return Math.ceil(params.damage * 0.5);
+			return params.damage;
+		}
+
+		// Without roll metadata, the incoming value already includes outcome scaling.
+		// In this fallback, only apply armor reduction.
+		if (applyHeavyArmor) return Math.ceil(params.damage * 0.5);
+		return params.damage;
+	}
+
+	let totalAdjustedDamage = 0;
+	for (const serializedRoll of serializedRolls) {
+		const rollTotal = getDamageRollTotal(serializedRoll);
+		const isCritical = serializedRoll.isCritical === true;
+
+		if (isCritical) {
+			const critAdjustedDamage = applyOutcomeHalfDamage ? Math.ceil(rollTotal * 0.5) : rollTotal;
+			totalAdjustedDamage += critAdjustedDamage;
+			continue;
+		}
+
+		const diceDamage = getDiceDamageTotal(serializedRoll) ?? rollTotal;
+		let adjustedDamage = diceDamage;
+		if (applyOutcomeHalfDamage) adjustedDamage = Math.ceil(adjustedDamage * 0.5);
+		if (applyHeavyArmor) adjustedDamage = Math.ceil(adjustedDamage * 0.5);
+		totalAdjustedDamage += adjustedDamage;
+	}
+
+	return Math.max(0, Math.floor(totalAdjustedDamage));
 }
 
 class NimbleChatMessage extends ChatMessage {
@@ -224,12 +350,12 @@ class NimbleChatMessage extends ChatMessage {
 		} as Record<string, unknown>) as Promise<ChatMessage | undefined>;
 	}
 
-	async applyDamage(value: number, options?: Record<string, unknown>): Promise<void> {
+	async applyDamage(value: number, options?: DamageApplyOptions): Promise<void> {
 		if (!this.isActivationCard()) return;
 		if (!game.user?.isGM) return;
 
 		if (options?.outcome === 'noDamage') {
-			ui.notifications?.info('No damage to apply.');
+			ui.notifications?.info(game.i18n.localize('NIMBLE.chat.noDamageToApply'));
 			return;
 		}
 
@@ -240,7 +366,7 @@ class NimbleChatMessage extends ChatMessage {
 		const targets = systemData.targets || [];
 
 		if (!targets.length) {
-			ui.notifications?.warn('No targets selected');
+			ui.notifications?.warn(game.i18n.localize('NIMBLE.chat.noTargetsSelected'));
 			return;
 		}
 
@@ -258,10 +384,13 @@ class NimbleChatMessage extends ChatMessage {
 			const currentHp = hpData?.value;
 			if (typeof currentHp !== 'number' || Number.isNaN(currentHp)) continue;
 
+			const adjustedDamage = resolveArmorAdjustedDamage({ actor, damage, options });
+			if (!Number.isFinite(adjustedDamage) || adjustedDamage <= 0) continue;
+
 			const currentTemp = typeof hpData?.temp === 'number' ? hpData.temp : 0;
-			const absorbedByTemp = Math.min(currentTemp, damage);
+			const absorbedByTemp = Math.min(currentTemp, adjustedDamage);
 			const nextTemp = currentTemp - absorbedByTemp;
-			const remainingDamage = damage - absorbedByTemp;
+			const remainingDamage = adjustedDamage - absorbedByTemp;
 			const nextHp = Math.max(currentHp - remainingDamage, 0);
 
 			const updates: Record<string, unknown> = {};

--- a/src/documents/chatMessage.ts
+++ b/src/documents/chatMessage.ts
@@ -452,8 +452,11 @@ class NimbleChatMessage extends ChatMessage {
 			return;
 		}
 
-		const damage = Math.floor(Math.abs(Number(value)));
-		if (!Number.isFinite(damage) || damage <= 0) return;
+		const damage = Math.floor(Number(value));
+		if (!Number.isFinite(damage) || damage <= 0) {
+			ui.notifications?.info(localize('NIMBLE.chat.noDamageToApply'));
+			return;
+		}
 
 		const systemData = this.system as ActivationCardSystemData;
 		const targets = systemData.targets || [];
@@ -496,7 +499,7 @@ class NimbleChatMessage extends ChatMessage {
 		if (!this.isActivationCard()) return false;
 		if (options?.outcome === 'noDamage') return false;
 
-		const damage = Math.floor(Math.abs(Number(value)));
+		const damage = Math.floor(Number(value));
 		if (!Number.isFinite(damage) || damage <= 0) return false;
 
 		const targets = (this.system as ActivationCardSystemData).targets || [];

--- a/src/view/chat/components/DamageRoll.svelte
+++ b/src/view/chat/components/DamageRoll.svelte
@@ -53,7 +53,7 @@
 		subheading={secondaryInfo}
 		total={Math.ceil(roll.total * multiplier)}
 		type="damage"
-		options={{ damageType, ignoreArmor, outcome, rollOptions }}
+		options={{ damageType, ignoreArmor, outcome, rollOptions, roll, isCritical: roll?.isCritical }}
 		showRollDetails={rollOptions.primaryDieValue != '0' || rollOptions?.primaryDieModifier != '0'}
 	/>
 {:else}
@@ -63,7 +63,7 @@
 		subheading={secondaryInfo}
 		total={Math.ceil((roll?.total ?? 0) * multiplier)}
 		type="damage"
-		options={{ damageType, ignoreArmor, outcome, rollOptions }}
+		options={{ damageType, ignoreArmor, outcome, rollOptions, roll, isCritical: roll?.isCritical }}
 		showRollDetails={false}
 	/>
 {/if}

--- a/src/view/chat/components/RollSummary.svelte
+++ b/src/view/chat/components/RollSummary.svelte
@@ -1,11 +1,35 @@
-<script>
-	import { getContext } from 'svelte';
+<script lang="ts">
+	import type { NimbleChatMessage } from '#documents/chatMessage.ts';
+	import type { RollSummaryProps } from '#types/components/RollSummary.d.ts';
 
-	let { label, subheading, tooltip, total, options, showRollDetails, type = '' } = $props();
+	import { getContext } from 'svelte';
+	import localize from '#utils/localize.ts';
+
+	const {
+		label,
+		subheading,
+		tooltip,
+		total,
+		options,
+		showRollDetails,
+		type = '',
+	}: RollSummaryProps = $props();
 	const { hitDice } = CONFIG.NIMBLE;
 	const autoExpand = game.settings.get('nimble', 'autoExpandRolls');
-	const messageDocument = getContext('messageDocument');
+	const messageDocument = getContext<NimbleChatMessage | undefined>('messageDocument');
 	let expanded = $state(autoExpand);
+	let canApplyDamage = $derived.by(() => {
+		if (type !== 'damage' || !game.user?.isGM) return false;
+
+		const canApplyDamageFunction = messageDocument?.canApplyDamage;
+		if (typeof canApplyDamageFunction !== 'function') return true;
+
+		return canApplyDamageFunction.call(messageDocument, total, options);
+	});
+	let applyDamageLabel = $derived(localize('NIMBLE.chat.applyDamage'));
+	let applyDamageTooltip = $derived(
+		canApplyDamage ? applyDamageLabel : localize('NIMBLE.chat.noDamageToApply'),
+	);
 </script>
 
 <div class="roll" class:roll--no-subheading={!subheading}>
@@ -55,12 +79,13 @@
 {#if type === 'damage' && game.user?.isGM}
 	<button
 		class="nimble-button nimble-button--apply-damage"
-		aria-label="Apply Damage"
-		data-tooltip="Apply Damage"
+		aria-label={applyDamageLabel}
+		data-tooltip={applyDamageTooltip}
 		data-tooltip-direction="UP"
+		disabled={!canApplyDamage}
 		onclick={() => messageDocument?.applyDamage(total, options)}
 	>
-		Apply Damage
+		{applyDamageLabel}
 	</button>
 {/if}
 

--- a/types/components/RollSummary.d.ts
+++ b/types/components/RollSummary.d.ts
@@ -1,0 +1,18 @@
+interface RollSummaryOptions {
+	rollOptions?: {
+		primaryDieValue?: string | number;
+		primaryDieModifier?: string | number;
+		[key: string]: unknown;
+	};
+	[key: string]: unknown;
+}
+
+export interface RollSummaryProps {
+	label: string;
+	subheading?: string | null;
+	tooltip?: string | null;
+	total: number;
+	options?: RollSummaryOptions;
+	showRollDetails?: boolean;
+	type?: string;
+}


### PR DESCRIPTION
- pass serialized damage roll data and critical flag into apply-damage
- apply armor logic per target in chatMessage damage handling
- medium armor: use dice-only damage unless the hit is a crit
- heavy armor: halve damage (round up) and ignore flat modifiers unless the hit is a crit
- respect global half-damage outcome in the armor-adjusted calculation
- add/adjust tests for armor + crit + half-damage scenarios
- add missing localization for 0 damage.