### PR TITLE
chore(compendium): Fix granted levels

### DIFF
--- a/packs/classFeatures/core/hunter/hunter-subclasses/keeper-of-the-wildheart/resourceful-herbalist.json
+++ b/packs/classFeatures/core/hunter/hunter-subclasses/keeper-of-the-wildheart/resourceful-herbalist.json
@@ -37,10 +37,10 @@
 		"featureType": "class",
 		"class": "hunter",
 		"group": "keeper-of-the-wildheart",
-		"gainedAtLevel": 3,
+		"gainedAtLevel": 7,
 		"subclass": true,
 		"gainedAtLevels": [
-			3
+			7
 		]
 	},
 	"effects": [],

--- a/packs/classFeatures/core/mage/mage-progression/elemental-mastery.json
+++ b/packs/classFeatures/core/mage/mage-progression/elemental-mastery.json
@@ -37,10 +37,12 @@
 		"featureType": "class",
 		"class": "mage",
 		"group": "mage-progression",
-		"gainedAtLevel": 2,
+		"gainedAtLevel": 3,
 		"subclass": false,
 		"gainedAtLevels": [
-			2
+			3,
+			6,
+			14
 		]
 	},
 	"effects": [],

--- a/packs/classFeatures/core/stormshifter/stormshifter-progression/stormborn-1.json
+++ b/packs/classFeatures/core/stormshifter/stormshifter-progression/stormborn-1.json
@@ -40,8 +40,7 @@
 		"gainedAtLevel": 8,
 		"subclass": false,
 		"gainedAtLevels": [
-			8,
-			13
+			8
 		]
 	},
 	"effects": [],

--- a/packs/classFeatures/core/stormshifter/stormshifter-progression/stormborn-2.json
+++ b/packs/classFeatures/core/stormshifter/stormshifter-progression/stormborn-2.json
@@ -37,10 +37,9 @@
 		"featureType": "class",
 		"class": "stormshifter",
 		"group": "stormshifter-progression",
-		"gainedAtLevel": 8,
+		"gainedAtLevel": 13,
 		"subclass": false,
 		"gainedAtLevels": [
-			8,
 			13
 		]
 	},

--- a/packs/classFeatures/core/stormshifter/stormshifter-subclasses/circle-of-fang-and-claw/master-of-forms-2.json
+++ b/packs/classFeatures/core/stormshifter/stormshifter-subclasses/circle-of-fang-and-claw/master-of-forms-2.json
@@ -37,10 +37,9 @@
 		"featureType": "class",
 		"class": "stormshifter",
 		"group": "circle-of-fang-and-claw",
-		"gainedAtLevel": 11,
+		"gainedAtLevel": 15,
 		"subclass": true,
 		"gainedAtLevels": [
-			11,
 			15
 		]
 	},

--- a/packs/classFeatures/core/stormshifter/stormshifter-subclasses/circle-of-fang-and-claw/master-of-forms.json
+++ b/packs/classFeatures/core/stormshifter/stormshifter-subclasses/circle-of-fang-and-claw/master-of-forms.json
@@ -40,8 +40,7 @@
 		"gainedAtLevel": 11,
 		"subclass": true,
 		"gainedAtLevels": [
-			11,
-			15
+			11
 		]
 	},
 	"effects": [],


### PR DESCRIPTION
## Summary

Fixes incorrect `gainedAtLevel` and `gainedAtLevels` values in class features and monster compendium data.

## Changes

- Corrected `gainedAtLevel` values to match the appropriate level for each feature
- Fixed `gainedAtLevels` arrays to only include levels where the feature is actually granted
- Updated 110 compendium JSON files (class features, legendary monsters, and monsters)

## Test Plan

1. Import a character that has affected class features (Hunter/Keeper of the Wildheart, Mage, Stormshifter)
2. Level up the character and verify features are granted at the correct levels
3. Check monster actors to ensure their granted abilities display correctly

## Checklist

- [ ] Added or updated unit tests
- [x] PR targets the `dev` branch
- [ ] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [ ] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** yes
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->