### PR TITLE
fix: Half-Giant Dwarvish predicate not evaluating INT condition

### DIFF
--- a/src/documents/actor/character.ts
+++ b/src/documents/actor/character.ts
@@ -227,6 +227,12 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 
 		// Prepare Wounds
 		actorData.attributes.wounds.max = 6 + actorData.attributes.wounds.bonus;
+
+		// Add ability score modifier tags for predicate evaluation
+		// This must happen after ability mods are calculated above
+		Object.entries(actorData.abilities).forEach(([key, ability]) => {
+			this.tags.add(`${key}:${ability.mod}`);
+		});
 	}
 
 	override _populateDerivedTags(): void {


### PR DESCRIPTION
## Summary
- Adds ability score modifier tags (e.g., `intelligence:-1`, `strength:2`) to the character domain for predicate evaluation
- Fixes Half-Giant ancestry granting Dwarvish language regardless of the INT condition

## Problem
The `grantProficiency` rule on Half-Giant ancestry uses predicate `{ intelligence: { min: 0 } }` to only grant Dwarvish if INT is not negative. However, the predicate system couldn't find `intelligence:X` values in the domain, causing it to incorrectly pass (NaN comparisons always return false).

## Solution
Add ability score modifier tags to the domain at the end of `prepareDerivedData()` after ability mods are calculated, allowing predicates to correctly evaluate ability-based conditions.

Closes #492

## Test plan
- [x] Create a Half-Giant character with negative INT (-1 or lower)
- [x] Verify Dwarvish is NOT granted
- [x] Create a Half-Giant character with INT >= 0
- [x] Verify Dwarvish IS granted