### PR TITLE
feat(zephyr): implement unarmored predicate for Swift Feet

### DIFF
--- a/packs/classFeatures/core/zephyr/zephyr-progression/swift-feet.json
+++ b/packs/classFeatures/core/zephyr/zephyr-progression/swift-feet.json
@@ -10,26 +10,28 @@
 			{
 				"type": "speedBonus",
 				"value": "2",
-				"label": "Swift Feet",
+				"label": "Swift Feet (2)",
 				"predicate": {
-					"unarmored": true
+					"armor": "unarmored"
 				}
 			},
 			{
 				"type": "initiativeBonus",
-				"value": "1",
+				"value": "@level",
 				"label": "Swift Feet Initiative Bonus",
 				"predicate": {
-					"unarmored": true
+					"armor": "unarmored"
 				}
 			},
 			{
 				"type": "speedBonus",
 				"value": "2",
-				"label": "Swift Feet Speed Bonus",
+				"label": "Swift Feet (9)",
 				"predicate": {
-					"level": 9,
-					"unarmored": true
+					"armor": "unarmored",
+					"level": {
+						"min": 9
+					}
 				}
 			}
 		],

--- a/src/documents/actor/base.svelte.ts
+++ b/src/documents/actor/base.svelte.ts
@@ -250,12 +250,13 @@ class NimbleBaseActor<ActorType extends SystemActorTypes = SystemActorTypes> ext
 	override prepareDerivedData(): void {
 		super.prepareDerivedData();
 
+		// Populate derived tags before rules run so predicates can evaluate against them
+		this._populateDerivedTags();
+
 		// Call rule hooks
 		this.rules.forEach((rule) => {
 			rule.prePrepareData?.();
 		});
-
-		this._populateDerivedTags();
 	}
 
 	_populateDerivedTags(): void {}

--- a/src/documents/actor/character.ts
+++ b/src/documents/actor/character.ts
@@ -255,6 +255,17 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 		if (this.background) {
 			this.tags.add(`background:${this.background.identifier}`);
 		}
+
+		// Add armor status tag - only count items that actually provide armor (have armorClass rules)
+		const hasArmor = this.items.some((item) => {
+			if (!item.isType('object')) return false;
+			const objectItem = item as unknown as NimbleObjectItem;
+			if (objectItem.system.objectType !== 'armor') return false;
+			// Check if this armor item has any armorClass rules that provide actual protection
+			// Items like "Traveling Robes & Sandals" have objectType "armor" but no armorClass rules
+			return [...item.rules.values()].some((rule) => rule.type === 'armorClass');
+		});
+		this.tags.add(`armor:${hasArmor ? 'equipped' : 'unarmored'}`);
 	}
 
 	getClassAbilityBonuses() {

--- a/src/migration/MigrationRunnerBase.ts
+++ b/src/migration/MigrationRunnerBase.ts
@@ -9,7 +9,7 @@ interface CollectionDiff<T = any> {
 class MigrationRunnerBase {
 	migrations: MigrationBase[];
 
-	static LATEST_SCHEMA_VERSION = 12;
+	static LATEST_SCHEMA_VERSION = 13;
 
 	static RECOMMENDED_SAFE_VERSION = 0;
 

--- a/src/migration/migrations/Migration013SwiftFeetPredicates.ts
+++ b/src/migration/migrations/Migration013SwiftFeetPredicates.ts
@@ -1,0 +1,85 @@
+import { MigrationBase } from '../MigrationBase.js';
+
+const SWIFT_FEET_SOURCE_ID = 'Compendium.nimble.class-features.Item.idKzxuxGapLyV4sP';
+
+const UPDATED_RULES = [
+	{
+		type: 'speedBonus',
+		value: '2',
+		label: 'Swift Feet (2)',
+		predicate: {
+			armor: 'unarmored',
+		},
+	},
+	{
+		type: 'initiativeBonus',
+		value: '@level',
+		label: 'Swift Feet Initiative Bonus',
+		predicate: {
+			armor: 'unarmored',
+		},
+	},
+	{
+		type: 'speedBonus',
+		value: '2',
+		label: 'Swift Feet (9)',
+		predicate: {
+			armor: 'unarmored',
+			level: { min: 9 },
+		},
+	},
+];
+
+/**
+ * Migration to update Swift Feet feature with proper unarmored predicates.
+ *
+ * The Swift Feet feature (Zephyr class) provides bonuses while unarmored:
+ * - +2 speed while unarmored (level 2+)
+ * - +LVL initiative while unarmored
+ * - +2 additional speed while unarmored (level 9+)
+ *
+ * This migration updates the predicate format from the invalid `{ unarmored: true }`
+ * to the correct `{ armor: "unarmored" }` format that works with the predicate system.
+ * It also updates the level check from `{ level: 9 }` to `{ level: { min: 9 } }`.
+ */
+class Migration013SwiftFeetPredicates extends MigrationBase {
+	static override readonly version = 13;
+
+	override readonly version = Migration013SwiftFeetPredicates.version;
+
+	override async updateItem(source: any): Promise<void> {
+		// Only process feature items
+		if (source.type !== 'feature') return;
+
+		// Check if this is the Swift Feet feature by sourceId or by name
+		const sourceId = this.getSourceId(source);
+		const isSwiftFeetBySourceId = sourceId === SWIFT_FEET_SOURCE_ID;
+		const isSwiftFeetByName = source.name === 'Swift Feet';
+
+		// For name-based matching, verify it has the expected rule structure
+		const hasExpectedRules =
+			isSwiftFeetByName &&
+			source.system.rules?.some(
+				(rule: any) => rule.type === 'speedBonus' || rule.type === 'initiativeBonus',
+			);
+
+		if (!isSwiftFeetBySourceId && !hasExpectedRules) return;
+
+		// Check if migration is needed by looking for old predicate format or missing predicates
+		const needsMigration = source.system.rules?.some(
+			(rule: any) =>
+				rule.predicate?.unarmored === true ||
+				(rule.predicate?.level !== undefined && typeof rule.predicate.level === 'number') ||
+				(rule.label === 'Swift Feet' && rule.type === 'speedBonus'),
+		);
+
+		if (!needsMigration) return;
+
+		// Replace all rules with updated versions
+		source.system.rules = UPDATED_RULES;
+
+		console.log(`Nimble Migration | ${source.name}: updated Swift Feet predicates`);
+	}
+}
+
+export { Migration013SwiftFeetPredicates };

--- a/src/migration/migrations/index.ts
+++ b/src/migration/migrations/index.ts
@@ -10,3 +10,4 @@ export { Migration009HealingEffects } from './Migration009HealingEffects.js';
 export { Migration010SwiftFistsUnarmedDamage } from './Migration010SwiftFistsUnarmedDamage.js';
 export { Migration011SwiftFistsUnarmedProficiency } from './Migration011SwiftFistsUnarmedProficiency.js';
 export { Migration012ViciousExplosionDamage } from './Migration012ViciousExplosionDamage.js';
+export { Migration013SwiftFeetPredicates } from './Migration013SwiftFeetPredicates.js';

--- a/src/models/rules/initiativeBonus.ts
+++ b/src/models/rules/initiativeBonus.ts
@@ -30,6 +30,7 @@ class InitiativeBonusRule extends NimbleBaseRule<InitiativeBonusRule.Schema> {
 	override afterPrepareData(): void {
 		const { item } = this;
 		if (!item.isEmbedded) return;
+		if (!this.test()) return;
 
 		const { actor } = item;
 		const value = this.resolveFormula(this.value) ?? 0;

--- a/src/models/rules/speedBonus.test.ts
+++ b/src/models/rules/speedBonus.test.ts
@@ -152,6 +152,12 @@ function createSpeedBonusRule(
 		configurable: true,
 	});
 
+	// Mock the _predicate property with an empty Predicate-like object that always passes
+	Object.defineProperty(rule, '_predicate', {
+		get: () => ({ size: 0 }),
+		configurable: true,
+	});
+
 	return rule;
 }
 

--- a/src/models/rules/speedBonus.ts
+++ b/src/models/rules/speedBonus.ts
@@ -97,6 +97,7 @@ class SpeedBonusRule extends NimbleBaseRule<SpeedBonusRule.Schema> {
 	 */
 	prePrepareData(): void {
 		if (!this.isNumericValue()) return;
+		if (!this.test()) return;
 		this.applySpeedBonus();
 	}
 
@@ -105,6 +106,7 @@ class SpeedBonusRule extends NimbleBaseRule<SpeedBonusRule.Schema> {
 	 */
 	override afterPrepareData(): void {
 		if (this.isNumericValue()) return;
+		if (!this.test()) return;
 		this.applySpeedBonus();
 	}
 }

--- a/src/view/dialogs/CharacterMovementConfigDialog.svelte
+++ b/src/view/dialogs/CharacterMovementConfigDialog.svelte
@@ -13,7 +13,7 @@
 	// Get current (derived) movement values with bonuses applied
 	let currentMovement = $derived(document.reactive?.system?.attributes?.movement ?? {});
 
-	// Collect speed bonuses from rules, grouped by movement type
+	// Collect speed bonuses from rules, grouped by movement type and item
 	let speedBonusesByType = $derived.by(() => {
 		const bonusesByType = {};
 		const rollData = document.getRollData?.() ?? {};
@@ -21,35 +21,51 @@
 		for (const item of document.items ?? []) {
 			if (!item.rules) continue;
 
+			// Group bonuses by movement type for this item
+			// Track value and unique labels that differ from item name
+			const itemBonusesByType = {};
+
 			for (const rule of item.rules.values()) {
 				if (rule.type !== 'speedBonus') continue;
 				if (rule.disabled) continue;
+
+				// Only include rules that pass their predicate
+				if (rule.test && !rule.test()) continue;
 
 				const value = getDeterministicBonus(rule.value, rollData) ?? 0;
 				if (value === 0) continue;
 
 				// Check if movementType was explicitly set in source data
 				const hasExplicitMovementType = rule._source?.movementType !== undefined;
+				const movementType = hasExplicitMovementType ? rule.movementType : 'walk';
 
-				if (hasExplicitMovementType) {
-					// Specific movement type bonus (e.g., "gain climb = walk")
-					const movementType = rule.movementType;
-					bonusesByType[movementType] ??= [];
-					bonusesByType[movementType].push({
-						itemName: item.name,
-						label: rule.label,
-						value,
-					});
-				} else {
-					// Generic speed bonus: only applies to walk
-					// (other movement types granted via formula inherit walk's bonuses)
-					bonusesByType['walk'] ??= [];
-					bonusesByType['walk'].push({
-						itemName: item.name,
-						label: rule.label,
-						value,
-					});
+				// Initialize tracking for this movement type
+				itemBonusesByType[movementType] ??= { value: 0, labels: new Set() };
+				itemBonusesByType[movementType].value += value;
+
+				// Track label if it's meaningfully different from the item name
+				// (not just the item name with a suffix like "(2)" or "(9)")
+				const label = rule.label ?? '';
+				const isLabelDifferent = label && !label.startsWith(item.name);
+				if (isLabelDifferent) {
+					itemBonusesByType[movementType].labels.add(label);
 				}
+			}
+
+			// Add accumulated bonuses for this item to the main list
+			for (const [movementType, data] of Object.entries(itemBonusesByType)) {
+				if (data.value === 0) continue;
+				bonusesByType[movementType] ??= [];
+
+				// Build display name: "ItemName" or "ItemName — Label" if label differs
+				const uniqueLabels = [...data.labels];
+				const displayName =
+					uniqueLabels.length > 0 ? `${item.name} — ${uniqueLabels.join(', ')}` : item.name;
+
+				bonusesByType[movementType].push({
+					itemName: displayName,
+					value: data.value,
+				});
 			}
 		}
 
@@ -111,12 +127,7 @@
 						<div class="movement-card__bonus-list">
 							{#each bonuses as bonus}
 								<div class="movement-card__bonus-item">
-									<div class="movement-card__bonus-source">
-										<span class="movement-card__bonus-item-name">{bonus.itemName}</span>
-										{#if bonus.label && bonus.label !== bonus.itemName}
-											<span class="movement-card__bonus-label">{bonus.label}</span>
-										{/if}
-									</div>
+									<span class="movement-card__bonus-item-name">{bonus.itemName}</span>
 									<span
 										class="movement-card__bonus-value"
 										class:movement-card__bonus-value--negative={bonus.value < 0}
@@ -270,20 +281,9 @@
 			font-size: var(--nimble-xs-text);
 		}
 
-		&__bonus-source {
-			display: flex;
-			flex-direction: column;
-			gap: 0.0625rem;
-		}
-
 		&__bonus-item-name {
 			color: var(--nimble-dark-text-color);
 			font-weight: 500;
-		}
-
-		&__bonus-label {
-			color: var(--nimble-medium-text-color);
-			font-size: var(--nimble-2xs-text, 0.625rem);
 		}
 
 		&__bonus-value {


### PR DESCRIPTION
## Summary
- Implements the unarmored predicate system for Zephyr's Swift Feet feature
- Fixes Configure Movement Speeds dialog to only show active bonuses and group by item

## Changes
- **Predicate System**: Add `armor:unarmored` / `armor:equipped` tags to character domain
  - Only items with actual `armorClass` rules count as armor (cloth robes don't count)
  - Tags populated before rules evaluate so predicates can test against them
- **Swift Feet Rules**: Updated to use proper predicate format
  - `{ armor: "unarmored" }` for unarmored check  
  - `{ level: { min: 9 } }` for level 9 bonus
  - Labels updated to "Swift Feet (2)" and "Swift Feet (9)"
- **Rule Predicate Tests**: Added `this.test()` checks to `speedBonus` and `initiativeBonus` rules
- **Migration013**: Updates existing Swift Feet items on characters to new predicate format
- **Configure Movement Speeds Dialog**:
  - Only shows rules that pass their predicate (hides level 9 bonus for low-level characters)
  - Groups bonuses from same item together (combines Swift Feet bonuses into one line)
  - Shows "ItemName — Label" when label differs (e.g., "Elf — Lithe")

## Test plan
- [x] Create a level 2 Elf Zephyr - should have 9 speed (6 base + 1 Lithe + 2 Swift Feet)
- [x] Configure Movement Speeds shows "Elf — Lithe +1" and "Swift Feet +2"
- [x] Add armor with armorClass rule - Swift Feet bonus should disappear
- [x] Level up to 9+ - should get additional +2 from Swift Feet (total +4)
- [x] Existing characters with Swift Feet should be migrated on world load