### PR TITLE
feat/fix: Initiative roll enricher

### DIFF
--- a/src/documents/actor/base.svelte.ts
+++ b/src/documents/actor/base.svelte.ts
@@ -59,6 +59,12 @@ interface HpTrackingOptions {
 	};
 }
 
+interface InitiativeRollData {
+	rollFormula: string;
+	rollMode: number;
+	visibilityMode?: string | undefined;
+}
+
 type HpScrollingEffectType = keyof typeof HP_SCROLLING_TEXT_COLORS;
 
 function toFiniteInteger(value: unknown): number {
@@ -632,6 +638,29 @@ class NimbleBaseActor<ActorType extends SystemActorTypes = SystemActorTypes> ext
 		return chatCard ?? null;
 	}
 
+	async rollInitiativeToChat(options = {} as ActorRollOptions): Promise<ChatMessage | null> {
+		const rollData = await this.resolveInitiativeRollData(options);
+		if (!rollData) return null;
+
+		const roll = Roll.create(rollData.rollFormula, this.getRollData());
+		await roll.evaluate();
+
+		const chatData = (await roll.toMessage(
+			{
+				speaker: ChatMessage.getSpeaker({ actor: this }),
+				flavor: game.i18n.format('COMBAT.RollsInitiative', { name: this.name }),
+				flags: { core: { initiativeRoll: true } },
+			},
+			{ create: false },
+		)) as ChatMessage.CreateData;
+		const visibilityMode = (rollData.visibilityMode ??
+			(game.settings.get('core', 'rollMode') as CONST.DICE_ROLL_MODES)) as CONST.DICE_ROLL_MODES;
+
+		ChatMessage.applyRollMode(chatData as Record<string, unknown>, visibilityMode);
+
+		return (await ChatMessage.create(chatData)) ?? null;
+	}
+
 	async rollSavingThrow(saveKey: SaveKeyType, options: ActorRollOptions = {}) {
 		const systemData = this.system as unknown as BaseActorSystemData;
 		const baseRollMode = calculateRollMode(
@@ -676,6 +705,34 @@ class NimbleBaseActor<ActorType extends SystemActorTypes = SystemActorTypes> ext
 		return { rollFormula, rollMode, visibilityMode: options.visibilityMode };
 	}
 
+	async resolveInitiativeRollData(
+		options = {} as ActorRollOptions,
+	): Promise<InitiativeRollData | null> {
+		const systemData = this.system as unknown as BaseActorSystemData & {
+			attributes: { initiative: { defaultRollMode?: number } };
+		};
+		const baseRollMode = calculateRollMode(
+			systemData.attributes.initiative?.defaultRollMode ?? 0,
+			options.rollModeModifier,
+			options.rollMode,
+		);
+
+		return options.skipRollDialog
+			? this.getDefaultInitiativeData(baseRollMode, options)
+			: await this.showCheckRollDialog('initiative', {
+					...options,
+					rollMode: baseRollMode,
+				});
+	}
+
+	getDefaultInitiativeData(rollMode: number, options = {} as ActorRollOptions): InitiativeRollData {
+		return {
+			rollFormula: this._getInitiativeFormula({ ...options, rollMode }),
+			rollMode,
+			visibilityMode: options.visibilityMode,
+		};
+	}
+
 	async prepareSavingThrowChatCardData(
 		saveKey: SaveKeyType,
 		roll: NimbleRoll | Roll<Record<string, unknown>>,
@@ -697,7 +754,7 @@ class NimbleBaseActor<ActorType extends SystemActorTypes = SystemActorTypes> ext
 	}
 
 	async showCheckRollDialog(
-		type: 'abilityCheck' | 'savingThrow' | 'skillCheck',
+		type: 'abilityCheck' | 'savingThrow' | 'skillCheck' | 'initiative',
 		data: CheckRollDialogData,
 	): Promise<any> {
 		let title = '';
@@ -713,6 +770,9 @@ class NimbleBaseActor<ActorType extends SystemActorTypes = SystemActorTypes> ext
 				break;
 			case 'skillCheck':
 				title = `${this.name}: Configure ${CONFIG.NIMBLE.skills[data?.skillKey ?? '']} Skill Check`;
+				break;
+			case 'initiative':
+				title = `${this.name}: Configure Initiative`;
 				break;
 			default:
 				return null;

--- a/src/documents/combat/combat.svelte.test.ts
+++ b/src/documents/combat/combat.svelte.test.ts
@@ -999,6 +999,192 @@ describe('NimbleCombat', () => {
 		]);
 	});
 
+	it('uses prompted initiative roll data for single-combatant initiative rolls', async () => {
+		const combatId = 'combat-initiative-prompted-roll';
+		const actor = Object.assign(
+			createCombatActorFixture({
+				id: 'actor-initiative-prompted-roll',
+				type: 'character',
+				isOwner: true,
+				hp: 8,
+				woundsValue: 0,
+				woundsMax: 6,
+			}),
+			{
+				resolveInitiativeRollData: vi.fn().mockResolvedValue({
+					rollFormula: '2d20kh + 5',
+					rollMode: 1,
+					visibilityMode: 'blindroll',
+				}),
+			},
+		) as Actor.Implementation & {
+			resolveInitiativeRollData: ReturnType<typeof vi.fn>;
+		};
+
+		const combatant = createMockCombatant({
+			id: 'character-initiative-prompted-roll',
+			type: 'character',
+			sort: 1,
+			isOwner: true,
+			initiative: null,
+			actor,
+			combatId,
+			flags: {},
+		}) as unknown as Combatant.Implementation & {
+			getInitiativeRoll: ReturnType<typeof vi.fn>;
+		};
+
+		const initiativeRoll = {
+			total: 18,
+			evaluate: vi.fn().mockResolvedValue(null),
+			toMessage: vi.fn().mockResolvedValue({ id: 'initiative-chat-data' }),
+		};
+		combatant.getInitiativeRoll = vi.fn().mockReturnValue(initiativeRoll);
+
+		const combat = new NimbleCombat({
+			id: combatId,
+			scene: { id: 'scene-1' },
+			combatants: createCombatantsCollectionFixture([combatant]),
+			turns: [],
+		} as unknown as Combat.CreateData) as NimbleCombat & {
+			updateEmbeddedDocuments: ReturnType<typeof vi.fn>;
+			update: ReturnType<typeof vi.fn>;
+		};
+
+		combat.updateEmbeddedDocuments = vi
+			.fn()
+			.mockImplementation(async (_embeddedName: string, updates: Record<string, unknown>[]) => {
+				for (const update of updates) {
+					const combatantId = update._id as string;
+					const targetCombatant = combat.combatants.get(combatantId) as unknown as Record<
+						string,
+						unknown
+					> | null;
+					if (!targetCombatant) continue;
+
+					for (const [path, value] of Object.entries(update)) {
+						if (path === '_id') continue;
+						foundry.utils.setProperty(targetCombatant, path, value);
+					}
+				}
+
+				return [];
+			});
+		combat.update = vi.fn().mockResolvedValue(combat);
+
+		const chatMessageCreate = (
+			globalThis as unknown as {
+				ChatMessage: {
+					implementation: {
+						create: ReturnType<typeof vi.fn>;
+					};
+				};
+			}
+		).ChatMessage.implementation.create;
+
+		await combat.rollInitiative(['character-initiative-prompted-roll'], {
+			promptRollDialog: true,
+			updateTurn: false,
+		});
+
+		expect(actor.resolveInitiativeRollData).toHaveBeenCalledTimes(1);
+		expect(combatant.getInitiativeRoll).toHaveBeenCalledWith('2d20kh + 5');
+		expect(combatant.initiative).toBe(18);
+		expect(chatMessageCreate).toHaveBeenCalledWith([
+			expect.objectContaining({
+				id: 'initiative-chat-data',
+				rollMode: 'blindroll',
+			}),
+		]);
+	});
+
+	it('releases the initiative lock when the prompted initiative dialog is cancelled', async () => {
+		const combatId = 'combat-initiative-prompt-cancel';
+		const actor = Object.assign(
+			createCombatActorFixture({
+				id: 'actor-initiative-prompt-cancel',
+				type: 'character',
+				isOwner: true,
+				hp: 8,
+				woundsValue: 0,
+				woundsMax: 6,
+			}),
+			{
+				resolveInitiativeRollData: vi.fn().mockResolvedValue(null),
+			},
+		) as Actor.Implementation & {
+			resolveInitiativeRollData: ReturnType<typeof vi.fn>;
+		};
+
+		const combatant = createMockCombatant({
+			id: 'character-initiative-prompt-cancel',
+			type: 'character',
+			sort: 1,
+			isOwner: true,
+			initiative: null,
+			actor,
+			combatId,
+			flags: {},
+		}) as unknown as Combatant.Implementation & {
+			getInitiativeRoll: ReturnType<typeof vi.fn>;
+		};
+		const getInitiativeRollSpy = vi.fn();
+		combatant.getInitiativeRoll =
+			getInitiativeRollSpy as unknown as typeof combatant.getInitiativeRoll;
+
+		const combat = new NimbleCombat({
+			id: combatId,
+			scene: { id: 'scene-1' },
+			combatants: createCombatantsCollectionFixture([combatant]),
+			turns: [],
+		} as unknown as Combat.CreateData) as NimbleCombat & {
+			updateEmbeddedDocuments: ReturnType<typeof vi.fn>;
+			update: ReturnType<typeof vi.fn>;
+		};
+
+		combat.updateEmbeddedDocuments = vi
+			.fn()
+			.mockImplementation(async (_embeddedName: string, updates: Record<string, unknown>[]) => {
+				for (const update of updates) {
+					const combatantId = update._id as string;
+					const targetCombatant = combat.combatants.get(combatantId) as unknown as Record<
+						string,
+						unknown
+					> | null;
+					if (!targetCombatant) continue;
+
+					for (const [path, value] of Object.entries(update)) {
+						if (path === '_id') continue;
+						foundry.utils.setProperty(targetCombatant, path, value);
+					}
+				}
+
+				return [];
+			});
+		combat.update = vi.fn().mockResolvedValue(combat);
+
+		const chatMessageCreate = (
+			globalThis as unknown as {
+				ChatMessage: {
+					implementation: {
+						create: ReturnType<typeof vi.fn>;
+					};
+				};
+			}
+		).ChatMessage.implementation.create;
+
+		await combat.rollInitiative(['character-initiative-prompt-cancel'], {
+			promptRollDialog: true,
+			updateTurn: false,
+		});
+
+		expect(actor.resolveInitiativeRollData).toHaveBeenCalledTimes(1);
+		expect(getInitiativeRollSpy).not.toHaveBeenCalled();
+		expect(combatant.initiative).toBeNull();
+		expect(initiativeRollLock.hasActiveLock(combatant)).toBe(false);
+		expect(chatMessageCreate).not.toHaveBeenCalled();
+	});
+
 	it('skips rolling initiative when another client already holds the combatant lock', async () => {
 		const combatId = 'combat-initiative-foreign-lock';
 		globals().game.user = {

--- a/src/documents/combat/combat.svelte.ts
+++ b/src/documents/combat/combat.svelte.ts
@@ -1,4 +1,5 @@
 import { createSubscriber } from 'svelte/reactivity';
+import type { ActorRollOptions } from '#documents/actor/actorInterfaces.ts';
 import type { NimbleCombatant } from '#documents/combatant/combatant.svelte.js';
 import { getHeroicReactionUsageState } from '#utils/getHeroicReactionUsageState.js';
 import {
@@ -48,6 +49,18 @@ interface LockedInitiativeRollOutcome {
 	combatantId: string;
 	requestId: string;
 	outcome: InitiativeRollOutcome;
+}
+
+interface ResolvedInitiativeRollData {
+	rollFormula: string;
+	rollMode: number;
+	visibilityMode?: string | undefined;
+}
+
+interface ActorWithInitiativeRollConfiguration extends Actor {
+	resolveInitiativeRollData?: (
+		options?: ActorRollOptions,
+	) => Promise<ResolvedInitiativeRollData | null>;
 }
 
 class NimbleCombat extends Combat {
@@ -722,6 +735,15 @@ class NimbleCombat extends Combat {
 		]);
 	}
 
+	async #resolvePromptedInitiativeRollData(
+		combatantId: string,
+	): Promise<ResolvedInitiativeRollData | null | undefined> {
+		const actor = this.combatants.get(combatantId)
+			?.actor as ActorWithInitiativeRollConfiguration | null;
+		if (typeof actor?.resolveInitiativeRollData !== 'function') return undefined;
+		return actor.resolveInitiativeRollData();
+	}
+
 	async #performInitiativeRollForCombatant(params: {
 		combatantId: string;
 		formula: string | null;
@@ -729,6 +751,7 @@ class NimbleCombat extends Combat {
 		chatRollMode: string | null;
 		rollIndex: number;
 		combatManaUpdates: Promise<unknown>[];
+		promptRollDialog: boolean;
 	}): Promise<LockedInitiativeRollOutcome | null> {
 		const combatant = this.combatants.get(params.combatantId);
 		if (!combatant?.isOwner) return null;
@@ -746,11 +769,23 @@ class NimbleCombat extends Combat {
 			if (lockedCombatant.initiative !== null) return null;
 			if (!initiativeRollLock.matches(lockedCombatant, lockData.requestId)) return null;
 
+			const promptedRollData = params.promptRollDialog
+				? await this.#resolvePromptedInitiativeRollData(params.combatantId)
+				: undefined;
+			if (params.promptRollDialog && promptedRollData === null) return null;
+
+			const resolvedMessageOptions = {
+				...params.messageOptions,
+			} as ChatMessage.CreateData & { rollMode?: string };
+			if (promptedRollData?.visibilityMode) {
+				resolvedMessageOptions.rollMode = promptedRollData.visibilityMode;
+			}
+
 			const rollOutcome = await rollInitiativeForCombatant({
 				combat: this,
 				combatantId: params.combatantId,
-				formula: params.formula,
-				messageOptions: params.messageOptions,
+				formula: promptedRollData?.rollFormula ?? params.formula,
+				messageOptions: resolvedMessageOptions,
 				chatRollMode: params.chatRollMode,
 				rollIndex: params.rollIndex,
 				combatManaUpdates: params.combatManaUpdates,
@@ -779,6 +814,7 @@ class NimbleCombat extends Combat {
 		chatRollMode: string | null;
 		rollIndex: number;
 		combatManaUpdates: Promise<unknown>[];
+		promptRollDialog: boolean;
 	}): Promise<LockedInitiativeRollOutcome | null> {
 		const inFlightRequest = this.#initiativeRollRequests.get(params.combatantId);
 		if (inFlightRequest) {
@@ -800,14 +836,23 @@ class NimbleCombat extends Combat {
 
 	override async rollInitiative(
 		ids: string | string[],
-		options?: Combat.InitiativeOptions & { rollOptions?: Record<string, unknown> },
+		options?: Combat.InitiativeOptions & {
+			promptRollDialog?: boolean;
+			rollOptions?: Record<string, unknown>;
+		},
 	): Promise<this> {
-		const { formula = null, updateTurn = true, messageOptions = {} } = options ?? {};
+		const {
+			formula = null,
+			messageOptions = {},
+			promptRollDialog = false,
+			updateTurn = true,
+		} = options ?? {};
 
 		// Structure Input data
 		const combatantIds = [...new Set((typeof ids === 'string' ? [ids] : ids).filter(Boolean))];
 		const currentId = this.combatant?.id;
 		const chatRollMode = game.settings.get('core', 'rollMode');
+		const shouldPromptRollDialog = promptRollDialog && combatantIds.length === 1;
 
 		// Iterate over Combatants, performing an initiative roll for each
 		const updates: Record<string, unknown>[] = [];
@@ -823,6 +868,7 @@ class NimbleCombat extends Combat {
 				chatRollMode,
 				rollIndex: messages.length,
 				combatManaUpdates,
+				promptRollDialog: shouldPromptRollDialog,
 			});
 			if (!rollOutcome) continue;
 			lockedRollOutcomes.push(rollOutcome);

--- a/src/view/dialogs/CheckRollDialog.svelte
+++ b/src/view/dialogs/CheckRollDialog.svelte
@@ -1,31 +1,12 @@
 <script lang="ts">
+	import type { CheckRollDialogProps } from '#types/components/CheckRollDialog.d.ts';
+
 	import { untrack } from 'svelte';
+
 	import getRollFormula from '../../utils/getRollFormula.js';
 	import RollModeConfig from './components/RollModeConfig.svelte';
 
 	const { skillCheckDialog } = CONFIG.NIMBLE;
-
-	type RollDialogType = 'abilityCheck' | 'savingThrow' | 'skillCheck' | 'initiative';
-
-	interface InitiativeDialogActor extends Actor {
-		_getInitiativeFormula: (options: Record<string, unknown>) => string;
-	}
-
-	interface CheckRollDialogProps {
-		actor: InitiativeDialogActor;
-		dialog: {
-			submitRoll: (results: {
-				rollMode: number;
-				rollFormula: string;
-				visibilityMode: string;
-			}) => void;
-		};
-		type?: RollDialogType;
-		abilityKey?: string;
-		rollMode?: number;
-		saveKey?: string;
-		skillKey?: string;
-	}
 
 	let { actor, dialog, type = 'abilityCheck', ...data }: CheckRollDialogProps = $props();
 	let selectedRollMode = $state(untrack(() => [Math.clamp(Number(data.rollMode ?? 0), -6, 6)]));

--- a/src/view/dialogs/CheckRollDialog.svelte
+++ b/src/view/dialogs/CheckRollDialog.svelte
@@ -1,20 +1,48 @@
-<script>
+<script lang="ts">
 	import { untrack } from 'svelte';
+	import getRollFormula from '../../utils/getRollFormula.js';
 	import RollModeConfig from './components/RollModeConfig.svelte';
 
-	import getRollFormula from '../../utils/getRollFormula.js';
 	const { skillCheckDialog } = CONFIG.NIMBLE;
 
-	let { actor, dialog, ...data } = $props();
-	let selectedRollMode = $state(untrack(() => Math.clamp(data.rollMode ?? 0, -6, 6)));
-	let shouldRollBeHidden = $state(!!game.settings.get('nimble', 'hideRolls'));
+	type RollDialogType = 'abilityCheck' | 'savingThrow' | 'skillCheck' | 'initiative';
 
-	let rollFormula = $derived(
-		getRollFormula(actor, {
+	interface InitiativeDialogActor extends Actor {
+		_getInitiativeFormula: (options: Record<string, unknown>) => string;
+	}
+
+	interface CheckRollDialogProps {
+		actor: InitiativeDialogActor;
+		dialog: {
+			submitRoll: (results: {
+				rollMode: number;
+				rollFormula: string;
+				visibilityMode: string;
+			}) => void;
+		};
+		type?: RollDialogType;
+		abilityKey?: string;
+		rollMode?: number;
+		saveKey?: string;
+		skillKey?: string;
+	}
+
+	let { actor, dialog, type = 'abilityCheck', ...data }: CheckRollDialogProps = $props();
+	let selectedRollMode = $state(untrack(() => [Math.clamp(Number(data.rollMode ?? 0), -6, 6)]));
+	let shouldRollBeHidden = $state(Boolean(game.settings.get('nimble', 'hideRolls')));
+
+	let selectedRollModeValue = $derived(selectedRollMode[0] ?? 0);
+	let rollFormula = $derived.by(() => {
+		if (type === 'initiative') {
+			return actor._getInitiativeFormula({ rollMode: selectedRollModeValue });
+		}
+
+		return getRollFormula(actor as Parameters<typeof getRollFormula>[0], {
 			...data,
-			rollMode: selectedRollMode,
-		}),
-	);
+			rollMode: selectedRollModeValue,
+			type,
+		});
+	});
 </script>
 
 <article class="nimble-sheet__body" style="--nimble-sheet-body-padding-block-start: 0.5rem">
@@ -36,7 +64,7 @@
 		data-button-variant="basic"
 		onclick={() =>
 			dialog.submitRoll({
-				rollMode: selectedRollMode[0],
+				rollMode: selectedRollModeValue,
 				rollFormula,
 				visibilityMode: shouldRollBeHidden ? 'blindroll' : 'publicroll',
 			})}

--- a/src/view/sheets/components/ActionTracker.svelte.ts
+++ b/src/view/sheets/components/ActionTracker.svelte.ts
@@ -18,6 +18,10 @@ interface ActionsData {
 	max: number;
 }
 
+type PromptedInitiativeOptions = Combat.InitiativeOptions & {
+	promptRollDialog: boolean;
+};
+
 // ============================================================================
 // Dice Icons
 // ============================================================================
@@ -111,7 +115,9 @@ export function createActionTrackerState(getActor: () => NimbleCharacter) {
 		if (initiativeRollLock.hasActiveLock(combatant)) return;
 
 		try {
-			await combat.rollInitiative([combatant.id]);
+			await combat.rollInitiative([combatant.id], {
+				promptRollDialog: true,
+			} as PromptedInitiativeOptions);
 		} catch (_error) {
 			ui.notifications?.warn(localize('NIMBLE.ui.heroicActions.noPermissionRollInitiative'));
 		}

--- a/src/view/sheets/components/ActionTracker.svelte.ts
+++ b/src/view/sheets/components/ActionTracker.svelte.ts
@@ -2,6 +2,7 @@ import { untrack } from 'svelte';
 import { createSubscriber } from 'svelte/reactivity';
 import type { NimbleCharacter } from '#documents/actor/character.js';
 import { getCombatantBaseActions } from '#documents/combat/combatantSystem.js';
+import type { PromptedInitiativeOptions } from '#types/combat.js';
 import { getActiveCombatForCurrentScene, registerCombatStateHooks } from '#utils/combatState.js';
 import { requestAdvanceCombatTurn } from '#utils/combatTurnActions.js';
 import { getActiveCombatant } from '#utils/combatTurnSync.js';
@@ -17,10 +18,6 @@ interface ActionsData {
 	current: number;
 	max: number;
 }
-
-type PromptedInitiativeOptions = Combat.InitiativeOptions & {
-	promptRollDialog: boolean;
-};
 
 // ============================================================================
 // Dice Icons

--- a/src/view/sheets/pages/PlayerCharacterCoreTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterCoreTab.svelte
@@ -16,6 +16,10 @@
 	import SavingThrows from '../components/SavingThrows.svelte';
 	import Skills from '../components/Skills.svelte';
 
+	type PromptedInitiativeOptions = Combat.InitiativeOptions & {
+		promptRollDialog: boolean;
+	};
+
 	function getArmorProficiencies(proficiencies: Iterable<string>) {
 		return [...proficiencies]
 			.map((key): string => armorTypesPlural[key] ?? key)
@@ -55,18 +59,13 @@
 				}
 				if (!combat || !combatant.id) return;
 
-				await combat.rollInitiative([combatant.id]);
+				await combat.rollInitiative([combatant.id], {
+					promptRollDialog: true,
+				} as PromptedInitiativeOptions);
 				return;
 			}
 
-			const roll = Roll.create(actor._getInitiativeFormula({}), actor.getRollData());
-			await roll.evaluate();
-
-			await roll.toMessage({
-				speaker: ChatMessage.getSpeaker({ actor }),
-				flavor: game.i18n.format('COMBAT.RollsInitiative', { name: actor.name }),
-				flags: { core: { initiativeRoll: true } },
-			});
+			await actor.rollInitiativeToChat();
 		} finally {
 			initiativeRequestPending = false;
 		}

--- a/src/view/sheets/pages/PlayerCharacterCoreTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterCoreTab.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	// Types
+	import type { PromptedInitiativeOptions } from '#types/combat.js';
 
 	// Helper Functions
 	import { getContext } from 'svelte';
@@ -15,10 +16,6 @@
 	import MovementSpeed from '../components/MovementSpeed.svelte';
 	import SavingThrows from '../components/SavingThrows.svelte';
 	import Skills from '../components/Skills.svelte';
-
-	type PromptedInitiativeOptions = Combat.InitiativeOptions & {
-		promptRollDialog: boolean;
-	};
 
 	function getArmorProficiencies(proficiencies: Iterable<string>) {
 		return [...proficiencies]

--- a/src/view/sheets/pages/PlayerCharacterCoreTab.test.ts
+++ b/src/view/sheets/pages/PlayerCharacterCoreTab.test.ts
@@ -50,6 +50,7 @@ function createCoreTabActor() {
 		},
 		_getInitiativeFormula: vi.fn().mockReturnValue('1d20 + 2'),
 		getRollData: vi.fn().mockReturnValue({}),
+		rollInitiativeToChat: vi.fn(),
 		rollAbilityCheckToChat: vi.fn(),
 		configureAbilityScores: vi.fn(),
 		rollSavingThrowToChat: vi.fn(),
@@ -84,33 +85,17 @@ describe('PlayerCharacterCoreTab', () => {
 		).game.combats = { viewed: null };
 		setCurrentScene('scene-core-tab-test');
 
-		const roll = {
-			evaluate: vi.fn(),
-			toMessage: vi.fn().mockResolvedValue({ id: 'chat-message-initiative' }),
-		} as const;
-
-		let hasPendingEvaluate = false;
-		let resolveEvaluate: () => void = () => {
+		let hasPendingRoll = false;
+		let resolveRoll: () => void = () => {
 			throw new Error('Expected initiative roll evaluation to remain pending.');
 		};
-		roll.evaluate.mockImplementation(async () => {
+		actor.rollInitiativeToChat.mockImplementation(async () => {
 			await new Promise<void>((resolve) => {
-				hasPendingEvaluate = true;
-				resolveEvaluate = resolve;
+				hasPendingRoll = true;
+				resolveRoll = resolve;
 			});
-			return roll;
+			return null;
 		});
-
-		const rollCreate = vi.fn().mockReturnValue(roll);
-		(
-			globalThis as unknown as {
-				ChatMessage: {
-					getSpeaker: ReturnType<typeof vi.fn>;
-				};
-			}
-		).ChatMessage.getSpeaker = vi.fn().mockReturnValue({ actor: actor.id });
-		(globalThis as unknown as { Roll: { create: ReturnType<typeof vi.fn> } }).Roll.create =
-			rollCreate;
 
 		render(PlayerCharacterCoreTabTestHarness, { actor });
 
@@ -118,18 +103,15 @@ describe('PlayerCharacterCoreTab', () => {
 		await fireEvent.click(initiativeButton);
 		await fireEvent.click(initiativeButton);
 
-		expect(rollCreate).toHaveBeenCalledTimes(1);
-		expect(roll.evaluate).toHaveBeenCalledTimes(1);
-		expect(roll.toMessage).not.toHaveBeenCalled();
+		expect(actor.rollInitiativeToChat).toHaveBeenCalledTimes(1);
 
 		await waitFor(() => expect(initiativeButton).toBeDisabled());
 
-		if (!hasPendingEvaluate) {
+		if (!hasPendingRoll) {
 			throw new Error('Expected initiative roll evaluation to remain pending.');
 		}
-		resolveEvaluate();
+		resolveRoll();
 
-		await waitFor(() => expect(roll.toMessage).toHaveBeenCalledTimes(1));
 		await waitFor(() => expect(initiativeButton).not.toBeDisabled());
 	});
 
@@ -161,17 +143,13 @@ describe('PlayerCharacterCoreTab', () => {
 			} as unknown as Combat,
 		};
 
-		const rollCreate = vi.fn();
-		(globalThis as unknown as { Roll: { create: ReturnType<typeof vi.fn> } }).Roll.create =
-			rollCreate;
-
 		render(PlayerCharacterCoreTabTestHarness, { actor });
 
 		const initiativeButton = screen.getByRole('button', { name: /roll initiative/i });
 		await fireEvent.click(initiativeButton);
 
 		expect(combatRollInitiative).not.toHaveBeenCalled();
-		expect(rollCreate).not.toHaveBeenCalled();
+		expect(actor.rollInitiativeToChat).not.toHaveBeenCalled();
 		expect(
 			(
 				globalThis as unknown as {

--- a/src/view/ui/CtTopTracker.state.svelte.ts
+++ b/src/view/ui/CtTopTracker.state.svelte.ts
@@ -58,6 +58,10 @@ interface ExpandedMonsterGroupBar {
 	widthPx: number;
 }
 
+type PromptedInitiativeOptions = Combat.InitiativeOptions & {
+	promptRollDialog: boolean;
+};
+
 export function createCtTopTrackerState() {
 	const trackerStore = new CtTopTrackerStore();
 
@@ -100,7 +104,10 @@ export function createCtTopTrackerState() {
 		if (!actionCombat || !combatantId) return;
 
 		try {
-			await actionCombat.rollInitiative([combatantId], { updateTurn: false });
+			await actionCombat.rollInitiative([combatantId], {
+				promptRollDialog: true,
+				updateTurn: false,
+			} as PromptedInitiativeOptions);
 			updateCurrentCombat(true);
 		} catch (error) {
 			console.error('[Nimble][CT] Initiative roll failed', { combatantId, error });

--- a/src/view/ui/CtTopTracker.state.svelte.ts
+++ b/src/view/ui/CtTopTracker.state.svelte.ts
@@ -1,5 +1,6 @@
 import { onDestroy, onMount, tick } from 'svelte';
 import GenericDialog from '#documents/dialogs/GenericDialog.svelte.js';
+import type { PromptedInitiativeOptions } from '#types/combat.js';
 import { canCurrentUserReorderCombatant } from '#utils/combatantOrdering.js';
 import {
 	COMBATANT_ACTIONS_CURRENT_PATH,
@@ -57,10 +58,6 @@ interface ExpandedMonsterGroupBar {
 	leftPx: number;
 	widthPx: number;
 }
-
-type PromptedInitiativeOptions = Combat.InitiativeOptions & {
-	promptRollDialog: boolean;
-};
 
 export function createCtTopTrackerState() {
 	const trackerStore = new CtTopTrackerStore();

--- a/types/combat.d.ts
+++ b/types/combat.d.ts
@@ -23,3 +23,7 @@ export type ActorResourceData = {
 };
 
 export type ActorHpData = ActorResourceData;
+
+export type PromptedInitiativeOptions = Combat.InitiativeOptions & {
+	promptRollDialog: boolean;
+};

--- a/types/components/CheckRollDialog.d.ts
+++ b/types/components/CheckRollDialog.d.ts
@@ -1,0 +1,23 @@
+import type { CheckRollDialogData } from '#documents/actor/actorInterfaces.ts';
+
+export type RollDialogType = 'abilityCheck' | 'savingThrow' | 'skillCheck' | 'initiative';
+
+export interface InitiativeDialogActor extends Actor {
+	_getInitiativeFormula: (options: Record<string, unknown>) => string;
+}
+
+export interface CheckRollDialogSubmitData {
+	rollMode: number;
+	rollFormula: string;
+	visibilityMode: string;
+}
+
+export interface CheckRollDialogInstance {
+	submitRoll: (results: CheckRollDialogSubmitData) => void;
+}
+
+export interface CheckRollDialogProps extends CheckRollDialogData {
+	actor: InitiativeDialogActor;
+	dialog: CheckRollDialogInstance;
+	type?: RollDialogType;
+}


### PR DESCRIPTION
## Summary

-   Single-character initiative rolls now use the popup roll enricher, so players can set advantage or disadvantage before rolling.
-   This applies to the two character-sheet initiative buttons and the combat tracker actor-card initiative button.
-   GM bulk initiative actions still skip the popup, including Combat Tracker `Roll Initiative` and `Start Combat`.
-   Out-of-combat initiative rolls from the character sheet now use the same popup flow for consistency.

## Changes

-   Added initiative support to the existing roll popup so initiative can be configured like other d20 rolls.
-   Updated single-actor initiative rolls in combat to open that popup before rolling.
-   Updated out-of-combat initiative rolls from the character sheet to use the same popup flow.
-   Kept group initiative rolls unchanged so GM bulk actions still roll immediately with no popup.
-   Added test coverage for the new single-roll popup behavior and for canceling the popup safely.

-

## Test Plan

- [x] -   Add a character to combat.
- [x] -   Click the initiative button on the character sheet.\
- [x]     Expected: a popup opens before the roll, and you can choose advantage or disadvantage.
- [x] -   Click the initiative button in the combat tracker on that character's row/card.\
- [x]     Expected: the same popup opens before the roll.
- [x] -   Cancel the popup.\
- [x]     Expected: no initiative roll happens.
- [x] -   Use the Combat Tracker `Roll Initiative` button.\
- [x]     Expected: initiative rolls immediately with no popup.
- [x] -   Start a new combat with unrolled combatants and click `Start Combat`.\
- [x]     Expected: initiative rolls immediately with no popup.



## Checklist

- [x] Added or updated unit tests
- [x] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [x] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** yes / no
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->
