### PR TITLE
chore: update Discord invite link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Discord Community
-    url: https://discord.gg/k2E2QUCzeT
+    url: https://discord.gg/SxVmHpu34R
     about: For questions, general discussion, or help with development setup

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Have an idea? We'd love to hear it. For large features, consider discussing on [Discord](https://discord.gg/WRf5hBqM) first.
+        Have an idea? We'd love to hear it. For large features, consider discussing on [Discord](https://discord.gg/SxVmHpu34R) first.
 
   - type: textarea
     id: problem

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,7 +151,7 @@ The system integrates deeply with FoundryVTT through:
 
 ### Community & Communication
 
-**Join our Discord server before contributing:** [Nimble FoundryVTT System](https://discord.gg/WRf5hBqM)
+**Join our Discord server before contributing:** [Nimble FoundryVTT System](https://discord.gg/SxVmHpu34R)
 
 We encourage all contributors to join the Discord and discuss changes before submitting large or architectural PRs. This helps ensure alignment with project direction and prevents wasted effort.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Nimble for FoundryVTT
 
 [![License: MIT](https://img.shields.io/badge/Software_License-MIT-blue.svg)](https://mit-license.org/)
-[![Discord](https://img.shields.io/discord/957965481455788032?label=Discord%20Server&logo=discord&logoColor=white)](https://discord.gg/SxVmHpu34R)
-[![Patreon](https://img.shields.io/badge/Patreon-F96854?logo=patreon&logoColor=white)](https://www.patreon.com/ForgemasterModules)
+[![Nimble RPG Discord](https://img.shields.io/badge/Nimble_RPG-Discord-8B4513?logo=discord&logoColor=white)](https://discord.gg/APTKATGeJW)
+[![Nimble FoundryVTT Discord](https://img.shields.io/badge/Nimble_FoundryVTT-Discord-5865F2?logo=discord&logoColor=white)](https://discord.gg/SxVmHpu34R)
 
 An official implementation of the Nimble 2 RPG system for Foundry Virtual Tabletop, built with TypeScript and Svelte.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Nimble for FoundryVTT
 
 [![License: MIT](https://img.shields.io/badge/Software_License-MIT-blue.svg)](https://mit-license.org/)
-[![Discord](https://img.shields.io/discord/957965481455788032?label=Discord%20Server&logo=discord&logoColor=white)](https://discord.gg/APTKATGeJW)
+[![Discord](https://img.shields.io/discord/957965481455788032?label=Discord%20Server&logo=discord&logoColor=white)](https://discord.gg/SxVmHpu34R)
 [![Patreon](https://img.shields.io/badge/Patreon-F96854?logo=patreon&logoColor=white)](https://www.patreon.com/ForgemasterModules)
 
 An official implementation of the Nimble 2 RPG system for Foundry Virtual Tabletop, built with TypeScript and Svelte.

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -79,7 +79,7 @@ export default defineConfig({
 
 		socialLinks: [
 			{ icon: 'github', link: 'https://github.com/Nimble-Co/FoundryVTT-Nimble' },
-			{ icon: 'discord', link: 'https://discord.gg/WRf5hBqM' },
+			{ icon: 'discord', link: 'https://discord.gg/SxVmHpu34R' },
 		],
 
 		search: {

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ hero:
       link: /contributing
     - theme: brand
       text: Join the Discord
-      link: https://discord.gg/WRf5hBqM
+      link: https://discord.gg/SxVmHpu34R
     - theme: alt
       text: View on GitHub
       link: https://github.com/Nimble-Co/FoundryVTT-Nimble
@@ -27,5 +27,5 @@ features:
   - icon: 🤝
     title: Community Driven!
     details: Open source under MIT. Contributions welcome, check the contributing guide to get started.
-		link: https://discord.gg/WRf5hBqM
+		link: https://discord.gg/SxVmHpu34R
 ---


### PR DESCRIPTION
## Summary
- Updates the Discord invite link to the new permanent invite across all documentation and issue templates
- Replaces 3 different outdated invite codes with the single new link

## Files Changed
- `.github/ISSUE_TEMPLATE/config.yml`
- `.github/ISSUE_TEMPLATE/feature.yml`
- `CONTRIBUTING.md`
- `README.md`
- `docs/.vitepress/config.mts`
- `docs/index.md`

## Test plan
- [ ] Verify the new Discord link works: https://discord.gg/SxVmHpu34R