### PR TITLE
fix: CT Monster Stack button tooltip reversed

### DIFF
--- a/src/view/ui/CtTopTracker.svelte
+++ b/src/view/ui/CtTopTracker.svelte
@@ -239,11 +239,11 @@
 						<button
 							class="nimble-ct__icon-button"
 							aria-label={monsterCardsExpanded
-								? localizeWithFallback('NIMBLE.ct.unstackMonsterGroups', 'Unstack Monster Groups')
-								: localizeWithFallback('NIMBLE.ct.stackMonsterGroups', 'Stack Monster Groups')}
+								? localizeWithFallback('NIMBLE.ct.stackMonsterGroups', 'Stack Monster Groups')
+								: localizeWithFallback('NIMBLE.ct.unstackMonsterGroups', 'Unstack Monster Groups')}
 							data-tooltip={monsterCardsExpanded
-								? localizeWithFallback('NIMBLE.ct.unstackMonsterGroups', 'Unstack Monster Groups')
-								: localizeWithFallback('NIMBLE.ct.stackMonsterGroups', 'Stack Monster Groups')}
+								? localizeWithFallback('NIMBLE.ct.stackMonsterGroups', 'Stack Monster Groups')
+								: localizeWithFallback('NIMBLE.ct.unstackMonsterGroups', 'Unstack Monster Groups')}
 							data-tooltip-direction="LEFT"
 							onclick={toggleMonsterCardExpansion}
 						>


### PR DESCRIPTION
Current CT Monster stack button tooltip is incorrect showing the opposite of the expected tooltip:

<img width="649" height="379" alt="Screenshot 2026-03-27 153021" src="https://github.com/user-attachments/assets/6c5c6e76-ae93-49ae-8794-8853bdbad91b" />
<img width="596" height="375" alt="Screenshot 2026-03-27 153008" src="https://github.com/user-attachments/assets/adc09cdf-82df-48f6-8966-6ec80bf2506e" />



Fixed to show:

<img width="573" height="250" alt="Screenshot 2026-03-27 155625" src="https://github.com/user-attachments/assets/f2c377b7-586c-4b1e-a008-c7d9dc611b86" />
<img width="454" height="345" alt="Screenshot 2026-03-27 155634" src="https://github.com/user-attachments/assets/43027a6d-5b92-4282-8052-60622bb5f300" />
