### PR TITLE
fix(test): align PlayerCharacterCoreTab tests with implementation

### DIFF
--- a/src/view/sheets/pages/PlayerCharacterCoreTab.test.ts
+++ b/src/view/sheets/pages/PlayerCharacterCoreTab.test.ts
@@ -207,29 +207,13 @@ describe('PlayerCharacterCoreTab', () => {
 			} as unknown as Combat,
 		};
 
-		const roll = {
-			evaluate: vi.fn().mockResolvedValue(undefined),
-			toMessage: vi.fn().mockResolvedValue({ id: 'chat-message-initiative' }),
-		};
-		const rollCreate = vi.fn().mockReturnValue(roll);
-		(
-			globalThis as unknown as {
-				ChatMessage: {
-					getSpeaker: ReturnType<typeof vi.fn>;
-				};
-			}
-		).ChatMessage.getSpeaker = vi.fn().mockReturnValue({ actor: actor.id });
-		(globalThis as unknown as { Roll: { create: ReturnType<typeof vi.fn> } }).Roll.create =
-			rollCreate;
-
 		render(PlayerCharacterCoreTabTestHarness, { actor });
 
 		await fireEvent.click(screen.getByRole('button', { name: /roll initiative/i }));
 
 		expect(ensureCharacterCombatantForActorInCurrentScene).not.toHaveBeenCalled();
 		expect(combatRollInitiative).not.toHaveBeenCalled();
-		expect(rollCreate).toHaveBeenCalledTimes(1);
-		expect(roll.toMessage).toHaveBeenCalledTimes(1);
+		expect(actor.rollInitiativeToChat).toHaveBeenCalledTimes(1);
 	});
 
 	it('auto-adds the character to combat before rolling initiative when the setting is enabled', async () => {
@@ -287,7 +271,9 @@ describe('PlayerCharacterCoreTab', () => {
 		await fireEvent.click(screen.getByRole('button', { name: /roll initiative/i }));
 
 		expect(ensureCharacterCombatantForActorInCurrentScene).toHaveBeenCalledWith(actor);
-		expect(combatRollInitiative).toHaveBeenCalledWith(['late-join-combatant']);
+		expect(combatRollInitiative).toHaveBeenCalledWith(['late-join-combatant'], {
+			promptRollDialog: true,
+		});
 		expect(rollCreate).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
## Summary
- Update first initiative test to verify `actor.rollInitiativeToChat` is called when there's no combatant, rather than expecting `Roll.create`
- Update second initiative test to expect the `{ promptRollDialog: true }` option in `combat.rollInitiative` calls

## Test plan
- [x] All tests pass locally (696 tests)