### PR TITLE
feat(character-creator): require character name before creation

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -115,7 +115,8 @@
 			"incompleteCharacterTitle": "Unfinished Character",
 			"incompleteCharacterMessage": "This character isn’t finished. Create anyway?",
 			"incompleteCharacterProceed": "Create Anyway",
-			"incompleteCharacterReturn": "Back"
+			"incompleteCharacterReturn": "Back",
+			"missingCharacterName": "Please enter a name for your character before creating."
 		},
 		"ancestryOptions": {
 			"header": "Ancestry Options",

--- a/src/config.ts
+++ b/src/config.ts
@@ -118,6 +118,7 @@ const characterCreation = {
 	incompleteCharacterMessage: 'NIMBLE.characterCreation.incompleteCharacterMessage',
 	incompleteCharacterProceed: 'NIMBLE.characterCreation.incompleteCharacterProceed',
 	incompleteCharacterReturn: 'NIMBLE.characterCreation.incompleteCharacterReturn',
+	missingCharacterName: 'NIMBLE.characterCreation.missingCharacterName',
 };
 
 const actorImport = {

--- a/src/view/dialogs/CharacterCreationDialog.test.ts
+++ b/src/view/dialogs/CharacterCreationDialog.test.ts
@@ -1,0 +1,49 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import CharacterCreationDialog from './CharacterCreationDialog.svelte';
+
+function createProps(overrides: Record<string, unknown> = {}) {
+	return {
+		ancestryOptions: Promise.resolve({ core: [], exotic: [] }),
+		backgroundOptions: Promise.resolve([]),
+		bonusLanguageOptions: [],
+		classFeatureIndex: Promise.resolve(new Map()),
+		classOptions: Promise.resolve([]),
+		dialog: {
+			id: 'test-dialog',
+			submitCharacterCreation: vi.fn(),
+		},
+		statArrayOptions: [],
+		...overrides,
+	};
+}
+
+describe('CharacterCreationDialog', () => {
+	describe('name validation', () => {
+		it('shows a warning and does not submit when name is empty', async () => {
+			const props = createProps();
+			render(CharacterCreationDialog, { props });
+
+			await fireEvent.click(screen.getByText('Create Character'));
+
+			expect(ui.notifications?.warn).toHaveBeenCalledWith(
+				'Please enter a name for your character before creating.',
+			);
+			expect(props.dialog.submitCharacterCreation).not.toHaveBeenCalled();
+		});
+
+		it('shows a warning and does not submit when name is only whitespace', async () => {
+			const props = createProps();
+			render(CharacterCreationDialog, { props });
+
+			const nameInput = screen.getByPlaceholderText('New Character');
+			await fireEvent.input(nameInput, { target: { value: '   ' } });
+			await fireEvent.click(screen.getByText('Create Character'));
+
+			expect(ui.notifications?.warn).toHaveBeenCalledWith(
+				'Please enter a name for your character before creating.',
+			);
+			expect(props.dialog.submitCharacterCreation).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/src/view/dialogs/characterCreation/state.svelte.ts
+++ b/src/view/dialogs/characterCreation/state.svelte.ts
@@ -459,6 +459,13 @@ export function createCharacterCreationState(params: CharacterCreationStateParam
 
 	// Actions
 	async function handleCreateCharacter() {
+		if (!name.trim()) {
+			ui.notifications?.warn(
+				game.i18n.localize(CONFIG.NIMBLE.characterCreation.missingCharacterName),
+			);
+			return;
+		}
+
 		if (stage === CHARACTER_CREATION_STAGES.SUBMIT) {
 			submit();
 			return;


### PR DESCRIPTION
## Summary

- Blocks submission and shows a Foundry warning notification if the name field is empty when clicking "Create Character"
- Prevents characters from being silently created as "New Character"

## Changes

- `src/view/dialogs/characterCreation/state.svelte.ts` — `handleCreateCharacter` checks `name.trim()` before anything else; returns early with a warning if empty
- `src/config.ts` — added `missingCharacterName` lang key to the config map
- `public/lang/en.json` — added warning string: "Please enter a name for your character before creating."
- `src/view/dialogs/CharacterCreationDialog.test.ts` — added unit tests for empty and whitespace-only name cases

## Test Plan

- [x] Completing all steps without a name shows a warning notification and does not create the character
- [x] Whitespace-only name is also blocked
- [x] Completing all steps with a valid name creates the character normally

## Checklist

- [x] Added or updated unit tests
- [x] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [x] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** yes
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

Closes #526