### PR TITLE
Monsters marked as finished their turn on their turn

### DIFF
--- a/src/documents/combat/combat.svelte.test.ts
+++ b/src/documents/combat/combat.svelte.test.ts
@@ -68,6 +68,13 @@ describe('NimbleCombat', () => {
 		combatPrototype.previousRound = vi.fn(async function (this: Combat) {
 			return this;
 		});
+		combatPrototype.createEmbeddedDocuments = vi.fn(async function (
+			this: Combat,
+			_embeddedName: string,
+			data: unknown,
+		) {
+			return data as foundry.abstract.Document.StoredForName<Combat.Embedded.Name>[] | undefined;
+		});
 
 		const textEditorImpl =
 			globals().foundry.applications.ux.TextEditor.implementation.getDragEventData;
@@ -452,6 +459,192 @@ describe('NimbleCombat', () => {
 		});
 	});
 
+	it('restores non-player actions to max when rewinding to a previous monster turn', async () => {
+		const combatId = 'combat-rewind-restore-monster-actions';
+		const monster = createMockCombatant({
+			id: 'monster-rewind',
+			type: 'npc',
+			sort: 1,
+			isOwner: false,
+			initiative: 12,
+			actionsCurrent: 0,
+			actionsMax: 3,
+			actor: createCombatActorFixture({ hp: 10 }),
+			combatId,
+		});
+		const player = createMockCombatant({
+			id: 'player-current',
+			type: 'character',
+			sort: 2,
+			isOwner: true,
+			initiative: 10,
+			actor: createCombatActorFixture({ hp: 8, woundsValue: 0, woundsMax: 6 }),
+			combatId,
+		});
+
+		const superPreviousTurn = globals().Combat.prototype.previousTurn as ReturnType<typeof vi.fn>;
+		superPreviousTurn.mockImplementation(async function (
+			this: Combat & {
+				turn?: number;
+				combatant?: Combatant.Implementation | null;
+			},
+		) {
+			this.turn = 0;
+			this.combatant = monster;
+			return this;
+		});
+
+		const combat = new NimbleCombat({
+			id: combatId,
+			combatants: createCombatantsCollectionFixture([monster, player]),
+			turns: [monster, player],
+			turn: 1,
+			combatant: player,
+		} as unknown as Combat.CreateData) as NimbleCombat & {
+			update: ReturnType<typeof vi.fn>;
+			updateEmbeddedDocuments: ReturnType<typeof vi.fn>;
+		};
+
+		combat.update = vi.fn().mockResolvedValue(combat);
+		combat.updateEmbeddedDocuments = vi
+			.fn()
+			.mockImplementation(
+				async (_documentName: string, updates: Array<Record<string, unknown>>) => {
+					for (const update of updates) {
+						const id = update._id as string | undefined;
+						if (!id) continue;
+						const target = combat.combatants.get(id);
+						if (!target) continue;
+						const nextActions = update['system.actions.base.current'];
+						if (typeof nextActions === 'number') {
+							foundry.utils.setProperty(target, 'system.actions.base.current', nextActions);
+						}
+					}
+					return updates as unknown as Combatant.Implementation[];
+				},
+			);
+
+		await combat.previousTurn();
+
+		expect(combat.updateEmbeddedDocuments).toHaveBeenCalledWith('Combatant', [
+			{
+				_id: 'monster-rewind',
+				'system.actions.base.current': 3,
+			},
+		]);
+		expect(foundry.utils.getProperty(monster, 'system.actions.base.current')).toBe(3);
+	});
+
+	it('restores all alive minion-group member actions when rewinding to the group turn', async () => {
+		const combatId = 'combat-rewind-restore-minion-group-actions';
+		const leaderActor = {
+			...createCombatActorFixture({ id: 'minion-leader-actor', hp: 1 }),
+			type: 'minion',
+		} as unknown as Actor.Implementation;
+		const memberActor = {
+			...createCombatActorFixture({ id: 'minion-member-actor', hp: 1 }),
+			type: 'minion',
+		} as unknown as Actor.Implementation;
+		const player = createMockCombatant({
+			id: 'player-current',
+			type: 'character',
+			sort: 3,
+			isOwner: true,
+			initiative: 10,
+			actor: createCombatActorFixture({ hp: 8, woundsValue: 0, woundsMax: 6 }),
+			combatId,
+		});
+		const leader = createMockCombatant({
+			id: 'minion-leader',
+			type: 'npc',
+			sort: 1,
+			isOwner: false,
+			initiative: 12,
+			actionsCurrent: 0,
+			actionsMax: 1,
+			actor: leaderActor,
+			combatId,
+		});
+		const member = createMockCombatant({
+			id: 'minion-member',
+			type: 'npc',
+			sort: 2,
+			isOwner: false,
+			initiative: 12,
+			actionsCurrent: 0,
+			actionsMax: 1,
+			actor: memberActor,
+			combatId,
+		});
+
+		(leader as unknown as { flags: Record<string, unknown> }).flags = {
+			nimble: { minionGroup: { id: 'rewind-group-1', role: 'leader' } },
+		};
+		(member as unknown as { flags: Record<string, unknown> }).flags = {
+			nimble: { minionGroup: { id: 'rewind-group-1', role: 'member' } },
+		};
+
+		const superPreviousTurn = globals().Combat.prototype.previousTurn as ReturnType<typeof vi.fn>;
+		superPreviousTurn.mockImplementation(async function (
+			this: Combat & {
+				turn?: number;
+				combatant?: Combatant.Implementation | null;
+			},
+		) {
+			this.turn = 0;
+			this.combatant = leader;
+			return this;
+		});
+
+		const combat = new NimbleCombat({
+			id: combatId,
+			combatants: createCombatantsCollectionFixture([leader, member, player]),
+			turns: [leader, player],
+			turn: 1,
+			combatant: player,
+		} as unknown as Combat.CreateData) as NimbleCombat & {
+			update: ReturnType<typeof vi.fn>;
+			updateEmbeddedDocuments: ReturnType<typeof vi.fn>;
+		};
+
+		combat.update = vi.fn().mockResolvedValue(combat);
+		combat.updateEmbeddedDocuments = vi
+			.fn()
+			.mockImplementation(
+				async (_documentName: string, updates: Array<Record<string, unknown>>) => {
+					for (const update of updates) {
+						const id = update._id as string | undefined;
+						if (!id) continue;
+						const target = combat.combatants.get(id);
+						if (!target) continue;
+						const nextActions = update['system.actions.base.current'];
+						if (typeof nextActions === 'number') {
+							foundry.utils.setProperty(target, 'system.actions.base.current', nextActions);
+						}
+					}
+					return updates as unknown as Combatant.Implementation[];
+				},
+			);
+
+		await combat.previousTurn();
+
+		expect(combat.updateEmbeddedDocuments).toHaveBeenCalledWith(
+			'Combatant',
+			expect.arrayContaining([
+				{
+					_id: 'minion-leader',
+					'system.actions.base.current': 1,
+				},
+				{
+					_id: 'minion-member',
+					'system.actions.base.current': 1,
+				},
+			]),
+		);
+		expect(foundry.utils.getProperty(leader, 'system.actions.base.current')).toBe(1);
+		expect(foundry.utils.getProperty(member, 'system.actions.base.current')).toBe(1);
+	});
+
 	it('starts combat on the top-most character card after start initialization', async () => {
 		const combatId = 'combat-start-order';
 		const monster = createMockCombatant({
@@ -628,6 +821,65 @@ describe('NimbleCombat', () => {
 		expect(combat.updateEmbeddedDocuments).toHaveBeenCalledWith('Combatant', [
 			{ _id: 'npc-combatant', 'system.actions.base.current': 3 },
 		]);
+	});
+
+	it('initializes newly created non-character combatants with usable current actions', async () => {
+		const combatId = 'combat-create-combatant-action-initialization';
+		const combat = new NimbleCombat({
+			id: combatId,
+			combatants: createCombatantsCollectionFixture([]),
+		} as unknown as Combat.CreateData);
+
+		const superCreateEmbeddedDocuments = globals().Combat.prototype
+			.createEmbeddedDocuments as ReturnType<typeof vi.fn>;
+
+		await combat.createEmbeddedDocuments('Combatant', [
+			{
+				_id: 'created-npc',
+				type: 'npc',
+				system: {
+					actions: {
+						base: {
+							max: 3,
+						},
+					},
+				},
+			},
+			{
+				_id: 'created-minion',
+				type: 'minion',
+				system: {
+					actions: {
+						base: {
+							max: 2,
+						},
+					},
+				},
+			},
+			{
+				_id: 'created-solo',
+				type: 'soloMonster',
+			},
+			{
+				_id: 'created-character',
+				type: 'character',
+			},
+		] as unknown as foundry.abstract.Document.CreateDataForName<'Combatant'>[]);
+
+		const normalizedData = superCreateEmbeddedDocuments.mock.calls[0]?.[1] as Array<
+			Record<string, unknown>
+		>;
+		expect(normalizedData).toHaveLength(4);
+		expect(normalizedData[0]?.type).toBe('npc');
+		expect(foundry.utils.getProperty(normalizedData[0], 'system.actions.base.current')).toBe(3);
+		expect(normalizedData[1]?.type).toBe('npc');
+		expect(foundry.utils.getProperty(normalizedData[1], 'system.actions.base.current')).toBe(2);
+		expect(normalizedData[2]?.type).toBe('soloMonster');
+		expect(foundry.utils.getProperty(normalizedData[2], 'system.actions.base.current')).toBe(1);
+		expect(normalizedData[3]?.type).toBe('character');
+		expect(foundry.utils.getProperty(normalizedData[3], 'system.actions.base.current')).toBe(
+			undefined,
+		);
 	});
 
 	it('marks a heroic reaction unavailable without spending an action when the GM toggles it off-turn', async () => {

--- a/src/documents/combat/combat.svelte.test.ts
+++ b/src/documents/combat/combat.svelte.test.ts
@@ -2417,12 +2417,21 @@ describe('NimbleCombat', () => {
 		).not.toHaveBeenCalled();
 	});
 
-	it('skips exhausted non-character turns when advancing initiative', async () => {
+	it('does not skip exhausted non-character turns when advancing initiative', async () => {
 		const combatId = 'combat-next-turn-skip-exhausted';
+		const character = createMockCombatant({
+			id: 'active-character',
+			type: 'character',
+			sort: 1,
+			isOwner: true,
+			initiative: 14,
+			actor: createCombatActorFixture({ hp: 8, woundsValue: 0, woundsMax: 6 }),
+			combatId,
+		});
 		const exhaustedNpcA = createMockCombatant({
 			id: 'exhausted-npc-a',
 			type: 'npc',
-			sort: 1,
+			sort: 2,
 			isOwner: false,
 			initiative: 13,
 			actionsCurrent: 0,
@@ -2432,20 +2441,11 @@ describe('NimbleCombat', () => {
 		const exhaustedNpcB = createMockCombatant({
 			id: 'exhausted-npc-b',
 			type: 'npc',
-			sort: 2,
+			sort: 3,
 			isOwner: false,
 			initiative: 12,
 			actionsCurrent: 0,
 			actor: createCombatActorFixture({ hp: 6 }),
-			combatId,
-		});
-		const character = createMockCombatant({
-			id: 'active-character',
-			type: 'character',
-			sort: 3,
-			isOwner: true,
-			initiative: 11,
-			actor: createCombatActorFixture({ hp: 8, woundsValue: 0, woundsMax: 6 }),
 			combatId,
 		});
 
@@ -2465,10 +2465,10 @@ describe('NimbleCombat', () => {
 
 		const combat = new NimbleCombat({
 			id: combatId,
-			combatants: createCombatantsCollectionFixture([exhaustedNpcA, exhaustedNpcB, character]),
-			turns: [exhaustedNpcA, exhaustedNpcB, character],
+			combatants: createCombatantsCollectionFixture([character, exhaustedNpcA, exhaustedNpcB]),
+			turns: [character, exhaustedNpcA, exhaustedNpcB],
 			turn: 0,
-			combatant: exhaustedNpcA,
+			combatant: character,
 		} as unknown as Combat.CreateData) as NimbleCombat & {
 			update: ReturnType<typeof vi.fn>;
 		};
@@ -2477,8 +2477,8 @@ describe('NimbleCombat', () => {
 
 		await combat.nextTurn();
 
-		expect(combat.combatant?.id).toBe('active-character');
-		expect(superNextTurn).toHaveBeenCalledTimes(2);
+		expect(combat.combatant?.id).toBe('exhausted-npc-a');
+		expect(superNextTurn).toHaveBeenCalledTimes(1);
 	});
 
 	it('allows GM drop reorder for all active combatant types', async () => {

--- a/src/documents/combat/combat.svelte.ts
+++ b/src/documents/combat/combat.svelte.ts
@@ -282,19 +282,6 @@ class NimbleCombat extends Combat {
 		this.turn = Math.min(Math.max(currentTurn, 0), aliveTurns.length - 1);
 		this.#storeExpandedTurnIdentity(this.#resolveTurnIdentityAtIndex(aliveTurns, this.turn));
 	}
-	#combatantHasAnyActionsRemaining(combatant: Combatant.Implementation): boolean {
-		if (combatant.type === 'character' || combatant.type === 'soloMonster') return true;
-
-		const groupId = getMinionGroupId(combatant);
-		if (groupId) {
-			const summary = getMinionGroupSummaries(this.combatants.contents).get(groupId);
-			if (summary?.aliveMembers.length) {
-				return summary.aliveMembers.some((member) => getCombatantCurrentActions(member) > 0);
-			}
-		}
-
-		return getCombatantCurrentActions(combatant) > 0;
-	}
 
 	#getNonCharacterTurnResetTargets(
 		combatant: Combatant.Implementation | null,
@@ -359,40 +346,6 @@ class NimbleCombat extends Combat {
 			: 1;
 		foundry.utils.setProperty(normalizedEntry, 'system.actions.base.current', initialActions);
 		return { normalizedEntry, normalizedMinionType };
-	}
-
-	async #advancePastExhaustedTurns(result: this): Promise<this> {
-		if (!this.turns.length) return result;
-
-		const hasTurnWithActions = this.turns.some((combatant) =>
-			this.#combatantHasAnyActionsRemaining(combatant),
-		);
-		if (!hasTurnWithActions) return result;
-
-		let nextResult = result;
-		const maxIterations = Math.max(this.turns.length, 1);
-		for (let iteration = 0; iteration < maxIterations; iteration += 1) {
-			const activeCombatant = this.combatant;
-			if (!activeCombatant) break;
-			if (activeCombatant.type === 'character' || activeCombatant.type === 'soloMonster') break;
-			if (this.#combatantHasAnyActionsRemaining(activeCombatant)) break;
-
-			const previousActiveId = activeCombatant.id ?? null;
-			const preferredNextTurnIdentity = this.#resolveNextTurnIdentity();
-			const { intercepted, result: nextTurnResult } = await this.#runAtomicTurnStateOperation(
-				preferredNextTurnIdentity,
-				async () => (await super.nextTurn()) as this,
-			);
-			nextResult = nextTurnResult;
-			this.#syncTurnIndexWithAliveTurns({ preferredTurnIdentity: preferredNextTurnIdentity });
-			if (!intercepted) {
-				await this.#persistAtomicTurnState({ turn: this.turn });
-			}
-			const nextActiveId = this.combatant?.id ?? null;
-			if (!nextActiveId || nextActiveId === previousActiveId) break;
-		}
-
-		return nextResult;
 	}
 
 	constructor(
@@ -759,16 +712,14 @@ class NimbleCombat extends Combat {
 	override async nextTurn(): Promise<this> {
 		this.#syncTurnIndexWithAliveTurns();
 		const preferredNextTurnIdentity = this.#resolveNextTurnIdentity();
-		const { intercepted, result: nextTurnResult } = await this.#runAtomicTurnStateOperation(
+		const { intercepted, result } = await this.#runAtomicTurnStateOperation(
 			preferredNextTurnIdentity,
 			async () => (await super.nextTurn()) as this,
 		);
-		let result = nextTurnResult;
 		this.#syncTurnIndexWithAliveTurns({ preferredTurnIdentity: preferredNextTurnIdentity });
 		if (!intercepted) {
 			await this.#persistAtomicTurnState({ turn: this.turn });
 		}
-		result = await this.#advancePastExhaustedTurns(result);
 		return result;
 	}
 

--- a/src/documents/combat/combat.svelte.ts
+++ b/src/documents/combat/combat.svelte.ts
@@ -296,6 +296,71 @@ class NimbleCombat extends Combat {
 		return getCombatantCurrentActions(combatant) > 0;
 	}
 
+	#getNonCharacterTurnResetTargets(
+		combatant: Combatant.Implementation | null,
+	): Combatant.Implementation[] {
+		if (!combatant || combatant.type === 'character') return [];
+
+		const groupId = getMinionGroupId(combatant);
+		if (!groupId) return [combatant];
+
+		const summary = getMinionGroupSummaries(this.combatants.contents).get(groupId);
+		if (!summary?.aliveMembers.length) return [combatant];
+		return summary.aliveMembers;
+	}
+
+	async #restoreNonCharacterTurnState(combatant: Combatant.Implementation | null): Promise<void> {
+		const updates = this.#getNonCharacterTurnResetTargets(combatant).reduce<
+			Record<string, unknown>[]
+		>((accumulator, targetCombatant) => {
+			const combatantId = targetCombatant.id ?? null;
+			if (!combatantId) return accumulator;
+
+			const nextActions = getCombatantBaseActionMax(targetCombatant);
+			if (getCombatantCurrentActions(targetCombatant) === nextActions) return accumulator;
+
+			accumulator.push({
+				_id: combatantId,
+				'system.actions.base.current': nextActions,
+			});
+			return accumulator;
+		}, []);
+		if (updates.length < 1) return;
+		await this.updateEmbeddedDocuments('Combatant', updates);
+	}
+
+	#normalizeCombatantCreateData(entry: Record<string, unknown>): {
+		normalizedEntry: Record<string, unknown>;
+		normalizedMinionType: boolean;
+	} {
+		const normalizedEntry = { ...entry };
+		const normalizedMinionType = normalizedEntry.type === 'minion';
+		if (normalizedMinionType) {
+			normalizedEntry.type = 'npc';
+		}
+
+		if (normalizedEntry.type === 'character') {
+			return { normalizedEntry, normalizedMinionType };
+		}
+
+		const currentActions = foundry.utils.getProperty(
+			normalizedEntry,
+			'system.actions.base.current',
+		);
+		if (currentActions !== undefined && currentActions !== null) {
+			return { normalizedEntry, normalizedMinionType };
+		}
+
+		const explicitMaxActions = Number(
+			foundry.utils.getProperty(normalizedEntry, 'system.actions.base.max') ?? Number.NaN,
+		);
+		const initialActions = Number.isFinite(explicitMaxActions)
+			? Math.max(0, Math.trunc(explicitMaxActions))
+			: 1;
+		foundry.utils.setProperty(normalizedEntry, 'system.actions.base.current', initialActions);
+		return { normalizedEntry, normalizedMinionType };
+	}
+
 	async #advancePastExhaustedTurns(result: this): Promise<this> {
 		if (!this.turns.length) return result;
 
@@ -477,13 +542,13 @@ class NimbleCombat extends Combat {
 			let normalizedCount = 0;
 			normalizedData = data.map((entry) => {
 				if (!entry || typeof entry !== 'object') return entry;
-				const asRecord = entry as Record<string, unknown>;
-				if (asRecord.type !== 'minion') return entry;
-				normalizedCount += 1;
-				return {
-					...asRecord,
-					type: 'npc',
-				};
+				const { normalizedEntry, normalizedMinionType } = this.#normalizeCombatantCreateData(
+					entry as Record<string, unknown>,
+				);
+				if (normalizedMinionType) {
+					normalizedCount += 1;
+				}
+				return normalizedEntry;
 			}) as foundry.abstract.Document.CreateDataForName<EmbeddedName>[];
 
 			if (normalizedCount > 0) {
@@ -734,6 +799,7 @@ class NimbleCombat extends Combat {
 		if (!intercepted) {
 			await this.#persistAtomicTurnState({ turn: this.turn });
 		}
+		await this.#restoreNonCharacterTurnState(this.combatant ?? null);
 		return result;
 	}
 
@@ -751,6 +817,7 @@ class NimbleCombat extends Combat {
 		if (!intercepted) {
 			await this.#persistAtomicTurnState({ turn: this.turn });
 		}
+		await this.#restoreNonCharacterTurnState(this.combatant ?? null);
 		return result;
 	}
 

--- a/src/hooks/minionGroupTokenBadges.ts
+++ b/src/hooks/minionGroupTokenBadges.ts
@@ -17,12 +17,6 @@ type TurnCompleteBadgeContainer = PIXI.Container & {
 	label?: PIXI.Text;
 };
 
-function getCombatantCurrentActions(combatant: Combatant.Implementation): number {
-	const actions = Number(foundry.utils.getProperty(combatant, 'system.actions.base.current') ?? 0);
-	if (!Number.isFinite(actions)) return 0;
-	return Math.max(0, actions);
-}
-
 function getTurnOrderIndexForCombatant(
 	combat: Combat,
 	combatant: Combatant.Implementation,
@@ -118,8 +112,7 @@ function buildTurnCompleteBadgeTokenIdsForCurrentScene(): Set<string> {
 			continue;
 		}
 
-		const actionsRemaining = getCombatantCurrentActions(combatant);
-		if (actionsRemaining > 0 && !turnEnded) continue;
+		if (!turnEnded) continue;
 
 		tokenIds.add(combatant.tokenId);
 	}

--- a/src/hooks/minionGroupTokenBadges.ts
+++ b/src/hooks/minionGroupTokenBadges.ts
@@ -1,8 +1,5 @@
-﻿import {
-	getEffectiveMinionGroupLeader,
-	getMinionGroupId,
-	getMinionGroupSummaries,
-} from '../utils/minionGrouping.js';
+﻿import { hasCombatantTurnEndedThisRound } from '../utils/combatTurnProgress.js';
+import { getMinionGroupSummaries } from '../utils/minionGrouping.js';
 
 const TOKEN_TURN_COMPLETE_BADGE_KEY = '_nimbleTurnCompleteBadge';
 
@@ -16,52 +13,6 @@ type TurnCompleteBadgeContainer = PIXI.Container & {
 	background?: PIXI.Graphics;
 	label?: PIXI.Text;
 };
-
-function getTurnOrderIndexForCombatant(
-	combat: Combat,
-	combatant: Combatant.Implementation,
-	groupSummaries: ReturnType<typeof getMinionGroupSummaries>,
-): number {
-	const combatantId = combatant.id ?? '';
-	if (!combatantId) return -1;
-
-	const directIndex = combat.turns.findIndex((turnCombatant) => turnCombatant.id === combatantId);
-	if (directIndex >= 0) return directIndex;
-
-	const groupId = getMinionGroupId(combatant);
-	if (!groupId) return -1;
-
-	const groupSummary = groupSummaries.get(groupId);
-	if (!groupSummary) return -1;
-
-	const leader =
-		getEffectiveMinionGroupLeader(groupSummary, { aliveOnly: true }) ??
-		getEffectiveMinionGroupLeader(groupSummary);
-	if (!leader?.id) return -1;
-
-	return combat.turns.findIndex((turnCombatant) => turnCombatant.id === leader.id);
-}
-
-function hasCombatantTurnEndedThisRound(
-	combat: Combat,
-	combatant: Combatant.Implementation,
-	groupSummaries: ReturnType<typeof getMinionGroupSummaries>,
-): boolean {
-	if ((combat.round ?? 0) < 1) return false;
-
-	const activeCombatantId = combat.combatant?.id ?? '';
-	if (!activeCombatantId) return false;
-
-	const activeTurnIndex = combat.turns.findIndex(
-		(turnCombatant) => turnCombatant.id === activeCombatantId,
-	);
-	if (activeTurnIndex < 0) return false;
-
-	const combatantTurnIndex = getTurnOrderIndexForCombatant(combat, combatant, groupSummaries);
-	if (combatantTurnIndex < 0) return false;
-
-	return combatantTurnIndex < activeTurnIndex;
-}
 
 function getCombatantSceneId(combatant: Combatant.Implementation): string | undefined {
 	if (combatant.sceneId) return combatant.sceneId;

--- a/src/models/combatant/NPCCombatantDataModel.ts
+++ b/src/models/combatant/NPCCombatantDataModel.ts
@@ -6,7 +6,7 @@ const nimbleNPCCombatantSchema = () => ({
 		base: new fields.SchemaField({
 			current: new fields.NumberField({
 				required: true,
-				initial: 0,
+				initial: 1,
 				nullable: false,
 				integer: true,
 				min: 0,

--- a/src/models/combatant/SoloMonsterCombatantDataModel.ts
+++ b/src/models/combatant/SoloMonsterCombatantDataModel.ts
@@ -6,7 +6,7 @@ const nimbleSoloMonsterCombatantSchema = () => ({
 		base: new fields.SchemaField({
 			current: new fields.NumberField({
 				required: true,
-				initial: 0,
+				initial: 1,
 				nullable: false,
 				integer: true,
 				min: 0,

--- a/src/utils/combatTurnProgress.ts
+++ b/src/utils/combatTurnProgress.ts
@@ -1,0 +1,61 @@
+import {
+	getEffectiveMinionGroupLeader,
+	getMinionGroupId,
+	type getMinionGroupSummaries,
+} from './minionGrouping.js';
+
+function getCombatantIdValue(combatant: { id?: string | null } | null | undefined): string {
+	return combatant?.id ?? '';
+}
+
+export function getTurnOrderIndexForCombatant(
+	combat: Combat,
+	combatant: Combatant.Implementation,
+	groupSummaries: ReturnType<typeof getMinionGroupSummaries>,
+): number {
+	const combatantId = getCombatantIdValue(combatant);
+	if (!combatantId) return -1;
+
+	const directIndex = combat.turns.findIndex(
+		(turnCombatant) => getCombatantIdValue(turnCombatant) === combatantId,
+	);
+	if (directIndex >= 0) return directIndex;
+
+	const groupId = getMinionGroupId(combatant);
+	if (!groupId) return -1;
+
+	const groupSummary = groupSummaries.get(groupId);
+	if (!groupSummary) return -1;
+
+	const leader =
+		getEffectiveMinionGroupLeader(groupSummary, { aliveOnly: true }) ??
+		getEffectiveMinionGroupLeader(groupSummary);
+	if (!leader?.id) return -1;
+
+	return combat.turns.findIndex(
+		(turnCombatant) => getCombatantIdValue(turnCombatant) === leader.id,
+	);
+}
+
+export function hasCombatantTurnEndedThisRound(
+	combat: Combat,
+	combatant: Combatant.Implementation,
+	groupSummaries: ReturnType<typeof getMinionGroupSummaries>,
+): boolean {
+	if ((combat.round ?? 0) < 1) return false;
+
+	const turnIndex = Number(combat.turn ?? -1);
+	const activeTurnIndex =
+		Number.isInteger(turnIndex) && turnIndex >= 0 && turnIndex < combat.turns.length
+			? turnIndex
+			: combat.turns.findIndex(
+					(turnCombatant) =>
+						getCombatantIdValue(turnCombatant) === getCombatantIdValue(combat.combatant),
+				);
+	if (activeTurnIndex < 0) return false;
+
+	const combatantTurnIndex = getTurnOrderIndexForCombatant(combat, combatant, groupSummaries);
+	if (combatantTurnIndex < 0) return false;
+
+	return combatantTurnIndex < activeTurnIndex;
+}

--- a/src/view/ui/ctTopTracker/combat.utils.ts
+++ b/src/view/ui/ctTopTracker/combat.utils.ts
@@ -8,13 +8,10 @@ import {
 	getCombatantCurrentActions,
 	getCombatantMaxActions,
 } from '../../../utils/combatTurnActions.js';
+import { hasCombatantTurnEndedThisRound } from '../../../utils/combatTurnProgress.js';
 import { getHeroicReactionAvailability } from '../../../utils/heroicActions.js';
 import { isCombatantDead } from '../../../utils/isCombatantDead.js';
-import {
-	getEffectiveMinionGroupLeader,
-	getMinionGroupId,
-	getMinionGroupSummaries,
-} from '../../../utils/minionGrouping.js';
+import { getMinionGroupSummaries } from '../../../utils/minionGrouping.js';
 import type { ResolveActiveEntryKeyParams, SceneCombatantLists, TrackEntry } from './types.js';
 
 type CombatWithTurnIdentityHint = Combat & {
@@ -301,64 +298,6 @@ export function getCombatantsForScene(
 		.sort(sortDeadCombatants);
 
 	return { aliveCombatants, deadCombatants };
-}
-
-function getActiveTurnIndex(combat: Combat): number {
-	const turnIndex = Number(combat.turn ?? -1);
-	if (Number.isInteger(turnIndex) && turnIndex >= 0 && turnIndex < combat.turns.length) {
-		return turnIndex;
-	}
-
-	const currentTurnIdentity = resolveCurrentTurnIdentity(combat, combat.turns);
-	if (!currentTurnIdentity?.combatantId) return -1;
-	return findTurnIndexByOccurrence(
-		combat.turns,
-		currentTurnIdentity.combatantId,
-		currentTurnIdentity.occurrence,
-	);
-}
-
-function getTurnOrderIndexForCombatant(
-	combat: Combat,
-	combatant: Combatant.Implementation,
-	groupSummaries: ReturnType<typeof getMinionGroupSummaries>,
-): number {
-	const combatantId = getCombatantId(combatant);
-	if (!combatantId) return -1;
-
-	const directIndex = combat.turns.findIndex(
-		(turnCombatant) => getCombatantId(turnCombatant) === combatantId,
-	);
-	if (directIndex >= 0) return directIndex;
-
-	const groupId = getMinionGroupId(combatant);
-	if (!groupId) return -1;
-
-	const groupSummary = groupSummaries.get(groupId);
-	if (!groupSummary) return -1;
-
-	const leader =
-		getEffectiveMinionGroupLeader(groupSummary, { aliveOnly: true }) ??
-		getEffectiveMinionGroupLeader(groupSummary);
-	if (!leader?.id) return -1;
-
-	return combat.turns.findIndex((turnCombatant) => getCombatantId(turnCombatant) === leader.id);
-}
-
-function hasCombatantTurnEndedThisRound(
-	combat: Combat,
-	combatant: Combatant.Implementation,
-	groupSummaries: ReturnType<typeof getMinionGroupSummaries>,
-): boolean {
-	if ((combat.round ?? 0) < 1) return false;
-
-	const activeTurnIndex = getActiveTurnIndex(combat);
-	if (activeTurnIndex < 0) return false;
-
-	const combatantTurnIndex = getTurnOrderIndexForCombatant(combat, combatant, groupSummaries);
-	if (combatantTurnIndex < 0) return false;
-
-	return combatantTurnIndex < activeTurnIndex;
 }
 
 export function hasCombatantTurnRemainingThisRound(

--- a/src/view/ui/ctTopTracker/combat.utils.ts
+++ b/src/view/ui/ctTopTracker/combat.utils.ts
@@ -10,6 +10,11 @@ import {
 } from '../../../utils/combatTurnActions.js';
 import { getHeroicReactionAvailability } from '../../../utils/heroicActions.js';
 import { isCombatantDead } from '../../../utils/isCombatantDead.js';
+import {
+	getEffectiveMinionGroupLeader,
+	getMinionGroupId,
+	getMinionGroupSummaries,
+} from '../../../utils/minionGrouping.js';
 import type { ResolveActiveEntryKeyParams, SceneCombatantLists, TrackEntry } from './types.js';
 
 type CombatWithTurnIdentityHint = Combat & {
@@ -298,9 +303,75 @@ export function getCombatantsForScene(
 	return { aliveCombatants, deadCombatants };
 }
 
-export function hasCombatantTurnRemainingThisRound(combatant: Combatant.Implementation): boolean {
+function getActiveTurnIndex(combat: Combat): number {
+	const turnIndex = Number(combat.turn ?? -1);
+	if (Number.isInteger(turnIndex) && turnIndex >= 0 && turnIndex < combat.turns.length) {
+		return turnIndex;
+	}
+
+	const currentTurnIdentity = resolveCurrentTurnIdentity(combat, combat.turns);
+	if (!currentTurnIdentity?.combatantId) return -1;
+	return findTurnIndexByOccurrence(
+		combat.turns,
+		currentTurnIdentity.combatantId,
+		currentTurnIdentity.occurrence,
+	);
+}
+
+function getTurnOrderIndexForCombatant(
+	combat: Combat,
+	combatant: Combatant.Implementation,
+	groupSummaries: ReturnType<typeof getMinionGroupSummaries>,
+): number {
+	const combatantId = getCombatantId(combatant);
+	if (!combatantId) return -1;
+
+	const directIndex = combat.turns.findIndex(
+		(turnCombatant) => getCombatantId(turnCombatant) === combatantId,
+	);
+	if (directIndex >= 0) return directIndex;
+
+	const groupId = getMinionGroupId(combatant);
+	if (!groupId) return -1;
+
+	const groupSummary = groupSummaries.get(groupId);
+	if (!groupSummary) return -1;
+
+	const leader =
+		getEffectiveMinionGroupLeader(groupSummary, { aliveOnly: true }) ??
+		getEffectiveMinionGroupLeader(groupSummary);
+	if (!leader?.id) return -1;
+
+	return combat.turns.findIndex((turnCombatant) => getCombatantId(turnCombatant) === leader.id);
+}
+
+function hasCombatantTurnEndedThisRound(
+	combat: Combat,
+	combatant: Combatant.Implementation,
+	groupSummaries: ReturnType<typeof getMinionGroupSummaries>,
+): boolean {
+	if ((combat.round ?? 0) < 1) return false;
+
+	const activeTurnIndex = getActiveTurnIndex(combat);
+	if (activeTurnIndex < 0) return false;
+
+	const combatantTurnIndex = getTurnOrderIndexForCombatant(combat, combatant, groupSummaries);
+	if (combatantTurnIndex < 0) return false;
+
+	return combatantTurnIndex < activeTurnIndex;
+}
+
+export function hasCombatantTurnRemainingThisRound(
+	combat: Combat | null,
+	combatant: Combatant.Implementation,
+	groupSummaries?: ReturnType<typeof getMinionGroupSummaries>,
+): boolean {
 	if (isPlayerCombatant(combatant) || isLegendaryCombatant(combatant)) return true;
-	return getCombatantCurrentActions(combatant) > 0;
+	if (!combat) return true;
+
+	const resolvedGroupSummaries =
+		groupSummaries ?? getMinionGroupSummaries(combat.combatants.contents);
+	return !hasCombatantTurnEndedThisRound(combat, combatant, resolvedGroupSummaries);
 }
 
 export function isFriendlyCombatant(combatant: Combatant.Implementation): boolean {
@@ -466,20 +537,27 @@ export function orderEntriesForCenteredActive(
 	});
 }
 
-export function findRoundBoundaryIndex(sceneAliveCombatants: Combatant.Implementation[]): number {
+export function findRoundBoundaryIndex(
+	combat: Combat | null,
+	sceneAliveCombatants: Combatant.Implementation[],
+): number {
 	if (sceneAliveCombatants.length < 1) return -1;
+	const groupSummaries = combat ? getMinionGroupSummaries(combat.combatants.contents) : undefined;
 	for (let index = sceneAliveCombatants.length - 1; index >= 0; index -= 1) {
-		if (hasCombatantTurnRemainingThisRound(sceneAliveCombatants[index])) return index;
+		if (hasCombatantTurnRemainingThisRound(combat, sceneAliveCombatants[index], groupSummaries)) {
+			return index;
+		}
 	}
 	return sceneAliveCombatants.length - 1;
 }
 
 export function getRoundBoundaryKey(
+	combat: Combat | null,
 	sceneAliveCombatants: Combatant.Implementation[],
 	aliveEntries: TrackEntry[],
 	collapseMonsters: boolean,
 ): string | null {
-	const boundaryIndex = findRoundBoundaryIndex(sceneAliveCombatants);
+	const boundaryIndex = findRoundBoundaryIndex(combat, sceneAliveCombatants);
 	if (boundaryIndex < 0) return null;
 
 	const lastCurrentRoundCombatant = sceneAliveCombatants[boundaryIndex];

--- a/src/view/ui/ctTopTracker/combatTracker.utils.test.ts
+++ b/src/view/ui/ctTopTracker/combatTracker.utils.test.ts
@@ -2,9 +2,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
 	createCombatActorFixture,
 	createCombatantFixture,
+	createCombatantsCollectionFixture,
 } from '../../../../tests/fixtures/combat.js';
 import { clearExpandedTurnIdentityHint } from '../../../documents/combat/expandedTurnIdentityStore.js';
-import { syncCombatTurnsForCt } from './combat.utils.js';
+import { hasCombatantTurnRemainingThisRound, syncCombatTurnsForCt } from './combat.utils.js';
 import {
 	getCombatantCardResourceChips,
 	getCombatantOutlineClass,
@@ -342,5 +343,43 @@ describe('ctTopTracker helpers', () => {
 			combatantId: 'player-two',
 			occurrence: 0,
 		});
+	});
+
+	it('keeps an active zero-action non-player in the current round until initiative advances past it', () => {
+		const firstMonster = createCombatantFixture({
+			id: 'monster-one',
+			type: 'npc',
+			actor: createCombatActorFixture({ type: 'npc' }),
+			actionsCurrent: 0,
+			actionsMax: 1,
+		});
+		const secondMonster = createCombatantFixture({
+			id: 'monster-two',
+			type: 'npc',
+			actor: createCombatActorFixture({ type: 'npc' }),
+			actionsCurrent: 0,
+			actionsMax: 1,
+		});
+		const combat = {
+			round: 1,
+			turn: 0,
+			turns: [firstMonster, secondMonster],
+			combatant: firstMonster,
+			combatants: createCombatantsCollectionFixture([firstMonster, secondMonster]),
+		} as unknown as Combat;
+
+		expect(hasCombatantTurnRemainingThisRound(combat, firstMonster)).toBe(true);
+		expect(hasCombatantTurnRemainingThisRound(combat, secondMonster)).toBe(true);
+
+		(combat as { turn: number; combatant: Combatant.Implementation }).turn = 1;
+		(combat as { turn: number; combatant: Combatant.Implementation }).combatant = secondMonster;
+
+		expect(hasCombatantTurnRemainingThisRound(combat, firstMonster)).toBe(false);
+		expect(hasCombatantTurnRemainingThisRound(combat, secondMonster)).toBe(true);
+
+		(combat as { turn: number; combatant: Combatant.Implementation }).turn = 0;
+		(combat as { turn: number; combatant: Combatant.Implementation }).combatant = firstMonster;
+
+		expect(hasCombatantTurnRemainingThisRound(combat, firstMonster)).toBe(true);
 	});
 });

--- a/src/view/ui/ctTopTracker/topTrackerStore.svelte.ts
+++ b/src/view/ui/ctTopTracker/topTrackerStore.svelte.ts
@@ -169,6 +169,7 @@ export class CtTopTrackerStore {
 
 	roundBoundaryKey = $derived.by(() =>
 		getRoundBoundaryKey(
+			this.currentCombat,
 			this.sceneAliveCombatants,
 			this.aliveEntries,
 			this.shouldCollapseMonsterCards,


### PR DESCRIPTION
### PR Summary

Issue
-   Non-player combatants were being treated as if they had already finished their turn when their `current actions` hit `0`.
-   That caused two user-facing problems:
    -   the Combat Tracker could mark monsters as done too early
    -   the NCSW popup could become unusable because the monster looked like it had no valid turn left
-   This broke the intended behavior:
    -   a non-player should only be marked as having taken its turn after the GM advances past it
    -   if the GM goes back to that monster, its turn state should reset and its actions should be restored

Root Cause
-   The system was using the same value for two different meanings:
    -   remaining actions
    -   whether a non-player had already taken its turn
-   In several places, `current actions == 0` was being treated like "turn complete," which is not always true

What This PR Changes
-   Non-players are no longer auto-skipped just because they have `0` actions when their turn comes up
-   Combat Tracker turn-complete logic for non-players now follows initiative progression, not action count
-   Rewinding to a monster turn restores that monster's actions to max
-   Rewinding to a minion-group turn restores all alive members of that group to max actions
-   Newly created non-player combatants are initialized with usable current actions instead of falling into a zero-action state

Behavior After This Fix
-   A monster can become active even if its stored actions are `0`
-   The GM can still use the monster's turn/NCSW flow instead of the system skipping past it
-   A non-player is only marked "done" after initiative actually moves past it
-   If the GM rewinds to that non-player, the completed state clears and its actions are restored

Tests Added/Updated
-   Updated the combat turn test so exhausted non-players are not skipped on `nextTurn()`
-   Added tracker regression coverage to verify:
    -   an active zero-action monster is still considered current
    -   advancing past it marks it as done
    -   rewinding makes it active/current again