### PR TITLE
chore: added different backup images for heroes/monsters

### DIFF
--- a/src/view/ui/CtTopTracker.svelte
+++ b/src/view/ui/CtTopTracker.svelte
@@ -16,11 +16,11 @@
 		getCombatantDisplayName,
 		getCombatantImageForDisplay,
 		getCombatantOutlineClass,
+		getPortraitFallbackForCombatant,
 		getNonPlayerCombatantHpBarData,
 		getPlayerCombatantDrawerData,
 		shouldRenderCombatantActions,
 	} from './ctTopTracker/resources.utils.js';
-
 	const trackerViewState = createCtTopTrackerState();
 	const ctShellExtraWidth = `${CT_SHELL_EXTRA_WIDTH_REM}rem`;
 
@@ -94,6 +94,15 @@
 	const canDragCombatant = trackerViewState.canDragCombatant;
 	const canDragTrackEntry = trackerViewState.canDragTrackEntry;
 	const localize = game.i18n.localize.bind(game.i18n);
+
+	function handleCombatantPortraitImageError(event: Event) {
+		const img = event.currentTarget;
+		if (!(img instanceof HTMLImageElement)) return;
+		const fallback = img.dataset.portraitFallback;
+		if (!fallback) return;
+		if (img.src.includes(fallback)) return;
+		img.src = fallback;
+	}
 </script>
 
 {#snippet renderNameDrawer(cardName)}
@@ -380,6 +389,8 @@
 										src={getCombatantImageForDisplay(entry.combatant)}
 										alt="Combatant portrait"
 										draggable="false"
+										data-portrait-fallback={getPortraitFallbackForCombatant(entry.combatant)}
+										onerror={handleCombatantPortraitImageError}
 									/>
 									{#if canDragEntry}
 										<div
@@ -613,6 +624,8 @@
 										src={getCombatantImageForDisplay(combatant)}
 										alt="Dead combatant portrait"
 										draggable="false"
+										data-portrait-fallback={getPortraitFallbackForCombatant(combatant)}
+										onerror={handleCombatantPortraitImageError}
 									/>
 									{#if resourceChips.length > 0}
 										<div class="nimble-ct__resource-chips">

--- a/src/view/ui/ctTopTracker/constants.ts
+++ b/src/view/ui/ctTopTracker/constants.ts
@@ -1,4 +1,8 @@
-export const PORTRAIT_FALLBACK_IMAGE = 'icons/svg/mystery-man.svg';
+/** Foundry core: humanoid silhouette — default portrait for player characters when missing or failed to load. */
+export const PLAYER_PORTRAIT_FALLBACK_IMAGE = 'icons/svg/mystery-man.svg';
+
+/** Foundry core combat HUD icon — default portrait for monsters, NPCs, minions, and solo when missing or failed to load. */
+export const NON_PLAYER_PORTRAIT_FALLBACK_IMAGE = 'icons/svg/combat.svg';
 
 export const DRAG_TARGET_EXPANSION_REM = 0.85;
 export const DRAG_SWITCH_UPPER_RATIO = 0.4;

--- a/src/view/ui/ctTopTracker/resources.utils.ts
+++ b/src/view/ui/ctTopTracker/resources.utils.ts
@@ -25,7 +25,7 @@ import {
 	isPlayerCombatant,
 	localizeWithFallback,
 } from './combat.utils.js';
-import { PORTRAIT_FALLBACK_IMAGE } from './constants.js';
+import { NON_PLAYER_PORTRAIT_FALLBACK_IMAGE, PLAYER_PORTRAIT_FALLBACK_IMAGE } from './constants.js';
 import type {
 	CombatantCardResourceChip,
 	NonPlayerCombatantHpBarData,
@@ -453,11 +453,18 @@ export function getActionState(combatant: Combatant.Implementation): {
 	};
 }
 
+export function getPortraitFallbackForCombatant(combatant: Combatant.Implementation): string {
+	return isPlayerCombatant(combatant)
+		? PLAYER_PORTRAIT_FALLBACK_IMAGE
+		: NON_PLAYER_PORTRAIT_FALLBACK_IMAGE;
+}
+
 export function getCombatantImageForDisplay(combatant: Combatant.Implementation): string {
+	const fallback = getPortraitFallbackForCombatant(combatant);
 	return (
 		getCombatantImage(combatant, {
 			includeActorImage: true,
-			fallback: PORTRAIT_FALLBACK_IMAGE,
-		}) ?? PORTRAIT_FALLBACK_IMAGE
+			fallback,
+		}) ?? fallback
 	);
 }


### PR DESCRIPTION
Different backup images for heroes/monsters when the current image fails to load.

Before:

<img width="1118" height="263" alt="Screenshot 2026-03-27 at 8 43 49 PM" src="https://github.com/user-attachments/assets/6d84ae4d-2d0e-46c8-a5b6-e0edb63df317" />

After:

<img width="1146" height="242" alt="Screenshot 2026-03-27 at 8 44 30 PM" src="https://github.com/user-attachments/assets/c8f9701f-494e-40e7-a477-c107d5d7ff72" />
