### PR TITLE
chore(agents): add rules system context hook

### DIFF
--- a/.claude/hooks/rules-context.md
+++ b/.claude/hooks/rules-context.md
@@ -1,0 +1,71 @@
+# Rules System Context
+
+You are working with Nimble's **Rules system** — generic, data-driven modifiers attached to items that automatically apply effects to actors during data preparation.
+
+## Design Philosophy
+
+Rules are **intentionally generic building blocks**, not named after specific features. A rule like `abilityBonus` can be used by any item — a class feature, a magic item, a racial trait — to grant an ability score bonus. This generality enables **homebrewing**: game masters can compose any combination of rules on any item to create custom features without code changes. When creating new rule types, keep them general-purpose. Name them after *what they do* (e.g., `speedBonus`, `grantProficiency`), never after a specific feature that uses them.
+
+## Architecture
+
+- **Base class**: `NimbleBaseRule` (`src/models/rules/base.ts`) extends `foundry.abstract.DataModel`
+- **Registration**: `src/config/registerRulesConfig.ts` maps type strings to classes in `CONFIG.NIMBLE.ruleDataModels` and i18n labels in `CONFIG.NIMBLE.ruleTypes`
+- **Storage**: Plain objects in `item.system.rules` (`ArrayField` of `ObjectField`). Each has `id`, `type`, `disabled`, `priority`, `predicate`, and type-specific fields
+- **Instantiation**: `RulesManager` (`src/managers/RulesManager.ts`) is created per item in `prepareBaseData()`, looks up classes from `CONFIG.NIMBLE.ruleDataModels`, instantiates with item as parent
+
+## Lifecycle Hooks (execution order)
+
+1. `prePrepareData()` — called during `actor.prepareDerivedData()`. Modify actor system data (bonuses, stats)
+2. `afterPrepareData()` — called after `actor.prepareData()` completes. Final adjustments
+3. `preCreate(args)` — before item creation on actor. Can grant other items, modify pending items
+4. `preUpdate(changes)` / `afterUpdate(changes)` — around item updates
+5. `afterDelete()` — after item deletion, revert modifications
+6. `preUpdateActor(changes)` — before actor update, can create/delete embedded items
+
+The actor collects all enabled rules from all items, sorts by `priority`, then calls hooks in order.
+
+## Creating a New Rule Type
+
+1. Create `src/models/rules/yourRule.ts` extending `NimbleBaseRule`
+2. Define a local `schema()` function returning type-specific Foundry data fields
+3. Override `defineSchema()` merging `NimbleBaseRule.defineSchema()` with your schema
+4. Implement lifecycle hooks (most commonly `prePrepareData()`)
+5. Register in `src/config/registerRulesConfig.ts` — add to both `ruleTypes` and `ruleDataModels`
+6. Add the i18n label key to `en.json`
+7. Keep the rule **generic** — it should be reusable across any item type
+8. Add a co-located test file `src/models/rules/yourRule.test.ts` — see existing tests (e.g., `speedBonus.test.ts`) for the pattern: mock actor/item, instantiate the rule directly, and verify lifecycle hooks modify actor data correctly
+
+## Key Patterns
+
+- **Guard with `isEmbedded`**: Always `if (!item.isEmbedded) return;` at start of `prePrepareData()`
+- **Predicate testing**: `this.test()` checks domain tags. Empty predicate = always apply
+- **Formula resolution**: `this.resolveFormula(formula)` evaluates against actor roll data
+- **Forward declarations**: Use local interfaces for `NimbleBaseActor`/`NimbleBaseItem` to avoid circular imports (see base.ts pattern)
+- **Modify actor via `foundry.utils.setProperty()`**: e.g., `foundry.utils.setProperty(actor.system, 'abilities.${ability}.bonus', newValue)`
+
+## RulesManager API
+
+`RulesManager` extends `Map<string, NimbleBaseRule>`:
+- `addRule(data, options?)` / `updateRule(id, data)` / `deleteRule(id)` — CRUD
+- `hasRuleOfType(type)` / `getRuleOfType(type)` — query by type
+- `disableAllRules()` / `enableAllRules()` — bulk toggle
+
+## Example: AbilityBonusRule pattern
+
+```typescript
+class AbilityBonusRule extends NimbleBaseRule<AbilityBonusRule.Schema> {
+  static override defineSchema(): AbilityBonusRule.Schema {
+    return { ...NimbleBaseRule.defineSchema(), ...schema() };
+  }
+
+  prePrepareData(): void {
+    if (!this.item.isEmbedded) return;
+    const actor = this.item.actor as NimbleCharacter;
+    const value = this.resolveFormula(this.value);
+    for (const ability of this.abilities) {
+      const baseBonus = actor.system.abilities[ability]?.bonus ?? 0;
+      foundry.utils.setProperty(actor.system, `abilities.${ability}.bonus`, baseBonus + value);
+    }
+  }
+}
+```

--- a/.claude/hooks/rules-context.sh
+++ b/.claude/hooks/rules-context.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Injects rules system context when reading/editing files in src/models/rules/
+set -e
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+# Only inject for rules/ files
+if [[ ! "$FILE_PATH" == *"src/models/rules/"* ]] && [[ ! "$FILE_PATH" == *"src\\models\\rules\\"* ]]; then
+  exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CONTEXT=$(cat "$SCRIPT_DIR/rules-context.md")
+
+jq -n \
+  --arg context "$CONTEXT" \
+  '{
+    "hookSpecificOutput": {
+      "hookEventName": "PreToolUse",
+      "permissionDecision": "allow",
+      "additionalContext": $context
+    }
+  }'
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,18 @@
 {
+	"hooks": {
+		"PreToolUse": [
+			{
+				"matcher": "Read|Edit|Write",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/rules-context.sh\"",
+						"timeout": 5
+					}
+				]
+			}
+		]
+	},
 	"permissions": {
 		"allow": [
 			"Bash(find:*)",


### PR DESCRIPTION
## Summary

Adds a Claude Code hook that automatically injects rules system documentation when agents read or edit files in `src/models/rules/`, so they understand the architecture, lifecycle, and design philosophy without manual prompting.

## Changes

- Added `.claude/hooks/rules-context.md` — rules system documentation covering design philosophy, architecture, lifecycle hooks, creation steps, key patterns, and RulesManager API
- Added `.claude/hooks/rules-context.sh` — hook script that detects file paths in `src/models/rules/` and injects the context doc via `additionalContext`
- Updated `.claude/settings.json` — registered the `PreToolUse` hook on `Read|Edit|Write` tools

## Test Plan

1. Open a Claude Code session in this repo
2. Read or edit any file in `src/models/rules/` (e.g., `src/models/rules/abilityBonus.ts`)
3. Verify the rules system context appears as a system reminder in the conversation
4. Read a file outside `src/models/rules/` and verify no context is injected

## Checklist

- [ ] Added or updated unit tests
- [x] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [ ] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** yes
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues

<!-- No related issues -->