### PR TITLE
fix: CT, Choose turn order before starting combat

### DIFF
--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -1383,6 +1383,7 @@ export const myStore = writable<MyStoreState>(initialState);
 | Utility | Location | Purpose |
 |---------|----------|---------|
 | `localize()` | `src/utils/localize.ts` | Format i18n strings with optional interpolation |
+| `isCombatStarted()` | `src/utils/isCombatStarted.ts` | Determine whether a combat encounter has started |
 | `isCombatantDead()` | `src/utils/isCombatantDead.ts` | Check if a combatant is dead based on HP/wounds |
 | `combatantActionMutationQueue` | `src/utils/combatantActionMutationQueue.ts` | Serialize combatant action/reaction updates and clear combat-scoped pending entries |
 | `queueCombatantMutationWithFreshDocument()` | `src/utils/queueCombatantMutationWithFreshDocument.ts` | Queue a mutation and re-resolve the combatant document to avoid stale references |

--- a/src/documents/combat/combat.svelte.test.ts
+++ b/src/documents/combat/combat.svelte.test.ts
@@ -326,6 +326,73 @@ describe('NimbleCombat', () => {
 		]);
 	});
 
+	it('does not use initiative as a turn-order tiebreaker', () => {
+		const combatId = 'combat-order-ignores-initiative';
+		const alpha = createMockCombatant({
+			id: 'alpha',
+			type: 'character',
+			sort: 0,
+			isOwner: true,
+			initiative: 5,
+			actor: createCombatActorFixture({ hp: 8, woundsValue: 0, woundsMax: 6 }),
+			combatId,
+		});
+		(alpha as unknown as { name: string }).name = 'Alpha';
+		const beta = createMockCombatant({
+			id: 'beta',
+			type: 'character',
+			sort: 0,
+			isOwner: true,
+			initiative: 20,
+			actor: createCombatActorFixture({ hp: 8, woundsValue: 0, woundsMax: 6 }),
+			combatId,
+		});
+		(beta as unknown as { name: string }).name = 'Beta';
+
+		const combat = new NimbleCombat({
+			id: combatId,
+			combatants: createCombatantsCollectionFixture([alpha, beta]),
+		} as unknown as Combat.CreateData);
+
+		const turns = combat.setupTurns();
+		expect(turns.map((combatant) => combatant.id)).toEqual(['alpha', 'beta']);
+	});
+
+	it('defaults non-player combatants after players when manual sort ties', () => {
+		const combatId = 'combat-order-players-before-monsters';
+		const monster = createMockCombatant({
+			id: 'monster',
+			type: 'npc',
+			sort: 0,
+			isOwner: false,
+			initiative: null,
+			actor: createCombatActorFixture({ hp: 10 }),
+			combatId,
+		});
+		(monster as unknown as { name: string }).name = 'A Monster';
+		const player = createMockCombatant({
+			id: 'player',
+			type: 'character',
+			sort: 0,
+			isOwner: true,
+			initiative: null,
+			actor: createCombatActorFixture({ hp: 8, woundsValue: 0, woundsMax: 6 }),
+			combatId,
+		});
+		(player as unknown as { name: string }).name = 'Z Player';
+
+		const combat = new NimbleCombat({
+			id: combatId,
+			combatants: createCombatantsCollectionFixture([monster, player]),
+		} as unknown as Combat.CreateData);
+		combat.setupTurns = vi.fn(() =>
+			[...combat.combatants.contents].sort((a, b) => combat._sortCombatants(a, b)),
+		);
+
+		const turns = combat.setupTurns();
+		expect(turns.map((combatant) => combatant.id)).toEqual(['player', 'monster']);
+	});
+
 	it('preserves the second solo turn occurrence when advancing from the second player turn', async () => {
 		const combatId = 'combat-legendary-next-turn-occurrence';
 		const playerOne = createMockCombatant({
@@ -652,7 +719,7 @@ describe('NimbleCombat', () => {
 		expect(foundry.utils.getProperty(member, 'system.actions.base.current')).toBe(1);
 	});
 
-	it('starts combat on the top-most character card after start initialization', async () => {
+	it('starts combat on the left-most card after start initialization', async () => {
 		const combatId = 'combat-start-order';
 		const monster = createMockCombatant({
 			id: 'monster-top',
@@ -707,16 +774,16 @@ describe('NimbleCombat', () => {
 		await combat.startCombat();
 
 		expect(combat.update).toHaveBeenCalledWith({
-			turn: 1,
+			turn: 0,
 			'flags.nimble.expandedTurnIdentity': {
-				combatantId: 'player-top',
+				combatantId: 'monster-top',
 				occurrence: 0,
 			},
 		});
-		expect(combat.turn).toBe(1);
+		expect(combat.turn).toBe(0);
 	});
 
-	it('seeds the expanded turn identity hint for the chosen starting player turn at combat start', async () => {
+	it('seeds the expanded turn identity hint for the chosen starting turn at combat start', async () => {
 		const combatId = 'combat-start-local-combatant-sync';
 		const monster = createMockCombatant({
 			id: 'monster-top',
@@ -741,8 +808,8 @@ describe('NimbleCombat', () => {
 			id: combatId,
 			scene: { id: 'scene-1' },
 			combatants,
-			turn: 0,
-			combatant: monster,
+			turn: 1,
+			combatant: playerTop,
 		} as unknown as Combat.CreateData) as NimbleCombat & {
 			updateEmbeddedDocuments: ReturnType<typeof vi.fn>;
 			update: ReturnType<typeof vi.fn>;
@@ -763,9 +830,9 @@ describe('NimbleCombat', () => {
 
 		await combat.startCombat();
 
-		expect(combat.turn).toBe(1);
+		expect(combat.turn).toBe(0);
 		expect(combat._nimbleExpandedTurnIdentity).toEqual({
-			combatantId: 'player-top',
+			combatantId: 'monster-top',
 			occurrence: 0,
 		});
 	});

--- a/src/documents/combat/combat.svelte.ts
+++ b/src/documents/combat/combat.svelte.ts
@@ -443,11 +443,7 @@ class NimbleCombat extends Combat {
 	}
 
 	#resolveStartCombatTurnIndex(): number {
-		if (this.turns.length < 1) return 0;
-		const firstCharacterTurnIndex = this.turns.findIndex(
-			(combatant) => combatant.type === 'character',
-		);
-		return firstCharacterTurnIndex >= 0 ? firstCharacterTurnIndex : 0;
+		return 0;
 	}
 
 	override async startCombat(): Promise<this> {

--- a/src/documents/combat/combatMinionGroups.ts
+++ b/src/documents/combat/combatMinionGroups.ts
@@ -152,11 +152,6 @@ function sortCombatantsByCurrentTurnOrder(
 		const manualSortDiff = getCombatantManualSortValue(a) - getCombatantManualSortValue(b);
 		if (manualSortDiff !== 0) return manualSortDiff;
 
-		const initiativeDiff =
-			Number(b.initiative ?? Number.NEGATIVE_INFINITY) -
-			Number(a.initiative ?? Number.NEGATIVE_INFINITY);
-		if (initiativeDiff !== 0) return initiativeDiff;
-
 		return (a.name ?? '').localeCompare(b.name ?? '');
 	});
 }

--- a/src/documents/combat/combatSorting.ts
+++ b/src/documents/combat/combatSorting.ts
@@ -1,4 +1,7 @@
-import { canCurrentUserReorderCombatant } from '../../utils/combatantOrdering.js';
+import {
+	canCurrentUserReorderCombatant,
+	getCombatantTypePriority,
+} from '../../utils/combatantOrdering.js';
 import { isCombatantDead } from '../../utils/isCombatantDead.js';
 import { getCombatantManualSortValue } from './combatantSystem.js';
 import { getSourceSortValueForDrop } from './combatCommon.js';
@@ -37,10 +40,8 @@ export function sortCombatants(a: Combatant.Implementation, b: Combatant.Impleme
 	const manualSortDiff = sa - sb;
 	if (manualSortDiff !== 0) return manualSortDiff;
 
-	const initiativeA = Number(a.initiative ?? Number.NEGATIVE_INFINITY);
-	const initiativeB = Number(b.initiative ?? Number.NEGATIVE_INFINITY);
-	const initiativeDiff = initiativeB - initiativeA;
-	if (initiativeDiff !== 0) return initiativeDiff;
+	const typePriorityDiff = getCombatantTypePriority(a) - getCombatantTypePriority(b);
+	if (typePriorityDiff !== 0) return typePriorityDiff;
 
 	return (a.name ?? '').localeCompare(b.name ?? '');
 }

--- a/src/utils/combatTurnSync.test.ts
+++ b/src/utils/combatTurnSync.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createCombatActorFixture, createCombatantFixture } from '../../tests/fixtures/combat.js';
 import { clearExpandedTurnIdentityHint } from '../documents/combat/expandedTurnIdentityStore.js';
-import { syncCombatTurns } from './combatTurnSync.js';
+import { getActiveCombatantId, syncCombatTurns } from './combatTurnSync.js';
 
 describe('syncCombatTurns', () => {
 	beforeEach(() => {
@@ -29,6 +29,8 @@ describe('syncCombatTurns', () => {
 		const rawTurns = [playerOne, playerTwo, solo] as Combatant.Implementation[];
 		const combat = {
 			id: 'combat-turn-sync-active-combatant',
+			started: true,
+			round: 1,
 			flags: {
 				nimble: {
 					expandedTurnIdentity: {
@@ -62,5 +64,36 @@ describe('syncCombatTurns', () => {
 			combatantId: 'player-two',
 			occurrence: 0,
 		});
+	});
+
+	it('does not expose an active combatant before combat starts', () => {
+		const playerOne = createCombatantFixture({
+			id: 'player-one',
+			type: 'character',
+			actor: createCombatActorFixture({ type: 'character' }),
+		});
+		const playerTwo = createCombatantFixture({
+			id: 'player-two',
+			type: 'character',
+			actor: createCombatActorFixture({ type: 'character' }),
+		});
+
+		const turns = [playerOne, playerTwo] as Combatant.Implementation[];
+		const combat = {
+			id: 'combat-turn-sync-active-combatant',
+			started: false,
+			round: 0,
+			turns,
+			turn: 0,
+			setupTurns: vi.fn(() => turns),
+			combatant: playerOne,
+		} as unknown as Combat & {
+			_nimbleExpandedTurnIdentity?: { combatantId: string; occurrence: number | null } | null;
+		};
+
+		syncCombatTurns(combat);
+
+		expect(getActiveCombatantId(combat)).toBeNull();
+		expect(combat._nimbleExpandedTurnIdentity).toBeNull();
 	});
 });

--- a/src/utils/combatTurnSync.ts
+++ b/src/utils/combatTurnSync.ts
@@ -9,10 +9,19 @@ type CombatWithTurnIdentityHint = Combat & {
 	_nimbleExpandedTurnIdentity?: TurnIdentity | null;
 };
 
+function isCombatStarted(combat: Combat | null): boolean {
+	if (!combat) return false;
+	const asRecord = combat as unknown as { started?: boolean };
+	if (typeof asRecord.started === 'boolean') return asRecord.started;
+	return (combat.round ?? 0) > 0;
+}
+
 function resolveCurrentTurnIdentity(
 	combat: Combat,
 	existingTurns: Combatant.Implementation[],
 ): TurnIdentity | null {
+	if (!isCombatStarted(combat)) return null;
+
 	const combatWithHint = combat as CombatWithTurnIdentityHint;
 	const persistedTurnIdentity = getPersistedExpandedTurnIdentity(combat);
 	if (persistedTurnIdentity) return persistedTurnIdentity;
@@ -104,6 +113,12 @@ export function syncCombatTurns(combat: Combat | null): void {
 		return;
 	}
 
+	if (!isCombatStarted(combat)) {
+		combatWithHint._nimbleExpandedTurnIdentity = null;
+		setExpandedTurnIdentityHint(combat.id ?? null, null);
+		return;
+	}
+
 	if (currentTurnIdentity?.combatantId) {
 		const matchedIndex = findTurnIndexByOccurrence(
 			normalizedTurns,
@@ -143,6 +158,7 @@ export function syncCombatTurns(combat: Combat | null): void {
 
 export function getActiveCombatantId(combat: Combat | null): string | null {
 	if (!combat) return null;
+	if (!isCombatStarted(combat)) return null;
 	const turnIndex = Number(combat.turn ?? -1);
 	if (Number.isInteger(turnIndex) && turnIndex >= 0 && turnIndex < combat.turns.length) {
 		return combat.turns[turnIndex]?.id ?? null;
@@ -166,6 +182,7 @@ export function getActiveCombatantOccurrence(
 	activeId: string,
 ): number | null {
 	if (!combat) return null;
+	if (!isCombatStarted(combat)) return null;
 	const turnIndex = Number(combat.turn ?? -1);
 	if (!Number.isInteger(turnIndex) || turnIndex < 0 || turnIndex >= combat.turns.length)
 		return null;

--- a/src/utils/combatTurnSync.ts
+++ b/src/utils/combatTurnSync.ts
@@ -4,17 +4,11 @@ import {
 	getPersistedExpandedTurnIdentity,
 	setExpandedTurnIdentityHint,
 } from '../documents/combat/expandedTurnIdentityStore.js';
+import { isCombatStarted } from './isCombatStarted.js';
 
 type CombatWithTurnIdentityHint = Combat & {
 	_nimbleExpandedTurnIdentity?: TurnIdentity | null;
 };
-
-function isCombatStarted(combat: Combat | null): boolean {
-	if (!combat) return false;
-	const asRecord = combat as unknown as { started?: boolean };
-	if (typeof asRecord.started === 'boolean') return asRecord.started;
-	return (combat.round ?? 0) > 0;
-}
 
 function resolveCurrentTurnIdentity(
 	combat: Combat,

--- a/src/utils/getHeroicReactionUsageState.ts
+++ b/src/utils/getHeroicReactionUsageState.ts
@@ -4,6 +4,7 @@ import {
 	type HeroicReactionKey,
 } from './heroicActions.js';
 import { isCombatantDead } from './isCombatantDead.js';
+import { isCombatStarted } from './isCombatStarted.js';
 
 type HeroicReactionUsageBlockedReason =
 	| 'outsideCombat'
@@ -22,10 +23,6 @@ interface GetHeroicReactionUsageStateParams {
 
 function getCombatantId(combatant: Combatant.Implementation | null | undefined): string | null {
 	return combatant?.id ?? combatant?._id ?? null;
-}
-
-function isCombatStarted(combat: Combat | null): boolean {
-	return Number(combat?.round ?? 0) >= 1;
 }
 
 function getCombatantCurrentActions(

--- a/src/utils/isCombatStarted.test.ts
+++ b/src/utils/isCombatStarted.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { isCombatStarted } from './isCombatStarted.js';
+
+describe('isCombatStarted', () => {
+	it('returns the explicit started flag when present', () => {
+		expect(
+			isCombatStarted({
+				started: false,
+				round: 3,
+			} as Combat),
+		).toBe(false);
+		expect(
+			isCombatStarted({
+				started: true,
+				round: 0,
+			} as Combat),
+		).toBe(true);
+	});
+
+	it('falls back to round state when the started flag is unavailable', () => {
+		expect(
+			isCombatStarted({
+				round: 0,
+			} as Combat),
+		).toBe(false);
+		expect(
+			isCombatStarted({
+				round: 1,
+			} as Combat),
+		).toBe(true);
+		expect(isCombatStarted(null)).toBe(false);
+	});
+});

--- a/src/utils/isCombatStarted.ts
+++ b/src/utils/isCombatStarted.ts
@@ -1,0 +1,8 @@
+export function isCombatStarted(combat: Combat | null): boolean {
+	if (!combat) return false;
+
+	const asRecord = combat as unknown as { started?: boolean };
+	if (typeof asRecord.started === 'boolean') return asRecord.started;
+
+	return (combat.round ?? 0) > 0;
+}

--- a/src/utils/minionGrouping.test.ts
+++ b/src/utils/minionGrouping.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { createCombatActorFixture, createCombatantFixture } from '../../tests/fixtures/combat.js';
-import { isMinionCombatant } from './minionGrouping.js';
+import {
+	getEffectiveMinionGroupLeader,
+	getMinionGroupSummaries,
+	isMinionCombatant,
+} from './minionGrouping.js';
 
 describe('isMinionCombatant', () => {
 	it('returns true when actor type is minion', () => {
@@ -35,5 +39,55 @@ describe('isMinionCombatant', () => {
 		});
 
 		expect(isMinionCombatant(combatant)).toBe(false);
+	});
+
+	it('does not use initiative to choose a minion group leader when manual sort ties', () => {
+		const alphaLeader = createCombatantFixture({
+			id: 'alpha-leader',
+			type: 'npc',
+			sort: 0,
+			initiative: 5,
+			flags: {
+				nimble: {
+					minionGroup: {
+						id: 'group-1',
+						role: 'leader',
+					},
+				},
+			},
+			actor: {
+				...createCombatActorFixture({ id: 'actor-alpha-leader' }),
+				type: 'minion',
+			} as unknown as Actor.Implementation,
+		});
+		(alphaLeader as unknown as { name: string }).name = 'Alpha';
+		const betaMember = createCombatantFixture({
+			id: 'beta-member',
+			type: 'npc',
+			sort: 0,
+			initiative: 20,
+			flags: {
+				nimble: {
+					minionGroup: {
+						id: 'group-1',
+						role: 'member',
+					},
+				},
+			},
+			actor: {
+				...createCombatActorFixture({ id: 'actor-beta-member' }),
+				type: 'minion',
+			} as unknown as Actor.Implementation,
+		});
+		(betaMember as unknown as { name: string }).name = 'Beta';
+
+		const summary = getMinionGroupSummaries([alphaLeader, betaMember]).get('group-1');
+		if (!summary) throw new Error('Expected minion group summary');
+
+		expect(summary.members.map((combatant) => combatant.id)).toEqual([
+			'alpha-leader',
+			'beta-member',
+		]);
+		expect(getEffectiveMinionGroupLeader(summary)?.id).toBe('alpha-leader');
 	});
 });

--- a/src/utils/minionGrouping.ts
+++ b/src/utils/minionGrouping.ts
@@ -37,19 +37,12 @@ function getCombatantManualSortValue(combatant: Combatant.Implementation): numbe
 	return Number(foundry.utils.getProperty(combatant, 'system.sort') ?? 0);
 }
 
-function getCombatantInitiativeValue(combatant: Combatant.Implementation): number {
-	return Number(combatant.initiative ?? Number.NEGATIVE_INFINITY);
-}
-
 function compareCombatantsForGroupResolution(
 	a: Combatant.Implementation,
 	b: Combatant.Implementation,
 ): number {
 	const manualSortDiff = getCombatantManualSortValue(a) - getCombatantManualSortValue(b);
 	if (manualSortDiff !== 0) return manualSortDiff;
-
-	const initiativeDiff = getCombatantInitiativeValue(b) - getCombatantInitiativeValue(a);
-	if (initiativeDiff !== 0) return initiativeDiff;
 
 	return (a.name ?? '').localeCompare(b.name ?? '');
 }

--- a/src/view/ui/CtTopTracker.state.svelte.ts
+++ b/src/view/ui/CtTopTracker.state.svelte.ts
@@ -10,6 +10,7 @@ import {
 } from '#utils/combatTurnActions.js';
 import type { HeroicReactionKey } from '#utils/heroicActions.js';
 import { isCombatantDead } from '#utils/isCombatantDead.js';
+import { isCombatStarted } from '#utils/isCombatStarted.js';
 import { queueCombatantMutationWithFreshDocument } from '#utils/queueCombatantMutationWithFreshDocument.js';
 import CtSettingsDialogComponent from '#view/dialogs/CtSettingsDialog.svelte';
 import { COMBAT_TRACKER_CLIENT_SETTING_UPDATED_EVENT_NAME } from '../../settings/combatTrackerSettings.js';
@@ -20,7 +21,6 @@ import {
 	getCombatantSceneId,
 	getTrackEntryCombatantIds,
 	isCombatRoundStarted,
-	isCombatStarted,
 	isEligibleForInitiativeRoll,
 	isMonsterOrMinionCombatant,
 	isPlayerCombatant,

--- a/src/view/ui/ctTopTracker/combat.utils.ts
+++ b/src/view/ui/ctTopTracker/combat.utils.ts
@@ -12,6 +12,7 @@ import { hasCombatantTurnEndedThisRound } from '../../../utils/combatTurnProgres
 import { getHeroicReactionAvailability } from '../../../utils/heroicActions.js';
 import { initiativeRollLock } from '../../../utils/initiativeRollLock.js';
 import { isCombatantDead } from '../../../utils/isCombatantDead.js';
+import { isCombatStarted } from '../../../utils/isCombatStarted.js';
 import {
 	getEffectiveMinionGroupLeader,
 	getMinionGroupId,
@@ -219,13 +220,6 @@ export function getCombatantSceneId(combatant: Combatant.Implementation): string
 
 export function hasCombatantsForScene(combat: Combat, sceneId: string): boolean {
 	return combat.combatants.contents.some((combatant) => getCombatantSceneId(combatant) === sceneId);
-}
-
-export function isCombatStarted(combat: Combat | null): boolean {
-	if (!combat) return false;
-	const asRecord = combat as unknown as { started?: boolean };
-	if (typeof asRecord.started === 'boolean') return asRecord.started;
-	return (combat.round ?? 0) > 0;
 }
 
 export function isCombatRoundStarted(combat: Combat | null): boolean {

--- a/src/view/ui/ctTopTracker/combat.utils.ts
+++ b/src/view/ui/ctTopTracker/combat.utils.ts
@@ -37,6 +37,8 @@ function resolveCurrentTurnIdentity(
 	combat: Combat,
 	existingTurns: Combatant.Implementation[],
 ): TurnIdentity | null {
+	if (!isCombatStarted(combat)) return null;
+
 	const combatWithHint = combat as CombatWithTurnIdentityHint;
 	const persistedTurnIdentity = getPersistedExpandedTurnIdentity(combat);
 	if (persistedTurnIdentity) return persistedTurnIdentity;
@@ -154,6 +156,12 @@ export function syncCombatTurnsForCt(combat: Combat | null): void {
 	combat.turns = normalizedTurns;
 	if (normalizedTurns.length === 0) {
 		combat.turn = 0;
+		combatWithHint._nimbleExpandedTurnIdentity = null;
+		setExpandedTurnIdentityHint(combat.id ?? null, null);
+		return;
+	}
+
+	if (!isCombatStarted(combat)) {
 		combatWithHint._nimbleExpandedTurnIdentity = null;
 		setExpandedTurnIdentityHint(combat.id ?? null, null);
 		return;
@@ -432,6 +440,7 @@ export function buildAliveEntries(
 
 export function getActiveCombatantId(combat: Combat | null): string | null {
 	if (!combat) return null;
+	if (!isCombatStarted(combat)) return null;
 	const turnIndex = Number(combat.turn ?? -1);
 	if (Number.isInteger(turnIndex) && turnIndex >= 0 && turnIndex < combat.turns.length) {
 		return combat.turns[turnIndex]?.id ?? null;
@@ -455,6 +464,7 @@ export function getActiveCombatantOccurrence(
 	activeId: string,
 ): number | null {
 	if (!combat) return null;
+	if (!isCombatStarted(combat)) return null;
 	const turnIndex = Number(combat.turn ?? -1);
 	if (!Number.isInteger(turnIndex) || turnIndex < 0 || turnIndex >= combat.turns.length)
 		return null;
@@ -463,7 +473,7 @@ export function getActiveCombatantOccurrence(
 
 export function resolveActiveEntryKey(params: ResolveActiveEntryKeyParams): string | null {
 	const { activeCombatantId, activeOccurrence, aliveEntries, collapseMonsters } = params;
-	if (!activeCombatantId) return aliveEntries[0]?.key ?? null;
+	if (!activeCombatantId) return null;
 
 	if (collapseMonsters) {
 		const monsterStackEntry = findTrackEntryContainingCombatantId(aliveEntries, activeCombatantId);

--- a/src/view/ui/ctTopTracker/combatTracker.utils.test.ts
+++ b/src/view/ui/ctTopTracker/combatTracker.utils.test.ts
@@ -278,6 +278,8 @@ describe('ctTopTracker helpers', () => {
 		const rawTurns = [playerOne, playerTwo, solo] as Combatant.Implementation[];
 		const combat = {
 			id: 'combat-legendary-ct-sync',
+			started: true,
+			round: 1,
 			flags: {
 				nimble: {
 					expandedTurnIdentity: {
@@ -324,6 +326,8 @@ describe('ctTopTracker helpers', () => {
 		const rawTurns = [playerOne, playerTwo, solo] as Combatant.Implementation[];
 		const combat = {
 			id: 'combat-legendary-ct-sync',
+			started: true,
+			round: 1,
 			flags: {
 				nimble: {
 					expandedTurnIdentity: {

--- a/src/view/ui/ctTopTracker/topTrackerStore.svelte.test.ts
+++ b/src/view/ui/ctTopTracker/topTrackerStore.svelte.test.ts
@@ -320,6 +320,65 @@ describe('CtTopTrackerStore', () => {
 		).toEqual([2, 1]);
 	});
 
+	it('does not mark an active entry before combat starts', () => {
+		const player = createCombatantFixture({
+			id: 'player-one',
+			type: 'character',
+			actor: createCombatActorFixture({ type: 'character' }),
+			sceneId: 'scene-1',
+		});
+		(player as unknown as { visible: boolean }).visible = true;
+		const monster = createCombatantFixture({
+			id: 'monster-one',
+			type: 'npc',
+			actor: createCombatActorFixture({ type: 'npc' }),
+			sceneId: 'scene-1',
+		});
+		(monster as unknown as { visible: boolean }).visible = true;
+
+		const turns = [player, monster] as Combatant.Implementation[];
+		const combat = {
+			id: 'combat-store-prestart',
+			active: true,
+			started: false,
+			round: 0,
+			turn: 0,
+			combatant: player,
+			combatants: createCombatantsCollectionFixture([player, monster]),
+			turns,
+			setupTurns: vi.fn(() => turns),
+			scene: { id: 'scene-1' },
+			flags: {
+				nimble: {
+					ctMonsterCardsExpanded: true,
+					ctPlayersCanViewExpandedMonsters: true,
+				},
+			},
+		} as unknown as Combat;
+
+		const globals = globalThis as unknown as {
+			game: {
+				combats: { contents: Combat[]; viewed?: Combat | null };
+				combat?: Combat | null;
+			};
+		};
+		globals.game.combats = {
+			contents: [combat],
+			viewed: combat,
+		};
+		globals.game.combat = combat;
+
+		const store = new CtTopTrackerStore();
+		store.refreshCurrentCombat(true);
+
+		expect(store.combatStarted).toBe(false);
+		expect(store.activeEntryKey).toBeNull();
+		expect(store.orderedAliveEntries.map((entry) => entry.key)).toEqual([
+			'combatant-player-one-0',
+			'combatant-monster-one-0',
+		]);
+	});
+
 	it('does not expose grouped minion members as separate expanded monster turns', () => {
 		const player = createCombatantFixture({
 			id: 'player-one',

--- a/src/view/ui/ctTopTracker/topTrackerStore.svelte.ts
+++ b/src/view/ui/ctTopTracker/topTrackerStore.svelte.ts
@@ -10,6 +10,7 @@ import {
 import { canCurrentUserEndTurn as canCurrentUserEndCombatantTurn } from '../../../utils/combatTurnActions.js';
 import { getHeroicReactionUsageState } from '../../../utils/getHeroicReactionUsageState.js';
 import type { HeroicReactionKey } from '../../../utils/heroicActions.js';
+import { isCombatStarted } from '../../../utils/isCombatStarted.js';
 import {
 	buildAliveEntries,
 	buildCombatSyncSignature,
@@ -20,7 +21,6 @@ import {
 	getCombatForCurrentScene,
 	getRoundBoundaryKey,
 	getRoundSeparatorInsertionIndex,
-	isCombatStarted,
 	isMonsterOrMinionCombatant,
 	isPlayerCombatant,
 	orderEntriesForCenteredActive,


### PR DESCRIPTION
## Summary

This PR makes combat turn order fully manual and predictable. Initiative rolls still happen for their normal side effects, but they no longer reorder the tracker. The first current turn is now chosen only when the GM clicks Start Combat, and before that happens the tracker shows no active combatant at all. It also makes a fresh, not-yet-started combat default to players first and monsters/minions after them.

Why
-   It separates initiative from turn order, so rolling dice no longer scrambles a manually arranged tracker.
-   It makes the start of combat explicit: the GM decides when combat begins, and that is when the first active turn is assigned.
-   It removes misleading pre-start UI state where one card looked like the current turn even though combat had not started.
-   It gives a cleaner default layout for a fresh combat by putting players before monsters/minions until the GM reorders cards.

## Changes

-   Removed initiative as a turn-order tie-breaker from the main combat sorting logic.
-   Removed the same initiative-based tie-break behavior from related minion/group ordering helpers so order stays consistent everywhere.
-   Changed `Start Combat` to set the current turn to the left-most combatant in the tracker.
-   Kept initiative rolls from changing the current turn or reshuffling tracker order.
-   Changed the combat tracker so no combatant is treated as active before combat has started.
-   Stopped the tracker from falling back to the first card as the "active" card before start.
-   Changed the default pre-start ordering for equal-sort combatants so players appear before monsters/minions.
-   Added and updated regression tests for initiative stability, start-combat behavior, pre-start inactive UI state, and default player-first ordering.

-

## Test Plan

- [x]   Create a fresh combat with a mixed selection of player characters and monsters/minions.
- [x]   Before clicking Start Combat, confirm all player cards appear before the monster/minion stack.
- [x]   Before clicking Start Combat, confirm no card is enlarged or marked as the current turn.
- [x]   Roll initiative for one or more combatants before combat starts and confirm the tracker order does not change.
- [x]   Click Start Combat and confirm the left-most card becomes the current active turn.
- [x]   After combat has started, roll initiative for additional combatants and confirm the tracker order still does not change.
- [x]   Manually drag cards into a custom order, roll initiative again, and confirm your manual order is preserved.
- [x]   Advance turns normally and confirm only started combat shows an active/enlarged current-turn card.



## Checklist

- [x] Added or updated unit tests
- [x] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [x] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** yes / no
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->
