### PR TITLE
fix: Turn Tracking

### DIFF
--- a/src/utils/combatTurnSync.test.ts
+++ b/src/utils/combatTurnSync.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createCombatActorFixture, createCombatantFixture } from '../../tests/fixtures/combat.js';
+import { clearExpandedTurnIdentityHint } from '../documents/combat/expandedTurnIdentityStore.js';
+import { syncCombatTurns } from './combatTurnSync.js';
+
+describe('syncCombatTurns', () => {
+	beforeEach(() => {
+		clearExpandedTurnIdentityHint('combat-turn-sync-active-combatant');
+	});
+
+	it('syncs combat.combatant to the normalized active turn identity', () => {
+		const playerOne = createCombatantFixture({
+			id: 'player-one',
+			type: 'character',
+			actor: createCombatActorFixture({ type: 'character' }),
+		});
+		const playerTwo = createCombatantFixture({
+			id: 'player-two',
+			type: 'character',
+			actor: createCombatActorFixture({ type: 'character' }),
+		});
+		const solo = createCombatantFixture({
+			id: 'legendary-one',
+			type: 'soloMonster',
+			actor: createCombatActorFixture({ type: 'soloMonster' }),
+		});
+
+		const expandedTurns = [playerOne, solo, playerTwo, solo] as Combatant.Implementation[];
+		const rawTurns = [playerOne, playerTwo, solo] as Combatant.Implementation[];
+		const combat = {
+			id: 'combat-turn-sync-active-combatant',
+			flags: {
+				nimble: {
+					expandedTurnIdentity: {
+						combatantId: 'player-two',
+						occurrence: 0,
+					},
+				},
+			},
+			turns: rawTurns,
+			turn: 0,
+			setupTurns: vi.fn(() => expandedTurns),
+		} as unknown as Combat & {
+			_nimbleExpandedTurnIdentity?: { combatantId: string; occurrence: number | null } | null;
+		};
+		Object.defineProperty(combat, 'combatant', {
+			configurable: true,
+			get() {
+				const turnIndex =
+					typeof combat.turn === 'number' && combat.turn >= 0 && combat.turn < combat.turns.length
+						? combat.turn
+						: 0;
+				return combat.turns[turnIndex] ?? null;
+			},
+		});
+
+		syncCombatTurns(combat);
+
+		expect(combat.turn).toBe(2);
+		expect(combat.combatant?.id).toBe('player-two');
+		expect(combat._nimbleExpandedTurnIdentity).toEqual({
+			combatantId: 'player-two',
+			occurrence: 0,
+		});
+	});
+});

--- a/src/view/ui/ctTopTracker/combat.utils.ts
+++ b/src/view/ui/ctTopTracker/combat.utils.ts
@@ -12,7 +12,11 @@ import { hasCombatantTurnEndedThisRound } from '../../../utils/combatTurnProgres
 import { getHeroicReactionAvailability } from '../../../utils/heroicActions.js';
 import { initiativeRollLock } from '../../../utils/initiativeRollLock.js';
 import { isCombatantDead } from '../../../utils/isCombatantDead.js';
-import { getMinionGroupSummaries } from '../../../utils/minionGrouping.js';
+import {
+	getEffectiveMinionGroupLeader,
+	getMinionGroupId,
+	getMinionGroupSummaries,
+} from '../../../utils/minionGrouping.js';
 import type { ResolveActiveEntryKeyParams, SceneCombatantLists, TrackEntry } from './types.js';
 
 type CombatWithTurnIdentityHint = Combat & {
@@ -67,6 +71,21 @@ function resolveCurrentTurnIdentity(
 	}
 
 	return null;
+}
+
+function shouldExcludeNonTurnCombatantFromCtTrack(
+	combatant: Combatant.Implementation,
+	groupSummaries: ReturnType<typeof getMinionGroupSummaries>,
+): boolean {
+	const groupId = getMinionGroupId(combatant);
+	if (!groupId) return false;
+
+	const summary = groupSummaries.get(groupId);
+	if (!summary) return false;
+
+	const effectiveLeader = getEffectiveMinionGroupLeader(summary, { aliveOnly: true });
+	if (!effectiveLeader?.id) return false;
+	return effectiveLeader.id !== (combatant.id ?? '');
 }
 
 export function isLegendaryCombatant(combatant: Combatant.Implementation): boolean {
@@ -270,6 +289,7 @@ export function getCombatantsForScene(
 ): SceneCombatantLists {
 	if (!combat || !sceneId) return { aliveCombatants: [], deadCombatants: [] };
 
+	const groupSummaries = getMinionGroupSummaries(combat.combatants.contents);
 	const combatantsForScene = combat.combatants.contents.filter(
 		(combatant) =>
 			getCombatantSceneId(combatant) === sceneId && combatant.visible && combatant._id != null,
@@ -291,6 +311,7 @@ export function getCombatantsForScene(
 		...turnCombatants.filter((combatant) => !isCombatantDead(combatant)),
 		...combatantsForScene.filter((combatant) => {
 			if (isCombatantDead(combatant)) return false;
+			if (shouldExcludeNonTurnCombatantFromCtTrack(combatant, groupSummaries)) return false;
 			return !turnCombatantIds.has(combatant.id ?? '');
 		}),
 	];

--- a/src/view/ui/ctTopTracker/combatTracker.utils.test.ts
+++ b/src/view/ui/ctTopTracker/combatTracker.utils.test.ts
@@ -5,7 +5,11 @@ import {
 	createCombatantsCollectionFixture,
 } from '../../../../tests/fixtures/combat.js';
 import { clearExpandedTurnIdentityHint } from '../../../documents/combat/expandedTurnIdentityStore.js';
-import { hasCombatantTurnRemainingThisRound, syncCombatTurnsForCt } from './combat.utils.js';
+import {
+	getCombatantsForScene,
+	hasCombatantTurnRemainingThisRound,
+	syncCombatTurnsForCt,
+} from './combat.utils.js';
 import {
 	getCombatantCardResourceChips,
 	getCombatantOutlineClass,
@@ -330,19 +334,73 @@ describe('ctTopTracker helpers', () => {
 			},
 			turns: rawTurns,
 			turn: 0,
-			combatant: playerOne,
 			setupTurns: vi.fn(() => expandedTurns),
 		} as unknown as Combat & {
 			_nimbleExpandedTurnIdentity?: { combatantId: string; occurrence: number | null } | null;
 		};
+		Object.defineProperty(combat, 'combatant', {
+			configurable: true,
+			get() {
+				const turnIndex =
+					typeof combat.turn === 'number' && combat.turn >= 0 && combat.turn < combat.turns.length
+						? combat.turn
+						: 0;
+				return combat.turns[turnIndex] ?? null;
+			},
+		});
 
 		syncCombatTurnsForCt(combat);
 
 		expect(combat.turn).toBe(2);
+		expect(combat.combatant?.id).toBe('player-two');
 		expect(combat._nimbleExpandedTurnIdentity).toEqual({
 			combatantId: 'player-two',
 			occurrence: 0,
 		});
+	});
+
+	it('keeps grouped minion members out of the CT turn track while preserving other non-turn combatants', () => {
+		const minionLeader = createCombatantFixture({
+			id: 'minion-leader',
+			type: 'npc',
+			actor: createCombatActorFixture({ type: 'minion' }),
+			sceneId: 'scene-1',
+			flags: {
+				nimble: { minionGroup: { id: 'group-1', role: 'leader' } },
+			},
+		});
+		(minionLeader as unknown as { visible: boolean }).visible = true;
+		const minionMember = createCombatantFixture({
+			id: 'minion-member',
+			type: 'npc',
+			actor: createCombatActorFixture({ type: 'minion' }),
+			sceneId: 'scene-1',
+			flags: {
+				nimble: { minionGroup: { id: 'group-1', role: 'member' } },
+			},
+		});
+		(minionMember as unknown as { visible: boolean }).visible = true;
+		const lateJoiner = createCombatantFixture({
+			id: 'late-joiner',
+			type: 'npc',
+			actor: createCombatActorFixture({ type: 'npc' }),
+			sceneId: 'scene-1',
+		});
+		(lateJoiner as unknown as { visible: boolean }).visible = true;
+
+		const combat = {
+			combatants: createCombatantsCollectionFixture([minionLeader, minionMember, lateJoiner]),
+			turns: [minionLeader],
+			turn: 0,
+			combatant: minionLeader,
+		} as unknown as Combat;
+
+		const { aliveCombatants } = getCombatantsForScene(combat, 'scene-1');
+
+		expect(aliveCombatants.map((combatant) => combatant.id)).toEqual([
+			'minion-leader',
+			'late-joiner',
+		]);
 	});
 
 	it('keeps an active zero-action non-player in the current round until initiative advances past it', () => {

--- a/src/view/ui/ctTopTracker/topTrackerStore.svelte.test.ts
+++ b/src/view/ui/ctTopTracker/topTrackerStore.svelte.test.ts
@@ -320,6 +320,80 @@ describe('CtTopTrackerStore', () => {
 		).toEqual([2, 1]);
 	});
 
+	it('does not expose grouped minion members as separate expanded monster turns', () => {
+		const player = createCombatantFixture({
+			id: 'player-one',
+			type: 'character',
+			actor: createCombatActorFixture({ type: 'character' }),
+			sceneId: 'scene-1',
+		});
+		(player as unknown as { visible: boolean }).visible = true;
+		const minionLeader = createCombatantFixture({
+			id: 'minion-leader',
+			type: 'npc',
+			actor: createCombatActorFixture({ type: 'minion' }),
+			sceneId: 'scene-1',
+			flags: {
+				nimble: { minionGroup: { id: 'group-1', role: 'leader' } },
+			},
+		});
+		(minionLeader as unknown as { visible: boolean }).visible = true;
+		const minionMember = createCombatantFixture({
+			id: 'minion-member',
+			type: 'npc',
+			actor: createCombatActorFixture({ type: 'minion' }),
+			sceneId: 'scene-1',
+			flags: {
+				nimble: { minionGroup: { id: 'group-1', role: 'member' } },
+			},
+		});
+		(minionMember as unknown as { visible: boolean }).visible = true;
+
+		const turns = [player, minionLeader] as Combatant.Implementation[];
+		const combat = {
+			id: 'combat-store-expanded-minion-group',
+			active: true,
+			round: 1,
+			turn: 0,
+			combatant: player,
+			combatants: createCombatantsCollectionFixture([player, minionLeader, minionMember]),
+			turns,
+			setupTurns: vi.fn(() => turns),
+			scene: { id: 'scene-1' },
+			flags: {
+				nimble: {
+					ctMonsterCardsExpanded: true,
+					ctPlayersCanViewExpandedMonsters: true,
+				},
+			},
+		} as unknown as Combat;
+
+		const globals = globalThis as unknown as {
+			game: {
+				combats: { contents: Combat[]; viewed?: Combat | null };
+				combat?: Combat | null;
+			};
+		};
+		globals.game.combats = {
+			contents: [combat],
+			viewed: combat,
+		};
+		globals.game.combat = combat;
+
+		const store = new CtTopTrackerStore();
+		store.refreshCurrentCombat(true);
+
+		expect(store.monsterCardsExpanded).toBe(true);
+		expect(store.sceneAliveCombatants.map((combatant) => combatant.id)).toEqual([
+			'player-one',
+			'minion-leader',
+		]);
+		expect(store.aliveEntries.map((entry) => entry.key)).toEqual([
+			'combatant-player-one-0',
+			'combatant-minion-leader-0',
+		]);
+	});
+
 	it('updates the shared monster expansion flag when the GM toggles expansion', async () => {
 		const globals = globalThis as unknown as {
 			game: {


### PR DESCRIPTION
CODEX report:

Issue Summary
-   Reported issue: expanding the monster stack in the Combat Tracker makes turn tracking appear broken.
-   Scope: the custom top Combat Tracker UI, specifically the button that expands the monster stack into individual cards.

How I Investigated
-   Read the project guidance first to stay inside the repo's Svelte, Foundry, and testing conventions.
-   Traced the Combat Tracker flow through `CtTopTracker.state.svelte.ts`, `CtTopTrackerStore`, and `ctTopTracker/combat.utils.ts`.
-   Traced the real combat turn model through `documents/combat/combat.svelte.ts` and `combatTurns.ts`.
-   Compared the UI's visible entry construction against the actual normalized turn order used by the combat document.
-   Ran targeted tests during the investigation, then validated with the full repo check.

Key Findings
-   The underlying combat document already had a clear turn model.
-   `NimbleCombat.setupTurns()` removes dead combatants, normalizes grouped minions down to their effective leader, and expands solo monsters into repeated turns where appropriate.
-   The Combat Tracker UI rebuild path did not fully respect that normalized turn model.
-   `getCombatantsForScene()` in `ctTopTracker/combat.utils.ts` started with the normalized `combat.turns`, but then appended any other alive scene combatants that were not present in 'turns'.
-   For grouped minions, this was the critical mistake.
-   Grouped minion members are intentionally removed from the real turn order and represented by the leader's turn.
-   The CT rebuild path added those non-leader minions back into the visible list anyway.
-   When monster cards were collapsed, that mismatch was mostly hidden inside the single monster stack.
-   When monster cards were expanded, those extra minion members appeared as separate visible entries and made the tracker look like it had extra turns or a broken active position.

Root Cause
-   The expanded monster view mixed two different concepts:
-   combatants that are alive and visible in the scene
-   combatants that actually own initiative turns
-   Grouped minion members belong in the first category, but not the second.
-   The CT used both categories to build the expanded track, so the expanded UI could diverge from the real turn order.

What I Fixed
-   Updated `src/view/ui/ctTopTracker/combat.utils.ts`.
-   Added a grouped-minion exclusion step when rebuilding CT entries.
-   The CT now checks minion group summaries and excludes minion members that are not the effective alive leader.
-   This keeps the expanded monster view aligned with the real normalized turn order.
-   Non-grouped alive combatants still behave as before.
-   I did not change `NimbleCombat.setupTurns()` because the core combat turn model was already correct.

Follow-up Problem I Hit
-   During the first pass, I also tried to force `combat.combatant` to stay in sync by assigning to it directly.
-   That was a bad assumption for live Foundry.
-   In runtime, `Combat.combatant` is getter-only.
-   Foundry threw `TypeError: Cannot set property combatant of #<Combat> which has only a getter`.
-   I removed that mutation from both sync helpers.
-   I then adjusted the tests to model Foundry more accurately by using getter-based 'combatant' behavior instead of plain mutable object behavior.

Test Coverage Added
-   Added a helper-level regression in `src/view/ui/ctTopTracker/combatTracker.utils.test.ts`.
-   This test verifies that grouped minion members are excluded from CT turn-track reconstruction while other valid non-turn combatants are still preserved.
-   Added a store-level regression in `src/view/ui/ctTopTracker/topTrackerStore.svelte.test.ts`.
-   This test verifies that expanded monster mode does not surface grouped minion members as separate turn entries.
-   Added `src/utils/combatTurnSync.test.ts`.
-   This test locks in getter-based 'combatant' semantics so future changes do not repeat the same invalid assignment mistake.
-   Updated the CT sync expectations to match real Foundry behavior.

Files Changed
-   `src/view/ui/ctTopTracker/combat.utils.ts`
-   `src/view/ui/ctTopTracker/combatTracker.utils.test.ts
-   `src/view/ui/ctTopTracker/topTrackerStore.svelte.test.ts`
-   `src/utils/combatTurnSync.ts`
-   `src/utils/combatTurnSync.test.ts`

Verification
-   Ran targeted Combat Tracker and combat-document test suites while iterating.
-   Ran full `pnpm check` after the final fix.
-   Full validation passed:
-   formatting
-   linting
-   circular dependency check
-   type-checking
-   full test suite
-   Final full suite result: 648 passing tests.

Final Outcome
-   Expanding the monster stack no longer creates fake visible turn entries for grouped minion members.
-   The expanded Combat Tracker now reflects the real normalized initiative order instead of mixing turn owners with non-turn group members.
-   The temporary runtime error from the first patch attempt was removed, and the final implementation is compatible with Foundry's getter-only `combat.combatant` API.