### PR TITLE
fix: apply biome formatting to docs config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 CLAUDE.local.md
 .claude/settings.local.json
 
+# Release notes drafts
+release-notes-*.md
+
 # Node Modules
 node_modules/
 .npm/

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,107 +1,99 @@
-import { defineConfig } from 'vitepress'
+import { defineConfig } from 'vitepress';
 
 export default defineConfig({
-  title: 'Nimble FoundryVTT',
-  description: 'Documentation hub for the Nimble FoundryVTT system',
+	title: 'Nimble FoundryVTT',
+	description: 'Documentation hub for the Nimble FoundryVTT system',
 
-  // Exclude agent-only docs from the site build
-  srcExclude: ['PROJECT_CONTEXT.md'],
+	// Exclude agent-only docs from the site build
+	srcExclude: ['PROJECT_CONTEXT.md'],
 
-  // Ignore dead links from included CONTRIBUTING.md (repo-relative links to source files)
-  ignoreDeadLinks: true,
+	// Ignore dead links from included CONTRIBUTING.md (repo-relative links to source files)
+	ignoreDeadLinks: true,
 
-  // Set base path for GitHub Pages, update if using a custom domain
-  base: '/FoundryVTT-Nimble/',
+	// Set base path for GitHub Pages, update if using a custom domain
+	base: '/FoundryVTT-Nimble/',
 
-  head: [
-    ['link', { rel: 'icon', type: 'image/x-icon', href: '/FoundryVTT-Nimble/favicon.ico' }],
-  ],
+	head: [['link', { rel: 'icon', type: 'image/x-icon', href: '/FoundryVTT-Nimble/favicon.ico' }]],
 
-  themeConfig: {
-    nav: [
-      { text: 'Home', link: '/' },
-      { text: 'Contributing', link: '/contributing' },
-      {
-        text: 'Guides',
-        items: [
-          { text: 'Code Style Guide', link: '/STYLE_GUIDE' },
-          { text: 'Release Guide', link: '/RELEASE_GUIDE' },
-        ],
-      },
-      { text: 'System', link: '/system/' },
-      {
-        text: 'Planning',
-        items: [
-          { text: 'Project Vision', link: '/planning/product-vision' },
-          { text: 'Architecture', link: '/planning/architecture' },
-          {
-            text: 'UX Design',
-            link: '/planning/ux-design-specification',
-            items: [
-              { text: 'Design Directions', link: '/planning/ux-design-directions' },
-            ],
-          },
-          { text: 'Epics & Stories', link: '/planning/epics' },
-        ],
-      },
-    ],
+	themeConfig: {
+		nav: [
+			{ text: 'Home', link: '/' },
+			{ text: 'Contributing', link: '/contributing' },
+			{
+				text: 'Guides',
+				items: [
+					{ text: 'Code Style Guide', link: '/STYLE_GUIDE' },
+					{ text: 'Release Guide', link: '/RELEASE_GUIDE' },
+				],
+			},
+			{ text: 'System', link: '/system/' },
+			{
+				text: 'Planning',
+				items: [
+					{ text: 'Project Vision', link: '/planning/product-vision' },
+					{ text: 'Architecture', link: '/planning/architecture' },
+					{
+						text: 'UX Design',
+						link: '/planning/ux-design-specification',
+						items: [{ text: 'Design Directions', link: '/planning/ux-design-directions' }],
+					},
+					{ text: 'Epics & Stories', link: '/planning/epics' },
+				],
+			},
+		],
 
-    sidebar: [
-      {
-        text: 'Getting Started',
-        items: [
-          { text: 'Introduction', link: '/' },
-          { text: 'Contributing', link: '/contributing' },
-        ],
-      },
-      {
-        text: 'Guides',
-        items: [
-          { text: 'Code Style Guide', link: '/STYLE_GUIDE' },
-          { text: 'Release Guide', link: '/RELEASE_GUIDE' },
-        ],
-      },
-      {
-        text: 'System',
-        items: [
-          { text: 'Overview', link: '/system/' },
-        ],
-      },
-      {
-        text: 'Planning',
-        collapsed: true,
-        items: [
-          { text: 'Project Vision', link: '/planning/product-vision' },
-          { text: 'Architecture', link: '/planning/architecture' },
-          {
-            text: 'UX Design',
-            link: '/planning/ux-design-specification',
-            items: [
-              { text: 'Design Directions', link: '/planning/ux-design-directions' },
-            ],
-          },
-          { text: 'Epics & Stories', link: '/planning/epics' },
-        ],
-      },
-    ],
+		sidebar: [
+			{
+				text: 'Getting Started',
+				items: [
+					{ text: 'Introduction', link: '/' },
+					{ text: 'Contributing', link: '/contributing' },
+				],
+			},
+			{
+				text: 'Guides',
+				items: [
+					{ text: 'Code Style Guide', link: '/STYLE_GUIDE' },
+					{ text: 'Release Guide', link: '/RELEASE_GUIDE' },
+				],
+			},
+			{
+				text: 'System',
+				items: [{ text: 'Overview', link: '/system/' }],
+			},
+			{
+				text: 'Planning',
+				collapsed: true,
+				items: [
+					{ text: 'Project Vision', link: '/planning/product-vision' },
+					{ text: 'Architecture', link: '/planning/architecture' },
+					{
+						text: 'UX Design',
+						link: '/planning/ux-design-specification',
+						items: [{ text: 'Design Directions', link: '/planning/ux-design-directions' }],
+					},
+					{ text: 'Epics & Stories', link: '/planning/epics' },
+				],
+			},
+		],
 
-    socialLinks: [
-      { icon: 'github', link: 'https://github.com/Nimble-Co/FoundryVTT-Nimble' },
-      { icon: 'discord', link: 'https://discord.gg/WRf5hBqM' },
-    ],
+		socialLinks: [
+			{ icon: 'github', link: 'https://github.com/Nimble-Co/FoundryVTT-Nimble' },
+			{ icon: 'discord', link: 'https://discord.gg/WRf5hBqM' },
+		],
 
-    search: {
-      provider: 'local',
-    },
+		search: {
+			provider: 'local',
+		},
 
-    editLink: {
-      pattern: 'https://github.com/Nimble-Co/FoundryVTT-Nimble/edit/main/docs/:path',
-      text: 'Edit this page on GitHub',
-    },
+		editLink: {
+			pattern: 'https://github.com/Nimble-Co/FoundryVTT-Nimble/edit/main/docs/:path',
+			text: 'Edit this page on GitHub',
+		},
 
-    footer: {
-      message: 'Released under the MIT License.',
-      copyright: 'Copyright © 2026 Nimble Co.',
-    },
-  },
-})
+		footer: {
+			message: 'Released under the MIT License.',
+			copyright: 'Copyright © 2026 Nimble Co.',
+		},
+	},
+});

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,10 +1,10 @@
-import DefaultTheme from 'vitepress/theme'
-import FullscreenIframe from './components/FullscreenIframe.vue'
-import './style.css'
+import DefaultTheme from 'vitepress/theme';
+import FullscreenIframe from './components/FullscreenIframe.vue';
+import './style.css';
 
 export default {
-  extends: DefaultTheme,
-  enhanceApp({ app }) {
-    app.component('FullscreenIframe', FullscreenIframe)
-  },
-}
+	extends: DefaultTheme,
+	enhanceApp({ app }) {
+		app.component('FullscreenIframe', FullscreenIframe);
+	},
+};

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "nimble-docs",
-  "version": "1.0.0",
-  "private": true,
-  "type": "module",
-  "scripts": {
-    "dev": "vitepress dev",
-    "build": "vitepress build",
-    "preview": "vitepress preview"
-  },
-  "devDependencies": {
-    "vitepress": "^1.6.3"
-  }
+	"name": "nimble-docs",
+	"version": "1.0.0",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "vitepress dev",
+		"build": "vitepress build",
+		"preview": "vitepress preview"
+	},
+	"devDependencies": {
+		"vitepress": "^1.6.3"
+	}
 }


### PR DESCRIPTION
## Summary
- Add semicolons to statement endings in docs config files
- Convert indentation from spaces to tabs to match biome formatting rules
- Fixes formatting errors in `docs/.vitepress/config.mts`, `docs/.vitepress/theme/index.ts`, and `docs/package.json`

## Test plan
- [x] `npx biome check` passes on all three files
- [x] Pre-commit hooks pass
- [x] All tests pass