### PR TITLE
fix(ui): fix conditions menu being incorrectly oversized (#500)

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -236,7 +236,8 @@
 			"stunned": "Stunned",
 			"taunted": "Taunted",
 			"unconscious": "Unconscious",
-			"wounded": "Wounded"
+			"wounded": "Wounded",
+			"lastStand": "Last Stand"
 		},
 		"conditionDescriptions": {
 			"blinded": "<p>Can't see. Attacks against you have advantage, and your attacks have disadvantage.</p>",
@@ -255,6 +256,7 @@
 			"hampered": "<p>Any creature with their actions or movement reduce (e.g. Dazed, Grappled, Prone, Difficult Terrain).</p>",
 			"incapacitated": "<p>Can't do anything. Attacks against you have advantage, and melee attacks that hit, crit.</p>",
 			"invisible": "<p>Cannot be seen. Your attacks have advantage, and attacks against you have disadvantage.</p>",
+			"lastStand": "<p>At or below the Last Stand threshold. Triggers Last Stand abilities.</p>",
 			"paralyzed": "<p>Incapacitated. Can't do anything. Attacks against you have advantage, and melee attacks that hit, crit.</p>",
 			"petrified": "<p>Incapacitated. You have all the benefits and drawbacks of being a rock! Immune to most damage except from large explosions, picks, or similar tools.</p>",
 			"poisoned": "<p>Disadvantage on rolls.</p>",

--- a/src/view/pixi/NimbleTokenHUD.svelte
+++ b/src/view/pixi/NimbleTokenHUD.svelte
@@ -68,7 +68,7 @@
 <style lang="scss">
 	.status-effects-container {
 		display: grid;
-		grid-template-columns: repeat(3, minmax(8em, 1fr));
+		grid-template-columns: repeat(3, 12em);
 		gap: 0.75rem;
 		padding: 0.75rem;
 		padding-block-end: 0.5rem;


### PR DESCRIPTION
## Summary

Fix the conditions menu (right-click token → conditions) being incorrectly oversized by using fixed-width grid columns. Also adds missing `lastStand` localization strings.

## Changes

- Change `grid-template-columns` from `repeat(3, minmax(8em, 1fr))` to `repeat(3, 12em)` in `NimbleTokenHUD.svelte`
- Add missing `lastStand` entry to `conditions` and `conditionDescriptions` in `en.json`

## Test Plan

- [ ] Right-click a token and open the conditions menu
- [ ] Verify the menu is properly sized with three columns, not stretching across the screen
- [ ] Verify "Last Stand" condition shows its name, not a translation key
- [ ] Tested in Foundry with no console errors

## Checklist

- [ ] Added or updated unit tests
- [x] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [x] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** yes
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues

Fixes #500