### PR TITLE
feature(inventory): allow equipping any object item with rules.

### DIFF
--- a/src/view/sheets/pages/PlayerCharacterInventoryTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterInventoryTab.svelte
@@ -249,7 +249,7 @@
 								{item.reactive.name}
 							</h4>
 
-							{#if rules && rules.hasRuleOfType('armorClass')}
+							{#if rules && (item.reactive.system.rules?.length ?? 0) > 0}
 								<button
 									class="nimble-button"
 									data-button-variant="icon"


### PR DESCRIPTION
## Summary
Show the equip toggle for object items when they have at least one rule source, instead of limiting it to `armorClass` rules. This enables generic rule-driven equipment behavior while keeping existing equip/unequip rule enable/disable flow unchanged.

## Changes
- Change the `{#if rules && rules.hasRuleOfType('armorClass')}` to check for any rule.

## Test Plan
1. Create an Item that has no Armor Class Rule (e.g. Stat Bonus)
2. Drag it on a Character
3. Verify the button to toggle equipment appears
4. Toggle Equipment to Equipped
5. Verify the Bonus/Malus of the Rule now is active


## Checklist

- [ ] Added or updated unit tests
- [X] PR targets the `dev` branch
- [X] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [X] No hardcoded user-facing strings (used `localize()`)
- [X] Tested in Foundry with no console errors
- [ ] **Have you used AI to assist with this PR?** yes / no
- [ ] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues

Fixes #538 
