### PR TITLE
fix(chat): fix minion roll chat propagation and field rest mana feedback (#478, #481)

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -1080,7 +1080,8 @@
 			"healing": "Healing",
 			"rolled": "Rolled",
 			"advantage": "Advantage",
-			"restedWithoutSpending": "Rested without spending hit dice"
+			"restedWithoutSpending": "Rested without spending hit dice",
+			"manaRestored": "Mana Restored"
 		},
 		"npcSheet": {
 			"armor": "Armor",

--- a/src/config.ts
+++ b/src/config.ts
@@ -822,6 +822,7 @@ const fieldRest = {
 	rolled: 'NIMBLE.fieldRest.rolled',
 	advantage: 'NIMBLE.fieldRest.advantage',
 	restedWithoutSpending: 'NIMBLE.fieldRest.restedWithoutSpending',
+	manaRestored: 'NIMBLE.fieldRest.manaRestored',
 };
 
 const itemConfig = {

--- a/src/documents/chatMessage.ts
+++ b/src/documents/chatMessage.ts
@@ -94,18 +94,7 @@ class NimbleChatMessage extends ChatMessage {
 	}
 
 	isMinionGroupAttackCard(): boolean {
-		if (this.type === 'minionGroupAttack') return true;
-		const messageType = this.type as string;
-		if (messageType !== 'base') return false;
-
-		const nimbleChatCardType = (
-			this as unknown as {
-				flags?: {
-					nimble?: { chatCardType?: string };
-				};
-			}
-		).flags?.nimble?.chatCardType;
-		return nimbleChatCardType === 'minionGroupAttack';
+		return this.type === 'minionGroupAttack';
 	}
 
 	/** Check if this chat message is an activation card type (feature, object, or spell) */

--- a/src/documents/combat/combat.svelte.test.ts
+++ b/src/documents/combat/combat.svelte.test.ts
@@ -2141,11 +2141,8 @@ describe('NimbleCombat', () => {
 
 		expect(chatCreate).toHaveBeenCalledTimes(1);
 		const createdChatData = chatCreate.mock.calls[0]?.[0] as Record<string, unknown>;
-		expect(createdChatData.type).toBe('base');
+		expect(createdChatData.type).toBe('minionGroupAttack');
 		expect(createdChatData.content).toBe('');
-		const createdFlags = createdChatData.flags as Record<string, unknown>;
-		expect(createdFlags).toBeDefined();
-		expect((createdFlags.nimble as Record<string, unknown>).chatCardType).toBe('minionGroupAttack');
 		const createdSystem = createdChatData.system as Record<string, unknown>;
 		expect(createdSystem.actorName).toBe('Selected Minions');
 		expect(createdSystem.targetName).toBe('Target');

--- a/src/documents/combat/combatCommon.ts
+++ b/src/documents/combat/combatCommon.ts
@@ -160,11 +160,6 @@ export function buildNcsGroupAttackChatData(params: {
 		style: CONST.CHAT_MESSAGE_STYLES.OTHER,
 		sound: CONFIG.sounds.dice,
 		rollMode: game.settings.get('core', 'rollMode'),
-		flags: {
-			nimble: {
-				chatCardType: 'minionGroupAttack',
-			},
-		},
 		system: {
 			actorName: params.speakerAlias,
 			actorType: params.speakerCombatant?.actor?.type ?? 'minion',
@@ -180,7 +175,7 @@ export function buildNcsGroupAttackChatData(params: {
 			unsupportedWarnings: [...params.unsupportedWarnings],
 		},
 		content: '',
-		type: 'base',
+		type: 'minionGroupAttack',
 	};
 }
 

--- a/src/hooks/renderChatMessage.ts
+++ b/src/hooks/renderChatMessage.ts
@@ -103,60 +103,48 @@ export default function renderChatMessageHTML(message, html) {
 		| typeof NimbleSpellCard
 		| typeof NimbleLevelUpSummaryCard;
 
-	const nimbleChatCardType = (
-		message as {
-			flags?: {
-				nimble?: { chatCardType?: string };
-			};
-		}
-	).flags?.nimble?.chatCardType;
-
-	if (message.type === 'base' && nimbleChatCardType === 'minionGroupAttack') {
-		component = NimbleMinionGroupAttackCard;
-	} else {
-		switch (message.type) {
-			case 'abilityCheck':
-				component = NimbleAbilityCheckCard;
-				break;
-			case 'assessAction':
-				component = NimbleAssessActionCard;
-				break;
-			case 'feature':
-				component = NimbleFeatureCard;
-				break;
-			case 'fieldRest':
-				component = NimbleFieldRestCard;
-				break;
-			case 'object':
-				component = NimbleObjectCard;
-				break;
-			case 'reaction':
-				component = NimbleReactionCard;
-				break;
-			case 'safeRest':
-				component = NimbleSafeRestCard;
-				break;
-			case 'levelUpSummary':
-				component = NimbleLevelUpSummaryCard;
-				break;
-			case 'minionGroupAttack':
-				component = NimbleMinionGroupAttackCard;
-				break;
-			case 'moveAction':
-				component = NimbleMoveActionCard;
-				break;
-			case 'savingThrow':
-				component = NimbleSavingThrowCard;
-				break;
-			case 'skillCheck':
-				component = NimbleSkillCheckCard;
-				break;
-			case 'spell':
-				component = NimbleSpellCard;
-				break;
-			default:
-				return;
-		}
+	switch (message.type) {
+		case 'abilityCheck':
+			component = NimbleAbilityCheckCard;
+			break;
+		case 'assessAction':
+			component = NimbleAssessActionCard;
+			break;
+		case 'feature':
+			component = NimbleFeatureCard;
+			break;
+		case 'fieldRest':
+			component = NimbleFieldRestCard;
+			break;
+		case 'object':
+			component = NimbleObjectCard;
+			break;
+		case 'reaction':
+			component = NimbleReactionCard;
+			break;
+		case 'safeRest':
+			component = NimbleSafeRestCard;
+			break;
+		case 'levelUpSummary':
+			component = NimbleLevelUpSummaryCard;
+			break;
+		case 'minionGroupAttack':
+			component = NimbleMinionGroupAttackCard;
+			break;
+		case 'moveAction':
+			component = NimbleMoveActionCard;
+			break;
+		case 'savingThrow':
+			component = NimbleSavingThrowCard;
+			break;
+		case 'skillCheck':
+			component = NimbleSkillCheckCard;
+			break;
+		case 'spell':
+			component = NimbleSpellCard;
+			break;
+		default:
+			return;
 	}
 
 	target.classList.add('nimble-chat-card');

--- a/src/managers/RestManager.ts
+++ b/src/managers/RestManager.ts
@@ -1,5 +1,5 @@
-import { HitDiceManager } from './HitDiceManager.js';
 import { getManaRecoveryTypesFromClasses, restoresManaOnRest } from '../utils/manaRecovery.js';
+import { HitDiceManager } from './HitDiceManager.js';
 
 // Uses NimbleCharacterInterface ambient type from actor.d.ts
 
@@ -165,6 +165,7 @@ class RestManager {
 					wasMaximized,
 					hadAdvantage,
 					advantageSource,
+					manaRestored: this.#recovery.manaRestored,
 				},
 			} as unknown as ChatMessage.CreateData);
 		}

--- a/src/models/chat/FieldRestCardDataModel.ts
+++ b/src/models/chat/FieldRestCardDataModel.ts
@@ -20,6 +20,8 @@ const fieldRestCardSchema = () => ({
 	hadAdvantage: new fields.BooleanField({ required: true, initial: false, nullable: false }),
 	// Source of advantage (e.g., "Wild One - in the wild")
 	advantageSource: new fields.StringField({ required: false, nullable: true, initial: null }),
+	// Mana restored during the rest
+	manaRestored: new fields.NumberField({ required: true, nullable: false, initial: 0 }),
 });
 
 declare namespace NimbleFieldRestCardData {

--- a/src/scss/base/_theme.scss
+++ b/src/scss/base/_theme.scss
@@ -91,6 +91,16 @@
 	--nimble-action-info-icon-color: hsl(45, 70%, 55%);
 	--nimble-action-button-icon-color: hsl(210, 70%, 65%);
 
+	/** CHAT CARD COLORS **/
+	--nimble-chat-hit-dice-value-color: hsl(45, 80%, 60%);
+	--nimble-chat-mana-value-color: hsl(220, 75%, 70%);
+	--nimble-chat-maximize-background: hsla(120, 45%, 45%, 0.2);
+	--nimble-chat-maximize-color: hsl(120, 50%, 60%);
+	--nimble-chat-maximize-border-color: hsla(120, 45%, 45%, 0.4);
+	--nimble-chat-advantage-background: hsla(210, 70%, 50%, 0.2);
+	--nimble-chat-advantage-color: hsl(210, 70%, 65%);
+	--nimble-chat-advantage-border-color: hsla(210, 70%, 50%, 0.4);
+
 	/** REACTION COLORS **/
 	// Defend (blue)
 	--nimble-reaction-defend-primary: hsl(210, 60%, 55%);

--- a/src/scss/base/_variables.scss
+++ b/src/scss/base/_variables.scss
@@ -178,6 +178,16 @@
 	--nimble-reaction-move-text: hsl(185, 60%, 25%);
 	--nimble-reaction-move-accent: hsl(185, 60%, 40%);
 
+	/** CHAT CARD COLORS **/
+	--nimble-chat-hit-dice-value-color: hsl(45, 70%, 40%);
+	--nimble-chat-mana-value-color: hsl(220, 70%, 50%);
+	--nimble-chat-maximize-background: hsla(120, 45%, 45%, 0.15);
+	--nimble-chat-maximize-color: hsl(120, 45%, 35%);
+	--nimble-chat-maximize-border-color: hsla(120, 45%, 45%, 0.3);
+	--nimble-chat-advantage-background: hsla(210, 70%, 50%, 0.15);
+	--nimble-chat-advantage-color: hsl(210, 70%, 40%);
+	--nimble-chat-advantage-border-color: hsla(210, 70%, 50%, 0.3);
+
 	/** ANIMATION **/
 	--nimble-standard-transition: all 0.15s ease-in-out;
 	--nimble-slow-transition: all 0.25s ease-in-out;

--- a/src/view/chat/FieldRestCard.svelte
+++ b/src/view/chat/FieldRestCard.svelte
@@ -138,7 +138,7 @@
 		&__value {
 			font-size: var(--nimble-sm-text);
 			font-weight: 700;
-			color: hsl(45, 70%, 40%);
+			color: var(--nimble-chat-hit-dice-value-color);
 		}
 	}
 
@@ -167,7 +167,7 @@
 		&__value {
 			font-size: var(--nimble-sm-text);
 			font-weight: 700;
-			color: hsl(220, 70%, 50%);
+			color: var(--nimble-chat-mana-value-color);
 		}
 	}
 
@@ -196,15 +196,15 @@
 		border-radius: 3px;
 
 		&--maximize {
-			background: hsla(120, 45%, 45%, 0.15);
-			color: hsl(120, 45%, 35%);
-			border: 1px solid hsla(120, 45%, 45%, 0.3);
+			background: var(--nimble-chat-maximize-background);
+			color: var(--nimble-chat-maximize-color);
+			border: 1px solid var(--nimble-chat-maximize-border-color);
 		}
 
 		&--advantage {
-			background: hsla(210, 70%, 50%, 0.15);
-			color: hsl(210, 70%, 40%);
-			border: 1px solid hsla(210, 70%, 50%, 0.3);
+			background: var(--nimble-chat-advantage-background);
+			color: var(--nimble-chat-advantage-color);
+			border: 1px solid var(--nimble-chat-advantage-border-color);
 		}
 
 		&__source {
@@ -212,43 +212,5 @@
 			font-style: italic;
 			opacity: 0.8;
 		}
-	}
-
-	:global(.theme-dark) .modifier-badge {
-		&--maximize {
-			background: hsla(120, 45%, 45%, 0.2);
-			color: hsl(120, 50%, 60%);
-			border-color: hsla(120, 45%, 45%, 0.4);
-		}
-
-		&--advantage {
-			background: hsla(210, 70%, 50%, 0.2);
-			color: hsl(210, 70%, 65%);
-			border-color: hsla(210, 70%, 50%, 0.4);
-		}
-	}
-
-	:global(.theme-dark) .hit-dice-spent {
-		&__label {
-			color: hsl(0, 0%, 70%);
-		}
-
-		&__value {
-			color: hsl(45, 80%, 60%);
-		}
-	}
-
-	:global(.theme-dark) .mana-restored {
-		&__label {
-			color: hsl(0, 0%, 90%);
-		}
-
-		&__value {
-			color: hsl(220, 75%, 70%);
-		}
-	}
-
-	:global(.theme-dark) .no-dice-message {
-		color: hsl(0, 0%, 70%);
 	}
 </style>

--- a/src/view/chat/FieldRestCard.svelte
+++ b/src/view/chat/FieldRestCard.svelte
@@ -18,6 +18,7 @@
 	const wasMaximized = $derived(system.wasMaximized);
 	const hadAdvantage = $derived(system.hadAdvantage);
 	const advantageSource = $derived(system.advantageSource);
+	const manaRestored = $derived(system.manaRestored);
 
 	const headerBackgroundColor = $derived(messageDocument.reactive.author.color);
 	const headerTextColor = $derived(calculateHeaderTextColor(headerBackgroundColor));
@@ -75,8 +76,16 @@
 				tooltip={rollTooltip}
 				total={totalHealing}
 			/>
-		{:else if !hitDiceDisplay}
+		{:else if !hitDiceDisplay && !manaRestored}
 			<div class="no-dice-message">{CONFIG.NIMBLE.fieldRest.restedWithoutSpending}</div>
+		{/if}
+
+		{#if manaRestored > 0}
+			<div class="mana-restored">
+				<i class="mana-restored__icon fa-solid fa-sparkles"></i>
+				<span class="mana-restored__label">{CONFIG.NIMBLE.fieldRest.manaRestored}</span>
+				<span class="mana-restored__value">+{manaRestored}</span>
+			</div>
 		{/if}
 
 		{#if wasMaximized || hadAdvantage}
@@ -130,6 +139,35 @@
 			font-size: var(--nimble-sm-text);
 			font-weight: 700;
 			color: hsl(45, 70%, 40%);
+		}
+	}
+
+	.mana-restored {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.375rem 0.5rem;
+		background: var(--nimble-box-background-color);
+		border: 1px solid var(--nimble-card-border-color);
+		border-radius: 4px;
+
+		&__icon {
+			width: 1rem;
+			text-align: center;
+			font-size: var(--nimble-sm-text);
+			color: var(--nimble-medium-text-color);
+		}
+
+		&__label {
+			flex: 1;
+			font-size: var(--nimble-sm-text);
+			color: var(--nimble-dark-text-color);
+		}
+
+		&__value {
+			font-size: var(--nimble-sm-text);
+			font-weight: 700;
+			color: hsl(220, 70%, 50%);
 		}
 	}
 
@@ -197,6 +235,16 @@
 
 		&__value {
 			color: hsl(45, 80%, 60%);
+		}
+	}
+
+	:global(.theme-dark) .mana-restored {
+		&__label {
+			color: hsl(0, 0%, 90%);
+		}
+
+		&__value {
+			color: hsl(220, 75%, 70%);
 		}
 	}
 


### PR DESCRIPTION
## Summary

Fix two related chat propagation bugs: minion roll results not visible to other users, and field rest chat card missing mana recovery feedback.

## Changes

**#478 — Minion rolls:**
- Change minion group attack chat message type from `'base'` to `'minionGroupAttack'` (the registered TypeDataModel)
- Remove legacy `flags.nimble.chatCardType` detection from `renderChatMessage.ts` and `chatMessage.ts`
- Simplify chat card component lookup to a clean switch statement
- Update test assertions

**#481 — Field rest mana:**
- Add `manaRestored` field to `FieldRestCardDataModel`
- Pass `manaRestored` from `RestManager` into field rest chat message data
- Add mana restored display row with sparkles icon in `FieldRestCard.svelte`
- Add `manaRestored` localization key to config and `en.json`

## Test Plan

**#478:**
- [ ] Start combat with a minion group and connect a second client
- [ ] Roll a minion group attack from the combat tracker
- [ ] Verify the roll results appear in chat on both clients

**#481:**
- [ ] Have a character with a class that recovers mana on field rest
- [ ] Trigger a field rest
- [ ] Verify the chat card shows a "Mana Restored" row with the correct amount
- [ ] Tested in Foundry with no console errors

## Checklist

- [ ] Added or updated unit tests
- [x] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [x] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** yes
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues

Fixes #478, Fixes #481