### PR TITLE
fix(docs-deploy): restrict deployment trigger to main branch only

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -2,7 +2,7 @@ name: Deploy Docs
 
 on:
   push:
-    branches: [dev, main]
+    branches: [main]
     paths:
       - 'docs/**'
 


### PR DESCRIPTION
## Summary

Fix docs-deploy triggering on pushes to `dev` branch due to github pages only allows actions to deploy on the branch that is set as the main branch.

## Changes

- Change on push trigger to only fire when `main` updates

## Test Plan

- This merge should not trigger a deploy of docs-pages

## Checklist

- [ ] Added or updated unit tests
- [X] PR targets the `dev` branch
- [ ] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [ ] No hardcoded user-facing strings (used `localize()`)
- [ ] Tested in Foundry with no console errors
- [ ] **Have you used AI to assist with this PR?** yes / no
- [ ] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues

