### PR TITLE
feat(rules): add initiativeMessage rule type

### DIFF
--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -1392,6 +1392,7 @@ export const myStore = writable<MyStoreState>(initialState);
 | `sortDocumentsByName()` | `src/utils/sortDocumentsByName.ts` | Sort Foundry documents alphabetically |
 | `isValidDiceModifier()` | `src/utils/isValidDiceModifier.ts` | Validate dice modifier strings |
 | `combatManaRules` | `src/utils/combatManaRules.ts` | Combat mana calculation and rules |
+| `itemSourceRules` | `src/utils/itemSourceRules.ts` | Resolve compendium source IDs and rules for embedded items |
 | `manaRecovery` | `src/utils/manaRecovery.ts` | Mana recovery calculations |
 | `prelocalize()` | `src/utils/prelocalize.ts` | Pre-localize configuration objects |
 | `getChoicesFromCompendium()` | `src/utils/getChoicesFromCompendium.ts` | Fetch selectable options from compendiums |

--- a/packs/classFeatures/core/berserker/savage-arsenal/eager-for-battle.json
+++ b/packs/classFeatures/core/berserker/savage-arsenal/eager-for-battle.json
@@ -13,6 +13,12 @@
 				"value": 1,
 				"mode": "adjust",
 				"label": "Eager for Battle (Advantage on Initiative)"
+			},
+			{
+				"type": "initiativeMessage",
+				"formula": "2 * @dexterity",
+				"label": "Eager for Battle",
+				"message": "You can move {value} spaces for free on your first turn!"
 			}
 		],
 		"activation": {

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -534,6 +534,7 @@
 			"hitDiceAdvantage": "Hit Dice Advantage",
 			"incrementHitDice": "Increment Hit Dice",
 			"initiativeBonus": "Initiative Bonus",
+			"initiativeMessage": "Initiative Message",
 			"initiativeRollMode": "Initiative Roll Mode",
 			"maxHitDice": "Hit Dice",
 			"maxHpBonus": "Hit Points",

--- a/src/config/registerRulesConfig.ts
+++ b/src/config/registerRulesConfig.ts
@@ -7,6 +7,7 @@ import { HealingPotionBonusRule } from '../models/rules/healingPotionBonus.js';
 import { HitDiceAdvantageRule } from '../models/rules/hitDiceAdvantage.js';
 import { IncrementHitDiceRule } from '../models/rules/incrementHitDice.js';
 import { InitiativeBonusRule } from '../models/rules/initiativeBonus.js';
+import { InitiativeMessageRule } from '../models/rules/initiativeMessage.js';
 import { InitiativeRollModeRule } from '../models/rules/initiativeRollMode.js';
 import { MaxHitDiceRule } from '../models/rules/maxHitDice.js';
 import { MaxHpBonusRule } from '../models/rules/maxHpBonus.js';
@@ -31,6 +32,7 @@ export default function registerRulesConfig() {
 		hitDiceAdvantage: 'NIMBLE.ruleTypes.hitDiceAdvantage',
 		incrementHitDice: 'NIMBLE.ruleTypes.incrementHitDice',
 		initiativeBonus: 'NIMBLE.ruleTypes.initiativeBonus',
+		initiativeMessage: 'NIMBLE.ruleTypes.initiativeMessage',
 		initiativeRollMode: 'NIMBLE.ruleTypes.initiativeRollMode',
 		maxHitDice: 'NIMBLE.ruleTypes.maxHitDice',
 		maxHpBonus: 'NIMBLE.ruleTypes.maxHpBonus',
@@ -55,6 +57,7 @@ export default function registerRulesConfig() {
 		hitDiceAdvantage: HitDiceAdvantageRule,
 		incrementHitDice: IncrementHitDiceRule,
 		initiativeBonus: InitiativeBonusRule,
+		initiativeMessage: InitiativeMessageRule,
 		initiativeRollMode: InitiativeRollModeRule,
 		maxHitDice: MaxHitDiceRule,
 		maxHpBonus: MaxHpBonusRule,

--- a/src/documents/combat/handleInitiativeRules.ts
+++ b/src/documents/combat/handleInitiativeRules.ts
@@ -1,4 +1,5 @@
 import combatManaHandler from './handlers/combatManaHandler.js';
+import initiativeMessageHandler from './handlers/initiativeMessageHandler.js';
 
 interface HandleInitiativeRulesParams {
 	combatId: string | null;
@@ -8,4 +9,5 @@ interface HandleInitiativeRulesParams {
 
 export async function handleInitiativeRules(params: HandleInitiativeRulesParams): Promise<void> {
 	await combatManaHandler(params);
+	await initiativeMessageHandler(params.combatant);
 }

--- a/src/documents/combat/handlers/initiativeMessageHandler.ts
+++ b/src/documents/combat/handlers/initiativeMessageHandler.ts
@@ -13,19 +13,10 @@ type ActorWithRules = Actor & {
 	items?: Iterable<ItemLike>;
 };
 
-/**
- * Returns the compendium UUID for an embedded item, falling back through the
- * various locations Foundry uses across different versions.
- */
 function getItemSourceId(item: ItemLike): string | undefined {
 	return item.sourceId ?? item._stats?.compendiumSource ?? item.flags?.core?.source;
 }
 
-/**
- * Reads rules from the item's compendium source via `fromUuidSync`.
- * Used to hydrate rules on embedded items that predate the rule being added
- * to the compendium — the same fallback pattern used in `combatManaRules.ts`.
- */
 function getRulesFromCompendiumSource(item: ItemLike): Record<string, unknown>[] {
 	const sourceId = getItemSourceId(item);
 	if (!sourceId) return [];
@@ -42,11 +33,7 @@ function getRulesFromCompendiumSource(item: ItemLike): Record<string, unknown>[]
 	return Array.isArray(sourceItem?.system?.rules) ? sourceItem.system.rules : [];
 }
 
-/**
- * Returns all `initiativeMessage` rule sources for an item.
- * Prefers the embedded item's own rules; falls back to the compendium source
- * when the embedded copy predates the rule addition.
- */
+// Prefers embedded rules; falls back to compendium source for items that predate the rule addition.
 function getInitiativeMessageRuleSources(item: ItemLike): Record<string, unknown>[] {
 	const embeddedRules = item.system?.rules ?? [];
 	const hasLocalDefinition = embeddedRules.some((r) => r.type === 'initiativeMessage');
@@ -55,14 +42,6 @@ function getInitiativeMessageRuleSources(item: ItemLike): Record<string, unknown
 	return ruleSources.filter((r) => r.type === 'initiativeMessage' && r.disabled !== true);
 }
 
-/**
- * Fires when a character rolls initiative.  Collects every `initiativeMessage`
- * rule from the actor's items (using the compendium source as a fallback for
- * stale embedded copies) and whispers each resolved message to the owning player.
- *
- * Adding the behaviour to any feature requires only a `"type": "initiativeMessage"`
- * entry in that feature's `system.rules` array — no code changes needed.
- */
 export default async function initiativeMessageHandler(
 	combatant: Combatant.Implementation,
 ): Promise<void> {

--- a/src/documents/combat/handlers/initiativeMessageHandler.ts
+++ b/src/documents/combat/handlers/initiativeMessageHandler.ts
@@ -1,0 +1,100 @@
+import { InitiativeMessageRule } from '../../../models/rules/initiativeMessage.js';
+
+type ItemLike = {
+	uuid?: string;
+	id?: string;
+	sourceId?: string;
+	_stats?: { compendiumSource?: string };
+	flags?: { core?: { source?: string } };
+	system?: { rules?: Record<string, unknown>[] };
+};
+
+type ActorWithRules = Actor & {
+	items?: Iterable<ItemLike>;
+};
+
+/**
+ * Returns the compendium UUID for an embedded item, falling back through the
+ * various locations Foundry uses across different versions.
+ */
+function getItemSourceId(item: ItemLike): string | undefined {
+	return item.sourceId ?? item._stats?.compendiumSource ?? item.flags?.core?.source;
+}
+
+/**
+ * Reads rules from the item's compendium source via `fromUuidSync`.
+ * Used to hydrate rules on embedded items that predate the rule being added
+ * to the compendium — the same fallback pattern used in `combatManaRules.ts`.
+ */
+function getRulesFromCompendiumSource(item: ItemLike): Record<string, unknown>[] {
+	const sourceId = getItemSourceId(item);
+	if (!sourceId) return [];
+
+	const fromUuidSyncFn = (globalThis as Record<string, unknown>).fromUuidSync as
+		| ((uuid: string) => unknown)
+		| undefined;
+	if (typeof fromUuidSyncFn !== 'function') return [];
+
+	const sourceItem = fromUuidSyncFn(sourceId) as {
+		system?: { rules?: Record<string, unknown>[] };
+	} | null;
+
+	return Array.isArray(sourceItem?.system?.rules) ? sourceItem.system.rules : [];
+}
+
+/**
+ * Returns all `initiativeMessage` rule sources for an item.
+ * Prefers the embedded item's own rules; falls back to the compendium source
+ * when the embedded copy predates the rule addition.
+ */
+function getInitiativeMessageRuleSources(item: ItemLike): Record<string, unknown>[] {
+	const embeddedRules = item.system?.rules ?? [];
+	const hasLocalDefinition = embeddedRules.some((r) => r.type === 'initiativeMessage');
+
+	const ruleSources = hasLocalDefinition ? embeddedRules : getRulesFromCompendiumSource(item);
+	return ruleSources.filter((r) => r.type === 'initiativeMessage' && r.disabled !== true);
+}
+
+/**
+ * Fires when a character rolls initiative.  Collects every `initiativeMessage`
+ * rule from the actor's items (using the compendium source as a fallback for
+ * stale embedded copies) and whispers each resolved message to the owning player.
+ *
+ * Adding the behaviour to any feature requires only a `"type": "initiativeMessage"`
+ * entry in that feature's `system.rules` array — no code changes needed.
+ */
+export default async function initiativeMessageHandler(
+	combatant: Combatant.Implementation,
+): Promise<void> {
+	const actor = combatant.actor as ActorWithRules | null;
+
+	const shouldRun =
+		combatant.type === 'character' && combatant.initiative === null && actor?.isOwner === true;
+
+	if (!shouldRun || !actor) return;
+
+	const whisperTargets = game.user?.id ? [game.user.id] : [];
+	const speaker = ChatMessage.getSpeaker({
+		actor: actor as unknown as Actor,
+		token: combatant.token,
+	});
+
+	for (const item of actor.items ?? []) {
+		for (const ruleSource of getInitiativeMessageRuleSources(item)) {
+			const rule = new InitiativeMessageRule(
+				ruleSource as Parameters<typeof InitiativeMessageRule.prototype.resolveMessage>[never],
+				{ parent: item as unknown as foundry.abstract.DataModel.Any },
+			);
+
+			const content = rule.resolveMessage();
+			if (!content) continue;
+
+			await ChatMessage.create({
+				author: game.user?.id,
+				speaker,
+				whisper: whisperTargets,
+				content: `<p><strong>${rule.label}</strong>: ${content}</p>`,
+			} as ChatMessage.CreateData);
+		}
+	}
+}

--- a/src/documents/combat/handlers/initiativeMessageHandler.ts
+++ b/src/documents/combat/handlers/initiativeMessageHandler.ts
@@ -1,4 +1,5 @@
 import { InitiativeMessageRule } from '../../../models/rules/initiativeMessage.js';
+import { getRulesFromCompendiumSource } from '../../../utils/itemSourceRules.js';
 
 type ItemLike = {
 	uuid?: string;
@@ -13,28 +14,8 @@ type ActorWithRules = Actor & {
 	items?: Iterable<ItemLike>;
 };
 
-function getItemSourceId(item: ItemLike): string | undefined {
-	return item.sourceId ?? item._stats?.compendiumSource ?? item.flags?.core?.source;
-}
-
-function getRulesFromCompendiumSource(item: ItemLike): Record<string, unknown>[] {
-	const sourceId = getItemSourceId(item);
-	if (!sourceId) return [];
-
-	const fromUuidSyncFn = (globalThis as Record<string, unknown>).fromUuidSync as
-		| ((uuid: string) => unknown)
-		| undefined;
-	if (typeof fromUuidSyncFn !== 'function') return [];
-
-	const sourceItem = fromUuidSyncFn(sourceId) as {
-		system?: { rules?: Record<string, unknown>[] };
-	} | null;
-
-	return Array.isArray(sourceItem?.system?.rules) ? sourceItem.system.rules : [];
-}
-
 // Prefers embedded rules; falls back to compendium source for items that predate the rule addition.
-function getInitiativeMessageRuleSources(item: ItemLike): Record<string, unknown>[] {
+export function getInitiativeMessageRuleSources(item: ItemLike): Record<string, unknown>[] {
 	const embeddedRules = item.system?.rules ?? [];
 	const hasLocalDefinition = embeddedRules.some((r) => r.type === 'initiativeMessage');
 
@@ -61,18 +42,19 @@ export default async function initiativeMessageHandler(
 	for (const item of actor.items ?? []) {
 		for (const ruleSource of getInitiativeMessageRuleSources(item)) {
 			const rule = new InitiativeMessageRule(
-				ruleSource as Parameters<typeof InitiativeMessageRule.prototype.resolveMessage>[never],
+				ruleSource as ConstructorParameters<typeof InitiativeMessageRule>[0],
 				{ parent: item as unknown as foundry.abstract.DataModel.Any },
 			);
 
 			const content = rule.resolveMessage();
 			if (!content) continue;
 
+			const label = foundry.utils.escapeHTML(rule.label);
 			await ChatMessage.create({
 				author: game.user?.id,
 				speaker,
 				whisper: whisperTargets,
-				content: `<p><strong>${rule.label}</strong>: ${content}</p>`,
+				content: `<p><strong>${label}</strong>: ${content}</p>`,
 			} as ChatMessage.CreateData);
 		}
 	}

--- a/src/models/rules/initiativeMessage.test.ts
+++ b/src/models/rules/initiativeMessage.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getInitiativeMessageRuleSources } from '../../documents/combat/handlers/initiativeMessageHandler.js';
+import { InitiativeMessageRule } from './initiativeMessage.js';
+
+function createMockItem() {
+	const mockActor = {
+		system: {},
+		getDomain: () => new Set<string>(),
+		getRollData: vi.fn(() => ({ dexterity: 3 })),
+	};
+	return {
+		isEmbedded: true,
+		actor: mockActor,
+		name: 'Test Item',
+		uuid: 'test-uuid',
+		getDomain: () => new Set<string>(),
+	};
+}
+
+function createRule(overrides: Record<string, unknown> = {}) {
+	const item = createMockItem();
+	const rule = new InitiativeMessageRule(
+		{
+			formula: '6',
+			message: 'Move {value} spaces!',
+			label: 'Test Rule',
+			disabled: false,
+			id: 'test-id',
+			identifier: '',
+			priority: 1,
+			predicate: {},
+			type: 'initiativeMessage',
+			...overrides,
+		},
+		{
+			parent: item as unknown as foundry.abstract.DataModel.Any,
+			strict: false,
+		},
+	);
+	Object.defineProperty(rule, 'item', { get: () => item, configurable: true });
+	rule.formula = (overrides.formula as string) ?? '6';
+	rule.message = (overrides.message as string) ?? 'Move {value} spaces!';
+	rule.label = (overrides.label as string) ?? 'Test Rule';
+	return rule;
+}
+
+describe('InitiativeMessageRule', () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe('resolveMessage', () => {
+		it('substitutes a literal formula result into {value}', () => {
+			const rule = createRule({ formula: '6', message: 'Move {value} spaces!' });
+			expect(rule.resolveMessage()).toBe('Move 6 spaces!');
+		});
+
+		it('replaces multiple {value} tokens', () => {
+			const rule = createRule({ formula: '4', message: '{value} here and {value} there' });
+			expect(rule.resolveMessage()).toBe('4 here and 4 there');
+		});
+
+		it('returns empty string when message is empty', () => {
+			const rule = createRule({ formula: '4', message: '' });
+			expect(rule.resolveMessage()).toBe('');
+		});
+
+		it('defaults to 0 when formula is empty', () => {
+			const rule = createRule({ formula: '', message: 'Move {value} spaces!' });
+			expect(rule.resolveMessage()).toBe('Move 0 spaces!');
+		});
+	});
+});
+
+describe('getInitiativeMessageRuleSources', () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+	});
+
+	it('returns initiativeMessage rules from embedded item', () => {
+		const item = {
+			system: {
+				rules: [
+					{ type: 'initiativeMessage', formula: '4', message: 'test', disabled: false },
+					{ type: 'speedBonus', value: '1' },
+				],
+			},
+		};
+		const result = getInitiativeMessageRuleSources(item);
+		expect(result).toHaveLength(1);
+		expect(result[0].type).toBe('initiativeMessage');
+	});
+
+	it('filters out disabled rules', () => {
+		const item = {
+			system: {
+				rules: [{ type: 'initiativeMessage', formula: '4', message: 'test', disabled: true }],
+			},
+		};
+		expect(getInitiativeMessageRuleSources(item)).toHaveLength(0);
+	});
+
+	it('falls back to compendium source when embedded item has no initiativeMessage rule', () => {
+		const compendiumRules = [
+			{ type: 'initiativeMessage', formula: '4', message: 'from compendium', disabled: false },
+		];
+		vi.stubGlobal('fromUuidSync', () => ({ system: { rules: compendiumRules } }));
+
+		const item = {
+			sourceId: 'Compendium.nimble.features.Item.abc123',
+			system: { rules: [{ type: 'speedBonus', value: '1' }] },
+		};
+
+		const result = getInitiativeMessageRuleSources(item);
+		expect(result).toHaveLength(1);
+		expect(result[0].message).toBe('from compendium');
+	});
+
+	it('returns empty array when item has no rules and no compendium source', () => {
+		const item = { system: { rules: [] } };
+		expect(getInitiativeMessageRuleSources(item)).toHaveLength(0);
+	});
+});

--- a/src/models/rules/initiativeMessage.ts
+++ b/src/models/rules/initiativeMessage.ts
@@ -4,21 +4,9 @@ function schema() {
 	const { fields } = foundry.data;
 
 	return {
-		/**
-		 * A roll formula evaluated against the actor's roll data.
-		 * Supports `@`-references such as `@dexterity`.
-		 * The resolved numeric result is substituted for every `{value}`
-		 * placeholder in the `message` field.
-		 */
+		// Supports @-references (e.g. @dexterity). Use {value} in message to insert the result.
 		formula: new fields.StringField({ required: true, nullable: false, initial: '' }),
-
-		/**
-		 * The whispered chat message shown to the owning player when they roll
-		 * initiative.  Use `{value}` as a placeholder for the resolved `formula`.
-		 * Example: `"You can move {value} spaces for free on your first turn!"`
-		 */
 		message: new fields.StringField({ required: true, nullable: false, initial: '' }),
-
 		type: new fields.StringField({
 			required: true,
 			nullable: false,
@@ -31,14 +19,6 @@ declare namespace InitiativeMessageRule {
 	type Schema = NimbleBaseRule.Schema & ReturnType<typeof schema>;
 }
 
-/**
- * Rule that whispers a calculated reminder to the owning player when they roll
- * initiative.  The `formula` is evaluated against the actor's roll data and its
- * result is substituted into every `{value}` token in `message`.
- *
- * This rule is feature-agnostic: any item can carry it by adding an entry with
- * `"type": "initiativeMessage"` to its `system.rules` array.
- */
 class InitiativeMessageRule extends NimbleBaseRule<InitiativeMessageRule.Schema> {
 	declare formula: string;
 	declare message: string;
@@ -59,10 +39,6 @@ class InitiativeMessageRule extends NimbleBaseRule<InitiativeMessageRule.Schema>
 		);
 	}
 
-	/**
-	 * Evaluates `formula` against the actor's roll data and returns the
-	 * `message` string with every `{value}` token replaced by the result.
-	 */
 	resolveMessage(): string {
 		const value = this.resolveFormula(this.formula) ?? 0;
 		return this.message.replaceAll('{value}', String(value));

--- a/src/models/rules/initiativeMessage.ts
+++ b/src/models/rules/initiativeMessage.ts
@@ -1,0 +1,72 @@
+import { NimbleBaseRule } from './base.js';
+
+function schema() {
+	const { fields } = foundry.data;
+
+	return {
+		/**
+		 * A roll formula evaluated against the actor's roll data.
+		 * Supports `@`-references such as `@dexterity`.
+		 * The resolved numeric result is substituted for every `{value}`
+		 * placeholder in the `message` field.
+		 */
+		formula: new fields.StringField({ required: true, nullable: false, initial: '' }),
+
+		/**
+		 * The whispered chat message shown to the owning player when they roll
+		 * initiative.  Use `{value}` as a placeholder for the resolved `formula`.
+		 * Example: `"You can move {value} spaces for free on your first turn!"`
+		 */
+		message: new fields.StringField({ required: true, nullable: false, initial: '' }),
+
+		type: new fields.StringField({
+			required: true,
+			nullable: false,
+			initial: 'initiativeMessage',
+		}),
+	};
+}
+
+declare namespace InitiativeMessageRule {
+	type Schema = NimbleBaseRule.Schema & ReturnType<typeof schema>;
+}
+
+/**
+ * Rule that whispers a calculated reminder to the owning player when they roll
+ * initiative.  The `formula` is evaluated against the actor's roll data and its
+ * result is substituted into every `{value}` token in `message`.
+ *
+ * This rule is feature-agnostic: any item can carry it by adding an entry with
+ * `"type": "initiativeMessage"` to its `system.rules` array.
+ */
+class InitiativeMessageRule extends NimbleBaseRule<InitiativeMessageRule.Schema> {
+	declare formula: string;
+	declare message: string;
+
+	static override defineSchema(): InitiativeMessageRule.Schema {
+		return {
+			...NimbleBaseRule.defineSchema(),
+			...schema(),
+		};
+	}
+
+	override tooltipInfo(): string {
+		return super.tooltipInfo(
+			new Map([
+				['formula', 'string'],
+				['message', 'string'],
+			]),
+		);
+	}
+
+	/**
+	 * Evaluates `formula` against the actor's roll data and returns the
+	 * `message` string with every `{value}` token replaced by the result.
+	 */
+	resolveMessage(): string {
+		const value = this.resolveFormula(this.formula) ?? 0;
+		return this.message.replaceAll('{value}', String(value));
+	}
+}
+
+export { InitiativeMessageRule };

--- a/src/utils/combatManaRules.ts
+++ b/src/utils/combatManaRules.ts
@@ -1,4 +1,9 @@
 import getDeterministicBonus from '../dice/getDeterministicBonus.js';
+import {
+	getItemSourceId,
+	getRulesFromCompendiumSource,
+	sourceRuleCache,
+} from './itemSourceRules.js';
 
 interface CombatManaRuleLike {
 	id?: string;
@@ -25,15 +30,6 @@ type ActorWithCollections = Actor & {
 
 const COMBAT_MANA_FLAG_SCOPE = 'nimble';
 const COMBAT_MANA_FLAG_KEY = 'combatManaGrants';
-const sourceRuleCache = new Map<string, Record<string, unknown>[]>();
-
-function getItemSourceId(item: {
-	sourceId?: string;
-	_stats?: { compendiumSource?: string };
-	flags?: { core?: { source?: string } };
-}): string | undefined {
-	return item.sourceId ?? item._stats?.compendiumSource ?? item.flags?.core?.source;
-}
 
 function normalizeGrantMap(value: unknown): CombatManaGrantMap {
 	if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
@@ -85,27 +81,7 @@ function getRuleSourcesFromItemSource(item: {
 	_stats?: { compendiumSource?: string };
 	flags?: { core?: { source?: string } };
 }): Record<string, unknown>[] {
-	const sourceId = getItemSourceId(item);
-	if (!sourceId) return [];
-
-	const cachedRules = sourceRuleCache.get(sourceId);
-	if (cachedRules && cachedRules.length > 0) {
-		return foundry.utils.deepClone(cachedRules);
-	}
-
-	const fromUuidSyncFn = (globalThis as Record<string, unknown>).fromUuidSync as
-		| ((uuid: string) => unknown)
-		| undefined;
-	if (typeof fromUuidSyncFn !== 'function') return [];
-
-	const sourceItem = fromUuidSyncFn(sourceId) as {
-		system?: { rules?: Record<string, unknown>[] };
-	} | null;
-	const sourceRules = Array.isArray(sourceItem?.system?.rules) ? sourceItem.system.rules : [];
-	if (sourceRules.length > 0) {
-		sourceRuleCache.set(sourceId, foundry.utils.deepClone(sourceRules));
-	}
-	return foundry.utils.deepClone(sourceRules);
+	return getRulesFromCompendiumSource(item);
 }
 
 export async function primeActorCombatManaSourceRules(

--- a/src/utils/itemSourceRules.ts
+++ b/src/utils/itemSourceRules.ts
@@ -1,0 +1,32 @@
+type ItemSourceLike = {
+	sourceId?: string;
+	_stats?: { compendiumSource?: string };
+	flags?: { core?: { source?: string } };
+};
+
+export const sourceRuleCache = new Map<string, Record<string, unknown>[]>();
+
+export function getItemSourceId(item: ItemSourceLike): string | undefined {
+	return item.sourceId ?? item._stats?.compendiumSource ?? item.flags?.core?.source;
+}
+
+export function getRulesFromCompendiumSource(item: ItemSourceLike): Record<string, unknown>[] {
+	const sourceId = getItemSourceId(item);
+	if (!sourceId) return [];
+
+	const cached = sourceRuleCache.get(sourceId);
+	if (cached && cached.length > 0) return foundry.utils.deepClone(cached);
+
+	const fromUuidSyncFn = (globalThis as Record<string, unknown>).fromUuidSync as
+		| ((uuid: string) => unknown)
+		| undefined;
+	if (typeof fromUuidSyncFn !== 'function') return [];
+
+	const sourceItem = fromUuidSyncFn(sourceId) as {
+		system?: { rules?: Record<string, unknown>[] };
+	} | null;
+
+	const rules = Array.isArray(sourceItem?.system?.rules) ? sourceItem.system.rules : [];
+	if (rules.length > 0) sourceRuleCache.set(sourceId, foundry.utils.deepClone(rules));
+	return foundry.utils.deepClone(rules);
+}


### PR DESCRIPTION
Adds a generic initiativeMessage rule type that whispers a calculated reminder to the player on initiative roll. Any feature can use it by adding a rule entry with type "initiativeMessage", a formula, and a message template.

Falls back to the compendium source rules for embedded items that predate the rule addition, ensuring the feature works even if the player hasn't re-added it to their character sheet.

## Summary
Adds a reusable initiativeMessage rule type that whispers a calculated reminder to the owning player when they roll initiative. Updates Eager for Battle to use it as the first example.

## Changes
- New initiativeMessage rule type (src/models/rules/initiativeMessage.ts) with formula and message fields — {value} in the message is replaced by the evaluated formula result
- New initiativeMessageHandler that reads initiativeMessage rules from all actor items, falling back to the compendium source for stale embedded copies
- Registered initiativeMessage in registerRulesConfig.ts with English localization string
- Updated Eager for Battle (eager-for-battle.json) to use the new rule with formula: "2 * @dexterity"


## Test Plan
1. Run pnpm build:compendia && pnpm build to rebuild packs and bundle
2. Fully restart the Foundry server (not just browser refresh)
3. Open a world with a character that has Eager for Battle on their sheet
4. Start a combat and roll initiative for that character
5. Confirm a whispered chat message appears showing the correct 2 × DEX spaces value
6. Roll initiative for a character without the feature — confirm no message appears


## Checklist

- [] Added or updated unit tests
- [x] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [x] Tested in Foundry with no console errors
- [yes] **Have you used AI to assist with this PR?** yes / no
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues

#407 
