### PR TITLE
Initiative Duplicate fix

### DIFF
--- a/src/documents/combat/combat.svelte.test.ts
+++ b/src/documents/combat/combat.svelte.test.ts
@@ -9,6 +9,7 @@ import {
 	getTestGlobals,
 	type NimbleCombatDocumentTestGlobals,
 } from '../../../tests/mocks/combat.js';
+import { initiativeRollLock } from '../../utils/initiativeRollLock.js';
 import { NimbleCombat } from './combat.svelte.js';
 import { clearExpandedTurnIdentityHint } from './expandedTurnIdentityStore.js';
 
@@ -84,12 +85,18 @@ describe('NimbleCombat', () => {
 			globalThis as unknown as {
 				ChatMessage: {
 					create: ReturnType<typeof vi.fn>;
+					implementation: {
+						create: ReturnType<typeof vi.fn>;
+					};
 					getSpeaker: ReturnType<typeof vi.fn>;
 					applyRollMode: ReturnType<typeof vi.fn>;
 				};
 			}
 		).ChatMessage = {
 			create: vi.fn().mockResolvedValue({ id: 'chat-message' }),
+			implementation: {
+				create: vi.fn().mockResolvedValue([{ id: 'chat-message' }]),
+			},
 			getSpeaker: vi.fn().mockReturnValue({}),
 			applyRollMode: vi.fn(),
 		};
@@ -880,6 +887,187 @@ describe('NimbleCombat', () => {
 		expect(foundry.utils.getProperty(normalizedData[3], 'system.actions.base.current')).toBe(
 			undefined,
 		);
+	});
+
+	it('rolls initiative only once when concurrent requests target the same combatant', async () => {
+		const combatId = 'combat-initiative-request-lock';
+		const actor = createCombatActorFixture({
+			id: 'actor-initiative-lock',
+			type: 'character',
+			isOwner: true,
+			hp: 8,
+			woundsValue: 0,
+			woundsMax: 6,
+		}) as Actor.Implementation & {
+			update: ReturnType<typeof vi.fn>;
+		};
+		actor.update = vi.fn().mockResolvedValue(actor);
+
+		const combatant = createMockCombatant({
+			id: 'character-initiative-lock',
+			type: 'character',
+			sort: 1,
+			isOwner: true,
+			initiative: null,
+			actor,
+			combatId,
+			flags: {},
+		}) as unknown as Combatant.Implementation & {
+			getInitiativeRoll: ReturnType<typeof vi.fn>;
+		};
+
+		let resolveEvaluate: (() => void) | undefined;
+		const initiativeRoll = {
+			total: 17,
+			evaluate: vi.fn(
+				() =>
+					new Promise((resolve) => {
+						resolveEvaluate = () => resolve(initiativeRoll);
+					}),
+			),
+			toMessage: vi.fn().mockResolvedValue({ id: 'initiative-chat-data' }),
+		};
+		combatant.getInitiativeRoll = vi.fn().mockReturnValue(initiativeRoll);
+
+		const combat = new NimbleCombat({
+			id: combatId,
+			scene: { id: 'scene-1' },
+			combatants: createCombatantsCollectionFixture([combatant]),
+			turns: [],
+		} as unknown as Combat.CreateData) as NimbleCombat & {
+			updateEmbeddedDocuments: ReturnType<typeof vi.fn>;
+			update: ReturnType<typeof vi.fn>;
+		};
+
+		combat.updateEmbeddedDocuments = vi
+			.fn()
+			.mockImplementation(async (_embeddedName: string, updates: Record<string, unknown>[]) => {
+				for (const update of updates) {
+					const combatantId = update._id as string;
+					const targetCombatant = combat.combatants.get(combatantId) as unknown as Record<
+						string,
+						unknown
+					> | null;
+					if (!targetCombatant) continue;
+
+					for (const [path, value] of Object.entries(update)) {
+						if (path === '_id') continue;
+						foundry.utils.setProperty(targetCombatant, path, value);
+					}
+				}
+
+				return [];
+			});
+		combat.update = vi.fn().mockResolvedValue(combat);
+
+		const chatMessageCreate = (
+			globalThis as unknown as {
+				ChatMessage: {
+					implementation: {
+						create: ReturnType<typeof vi.fn>;
+					};
+				};
+			}
+		).ChatMessage.implementation.create;
+		const combatantId = combatant.id ?? '';
+		if (combatantId.length < 1) {
+			throw new Error('Expected combatant id for initiative concurrency test.');
+		}
+
+		const firstRollRequest = combat.rollInitiative([combatantId], { updateTurn: false });
+		const secondRollRequest = combat.rollInitiative([combatantId], { updateTurn: false });
+
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(combatant.getInitiativeRoll).toHaveBeenCalledTimes(1);
+		expect(initiativeRoll.evaluate).toHaveBeenCalledTimes(1);
+		expect(initiativeRollLock.hasActiveLock(combatant)).toBe(true);
+
+		if (!resolveEvaluate) {
+			throw new Error('Expected initiative roll evaluation to be pending.');
+		}
+		resolveEvaluate();
+
+		await Promise.all([firstRollRequest, secondRollRequest]);
+
+		expect(combatant.initiative).toBe(17);
+		expect(initiativeRollLock.hasActiveLock(combatant)).toBe(false);
+		expect(chatMessageCreate).toHaveBeenCalledTimes(1);
+		expect(chatMessageCreate).toHaveBeenCalledWith([
+			expect.objectContaining({ id: 'initiative-chat-data' }),
+		]);
+	});
+
+	it('skips rolling initiative when another client already holds the combatant lock', async () => {
+		const combatId = 'combat-initiative-foreign-lock';
+		globals().game.user = {
+			id: 'current-user',
+			isGM: true,
+			role: 4,
+		} as unknown as { isGM: boolean; role?: number };
+
+		const actor = createCombatActorFixture({
+			id: 'actor-initiative-foreign-lock',
+			type: 'character',
+			isOwner: true,
+			hp: 8,
+			woundsValue: 0,
+			woundsMax: 6,
+		});
+		const combatant = createMockCombatant({
+			id: 'character-initiative-foreign-lock',
+			type: 'character',
+			sort: 1,
+			isOwner: true,
+			initiative: null,
+			actor,
+			combatId,
+			flags: {
+				nimble: {
+					initiativeRollLock: {
+						requestId: 'other-request',
+						userId: 'other-user',
+						startedAt: Date.now(),
+					},
+				},
+			},
+		}) as unknown as Combatant.Implementation & {
+			getInitiativeRoll: ReturnType<typeof vi.fn>;
+		};
+		const getInitiativeRollSpy = vi.fn();
+		combatant.getInitiativeRoll =
+			getInitiativeRollSpy as unknown as typeof combatant.getInitiativeRoll;
+
+		const combat = new NimbleCombat({
+			id: combatId,
+			scene: { id: 'scene-1' },
+			combatants: createCombatantsCollectionFixture([combatant]),
+			turns: [],
+		} as unknown as Combat.CreateData) as NimbleCombat & {
+			updateEmbeddedDocuments: ReturnType<typeof vi.fn>;
+			update: ReturnType<typeof vi.fn>;
+		};
+
+		combat.updateEmbeddedDocuments = vi.fn().mockResolvedValue([]);
+		combat.update = vi.fn().mockResolvedValue(combat);
+
+		const chatMessageCreate = (
+			globalThis as unknown as {
+				ChatMessage: {
+					implementation: {
+						create: ReturnType<typeof vi.fn>;
+					};
+				};
+			}
+		).ChatMessage.implementation.create;
+
+		await combat.rollInitiative(['character-initiative-foreign-lock'], { updateTurn: false });
+
+		expect(initiativeRollLock.hasActiveLock(combatant)).toBe(true);
+		expect(getInitiativeRollSpy).not.toHaveBeenCalled();
+		expect(combat.updateEmbeddedDocuments).not.toHaveBeenCalled();
+		expect(chatMessageCreate).not.toHaveBeenCalled();
 	});
 
 	it('marks a heroic reaction unavailable without spending an action when the GM toggles it off-turn', async () => {

--- a/src/documents/combat/combat.svelte.ts
+++ b/src/documents/combat/combat.svelte.ts
@@ -7,6 +7,7 @@ import {
 	HEROIC_REACTIONS,
 	type HeroicReactionKey,
 } from '../../utils/heroicActions.js';
+import { initiativeRollLock } from '../../utils/initiativeRollLock.js';
 import { isCombatantDead } from '../../utils/isCombatantDead.js';
 import { getMinionGroupId, getMinionGroupSummaries } from '../../utils/minionGrouping.js';
 import type { NimbleCombatant } from '../combatant/combatant.svelte.js';
@@ -26,6 +27,7 @@ import {
 } from './combatSorting.js';
 import { expandLegendaryTurns, normalizeMinionTurns } from './combatTurns.js';
 import type {
+	InitiativeRollOutcome,
 	MinionGroupAttackParams,
 	MinionGroupAttackResult,
 	TurnIdentity,
@@ -41,11 +43,18 @@ type CombatWithTurnIdentityHint = Combat & {
 	_nimbleExpandedTurnIdentity?: TurnIdentity | null;
 };
 
+interface LockedInitiativeRollOutcome {
+	combatantId: string;
+	requestId: string;
+	outcome: InitiativeRollOutcome;
+}
+
 class NimbleCombat extends Combat {
 	#subscribe: ReturnType<typeof createSubscriber>;
 	#expandedTurnIdentity: TurnIdentity | null = null;
 	#pendingAtomicTurnIdentity: TurnIdentity | null = null;
 	#didInterceptAtomicTurnStateUpdate = false;
+	#initiativeRollRequests = new Map<string, Promise<LockedInitiativeRollOutcome | null>>();
 
 	#readStoredExpandedTurnIdentity(): TurnIdentity | null {
 		const persistedTurnIdentity = getPersistedExpandedTurnIdentity(this);
@@ -655,6 +664,120 @@ class NimbleCombat extends Combat {
 		});
 	}
 
+	async #acquireInitiativeRollLock(
+		combatantId: string,
+		lockData: ReturnType<typeof initiativeRollLock.create>,
+	): Promise<boolean> {
+		const combatant = this.combatants.get(combatantId);
+		if (!combatant || combatant.initiative !== null) return false;
+
+		const currentLock = initiativeRollLock.get(combatant);
+		if (currentLock && !initiativeRollLock.isStale(currentLock)) return false;
+
+		await this.updateEmbeddedDocuments('Combatant', [
+			{
+				_id: combatantId,
+				[initiativeRollLock.path]: lockData,
+			},
+		]);
+
+		const refreshedCombatant = this.combatants.get(combatantId);
+		if (!refreshedCombatant || refreshedCombatant.initiative !== null) {
+			await this.#releaseInitiativeRollLock(combatantId, lockData.requestId);
+			return false;
+		}
+
+		return initiativeRollLock.matches(refreshedCombatant, lockData.requestId);
+	}
+
+	async #releaseInitiativeRollLock(combatantId: string, requestId: string): Promise<void> {
+		const combatant = this.combatants.get(combatantId);
+		if (!combatant || !initiativeRollLock.matches(combatant, requestId)) return;
+
+		await this.updateEmbeddedDocuments('Combatant', [
+			{
+				_id: combatantId,
+				[initiativeRollLock.path]: null,
+			},
+		]);
+	}
+
+	async #performInitiativeRollForCombatant(params: {
+		combatantId: string;
+		formula: string | null;
+		messageOptions: ChatMessage.CreateData;
+		chatRollMode: string | null;
+		rollIndex: number;
+		combatManaUpdates: Promise<unknown>[];
+	}): Promise<LockedInitiativeRollOutcome | null> {
+		const combatant = this.combatants.get(params.combatantId);
+		if (!combatant?.isOwner) return null;
+		if (combatant.initiative !== null) return null;
+		if (initiativeRollLock.hasActiveLock(combatant)) return null;
+
+		const lockData = initiativeRollLock.create();
+		const acquiredLock = await this.#acquireInitiativeRollLock(params.combatantId, lockData);
+		if (!acquiredLock) return null;
+
+		let shouldReleaseLock = true;
+		try {
+			const lockedCombatant = this.combatants.get(params.combatantId);
+			if (!lockedCombatant?.isOwner) return null;
+			if (lockedCombatant.initiative !== null) return null;
+			if (!initiativeRollLock.matches(lockedCombatant, lockData.requestId)) return null;
+
+			const rollOutcome = await rollInitiativeForCombatant({
+				combat: this,
+				combatantId: params.combatantId,
+				formula: params.formula,
+				messageOptions: params.messageOptions,
+				chatRollMode: params.chatRollMode,
+				rollIndex: params.rollIndex,
+				combatManaUpdates: params.combatManaUpdates,
+			});
+			if (!rollOutcome) return null;
+
+			rollOutcome.combatantUpdate[initiativeRollLock.path] = null;
+			shouldReleaseLock = false;
+
+			return {
+				combatantId: params.combatantId,
+				requestId: lockData.requestId,
+				outcome: rollOutcome,
+			};
+		} finally {
+			if (shouldReleaseLock) {
+				await this.#releaseInitiativeRollLock(params.combatantId, lockData.requestId);
+			}
+		}
+	}
+
+	async #rollInitiativeForCombatant(params: {
+		combatantId: string;
+		formula: string | null;
+		messageOptions: ChatMessage.CreateData;
+		chatRollMode: string | null;
+		rollIndex: number;
+		combatManaUpdates: Promise<unknown>[];
+	}): Promise<LockedInitiativeRollOutcome | null> {
+		const inFlightRequest = this.#initiativeRollRequests.get(params.combatantId);
+		if (inFlightRequest) {
+			await inFlightRequest;
+			return null;
+		}
+
+		const request = this.#performInitiativeRollForCombatant(params);
+		this.#initiativeRollRequests.set(params.combatantId, request);
+
+		try {
+			return await request;
+		} finally {
+			if (this.#initiativeRollRequests.get(params.combatantId) === request) {
+				this.#initiativeRollRequests.delete(params.combatantId);
+			}
+		}
+	}
+
 	override async rollInitiative(
 		ids: string | string[],
 		options?: Combat.InitiativeOptions & { rollOptions?: Record<string, unknown> },
@@ -662,7 +785,7 @@ class NimbleCombat extends Combat {
 		const { formula = null, updateTurn = true, messageOptions = {} } = options ?? {};
 
 		// Structure Input data
-		const combatantIds = typeof ids === 'string' ? [ids] : ids;
+		const combatantIds = [...new Set((typeof ids === 'string' ? [ids] : ids).filter(Boolean))];
 		const currentId = this.combatant?.id;
 		const chatRollMode = game.settings.get('core', 'rollMode');
 
@@ -670,36 +793,49 @@ class NimbleCombat extends Combat {
 		const updates: Record<string, unknown>[] = [];
 		const combatManaUpdates: Promise<unknown>[] = [];
 		const messages: ChatMessage.CreateData[] = [];
+		const lockedRollOutcomes: LockedInitiativeRollOutcome[] = [];
 
-		for await (const [i, id] of combatantIds.entries()) {
-			const rollOutcome = await rollInitiativeForCombatant({
-				combat: this,
+		for (const id of combatantIds) {
+			const rollOutcome = await this.#rollInitiativeForCombatant({
 				combatantId: id,
 				formula,
 				messageOptions,
 				chatRollMode,
-				rollIndex: i,
+				rollIndex: messages.length,
 				combatManaUpdates,
 			});
 			if (!rollOutcome) continue;
-			updates.push(rollOutcome.combatantUpdate);
-			messages.push(rollOutcome.chatData);
+			lockedRollOutcomes.push(rollOutcome);
+			updates.push(rollOutcome.outcome.combatantUpdate);
+			messages.push(rollOutcome.outcome.chatData);
 		}
 
-		// Update multiple combatants
-		await this.updateEmbeddedDocuments('Combatant', updates);
+		try {
+			if (updates.length > 0) {
+				await this.updateEmbeddedDocuments('Combatant', updates);
+			}
+		} catch (error) {
+			await Promise.allSettled(
+				lockedRollOutcomes.map((rollOutcome) =>
+					this.#releaseInitiativeRollLock(rollOutcome.combatantId, rollOutcome.requestId),
+				),
+			);
+			throw error;
+		}
 
 		if (combatManaUpdates.length > 0) {
 			await Promise.all(combatManaUpdates);
 		}
 
 		// Ensure the turn order remains with the same combatant
-		if (updateTurn && currentId) {
+		if (updateTurn && currentId && updates.length > 0) {
 			await this.update({ turn: this.turns.findIndex((t) => t.id === currentId) });
 		}
 
 		// Create multiple chat messages
-		await ChatMessage.implementation.create(messages);
+		if (messages.length > 0) {
+			await ChatMessage.implementation.create(messages);
+		}
 		return this;
 	}
 

--- a/src/documents/combatant/combatant.svelte.test.ts
+++ b/src/documents/combatant/combatant.svelte.test.ts
@@ -1,0 +1,98 @@
+/// <reference types="vitest/globals" />
+
+import { initiativeRollLock } from '../../utils/initiativeRollLock.js';
+import { NimbleCombatant } from './combatant.svelte.js';
+
+describe('NimbleCombatant', () => {
+	it('rejects overwriting an active initiative roll lock with a different request id', async () => {
+		const combatant = new NimbleCombatant(
+			{
+				id: 'combatant-active-lock',
+				flags: {
+					nimble: {
+						initiativeRollLock: {
+							requestId: 'request-active',
+							userId: 'user-active',
+							startedAt: Date.now(),
+						},
+					},
+				},
+			} as unknown as Combatant.CreateData,
+			{},
+		);
+
+		const result = await combatant._preUpdate(
+			{
+				[initiativeRollLock.path]: {
+					requestId: 'request-other',
+					userId: 'user-other',
+					startedAt: Date.now(),
+				},
+			},
+			{},
+			{},
+		);
+
+		expect(result).toBe(false);
+	});
+
+	it('allows replacing a stale initiative roll lock', async () => {
+		const combatant = new NimbleCombatant(
+			{
+				id: 'combatant-stale-lock',
+				flags: {
+					nimble: {
+						initiativeRollLock: {
+							requestId: 'request-stale',
+							userId: 'user-stale',
+							startedAt: Date.now() - 16_000,
+						},
+					},
+				},
+			} as unknown as Combatant.CreateData,
+			{},
+		);
+
+		const result = await combatant._preUpdate(
+			{
+				[initiativeRollLock.path]: {
+					requestId: 'request-new',
+					userId: 'user-new',
+					startedAt: Date.now(),
+				},
+			},
+			{},
+			{},
+		);
+
+		expect(result).toBe(true);
+	});
+
+	it('allows clearing an active initiative roll lock', async () => {
+		const combatant = new NimbleCombatant(
+			{
+				id: 'combatant-clear-lock',
+				flags: {
+					nimble: {
+						initiativeRollLock: {
+							requestId: 'request-clear',
+							userId: 'user-clear',
+							startedAt: Date.now(),
+						},
+					},
+				},
+			} as unknown as Combatant.CreateData,
+			{},
+		);
+
+		const result = await combatant._preUpdate(
+			{
+				[initiativeRollLock.path]: null,
+			},
+			{},
+			{},
+		);
+
+		expect(result).toBe(true);
+	});
+});

--- a/src/documents/combatant/combatant.svelte.ts
+++ b/src/documents/combatant/combatant.svelte.ts
@@ -1,4 +1,22 @@
 import { createSubscriber } from 'svelte/reactivity';
+import { initiativeRollLock } from '../../utils/initiativeRollLock.js';
+
+function getRequestedInitiativeRollLockData(
+	changes: Record<string, unknown>,
+): ReturnType<typeof initiativeRollLock.get> | null | undefined {
+	const nextLock =
+		changes[initiativeRollLock.path] ?? foundry.utils.getProperty(changes, initiativeRollLock.path);
+	if (nextLock === undefined) return undefined;
+	if (nextLock === null) return null;
+
+	return initiativeRollLock.get({
+		flags: {
+			nimble: {
+				initiativeRollLock: nextLock,
+			},
+		},
+	});
+}
 
 export class NimbleCombatant extends Combatant {
 	#subscribe: any;
@@ -58,6 +76,33 @@ export class NimbleCombatant extends Combatant {
 		await roll.evaluate();
 
 		return this.update({ initiative: roll.total ?? 0 });
+	}
+
+	override async _preUpdate(changes, options, user) {
+		const changesAsRecord = changes as Record<string, unknown>;
+		const currentLock = initiativeRollLock.get(this);
+		const requestedLock = getRequestedInitiativeRollLockData(changesAsRecord);
+
+		if (
+			currentLock &&
+			!initiativeRollLock.isStale(currentLock) &&
+			requestedLock !== undefined &&
+			requestedLock !== null &&
+			requestedLock?.requestId !== currentLock.requestId
+		) {
+			return false;
+		}
+
+		const parentPrototype = Object.getPrototypeOf(NimbleCombatant.prototype) as {
+			_preUpdate?: (
+				changes: Combatant.UpdateData,
+				options: Combatant.Database.PreUpdateOptions,
+				user: User.Implementation,
+			) => Promise<boolean | undefined> | boolean | undefined;
+		};
+		const parentPreUpdate = parentPrototype._preUpdate;
+		if (typeof parentPreUpdate !== 'function') return true;
+		return parentPreUpdate.call(this, changes, options, user);
 	}
 
 	override toObject(source = true) {

--- a/src/documents/combatant/combatant.svelte.ts
+++ b/src/documents/combatant/combatant.svelte.ts
@@ -93,16 +93,8 @@ export class NimbleCombatant extends Combatant {
 			return false;
 		}
 
-		const parentPrototype = Object.getPrototypeOf(NimbleCombatant.prototype) as {
-			_preUpdate?: (
-				changes: Combatant.UpdateData,
-				options: Combatant.Database.PreUpdateOptions,
-				user: User.Implementation,
-			) => Promise<boolean | undefined> | boolean | undefined;
-		};
-		const parentPreUpdate = parentPrototype._preUpdate;
-		if (typeof parentPreUpdate !== 'function') return true;
-		return parentPreUpdate.call(this, changes, options, user);
+		if (typeof super._preUpdate !== 'function') return true;
+		return super._preUpdate(changes, options, user);
 	}
 
 	override toObject(source = true) {

--- a/src/utils/initiativeRollLock.ts
+++ b/src/utils/initiativeRollLock.ts
@@ -1,0 +1,74 @@
+interface InitiativeRollLockData {
+	requestId: string;
+	userId: string | null;
+	startedAt: number;
+}
+
+const INITIATIVE_ROLL_LOCK_PATH = 'flags.nimble.initiativeRollLock';
+const INITIATIVE_ROLL_LOCK_TIMEOUT_MS = 15_000;
+
+function normalizeInitiativeRollLockData(value: unknown): InitiativeRollLockData | null {
+	if (!value || typeof value !== 'object') return null;
+
+	const valueAsRecord = value as Record<string, unknown>;
+	const requestId = typeof valueAsRecord.requestId === 'string' ? valueAsRecord.requestId : '';
+	if (requestId.length < 1) return null;
+
+	const startedAt =
+		typeof valueAsRecord.startedAt === 'number' ? valueAsRecord.startedAt : Number.NaN;
+	if (!Number.isFinite(startedAt)) return null;
+
+	const userId = typeof valueAsRecord.userId === 'string' ? valueAsRecord.userId : null;
+	return {
+		requestId,
+		userId,
+		startedAt,
+	};
+}
+
+function getInitiativeRollLockData(
+	combatant: { flags?: Record<string, unknown> } | null | undefined,
+): InitiativeRollLockData | null {
+	return normalizeInitiativeRollLockData(
+		foundry.utils.getProperty(combatant ?? {}, INITIATIVE_ROLL_LOCK_PATH),
+	);
+}
+
+function isInitiativeRollLockStale(lockData: InitiativeRollLockData): boolean {
+	return Date.now() - lockData.startedAt >= INITIATIVE_ROLL_LOCK_TIMEOUT_MS;
+}
+
+function hasActiveInitiativeRollLock(
+	combatant: { flags?: Record<string, unknown> } | null | undefined,
+): boolean {
+	const lockData = getInitiativeRollLockData(combatant);
+	if (!lockData) return false;
+	return !isInitiativeRollLockStale(lockData);
+}
+
+function doesInitiativeRollLockMatch(
+	combatant: { flags?: Record<string, unknown> } | null | undefined,
+	requestId: string,
+): boolean {
+	const lockData = getInitiativeRollLockData(combatant);
+	if (!lockData) return false;
+	if (isInitiativeRollLockStale(lockData)) return false;
+	return lockData.requestId === requestId;
+}
+
+function createInitiativeRollLockData(): InitiativeRollLockData {
+	return {
+		requestId: foundry.utils.randomID(),
+		userId: game.user?.id ?? null,
+		startedAt: Date.now(),
+	};
+}
+
+export const initiativeRollLock = {
+	path: INITIATIVE_ROLL_LOCK_PATH,
+	create: createInitiativeRollLockData,
+	get: getInitiativeRollLockData,
+	isStale: isInitiativeRollLockStale,
+	hasActiveLock: hasActiveInitiativeRollLock,
+	matches: doesInitiativeRollLockMatch,
+};

--- a/src/view/sheets/components/ActionTracker.svelte
+++ b/src/view/sheets/components/ActionTracker.svelte
@@ -21,13 +21,14 @@
 {#if state.showCombatBar}
 	<div class="action-tracker">
 		<div class="action-tracker__panel">
-			{#if state.needsInitiative}
+			{#if state.needsInitiative || state.initiativePending}
 				<button
 					class="action-tracker__initiative-btn"
 					type="button"
 					aria-label={localize('NIMBLE.ui.heroicActions.rollInitiative')}
 					data-tooltip={localize('NIMBLE.ui.heroicActions.rollInitiative')}
 					data-tooltip-direction="RIGHT"
+					disabled={state.initiativePending}
 					onclick={state.rollInitiative}
 				>
 					<i class="fa-solid fa-dice-d20"></i>
@@ -120,6 +121,11 @@
 			&:hover {
 				background: hsl(210, 60%, 44%);
 				border-color: hsl(210, 60%, 38%);
+			}
+
+			&:disabled {
+				cursor: wait;
+				opacity: 0.7;
 			}
 		}
 

--- a/src/view/sheets/components/ActionTracker.svelte.ts
+++ b/src/view/sheets/components/ActionTracker.svelte.ts
@@ -8,6 +8,7 @@ import {
 } from '../../../utils/combatState.js';
 import { requestAdvanceCombatTurn } from '../../../utils/combatTurnActions.js';
 import { getActiveCombatant } from '../../../utils/combatTurnSync.js';
+import { initiativeRollLock } from '../../../utils/initiativeRollLock.js';
 import localize from '../../../utils/localize.js';
 
 // ============================================================================
@@ -69,7 +70,14 @@ export function createActionTrackerState(getActor: () => NimbleCharacter) {
 	function needsToRollInitiative(): boolean {
 		const combatant = getCombatantInCombat();
 		if (!combatant) return false;
+		if (initiativeRollLock.hasActiveLock(combatant)) return false;
 		return combatant.initiative === null;
+	}
+
+	function isInitiativePending(): boolean {
+		const combatant = getCombatantInCombat();
+		if (!combatant) return false;
+		return initiativeRollLock.hasActiveLock(combatant);
 	}
 
 	function getActionsData(): ActionsData {
@@ -102,6 +110,7 @@ export function createActionTrackerState(getActor: () => NimbleCharacter) {
 		if (!combat) return;
 		const combatant = combat.combatants.find((entry) => entry.actorId === getActor().id);
 		if (!combatant?.id) return;
+		if (initiativeRollLock.hasActiveLock(combatant)) return;
 
 		try {
 			await combat.rollInitiative([combatant.id]);
@@ -144,6 +153,11 @@ export function createActionTrackerState(getActor: () => NimbleCharacter) {
 		return hasRolledInitiative();
 	});
 
+	const initiativePending = $derived.by(() => {
+		subscribeCombatState();
+		return isInitiativePending();
+	});
+
 	const actionsData = $derived.by(() => {
 		subscribeCombatState();
 		return getActionsData();
@@ -154,7 +168,7 @@ export function createActionTrackerState(getActor: () => NimbleCharacter) {
 		return isCharactersTurn();
 	});
 
-	const showCombatBar = $derived(hasInitiative || needsInitiative);
+	const showCombatBar = $derived(hasInitiative || needsInitiative || initiativePending);
 
 	// ============================================================================
 	// Pip Interaction
@@ -230,6 +244,9 @@ export function createActionTrackerState(getActor: () => NimbleCharacter) {
 		},
 		get hasInitiative() {
 			return hasInitiative;
+		},
+		get initiativePending() {
+			return initiativePending;
 		},
 		get actionsData() {
 			return actionsData;

--- a/src/view/sheets/pages/PlayerCharacterCoreTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterCoreTab.svelte
@@ -3,7 +3,10 @@
 
 	// Helper Functions
 	import { getContext } from 'svelte';
+	import { createSubscriber } from 'svelte/reactivity';
 	import type { NimbleCharacter } from '../../../documents/actor/character.js';
+	import { registerCombatStateHooks } from '../../../utils/combatState.js';
+	import { initiativeRollLock } from '../../../utils/initiativeRollLock.js';
 	import localize from '../../../utils/localize.js';
 	import replaceHyphenWithMinusSign from '../../dataPreparationHelpers/replaceHyphenWithMinusSign.js';
 	// Components
@@ -29,6 +32,13 @@
 		return [...proficiencies];
 	}
 
+	function getViewedCombatantForCurrentScene(): Combatant | null {
+		const combat = game.combats?.viewed;
+		const sceneId = canvas.scene?.id;
+		if (!combat || !sceneId || combat.scene?.id !== sceneId) return null;
+		return combat.combatants.find((entry) => entry.actorId === actor.id) ?? null;
+	}
+
 	async function rollInitiative() {
 		// Check if there's an active combat on the current scene with this character
 		const combat = game.combats?.viewed;
@@ -36,7 +46,8 @@
 
 		// If character is in combat for the current scene and hasn't rolled, use combat.rollInitiative
 		if (combat && sceneId && combat.scene?.id === sceneId) {
-			const combatant = combat.combatants.find((c) => c.actorId === actor.id);
+			const combatant = getViewedCombatantForCurrentScene();
+			if (combatant && initiativeRollLock.hasActiveLock(combatant)) return;
 
 			if (combatant && combatant.initiative === null && combatant.id) {
 				await combat.rollInitiative([combatant.id]);
@@ -57,6 +68,7 @@
 
 	const { armorTypesPlural, languages } = CONFIG.NIMBLE;
 	let actor: NimbleCharacter = getContext('actor');
+	const subscribeCombatState = createSubscriber(registerCombatStateHooks);
 
 	let flags = $derived(actor.reactive.flags.nimble);
 	let editingEnabled = $derived(flags?.editingEnabled ?? false);
@@ -65,6 +77,12 @@
 	let abilities = $derived(actor.reactive.system.abilities);
 	let characterSavingThrows = $derived(actor.reactive.system.savingThrows);
 	let initiative = $derived(actor.reactive.system.attributes.initiative.mod);
+	let initiativePending = $derived.by(() => {
+		subscribeCombatState();
+		const combatant = getViewedCombatantForCurrentScene();
+		if (!combatant) return false;
+		return initiativeRollLock.hasActiveLock(combatant);
+	});
 
 	// Proficiencies
 	let armorProficiencies = $derived(
@@ -96,6 +114,8 @@
 				type="button"
 				aria-label={localize('NIMBLE.prompts.rollInitiative')}
 				data-tooltip="NIMBLE.prompts.rollInitiative"
+				aria-busy={initiativePending}
+				disabled={initiativePending}
 				onclick={rollInitiative}
 			>
 				{replaceHyphenWithMinusSign(
@@ -176,6 +196,11 @@
 		&:focus {
 			border-color: var(--color-border-highlight);
 			box-shadow: 0 0 6px var(--color-border-highlight);
+		}
+
+		&:disabled {
+			cursor: wait;
+			opacity: 0.7;
 		}
 	}
 

--- a/src/view/ui/CtTopTracker.state.svelte.ts
+++ b/src/view/ui/CtTopTracker.state.svelte.ts
@@ -10,6 +10,7 @@ import {
 	resolveCombatantCurrentActionsAfterDelta,
 } from '../../utils/combatTurnActions.js';
 import type { HeroicReactionKey } from '../../utils/heroicActions.js';
+import { initiativeRollLock } from '../../utils/initiativeRollLock.js';
 import { isCombatantDead } from '../../utils/isCombatantDead.js';
 import CtSettingsDialogComponent from '../dialogs/CtSettingsDialog.svelte';
 import {
@@ -70,6 +71,7 @@ export function createCtTopTrackerState() {
 			.filter((combatant) => {
 				if (sceneId && getCombatantSceneId(combatant) !== sceneId) return false;
 				if (!isEligibleForInitiativeRoll(combatant)) return false;
+				if (initiativeRollLock.hasActiveLock(combatant)) return false;
 				return combatant.initiative == null;
 			})
 			.map((combatant) => combatant.id)
@@ -89,6 +91,7 @@ export function createCtTopTrackerState() {
 		event.stopPropagation();
 
 		if (!shouldShowInitiativePromptForCombatant(combatant)) return;
+		if (initiativeRollLock.hasActiveLock(combatant)) return;
 		if (!canCurrentUserRollInitiativeForCombatant(combatant)) {
 			ui.notifications?.warn('Only the GM or the hero owner can roll initiative.');
 			return;

--- a/src/view/ui/CtTopTracker.state.svelte.ts
+++ b/src/view/ui/CtTopTracker.state.svelte.ts
@@ -10,7 +10,6 @@ import {
 	resolveCombatantCurrentActionsAfterDelta,
 } from '../../utils/combatTurnActions.js';
 import type { HeroicReactionKey } from '../../utils/heroicActions.js';
-import { initiativeRollLock } from '../../utils/initiativeRollLock.js';
 import { isCombatantDead } from '../../utils/isCombatantDead.js';
 import CtSettingsDialogComponent from '../dialogs/CtSettingsDialog.svelte';
 import {
@@ -71,7 +70,6 @@ export function createCtTopTrackerState() {
 			.filter((combatant) => {
 				if (sceneId && getCombatantSceneId(combatant) !== sceneId) return false;
 				if (!isEligibleForInitiativeRoll(combatant)) return false;
-				if (initiativeRollLock.hasActiveLock(combatant)) return false;
 				return combatant.initiative == null;
 			})
 			.map((combatant) => combatant.id)
@@ -91,7 +89,6 @@ export function createCtTopTrackerState() {
 		event.stopPropagation();
 
 		if (!shouldShowInitiativePromptForCombatant(combatant)) return;
-		if (initiativeRollLock.hasActiveLock(combatant)) return;
 		if (!canCurrentUserRollInitiativeForCombatant(combatant)) {
 			ui.notifications?.warn('Only the GM or the hero owner can roll initiative.');
 			return;

--- a/src/view/ui/ctTopTracker/combat.utils.ts
+++ b/src/view/ui/ctTopTracker/combat.utils.ts
@@ -10,6 +10,7 @@ import {
 } from '../../../utils/combatTurnActions.js';
 import { hasCombatantTurnEndedThisRound } from '../../../utils/combatTurnProgress.js';
 import { getHeroicReactionAvailability } from '../../../utils/heroicActions.js';
+import { initiativeRollLock } from '../../../utils/initiativeRollLock.js';
 import { isCombatantDead } from '../../../utils/isCombatantDead.js';
 import { getMinionGroupSummaries } from '../../../utils/minionGrouping.js';
 import type { ResolveActiveEntryKeyParams, SceneCombatantLists, TrackEntry } from './types.js';
@@ -566,6 +567,7 @@ export function buildCombatSyncSignature(
 export function canCurrentUserRollInitiativeForCombatant(
 	combatant: Combatant.Implementation,
 ): boolean {
+	if (initiativeRollLock.hasActiveLock(combatant)) return false;
 	const currentUser = game.user;
 	if (!currentUser) return false;
 	if (currentUser.isGM) return true;
@@ -577,6 +579,7 @@ export function shouldShowInitiativePromptForCombatant(
 	combatant: Combatant.Implementation,
 ): boolean {
 	if (!isPlayerCombatant(combatant)) return false;
+	if (initiativeRollLock.hasActiveLock(combatant)) return false;
 	return combatant.initiative == null;
 }
 

--- a/tests/fixtures/combat.ts
+++ b/tests/fixtures/combat.ts
@@ -17,6 +17,7 @@ export type CombatantFixtureOptions = {
 	sort?: number;
 	isOwner?: boolean;
 	initiative?: number | null;
+	flags?: Record<string, unknown>;
 	defeated?: boolean;
 	actor?: Actor.Implementation | null;
 	combatId?: string;
@@ -73,6 +74,7 @@ export function createCombatantFixture({
 	sort = 0,
 	isOwner = false,
 	initiative = null,
+	flags = {},
 	defeated = false,
 	actor = null,
 	combatId = 'combat-1',
@@ -91,6 +93,7 @@ export function createCombatantFixture({
 		isOwner,
 		defeated,
 		initiative,
+		flags,
 		actor,
 		actorId: resolvedActorId,
 		tokenId,


### PR DESCRIPTION
Checked using AGENTS.md and STYLE_GUIDE.md

Initiative Fix
-   Prevented duplicate initiative rolls by adding a per-combatant initiative lock at the combat document layer.
-   `rollInitiative `now dedupes repeated ids, serializes same-client in-flight requests, and skips rolling if a fresh lock already exists.
-   The lock is acquired before dice are rolled and cleared when the final initiative update is written.
-   Added a stale-lock timeout so abandoned locks do not block initiative forever.

Safety Guard
-   Added a combatant update guard so one request cannot overwrite another active initiative lock.
-   The guard still allows clearing an active lock and replacing a stale lock.

UI Updates
-   Updated the combat tracker to hide or block initiative prompts while a roll is already pending.
-   Updated the action tracker to disable the initiative button and show a waiting state during a pending roll.
-   Updated the core character sheet initiative button to subscribe to combat state and disable itself while the lock is active.

Test Coverage
-   Added a regression test proving two concurrent initiative requests against the same combatant only produce one roll.
-   Added a regression test proving a foreign active lock prevents another client from rolling.
-   Added combatant-level tests for lock overwrite behavior, stale-lock replacement, and lock clearing.

Docs
-   Added the new shared `initiativeRollLock `utility to the style guide inventory.