### PR TITLE
fix(ncsw): Preserve user targets when group attack panel refreshes

### DIFF
--- a/src/hooks/minionGroupTokenActions.ts
+++ b/src/hooks/minionGroupTokenActions.ts
@@ -1228,7 +1228,7 @@ function hideGroupAttackPanel(options: { clearTargets?: boolean } = {}): void {
 		minionGroupAttackPanelElement.hidden = true;
 		minionGroupAttackPanelElement.replaceChildren();
 	}
-	if (options.clearTargets ?? true) {
+	if (options.clearTargets === true) {
 		clearAllUserSelectedTargetsFromNcsw();
 	}
 	hideGroupAttackTargetPopover();


### PR DESCRIPTION
- stop clearing `game.user.targets` in `hideGroupAttackPanel()` by default
- only clear targets when `clearTargets: true` is explicitly requested
- prevents target loss during combat tracker updates, canvas/token left-clicks, and other NCSW refresh/hide paths