### PR TITLE
chore: add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,67 @@
+name: Bug Report
+description: Report a bug in the Nimble FoundryVTT system
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! Please fill out the sections below so we can reproduce and fix it.
+
+  - type: input
+    id: foundry-version
+    attributes:
+      label: Foundry VTT Version
+      placeholder: "e.g. 12.331"
+    validations:
+      required: true
+
+  - type: input
+    id: nimble-version
+    attributes:
+      label: Nimble System Version
+      placeholder: "e.g. 0.8.0"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear description of what the bug is.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      placeholder: |
+        1. Open a character sheet
+        2. Click on...
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Screenshots, console errors, active modules, browser info, etc.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discord Community
+    url: https://discord.gg/k2E2QUCzeT
+    about: For questions, general discussion, or help with development setup

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,6 +1,6 @@
 name: Feature Request
 description: Suggest a new feature or improvement
-labels: ["enhancement"]
+labels: ["feature request"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,40 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an idea? We'd love to hear it. For large features, consider discussing on [Discord](https://discord.gg/WRf5hBqM) first.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or Motivation
+      description: What problem does this solve, or what use case does it support?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: How do you think this should work?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any other approaches you thought about?
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Mockups, references to other systems, links, etc.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Summary
+
+<!-- One or two sentences: what does this PR do and why? -->
+
+## Changes
+
+<!-- Bullet list of the key changes. Keep it high-level. -->
+
+-
+
+## Test Plan
+
+<!-- How will the person reviewing this test it actually works? Include steps the reviewer needs to take to avoid too much guessing -->
+
+
+
+## Checklist
+
+- [ ] Added or updated unit tests
+- [ ] PR targets the `dev` branch
+- [ ] `pnpm check` passes (format, lint, circular deps, type-check, tests)
+- [ ] No hardcoded user-facing strings (used `localize()`)
+- [ ] Tested in Foundry with no console errors
+- [ ] **Have you used AI to assist with this PR?** yes / no
+- [ ] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)
+
+## Related Issues
+
+<!-- Link related issues: Closes #123, Fixes #456 -->


### PR DESCRIPTION
## Summary

Add structured GitHub issue templates (bug report, feature request) and a PR template with dev checklist to standardize contributions.

## Changes

- Bug report issue template (YAML form) with Foundry/Nimble version fields, repro steps, expected/actual behavior
- Feature request issue template (YAML form) with problem/motivation and proposed solution
- Issue template config that disables blank issues and links to Discord
- PR template with Summary, Changes, Test Plan, Checklist, and Related Issues sections

## Test Plan (can only be done after merge to main)

- Open a new issue on GitHub and verify both Bug Report and Feature Request forms render correctly
- Open a new PR and verify the template auto-populates with the correct sections
- Confirm blank issues are disabled and the Discord contact link appears

## Checklist

- [x] Added or updated unit tests — N/A (no code changes)
- [x] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`) — N/A
- [x] Tested in Foundry with no console errors — N/A
- [x] **Have you used AI to assist with this PR?** yes
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues
#511 