### PR TITLE
style: improve pc creator UI consistency

### DIFF
--- a/src/scss/components/_card.scss
+++ b/src/scss/components/_card.scss
@@ -74,6 +74,7 @@
     border-bottom-left-radius: var(--nimble-card-image-bl-border-radius,
     2px);
     filter: var(--nimble-card-image-filter);
+		transition: filter 0.3s ease;
 
     &[src$=".svg" i] {
       padding: 0.1rem;

--- a/src/view/dialogs/components/characterCreator/FeatureCard.svelte
+++ b/src/view/dialogs/components/characterCreator/FeatureCard.svelte
@@ -13,14 +13,13 @@
 	}
 </script>
 
-<li class="feature-item">
+<li class="feature-item" class:expanded={state.isExpanded}>
 	<div
 		class="feature-row"
 		class:selected={isSelected}
-		class:expanded={state.isExpanded}
-		onclick={state.toggleExpanded}
 		role="button"
 		tabindex="0"
+		onclick={state.toggleExpanded}
 		onkeydown={(e) => e.key === 'Enter' && state.toggleExpanded()}
 	>
 		{#if !isSelected}
@@ -47,45 +46,67 @@
 		</button>
 	</div>
 
-	{#if state.isExpanded}
-		<div class="accordion-content">
-			<div class="description">
-				{#if state.descriptionParts.length > 0}
-					{#each state.descriptionParts as part}
-						{#if part.type === 'spell' && part.spell}
-							<SpellReferenceCard spell={part.spell} />
-						{:else if part.type === 'text'}
-							{@html part.content}
-						{/if}
-					{/each}
-				{:else}
-					<p>{localize('NIMBLE.classFeatureSelection.noDescriptionAvailable')}</p>
-				{/if}
-			</div>
-
-			{#if onSelect}
-				<button
-					class="nimble-button"
-					data-button-variant="full-width"
-					type="button"
-					onclick={handleSelect}
-				>
-					{#if isSelected}
-						<i class="fa-solid fa-check"></i>
-						{localize('NIMBLE.classFeatureSelection.selected')}
-					{:else}
-						{localize('NIMBLE.classFeatureSelection.confirmSelection')}
+	<div class="accordion-content">
+		<div class="description">
+			{#if state.descriptionParts.length > 0}
+				{#each state.descriptionParts as part}
+					{#if part.type === 'spell' && part.spell}
+						<SpellReferenceCard spell={part.spell} />
+					{:else if part.type === 'text'}
+						{@html part.content}
 					{/if}
-				</button>
+				{/each}
+			{:else}
+				<p>{localize('NIMBLE.classFeatureSelection.noDescriptionAvailable')}</p>
 			{/if}
 		</div>
-	{/if}
+
+		{#if onSelect}
+			<button
+				class="nimble-button"
+				data-button-variant="full-width"
+				type="button"
+				onclick={handleSelect}
+			>
+				{#if isSelected}
+					<i class="fa-solid fa-check"></i>
+					{localize('NIMBLE.classFeatureSelection.selected')}
+				{:else}
+					{localize('NIMBLE.classFeatureSelection.confirmSelection')}
+				{/if}
+			</button>
+		{/if}
+	</div>
 </li>
 
 <style lang="scss">
 	.feature-item {
 		margin-bottom: 0.5rem;
+		&:last-child {
+			margin-bottom: 0;
+		}
 		list-style: none;
+		overflow: hidden;
+		display: grid;
+		grid-template-rows: 50px 0fr;
+		transition: grid-template-rows 0.3s ease;
+
+		&.expanded {
+			grid-template-rows: 50px 1fr;
+
+			.feature-row {
+				border-bottom-left-radius: 0;
+				border-bottom-right-radius: 0;
+			}
+
+			.expand-arrow {
+				transform: rotate(180deg);
+			}
+
+			.accordion-content {
+				opacity: 1;
+			}
+		}
 	}
 
 	.feature-row {
@@ -112,15 +133,6 @@
 				var(--nimble-accent-color) 10%,
 				var(--nimble-box-background-color)
 			);
-		}
-
-		&.expanded {
-			border-bottom-left-radius: 0;
-			border-bottom-right-radius: 0;
-
-			.expand-arrow {
-				transform: rotate(180deg);
-			}
 		}
 
 		.expand-arrow {
@@ -179,8 +191,10 @@
 		border: 1px solid var(--nimble-card-border-color);
 		border-top: none;
 		border-radius: 0 0 4px 4px;
-		padding: 0.75rem;
-		animation: slideDown 0.3s ease;
+		padding: 0rem 0.75rem;
+		overflow: hidden;
+		opacity: 0;
+		transition: opacity 0.3s ease;
 
 		.description {
 			margin-bottom: 0.5rem;
@@ -202,21 +216,6 @@
 					margin-bottom: 0;
 				}
 			}
-		}
-	}
-
-	@keyframes slideDown {
-		from {
-			opacity: 0;
-			max-height: 0;
-			padding-top: 0;
-			padding-bottom: 0;
-		}
-		to {
-			opacity: 1;
-			max-height: 400px;
-			padding-top: 0.75rem;
-			padding-bottom: 0.75rem;
 		}
 	}
 </style>

--- a/src/view/dialogs/components/characterCreator/StartingEquipmentSelection.svelte
+++ b/src/view/dialogs/components/characterCreator/StartingEquipmentSelection.svelte
@@ -124,8 +124,7 @@
 		display: grid;
 		grid-template-columns: repeat(2, 1fr);
 		align-items: stretch;
-		gap: 1rem;
-		padding: 0.5rem;
+		gap: 0.5rem;
 	}
 
 	.starting-equipment-option {

--- a/src/view/dialogs/components/characterCreator/StatAssignment.svelte
+++ b/src/view/dialogs/components/characterCreator/StatAssignment.svelte
@@ -293,7 +293,6 @@
 		display: flex;
 		justify-content: center;
 		gap: 1rem;
-		margin-bottom: 0.5rem;
 		padding: 0.375rem 0.5rem;
 		font-size: var(--nimble-xs-text);
 		color: var(--nimble-medium-text-color);
@@ -384,7 +383,6 @@
 
 	.nimble-cc-ability-score {
 		padding: 0.5rem;
-		margin: 0.5rem 0;
 		gap: 0.25rem;
 		display: flex;
 		flex-direction: column;


### PR DESCRIPTION
**Summary**
Tightens up spacing and animation in the character creator UI for a more consistent look and feel.

**Changes**
- Replaced `{#if}` toggle with CSS grid row animation (`0fr → 1fr`) for smoother accordion expand/collapse in `FeatureCard`
- Moved `expanded` class from `.feature-row` to `.feature-item` parent for cleaner state control
- Removed `@keyframes slideDown` in favour of CSS transitions
- Added `filter` transition to `.nimble-card__img` for smooth grayscale hover effect
- Removed excess margins in `StatAssignment` and padding in `StartingEquipmentSelection`
- Reduced gap in starting equipment grid from `1rem` to `0.5rem`

**Test Plan**
1. Open character creator and proceed to the class feature selection step
2. Click a feature card — accordion should expand/collapse smoothly with arrow rotating
3. Hover over a card image — grayscale should fade out smoothly
4. Check starting equipment selection layout looks evenly spaced
5. Check stat assignment panel has no excess vertical spacing
6. Verify no console errors throughout

## Checklist

- [ ] Added or updated unit tests
- [x] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [x] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** yes / no
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)