### PR TITLE
fix: Initiative dupe rolls

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -782,6 +782,7 @@
 				"useActionsFirst": "Use your actions first",
 				"noPermissionEndTurn": "You do not have permission to end turns.",
 				"noPermissionRollInitiative": "You do not have permission to roll initiative.",
+				"initiativeAlreadyRolled": "Initiative has already been rolled for this combatant.",
 				"selectAttack": "Attack",
 				"selectSpell": "Cast Spell",
 				"noWeapons": "No weapons or attack features found.",

--- a/src/view/sheets/pages/PlayerCharacterCoreTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterCoreTab.svelte
@@ -40,35 +40,42 @@
 	}
 
 	async function rollInitiative() {
-		// Check if there's an active combat on the current scene with this character
-		const combat = game.combats?.viewed;
-		const sceneId = canvas.scene?.id;
+		if (initiativeRequestPending) return;
+		initiativeRequestPending = true;
 
-		// If character is in combat for the current scene and hasn't rolled, use combat.rollInitiative
-		if (combat && sceneId && combat.scene?.id === sceneId) {
+		try {
+			const combat = game.combats?.viewed;
 			const combatant = getViewedCombatantForCurrentScene();
-			if (combatant && initiativeRollLock.hasActiveLock(combatant)) return;
 
-			if (combatant && combatant.initiative === null && combatant.id) {
+			if (combatant) {
+				if (initiativeRollLock.hasActiveLock(combatant)) return;
+				if (combatant.initiative !== null) {
+					ui.notifications?.info(localize('NIMBLE.ui.heroicActions.initiativeAlreadyRolled'));
+					return;
+				}
+				if (!combat || !combatant.id) return;
+
 				await combat.rollInitiative([combatant.id]);
 				return;
 			}
+
+			const roll = Roll.create(actor._getInitiativeFormula({}), actor.getRollData());
+			await roll.evaluate();
+
+			await roll.toMessage({
+				speaker: ChatMessage.getSpeaker({ actor }),
+				flavor: game.i18n.format('COMBAT.RollsInitiative', { name: actor.name }),
+				flags: { core: { initiativeRoll: true } },
+			});
+		} finally {
+			initiativeRequestPending = false;
 		}
-
-		// Always roll initiative to chat
-		const roll = Roll.create(actor._getInitiativeFormula({}), actor.getRollData());
-		await roll.evaluate();
-
-		await roll.toMessage({
-			speaker: ChatMessage.getSpeaker({ actor }),
-			flavor: game.i18n.format('COMBAT.RollsInitiative', { name: actor.name }),
-			flags: { core: { initiativeRoll: true } },
-		});
 	}
 
 	const { armorTypesPlural, languages } = CONFIG.NIMBLE;
 	let actor: NimbleCharacter = getContext('actor');
 	const subscribeCombatState = createSubscriber(registerCombatStateHooks);
+	let initiativeRequestPending = $state(false);
 
 	let flags = $derived(actor.reactive.flags.nimble);
 	let editingEnabled = $derived(flags?.editingEnabled ?? false);
@@ -79,6 +86,7 @@
 	let initiative = $derived(actor.reactive.system.attributes.initiative.mod);
 	let initiativePending = $derived.by(() => {
 		subscribeCombatState();
+		if (initiativeRequestPending) return true;
 		const combatant = getViewedCombatantForCurrentScene();
 		if (!combatant) return false;
 		return initiativeRollLock.hasActiveLock(combatant);

--- a/src/view/sheets/pages/PlayerCharacterCoreTab.test.ts
+++ b/src/view/sheets/pages/PlayerCharacterCoreTab.test.ts
@@ -1,0 +1,188 @@
+/// <reference types="vitest/globals" />
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import PlayerCharacterCoreTabTestHarness from './PlayerCharacterCoreTab.testHarness.svelte';
+
+function createCoreTabActor() {
+	return {
+		id: 'character-core-tab-actor',
+		name: 'Initiative Tester',
+		reactive: {
+			flags: {
+				nimble: {
+					editingEnabled: false,
+					compactSkillsView: true,
+					showPassiveSkillScores: false,
+				},
+			},
+			system: {
+				abilities: {
+					strength: { mod: 3 },
+					dexterity: { mod: 2 },
+					intelligence: { mod: 1 },
+					will: { mod: 1 },
+				},
+				skills: {
+					might: { mod: 5 },
+				},
+				savingThrows: {
+					fortitude: { mod: 4, defaultRollMode: 0 },
+					reflex: { mod: 2, defaultRollMode: 0 },
+					will: { mod: 1, defaultRollMode: 0 },
+				},
+				attributes: {
+					initiative: { mod: 2 },
+					armor: { value: 14 },
+					movement: {
+						walk: 6,
+						burrow: 0,
+						climb: 0,
+						fly: 0,
+						swim: 0,
+					},
+				},
+				proficiencies: {
+					armor: [],
+					languages: [],
+					weapons: [],
+				},
+			},
+		},
+		_getInitiativeFormula: vi.fn().mockReturnValue('1d20 + 2'),
+		getRollData: vi.fn().mockReturnValue({}),
+		rollAbilityCheckToChat: vi.fn(),
+		configureAbilityScores: vi.fn(),
+		rollSavingThrowToChat: vi.fn(),
+		configureSavingThrows: vi.fn(),
+		rollSkillCheckToChat: vi.fn(),
+		configureSkills: vi.fn(),
+		configureMovement: vi.fn(),
+		configureLanguageProficiencies: vi.fn(),
+		configureArmorProficiencies: vi.fn(),
+		configureWeaponProficiencies: vi.fn(),
+	};
+}
+
+function setCurrentScene(sceneId: string) {
+	(globalThis as unknown as { canvas?: { scene?: { id: string } } }).canvas ??= {};
+	(globalThis as unknown as { canvas: { scene: { id: string } } }).canvas.scene = {
+		id: sceneId,
+	};
+}
+
+describe('PlayerCharacterCoreTab', () => {
+	it('does not create a second chat initiative roll while the first one is still pending', async () => {
+		const actor = createCoreTabActor();
+		(
+			globalThis as unknown as {
+				game: {
+					combats: {
+						viewed: Combat | null;
+					};
+				};
+			}
+		).game.combats = { viewed: null };
+		setCurrentScene('scene-core-tab-test');
+
+		const roll = {
+			evaluate: vi.fn(),
+			toMessage: vi.fn().mockResolvedValue({ id: 'chat-message-initiative' }),
+		} as const;
+
+		let hasPendingEvaluate = false;
+		let resolveEvaluate: () => void = () => {
+			throw new Error('Expected initiative roll evaluation to remain pending.');
+		};
+		roll.evaluate.mockImplementation(async () => {
+			await new Promise<void>((resolve) => {
+				hasPendingEvaluate = true;
+				resolveEvaluate = resolve;
+			});
+			return roll;
+		});
+
+		const rollCreate = vi.fn().mockReturnValue(roll);
+		(
+			globalThis as unknown as {
+				ChatMessage: {
+					getSpeaker: ReturnType<typeof vi.fn>;
+				};
+			}
+		).ChatMessage.getSpeaker = vi.fn().mockReturnValue({ actor: actor.id });
+		(globalThis as unknown as { Roll: { create: ReturnType<typeof vi.fn> } }).Roll.create =
+			rollCreate;
+
+		render(PlayerCharacterCoreTabTestHarness, { actor });
+
+		const initiativeButton = screen.getByRole('button', { name: /roll initiative/i });
+		await fireEvent.click(initiativeButton);
+		await fireEvent.click(initiativeButton);
+
+		expect(rollCreate).toHaveBeenCalledTimes(1);
+		expect(roll.evaluate).toHaveBeenCalledTimes(1);
+		expect(roll.toMessage).not.toHaveBeenCalled();
+
+		await waitFor(() => expect(initiativeButton).toBeDisabled());
+
+		if (!hasPendingEvaluate) {
+			throw new Error('Expected initiative roll evaluation to remain pending.');
+		}
+		resolveEvaluate();
+
+		await waitFor(() => expect(roll.toMessage).toHaveBeenCalledTimes(1));
+		await waitFor(() => expect(initiativeButton).not.toBeDisabled());
+	});
+
+	it('does not fall back to a raw chat roll when the current-scene combatant already has initiative', async () => {
+		const actor = createCoreTabActor();
+		setCurrentScene('scene-core-tab-test');
+
+		const combatRollInitiative = vi.fn().mockResolvedValue(undefined);
+		(
+			globalThis as unknown as {
+				game: {
+					combats: {
+						viewed: Combat | null;
+					};
+				};
+			}
+		).game.combats = {
+			viewed: {
+				scene: { id: 'scene-core-tab-test' },
+				combatants: {
+					find: vi.fn().mockReturnValue({
+						id: 'combatant-core-tab-test',
+						actorId: actor.id,
+						initiative: 17,
+						flags: {},
+					}),
+				},
+				rollInitiative: combatRollInitiative,
+			} as unknown as Combat,
+		};
+
+		const rollCreate = vi.fn();
+		(globalThis as unknown as { Roll: { create: ReturnType<typeof vi.fn> } }).Roll.create =
+			rollCreate;
+
+		render(PlayerCharacterCoreTabTestHarness, { actor });
+
+		const initiativeButton = screen.getByRole('button', { name: /roll initiative/i });
+		await fireEvent.click(initiativeButton);
+
+		expect(combatRollInitiative).not.toHaveBeenCalled();
+		expect(rollCreate).not.toHaveBeenCalled();
+		expect(
+			(
+				globalThis as unknown as {
+					ui: {
+						notifications: {
+							info: ReturnType<typeof vi.fn>;
+						};
+					};
+				}
+			).ui.notifications.info,
+		).toHaveBeenCalledWith('Initiative has already been rolled for this combatant.');
+		expect(initiativeButton).not.toBeDisabled();
+	});
+});

--- a/src/view/sheets/pages/PlayerCharacterCoreTab.testHarness.svelte
+++ b/src/view/sheets/pages/PlayerCharacterCoreTab.testHarness.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import { setContext, untrack } from 'svelte';
+	import PlayerCharacterCoreTab from './PlayerCharacterCoreTab.svelte';
+
+	let { actor } = $props();
+
+	setContext(
+		'actor',
+		untrack(() => actor),
+	);
+</script>
+
+<PlayerCharacterCoreTab />


### PR DESCRIPTION
## Summary

This PR stops duplicate async initiative rolls from the character sheet's core initiative button.

It does two things:
-   prevents repeat clicks from starting multiple rolls while one initiative roll is already in progress
-   stops the sheet button from falling back to a raw chat initiative roll when the actor already has initiative in the current combat, and shows a notice instead

It also adds regression tests for both cases.

## Changes

- The PR changes the character sheet initiative button so repeated clicks do not start duplicate async initiative rolls. It also stops the button from creating a new raw chat initiative roll if that combatant already has initiative, and shows a notice instead.

-

## Test Plan

- [x] Click the initiative button rapidly and confirm only one roll happens. Then, after the character already has initiative in the current combat, click the button again and confirm no new roll is made and a notice appears.



## Checklist

- [x] Added or updated unit tests
- [x] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [x] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** yes / no
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->
