### PR TITLE
fix(combat-tracker): allow targeting friendly-disposition tokens (#469)

### DIFF
--- a/src/hooks/minionGroupTokenActions.ts
+++ b/src/hooks/minionGroupTokenActions.ts
@@ -635,10 +635,19 @@ function getCombatantRowImage(combatant: Combatant.Implementation): string {
 	);
 }
 
+function getSceneFriendlyAndCharacterTokens(): Token[] {
+	const placeables = (canvas?.tokens?.placeables ?? []) as Token[];
+	return placeables.filter((token) => isEligibleTargetToken(token));
+}
+
 function getCandidateTargetTokens(): Token[] {
 	const controlledTokens = (canvas?.tokens?.controlled ?? []) as Token[];
 	const candidateTokensById = new Map<string, Token>();
-	for (const token of [...controlledTokens, ...getCurrentUserTargetTokens()]) {
+	for (const token of [
+		...controlledTokens,
+		...getCurrentUserTargetTokens(),
+		...getSceneFriendlyAndCharacterTokens(),
+	]) {
 		const tokenId = getTargetTokenId(token);
 		if (!tokenId || candidateTokensById.has(tokenId)) continue;
 		candidateTokensById.set(tokenId, token);
@@ -646,9 +655,16 @@ function getCandidateTargetTokens(): Token[] {
 	return [...candidateTokensById.values()];
 }
 
-function isCharacterTargetToken(token: Token): boolean {
+function isFriendlyDispositionToken(token: Token): boolean {
+	// @ts-expect-error -- Token.disposition is not in the FoundryVTT type stubs but exists at runtime
+	const disposition = Number(token.document?.disposition ?? token.disposition);
+	return disposition === CONST.TOKEN_DISPOSITIONS.FRIENDLY;
+}
+
+function isEligibleTargetToken(token: Token): boolean {
 	const actorType = (token.actor?.type ?? token.document?.actor?.type ?? '').trim().toLowerCase();
-	return actorType === 'character';
+	if (actorType === 'character') return true;
+	return isFriendlyDispositionToken(token);
 }
 
 function resolveTargetTokenImage(token: Token): string {
@@ -670,7 +686,7 @@ function buildTargetTokenView(
 	token: Token,
 	selectedTargetIds: ReadonlySet<string>,
 ): TargetTokenView | null {
-	if (!isCharacterTargetToken(token)) return null;
+	if (!isEligibleTargetToken(token)) return null;
 	const tokenId = getTargetTokenId(token);
 	if (!tokenId) return null;
 


### PR DESCRIPTION
## Summary

Allow friendly-disposition tokens to be targeted for attack rolls in the combat tracker, not just character-type tokens.

## Changes

- Rename `isCharacterTargetToken` to `isEligibleTargetToken`, expanding eligibility to include tokens with `FRIENDLY` disposition
- Add `isFriendlyDispositionToken` helper to check token disposition
- Add `getSceneFriendlyAndCharacterTokens` to include eligible scene tokens in the candidate target pool

## Test Plan

- [ ] Start a combat encounter with a monster and a friendly NPC token (disposition set to "Friendly")
- [ ] Select the monster in the combat tracker
- [ ] Verify the friendly token appears in the target list
- [ ] Roll an attack targeting the friendly token and confirm it works
- [ ] Tested in Foundry with no console errors

## Checklist

- [ ] Added or updated unit tests
- [x] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [x] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** yes
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues

Fixes #469