### PR TITLE
feat(compendium): add Nimble Core Rules journal compendium

### DIFF
--- a/packs/ids.json
+++ b/packs/ids.json
@@ -1012,6 +1012,20 @@
 			}
 		}
 	},
+	"rules": {
+		"core": {
+			"ancestry-and-background": "xH5A2eJCr1PQLPLM",
+			"character-creation": "jTC8Q1wHRpyfcm3Z",
+			"combat": "7oaOqkg5Sp05mR2s",
+			"core-rules": "ZQjOBEMTFhOssTAV",
+			"equipment": "Oz9KSXS5xNFbsx3l",
+			"glossary": "ZuhDliTOf0Rp6Gng",
+			"optional-rules": "vHuQF7yF37WYL6uR",
+			"resting-and-downtime": "ZDLldXZlTUPQdNW0",
+			"spells": "vE3q1Ni1LLkfLlNK",
+			"start-here": "8aZw41YGlNWJ6OOP"
+		}
+	},
 	"secretSpells": {
 		"core": {
 			"fire": {

--- a/packs/rules/core/ancestry-and-background.json
+++ b/packs/rules/core/ancestry-and-background.json
@@ -1,0 +1,152 @@
+{
+	"name": "Ancestry & Background",
+	"pages": [
+		{
+			"_id": "mzrt9y9sXaFrXrxh",
+			"name": "Common Ancestries",
+			"type": "text",
+			"title": {
+				"show": true,
+				"level": 1
+			},
+			"text": {
+				"format": 1,
+				"content": "<p>Your kin, lineage, heritage, or race — this is how your character was born and how others see you at first glance. Choose 1 ancestry and add its bonus to your character sheet.</p><h3>Human (Medium)</h3><p>Found in every terrain and environment, their curiosity and ambition drive them to explore every corner of the world, making them a ubiquitous and versatile race.</p><p><strong>Tenacious.</strong> +1 to all skills and Initiative.</p><h3>Dwarf (Medium)</h3><p>You are resilient, solid, stout. Even when driven to exhaustion, you will not falter.</p><p><strong>Stout.</strong> +2 max Hit Dice, +1 max Wounds, –1 Speed. You know Dwarvish if your INT is not negative.</p><h3>Elf (Medium)</h3><p>Elves epitomize swiftness and grace. Formidable in both diplomacy and combat, elves strike swiftly, often preventing the worst by acting first.</p><p><strong>Lithe.</strong> Advantage on Initiative, +1 Speed. You know Elvish if your INT is not negative.</p><blockquote><p><strong>What About Half-Elves?</strong> Mix the ancestries however makes sense in your world. You can pick one ancestral bonus and use it instead of both, or use both half as effectively or half as often.</p></blockquote><h3>Halfling (Small)</h3><p>Kind of like a human, but smaller (except for the feet). Where does our luck come from?</p><p><strong>Elusive.</strong> +1 to Stealth. If you fail a save, you can succeed instead, 1/Safe Rest.</p><h3>Gnome (Small)</h3><p>Eccentric, curious, and perpetually optimistic, gnomes are cheerful. Known for their tinkering, spreading cheer, and playful antics.</p><p><strong>Optimistic.</strong> Allow an ally within Reach 6 to reroll any single die, resets when healed to your max HP. –1 Speed. You know Dwarvish if your INT is not negative.</p><blockquote><p><strong>Flavor Is Free.</strong> Want to play a Stout Halfling instead of an Elusive one? An Optimistic Human instead of Tenacious? As long as it makes sense and the GM is on board, go for it!</p></blockquote>"
+			},
+			"image": {
+				"caption": ""
+			},
+			"video": {
+				"controls": true,
+				"volume": 0.5
+			},
+			"src": null,
+			"sort": 100000,
+			"ownership": {
+				"default": -1
+			},
+			"flags": {},
+			"_stats": {
+				"coreVersion": "13.347",
+				"systemId": "nimble",
+				"systemVersion": "0.1.7",
+				"createdTime": null,
+				"modifiedTime": null,
+				"lastModifiedBy": null
+			}
+		},
+		{
+			"_id": "i4G3OeWVPcQuIhbL",
+			"name": "Exotic Ancestries",
+			"type": "text",
+			"title": {
+				"show": true,
+				"level": 1
+			},
+			"text": {
+				"format": 1,
+				"content": "<p><em>Your setting may or may not support these choices — check with your GM first before selecting one.</em></p><h3>Birdfolk (Small or Medium)</h3><p>Birdfolk find sanctuary in the boundless expanse of the sky. However, the gift of flight comes at a cost — hollow bones, and commensurate frailty.</p><p><strong>Hollow Bones.</strong> You have a fly Speed as long as you are wearing armor no heavier than Leather. Crits against you are Vicious (the attacker rolls 1 additional die). Forced movement moves you twice as far.</p><h3>Bunbun (Small)</h3><p>Bunbun are agile and unpredictable, using their powerful legs to leap great distances and catch foes off guard.</p><p><strong>Bunny Legs.</strong> Before Interposing or after Defending (after damage), hop up to your Speed in any direction for free, 1/encounter.</p><h3>Celestial (Medium)</h3><p>Descendants of divine beings, Celestials carry an aura of nobility and grace.</p><p><strong>Highborn.</strong> Your disadvantaged save is Neutral instead. You know Celestial if your INT isn't negative.</p><h3>Changeling (Medium)</h3><p>Often hunted for their silver blood, Changelings are natural survivors, slipping into new identities with ease.</p><p><strong>New Place, New Face.</strong> +2 shifting skill points. You may take on the appearance of any ancestry. When you do, place your 2 shifting skill points into any 1 skill. 1/day.</p><h3>Crystalborn (Medium)</h3><p>Formed from living crystal, the Crystalborn are beings of dazzling beauty and otherworldly toughness.</p><p><strong>Reflective Aura.</strong> When you Defend, gain KEY armor and deal KEY damage back to the attacker. 1/encounter.</p><h3>Dragonborn (Medium)</h3><p>The soul of a dragon burns within you, the scales of your body are like forged steel.</p><p><strong>Draconic Heritage.</strong> +1 Armor. When you attack: deal an additional LVL+KEY damage (ignoring armor) divided as you choose among any of your targets; recharges whenever you Safe Rest or gain a Wound. You know Draconic if your INT is not negative.</p><h3>Dryad/Shroomling (Small or Medium)</h3><p>Tied to the natural world, Dryads and Shroomlings embody the balance between flora and fauna.</p><p><strong>Danger Pollen/Spores.</strong> Whenever an enemy causes you one or more Wounds, you excrete soporic spores: all adjacent enemies are Dazed. You know Elvish if your INT is not negative.</p><h3>Fiendkin (Medium)</h3><p>Said to have been born from the union of man and fiend, or from a cursed bloodline. Their ancestors didn't emerge from the depths of the Everflame to succumb to minor setbacks!</p><p><strong>Flameborn.</strong> 1 of your neutral saves is advantaged instead. You know Infernal if your INT is not negative.</p><h3>Goblin (Small)</h3><p>Green, cunning, and perpetually vilified, Goblins thrive on the edge of chaos.</p><p><strong>Skedaddle.</strong> Can move 2 spaces for free after you become the target of an attack or negative effect (after damage, ignoring difficult terrain). You know Goblin if your INT is not negative.</p><h3>Half-Giant (Large)</h3><p>Towering beings whose strength is as immovable as the mountains they call home.</p><p><strong>Strength of Stone.</strong> Force an enemy to reroll a crit against you, 1/encounter. +2 Might. You know Dwarvish if your INT is not negative.</p><h3>Kobold (Small)</h3><p>Small, often maniacal, and dragon-obsessed. Kobolds prove time and again that even the smallest among us can wield great power.</p><p><strong>Wily.</strong> Force an enemy to reroll a non-critical attack against you, 1/encounter. +3 to Influence friendly characters. Advantage on skill checks related to dragons. You know Draconic if your INT is not negative.</p><h3>Minotaur/Beastfolk (Medium)</h3><p>Embody a primal connection to The Wild, combining strength with natural agility.</p><p><strong>Charge.</strong> When you move at least 4 spaces, you can push a creature in your path. Medium: 1 space; Small/Tiny: up to 2 spaces. 1/turn.</p><h3>Oozeling/Construct (Small or Medium)</h3><p>What even is a \"people\" anyway? If you can squish yourself into a pair of pants, or swing a sword like everyone else, who's to say you can't be a people, too?</p><p><strong>Odd Constitution.</strong> Increment your Hit Dice one step (d6 &raquo; d8 &raquo; d10 &raquo; d12 &raquo; d20); they always heal you for the maximum amount. Magical healing always heals you for the minimum amount.</p><h3>Orc (Medium)</h3><p>Just when you think you've bested a mighty Orc, you've merely succeeded in rousing their anger.</p><p><strong>Relentless.</strong> When you would drop to 0 HP, you may set your HP to LVL instead, 1/Safe Rest. +1 Might. You know Goblin if your INT is not negative.</p><h3>Planarbeing (Medium)</h3><p>You are not from this plane of existence. With vulnerability comes power — the ability to temporarily shift from one plane to another.</p><p><strong>Planeshift.</strong> Whenever you Defend, you can gain 1 Wound to temporarily phase out of the material plane and ignore the damage. –2 max Wounds.</p><h3>Ratfolk (Small)</h3><p>Agile, resourceful, and fiercely loyal to their own, they have a knack for turning scraps into solutions.</p><p><strong>Scurry.</strong> Gain +2 armor if you moved on your last turn.</p><h3>Stoatling (Small)</h3><p>Fierce determination and warrior hearts. They can take down foes many times their size.</p><p><strong>Small But Ferocious.</strong> Whenever you make a single-target attack against a creature larger than you, roll 1 additional d6 for each size category it is larger. They do the same.</p><h3>Turtlefolk (Small or Medium)</h3><p>Patient, sturdy, and slow to anger. They rely on their thick shells for protection.</p><p><strong>Slow &amp; Steady.</strong> +4 Armor, –2 speed.</p><h3>Wyrdling (Small)</h3><p>Unpredictable and chaotic, the result of magic gone awry. Their bodies pulse with raw arcane energy.</p><p><strong>Chaotic Surge.</strong> Whenever you or a willing ally within Reach 6 casts a tiered spell, you may allow them to roll on the Chaos Table. 1/encounter.</p><blockquote><p><strong>Flavor Is Free.</strong> Want to be a leaping Frogfolk instead of a Bunbun? A Flameborn Kobold? A winged Fairy instead of a Birdfolk? As long as it makes sense and your GM is game, go for it!</p></blockquote>"
+			},
+			"image": {
+				"caption": ""
+			},
+			"video": {
+				"controls": true,
+				"volume": 0.5
+			},
+			"src": null,
+			"sort": 200000,
+			"ownership": {
+				"default": -1
+			},
+			"flags": {},
+			"_stats": {
+				"coreVersion": "13.347",
+				"systemId": "nimble",
+				"systemVersion": "0.1.7",
+				"createdTime": null,
+				"modifiedTime": null,
+				"lastModifiedBy": null
+			}
+		},
+		{
+			"_id": "4zN2esPXpwdyu5vY",
+			"name": "Backgrounds",
+			"type": "text",
+			"title": {
+				"show": true,
+				"level": 1
+			},
+			"text": {
+				"format": 1,
+				"content": "<p>Backgrounds provide a glimpse into your character's past — how they were raised, the skills they honed before becoming an adventurer, or their defining personality traits. Feel free to adapt or reimagine these to suit your character's story. Choose 1 background.</p><ul><li><strong>Academy Dropout.</strong> Learn any 1 Utility Spell.</li><li><strong>Accidental Acrobat.</strong> (Req. 0 or negative DEX at creation.) Whenever you fail a DEX-related roll, you may roll again. If you still fail, the consequences are BAD.</li><li><strong>Acrobat.</strong> Can be thrown by a larger ally, REALLY far. Half damage from falling and forced movement.</li><li><strong>At Home Underground.</strong> You can dig twice as fast as others. Safe resting locations underground always count as Lavish lodging for you. You struggle to rest (INT save) while it's raining.</li><li><strong>Back Out of Retirement.</strong> You may gain 1 Wound to use an ability or cast a spell as if you were 1 level higher. –1 max Wounds.</li><li><strong>Bumblewise.</strong> (Req. 0 or negative WIL at creation.) A result of 1 or less on any WIL-related roll counts as a natural 20.</li><li><strong>Devoted Protector.</strong> Choose 1 ally in your party. You can survive +3 max Wounds as long as they are nearby. Whenever they take a Wound, you do too.</li><li><strong>Ear to the Ground.</strong> Advantage on checks to know or obtain gossip for events that will soon happen or have happened less than 1 year ago.</li><li><strong>Fearless.</strong> You are immune to the Frightened condition. +1 Initiative. –1 Armor.</li><li><strong>Fey Touched.</strong> You take half damage from all magical effects, double from weapons made of metal (before armor is applied).</li><li><strong>(Former) Con Artist.</strong> You can forge most documents or mimic voices flawlessly. You have a criminal contact in most major cities. However, your reputation often precedes you.</li><li><strong>Haunted Past.</strong> You are haunted by voices that occasionally give you cryptic advice — sometimes VERY helpful, sometimes wanting to see you suffer. Advantage against fear.</li><li><strong>History Buff.</strong> Advantage on all Lore checks related to knowledge about items, facts, or events that happened more than 100 years ago.</li><li><strong>Home at Sea.</strong> Recover twice as many Wounds and HP while resting on a ship or near water. Advantage on water-related skill checks.</li><li><strong>Made a BAD Choice.</strong> Start with 500 or 1000 extra gold, or an uncommon/rare magical item. Gain an equally powerful curse or enemy who wants it back.</li><li><strong>Raised by Goblins.</strong> You speak Goblin natively. You automatically notice and can avoid crudely-made traps and have advantage to notice and disarm more sophisticated traps.</li><li><strong>(Secretly) Undead.</strong> Immune to disease. Do not need to eat, drink, or breathe. Children, animals, and Celestials are uneasy in your presence.</li><li><strong>So Dumb I'm Smart Sometimes.</strong> (Req. 0 or negative INT at creation.) Reroll an INT-related skill check, 1/day. Reroll a failed INT save with advantage, 1/Safe Rest.</li><li><strong>Survivalist.</strong> You never run out of your own personal rations. Advantage against poison saves. +1 max Hit Die.</li><li><strong>Taste for the Finer Things.</strong> Always have up-to-date knowledge of the customs and dress of the upper classes. Advantage on Influence checks with the upper class.</li><li><strong>Tradesman/Artisan.</strong> Choose a profession. Checks you make related to that profession are made with advantage.</li><li><strong>What? I've Been Around.</strong> 1/per location, you happen to know JUST the person who has the information you're looking for, or could get you out of a jam. Roll 1d20: 1–5 they want you DEAD; 6–12 you owe them money; 13–19 they can be convinced to help; 20 they are your biggest fan.</li><li><strong>Wild One.</strong> Wild creatures are less frightened of you and more willing to aid you. +1 Naturecraft. While Field Resting, roll your Hit Dice with advantage while in the wild.</li><li><strong>Wily Underdog.</strong> (Req. 0 or negative STR at creation.) Reroll a failed STR-related roll and use another stat instead, 1/day.</li></ul><blockquote><p><strong>Make It Your Own!</strong> Backgrounds are just a starting point — you're free to adjust, reimagine, or completely rewrite them to suit your character's story. Work with your GM to ensure any changes align with your game's setting.</p></blockquote>"
+			},
+			"image": {
+				"caption": ""
+			},
+			"video": {
+				"controls": true,
+				"volume": 0.5
+			},
+			"src": null,
+			"sort": 300000,
+			"ownership": {
+				"default": -1
+			},
+			"flags": {},
+			"_stats": {
+				"coreVersion": "13.347",
+				"systemId": "nimble",
+				"systemVersion": "0.1.7",
+				"createdTime": null,
+				"modifiedTime": null,
+				"lastModifiedBy": null
+			}
+		},
+		{
+			"_id": "NzXP2xuxezHD9xpv",
+			"name": "Adventuring Motivation",
+			"type": "text",
+			"title": {
+				"show": true,
+				"level": 1
+			},
+			"text": {
+				"format": 1,
+				"content": "<p>The world is a dangerous place — people don't usually just \"go adventuring\" without a reason. Your motivation should make your character want to work with the rest of the group.</p><ul><li><strong>I owe a life debt to someone in my party.</strong> Chat with your party: Who else needs help with their backstory? What did they do to help you?</li><li><strong>I owe a LOT of money to some very dangerous people.</strong> What did you do with the money?</li><li><strong>I need to grow in power to defeat someone who has wronged me.</strong> Do you know who wronged you, or are they unknown?</li><li><strong>I am trying to get back home.</strong> Where is home for you, do you even remember? What caused you to leave?</li><li><strong>I was best friends with (and betrayed by) ______.</strong> Do you want to win them back? Get even? Warn others?</li><li><strong>I'm lost.</strong> Physically? Emotionally? Spiritually? Are you in the wrong country or even plane of existence?</li><li><strong>I am searching for a way to bring a loved one (or someone I hate) back from the dead.</strong> Who even told you this was possible?</li><li><strong>I am searching for the one who stole something valuable from me.</strong> Is it an object? A person? A memory?</li><li><strong>I was polymorphed into another kind of creature by a wizard.</strong> What did you do to anger the wizard?</li><li><strong>Duty calls. I am honor-bound to serve.</strong> Who calls you? Your king? Your family? An ancient alliance or grudge?</li><li><strong>Wanderlust/Pilgrimage.</strong> What amazing thing do you want to see or experience?</li><li><strong>My home town is in danger.</strong> Are you looking for a cure? Mercenaries? Personal strength?</li><li><strong>Curiosity! I want to learn the DEEP secrets.</strong> Which secrets? Magical, lore, politics, what really happened in history?</li><li><strong>To prove my worth.</strong> You were always underestimated — by your family, your village, your peers, or yourself.</li><li><strong>I'm following a prophecy.</strong> A mysterious figure or ancient text foretold that you would play a crucial role in the fate of the world.</li><li><strong>Or Make Your Own!</strong> A great character background has connections with the world, its people, your fellow heroes, or even the bad guys. Work with your GM and fellow players to find a motivation that will cross paths with where the story goes.</li></ul>"
+			},
+			"image": {
+				"caption": ""
+			},
+			"video": {
+				"controls": true,
+				"volume": 0.5
+			},
+			"src": null,
+			"sort": 400000,
+			"ownership": {
+				"default": -1
+			},
+			"flags": {},
+			"_stats": {
+				"coreVersion": "13.347",
+				"systemId": "nimble",
+				"systemVersion": "0.1.7",
+				"createdTime": null,
+				"modifiedTime": null,
+				"lastModifiedBy": null
+			}
+		}
+	],
+	"folder": null,
+	"flags": {},
+	"_stats": {
+		"coreVersion": "13.347",
+		"systemId": "nimble",
+		"systemVersion": "0.1.7",
+		"createdTime": null,
+		"modifiedTime": null,
+		"lastModifiedBy": null
+	},
+	"_id": "xH5A2eJCr1PQLPLM"
+}

--- a/packs/rules/core/character-creation.json
+++ b/packs/rules/core/character-creation.json
@@ -1,0 +1,118 @@
+{
+	"name": "Character Creation",
+	"pages": [
+		{
+			"_id": "obLgDP0QiZEuuE5t",
+			"name": "Making a Hero",
+			"type": "text",
+			"title": {
+				"show": true,
+				"level": 1
+			},
+			"text": {
+				"format": 1,
+				"content": "<p>Your hero is how you will make your mark on the world. Here's how to make your own hero:</p><h3>Step 1: Choose Your Class</h3><p>This will have the largest impact on the other character choices you make and how you interact with the world (see the Heroes book for more details):</p><ul><li><strong>Berserker.</strong> An unstoppable force of wrath and ruin.</li><li><strong>The Cheat.</strong> Sneaky, backstabbing, dirty-fighting rogue.</li><li><strong>Commander.</strong> A battlefield tactician, leader, and weapon master.</li><li><strong>Hunter.</strong> Resourceful survivalist, bow master, and skilled tracker.</li><li><strong>Mage.</strong> Wield and shape the elements of fire, ice, and lightning.</li><li><strong>Oathsworn.</strong> Faithful guardian, protector, and avenger of the weak.</li><li><strong>Shadowmancer.</strong> Summon hordes of expendable minions.</li><li><strong>Shepherd.</strong> Master life and death. Lead a faithful companion.</li><li><strong>Songweaver.</strong> Inspiring presence, sharp wit, sharper tongue.</li><li><strong>Stormshifter.</strong> Master of weather, beast, and nature.</li><li><strong>Zephyr.</strong> A disciplined martial artist with swift hands and swift feet.</li></ul><h3>Step 2: Choose Your Ancestry &amp; Background</h3><p>What made your hero want to start adventuring? How do you know the other heroes? (See @UUID[Compendium.nimble.nimble-rules.JournalEntry.xH5A2eJCr1PQLPLM]{Ancestry &amp; Background}.)</p><h3>Step 3: Fill in Your Character Sheet</h3><p>This handy sheet of paper helps you track your stats, abilities, loot, and other important game info. (See the Character Sheet page below.)</p>"
+			},
+			"image": {
+				"caption": ""
+			},
+			"video": {
+				"controls": true,
+				"volume": 0.5
+			},
+			"src": null,
+			"sort": 100000,
+			"ownership": {
+				"default": -1
+			},
+			"flags": {},
+			"_stats": {
+				"coreVersion": "13.347",
+				"systemId": "nimble",
+				"systemVersion": "0.1.7",
+				"createdTime": null,
+				"modifiedTime": null,
+				"lastModifiedBy": null
+			}
+		},
+		{
+			"_id": "he9BkEy0JCQGuyNV",
+			"name": "The Character Sheet",
+			"type": "text",
+			"title": {
+				"show": true,
+				"level": 1
+			},
+			"text": {
+				"format": 1,
+				"content": "<h3>1. Basic Details &amp; Stats</h3><p>Fill in your character details: Name, Ancestry, Class, Level, Height, and Weight. Fill in the arrow for your advantaged (+) and disadvantaged (–) Saves, and choose a stat array (recommended: place the highest numbers in the KEY stats for your class).</p><ul><li><strong>Standard:</strong> +2, +2, +0, –1</li><li><strong>Balanced:</strong> +2, +1, +1, +0</li><li><strong>Min–Max:</strong> +3, +1, –1, –1</li></ul><p><em>Example: The Cheat has DEX and INT as their KEY stats. With Min-Max, you might put +3 in DEX, +1 in INT, and –1 in WIL and STR. Mark ▲ for DEX saves and ▼ for WIL saves.</em></p><h3>2. Skill Points</h3><p>At level 1, mark your stat bonuses into each of your respective skills (e.g., a hero with +2 DEX marks +2 in Finesse and Stealth), then place 4 additional skill points wherever you like.</p><h3>3. Secondary Stats</h3><p>Mark your max HP and Hit Dice size (see your class), Hit Die amount (default: equal to your level), Initiative (default: DEX), Size, Speed (default: 6), max Wounds (default: 6), and inventory slots (10+STR).</p><h3>4. Equipment &amp; Money</h3><p>Heroes start at level 1 with the equipment listed for their class and background, OR 50 gp to buy their starting equipment. If starting at a higher level, multiply that by the level you are starting at.</p><h3>5. Languages</h3><p>All heroes speak Common by default. Each point of INT grants you an additional language known.</p><ul><li><strong>Common</strong> — Most intelligent creatures</li><li><strong>Dwarvish</strong> — Dwarves, Gnomes, and Giants</li><li><strong>Elvish</strong> — Elves, Fey, and Sylvan</li><li><strong>Goblin</strong> — Goblins and Orcs</li><li><strong>Infernal</strong> — Various Fiends and cultists</li><li><strong>Thieves' Cant</strong> — Scoundrels and rogues</li><li><strong>Celestial</strong> — Celestials and priests</li><li><strong>Draconic</strong> — Dragons, Dragonborn, and Kobolds</li><li><strong>Primordial</strong> — Elementals and Ancient Beings</li><li><strong>Deep Speak</strong> — Underworld dwellers</li></ul><h3>6. Other Abilities</h3><p>Mark any other special abilities you get from your class, ancestry, background, etc.</p><h3>7. Inventory Slots</h3><p>Each hero has 10+STR inventory slots for carrying equipment and loot (held, worn, or in a pack).</p><ul><li>1 slot: a one-handed weapon, shield, worn armor, stack of javelins, 500 gp, or 2 potions.</li><li>2 slots: a 2-handed weapon, unworn armor, or similarly bulky items.</li><li>Small, related items can be grouped into one slot (e.g., Camping Supplies: soap, blanket, brush, rations).</li></ul>"
+			},
+			"image": {
+				"caption": ""
+			},
+			"video": {
+				"controls": true,
+				"volume": 0.5
+			},
+			"src": null,
+			"sort": 200000,
+			"ownership": {
+				"default": -1
+			},
+			"flags": {},
+			"_stats": {
+				"coreVersion": "13.347",
+				"systemId": "nimble",
+				"systemVersion": "0.1.7",
+				"createdTime": null,
+				"modifiedTime": null,
+				"lastModifiedBy": null
+			}
+		},
+		{
+			"_id": "ynBM3JEVE0xPjMyQ",
+			"name": "Leveling Up",
+			"type": "text",
+			"title": {
+				"show": true,
+				"level": 1
+			},
+			"text": {
+				"format": 1,
+				"content": "<p>The GM may allow you to gain a level (LVL) whenever you complete an appropriately challenging quest or adventure. When a hero gains a level:</p><ul><li><strong>HP Increase.</strong> Roll your Hit Die with advantage and increase your max HP by that much.</li><li><strong>More Endurance.</strong> Your Hit Die max increases by 1 (it is typically equal to your level).</li><li><strong>More Skilled.</strong> Gain 1 skill point. Additionally, you may move 1 point from one skill to another (as long as the skill doesn't become negative), reflecting your hero's evolving expertise and priorities. The maximum bonus a skill can have is +12.</li><li><strong>Class Features.</strong> Gain new class features for your level. This may mean increasing your mana pool, new spells, or even selecting a subclass!</li><li><strong>Other Adjustments.</strong> If any of your base stats increase, remember to adjust other elements of your character sheet as needed (skills, damage, Initiative, armor, mana, languages, etc.).</li></ul>"
+			},
+			"image": {
+				"caption": ""
+			},
+			"video": {
+				"controls": true,
+				"volume": 0.5
+			},
+			"src": null,
+			"sort": 300000,
+			"ownership": {
+				"default": -1
+			},
+			"flags": {},
+			"_stats": {
+				"coreVersion": "13.347",
+				"systemId": "nimble",
+				"systemVersion": "0.1.7",
+				"createdTime": null,
+				"modifiedTime": null,
+				"lastModifiedBy": null
+			}
+		}
+	],
+	"folder": null,
+	"flags": {},
+	"_stats": {
+		"coreVersion": "13.347",
+		"systemId": "nimble",
+		"systemVersion": "0.1.7",
+		"createdTime": null,
+		"modifiedTime": null,
+		"lastModifiedBy": null
+	},
+	"_id": "jTC8Q1wHRpyfcm3Z"
+}

--- a/packs/rules/core/combat.json
+++ b/packs/rules/core/combat.json
@@ -1,0 +1,152 @@
+{
+	"name": "Combat",
+	"pages": [
+		{
+			"_id": "88BfZWt1WsX6hQd0",
+			"name": "Actions",
+			"type": "text",
+			"title": {
+				"show": true,
+				"level": 1
+			},
+			"text": {
+				"format": 1,
+				"content": "<p>On your turn, heroes get <strong>3 actions</strong> to attack, move around the battlefield, cast spells, etc. Generally doing any single thing in combat costs 1 action. Some very strong spells or special abilities may cost more. All 3 actions recharge at the end of your turn.</p><h3>Attack</h3><p>Any spell or ability that can harm an enemy counts as an attack. Roll the die listed on the spell, weapon, or ability, and deal that much damage. If you roll a 1, you miss, and the attack has no effect. The leftmost die is the <strong>Primary Die</strong> — it determines whether the attack is a hit or a miss.</p><p><strong>Exploding Critical Hits.</strong> Rolling the max on a Primary Die is a critical hit (crit). When you crit, roll the Primary Die again and add the result to the total. Repeat each time you roll the maximum — there's no limit, except your luck! Crits also ignore monster armor.</p><p><strong>Rushed Attacks.</strong> A hero may attack more than once on their turn, but these additional attacks are rushed, imposing cumulative disadvantage for each additional attack after the first. For abilities that trigger a save (e.g. Grappling), enemies roll with increasing instances of advantage instead.</p><h3>Cast Spell</h3><p>Casting a spell requires a hero to have 1 hand free (or a held spellcasting focus), the ability to speak, and may require mana. A spell's mana cost is equal to its spell tier; cantrips cost no mana.</p><p><strong>Upcasting Spells.</strong> Some spells have a greater effect for each additional mana spent. A hero can upcast a spell only up to the tier they have unlocked.</p><h3>Move</h3><p>A character can move up to their speed (6 spaces, unless otherwise noted). This movement can be broken up with other actions if desired, and a hero can use multiple Move actions on one turn. When in Difficult Terrain, movement speed is halved. Moving on a climbable surface counts as Difficult Terrain.</p><h3>Assess</h3><p>Choose one of the following and make a DC 12 skill check to:</p><ul><li><strong>Ask a Question.</strong> About a weakness, ability, or immediate plans of enemies, the environment, story, etc. The GM will answer honestly.</li><li><strong>Create an Opening.</strong> Increase the next Primary Die Roll against a target by 1 this round.</li><li><strong>Anticipate Danger.</strong> Reduce all Primary Dice rolled against you by 1 this round.</li></ul><p>You cannot assess using the same skill more than once in a single encounter, as your foes adapt to your tactics.</p><h3>Free Actions</h3><p>Simple tasks (open an unlocked door, shout a simple phrase, drop an item, end concentration, etc.) do not cost an action. Heroes can perform one free action per turn.</p>"
+			},
+			"image": {
+				"caption": ""
+			},
+			"video": {
+				"controls": true,
+				"volume": 0.5
+			},
+			"src": null,
+			"sort": 100000,
+			"ownership": {
+				"default": -1
+			},
+			"flags": {},
+			"_stats": {
+				"coreVersion": "13.347",
+				"systemId": "nimble",
+				"systemVersion": "0.1.7",
+				"createdTime": null,
+				"modifiedTime": null,
+				"lastModifiedBy": null
+			}
+		},
+		{
+			"_id": "D7MGafOpszttWdhz",
+			"name": "Reactions",
+			"type": "text",
+			"title": {
+				"show": true,
+				"level": 1
+			},
+			"text": {
+				"format": 1,
+				"content": "<p>Reactions cost 1 action and are performed when it is not your turn. A hero can perform each reaction no more than 1/round, and they will start their turn with fewer actions.</p><h3>Defend</h3><p>Reduce damage from any single attack by your Armor whenever you use this reaction. At the GM's discretion, some damage may not be avoidable (e.g., psychic damage or some areas of effect).</p><h3>Interpose</h3><p>If a creature within 2 spaces would be struck with an attack, you can push them out of the way and become the new target of the attack. You enter their space and move them to an adjacent space of your choice.</p><p><em>Interpose AND Defend? Yes! As long as you have enough actions, you can Interpose and Defend at the same time.</em></p><h3>Opportunity Attack</h3><p>A melee attack made with disadvantage against an adjacent enemy as it willingly moves away. Monsters do not make opportunity attacks — only heroes can.</p><h3>Help</h3><p>Grant an ally advantage on a roll if you can reasonably explain to the GM how you could help in a given situation (limit: one Help reaction for each roll). The GM may call for a skill check or grant advantage automatically, depending on how good the idea is.</p>"
+			},
+			"image": {
+				"caption": ""
+			},
+			"video": {
+				"controls": true,
+				"volume": 0.5
+			},
+			"src": null,
+			"sort": 200000,
+			"ownership": {
+				"default": -1
+			},
+			"flags": {},
+			"_stats": {
+				"coreVersion": "13.347",
+				"systemId": "nimble",
+				"systemVersion": "0.1.7",
+				"createdTime": null,
+				"modifiedTime": null,
+				"lastModifiedBy": null
+			}
+		},
+		{
+			"_id": "DbMyP7nSle3oP1CA",
+			"name": "Starting Combat & Turn Order",
+			"type": "text",
+			"title": {
+				"show": true,
+				"level": 1
+			},
+			"text": {
+				"format": 1,
+				"content": "<h2>Starting Combat</h2><p>A combat encounter begins when the GM tells the party to \"Roll Initiative!\" Each hero rolls 1d20 and adds their Initiative bonus (typically their DEX):</p><ul><li>A single digit: start combat with 1 action.</li><li>2 digits: start combat with 2 actions.</li><li>20+ (or a natural 20): start combat with all 3 actions.</li></ul><p>Regardless of Initiative, at the end of their turn every hero gains all 3 actions back.</p><p><strong>Surprise.</strong> If the party maneuvers so adeptly that their enemy is completely caught off guard, the GM may grant advantage on Initiative, or allow each hero to start with all 3 actions. Merely being hidden or punching first is not sufficient to gain Surprise — if an enemy is on guard or at all aware of your presence, they cannot be surprised. Heroes who are surprised may roll with disadvantage or start with only 1 action.</p><h2>Turn Order</h2><p>By default, the heroes go first. Whichever player is ready first goes first (or whoever makes the most sense story-wise), with play proceeding around the table clockwise. Monsters typically act last, though some may be fast enough to act sooner. A monster group should act at the same time each round.</p><h2>Turns, Rounds &amp; Encounters</h2><ul><li>A <strong>Turn</strong> is when 1 individual hero or monster group acts (roughly 6 seconds of in-world time).</li><li>A <strong>Round</strong> is when all players and monsters have taken a turn.</li><li>An <strong>Encounter</strong> is all of the rounds in a particular combat.</li></ul><p><strong>1/Turn Abilities:</strong> If you perform one on your turn, and can find a way to perform it on another creature's turn, you can do it again.</p><p><strong>1/Round Abilities:</strong> These reset whenever your own turn begins.</p><h2>Acting Over Multiple Turns</h2><p>For activities that cost more than 1 action, your actions can be spent over multiple turns in combat as long as Concentration is maintained and you do not perform other actions or reactions in the meantime (unless they are free).</p><p><em>Example: A Mage wants to cast Glacier Strike (3 actions) but only has 1 action left. She spends 1 action this turn to start casting, then spends 2 more on her next turn to finish.</em></p>"
+			},
+			"image": {
+				"caption": ""
+			},
+			"video": {
+				"controls": true,
+				"volume": 0.5
+			},
+			"src": null,
+			"sort": 300000,
+			"ownership": {
+				"default": -1
+			},
+			"flags": {},
+			"_stats": {
+				"coreVersion": "13.347",
+				"systemId": "nimble",
+				"systemVersion": "0.1.7",
+				"createdTime": null,
+				"modifiedTime": null,
+				"lastModifiedBy": null
+			}
+		},
+		{
+			"_id": "ri8qPrrkrXS14BOS",
+			"name": "Monsters & Minions",
+			"type": "text",
+			"title": {
+				"show": true,
+				"level": 1
+			},
+			"text": {
+				"format": 1,
+				"content": "<h2>Monster Armor</h2><p>Most monsters are unarmored, but some tougher foes might have:</p><ul><li><strong>Medium Armor:</strong> They take damage from only the dice rolled, ignoring all damage modifiers (unless negative).</li><li><strong>Heavy Armor:</strong> They take only half the damage from the dice, likewise ignoring damage modifiers.</li></ul><p>Crits and damage vulnerabilities ignore monster armor.</p><p>This means different heroes and different weapons, spells, and abilities will be more or less effective against various kinds of armor.</p><h2>Minions</h2><p>Minions are weak enemies that will die from any amount of damage. They move and attack at the same time, cannot crit, and their feeble attacks can be Defended against as if they were a single attack. Dealing a large amount of damage to a minion can (at the GM's discretion) overflow to other minions within range.</p>"
+			},
+			"image": {
+				"caption": ""
+			},
+			"video": {
+				"controls": true,
+				"volume": 0.5
+			},
+			"src": null,
+			"sort": 400000,
+			"ownership": {
+				"default": -1
+			},
+			"flags": {},
+			"_stats": {
+				"coreVersion": "13.347",
+				"systemId": "nimble",
+				"systemVersion": "0.1.7",
+				"createdTime": null,
+				"modifiedTime": null,
+				"lastModifiedBy": null
+			}
+		}
+	],
+	"folder": null,
+	"flags": {},
+	"_stats": {
+		"coreVersion": "13.347",
+		"systemId": "nimble",
+		"systemVersion": "0.1.7",
+		"createdTime": null,
+		"modifiedTime": null,
+		"lastModifiedBy": null
+	},
+	"_id": "7oaOqkg5Sp05mR2s"
+}

--- a/packs/rules/core/core-rules.json
+++ b/packs/rules/core/core-rules.json
@@ -1,0 +1,322 @@
+{
+	"name": "Core Rules",
+	"pages": [
+		{
+			"_id": "tgoKK0GAz2eqY5sg",
+			"name": "Stats",
+			"type": "text",
+			"title": {
+				"show": true,
+				"level": 1
+			},
+			"text": {
+				"format": 1,
+				"content": "<p>Heroes have 4 stats that impact their effectiveness in various tasks: 2 Key Stats crucial to their class and 2 Secondary Stats. The maximum a hero's stat can typically go is +5.</p><p><strong>KEY.</strong> When an ability or spell references \"KEY,\" use one of your Key Stats. If a stat is listed before a die roll, roll a number of dice equal to the stat. For example, \"WIL d8\" means that if your WIL is 2, you roll 2d8.</p><ul><li><strong>Strength (STR).</strong> Your raw physical power and resilience, endurance, and resistance to harm. Affects STR weapon damage, resistance to Wounds, HP recovery, Concentration, STR saves, carrying capacity, Grappling, and the Might skill.</li><li><strong>Dexterity (DEX).</strong> Your agility, reflexes, and precision with blades or bows. Affects DEX weapon damage, Initiative, DEX saves, Grappling, and can contribute to Armor, as well as the Stealth and Finesse skills.</li><li><strong>Intelligence (INT).</strong> Your knowledge and reasoning across fields like the arcane, tactics, or street smarts. Affects languages, spellcasting, use of wands, spell scrolls, INT saves, as well as the Arcana, Examination, and Lore skills.</li><li><strong>Will (WIL).</strong> Your force of personality, courage, and wisdom. Affects spellcasting and WIL saves, as well as the Insight, Influence, Naturecraft, and Perception skills.</li></ul>"
+			},
+			"image": {
+				"caption": ""
+			},
+			"video": {
+				"controls": true,
+				"volume": 0.5
+			},
+			"src": null,
+			"sort": 100000,
+			"ownership": {
+				"default": -1
+			},
+			"flags": {},
+			"_stats": {
+				"coreVersion": "13.347",
+				"systemId": "nimble",
+				"systemVersion": "0.1.7",
+				"createdTime": null,
+				"modifiedTime": null,
+				"lastModifiedBy": null
+			}
+		},
+		{
+			"_id": "t4sbTNPpWbUQksli",
+			"name": "Skills",
+			"type": "text",
+			"title": {
+				"show": true,
+				"level": 1
+			},
+			"text": {
+				"format": 1,
+				"content": "<p>Skills gauge how well your hero interacts with the world. Whenever you tell the GM what you are doing, they may ask you to use one of your skills.</p><ul><li><strong>Arcana (INT).</strong> Your understanding of magical phenomena, spells, and enchantments. Identify magical effects, decipher arcane symbols, discern properties of magical items, and know the abilities and weaknesses of Aberrations, Elementals, and Oozes.</li><li><strong>Examination (INT).</strong> Your aptitude for thorough analysis and deduction. Diagnose injuries, determine causes of death, uncover clues, and unravel traps or mechanical devices. Also grants insights into Constructs.</li><li><strong>Finesse (DEX).</strong> Your ability to use your hands and feet in careful ways. Pick locks, disarm traps, pilot vehicles, tinker, perform card tricks, steal or plant items, climb a mossy wall, or any other task requiring precise, careful movement.</li><li><strong>Influence (WIL).</strong> Your persuasiveness, charm, and ability to influence others. Convince or deceive people, negotiate deals, build trust, win allies, or put on a captivating performance.</li><li><strong>Insight (WIL).</strong> Your ability to understand people and situations beyond the obvious. Sense motives, detect lies, read hidden emotions, and make sense of clues. Can be used retroactively: <em>\"Oh no! I forgot to buy rope!\"</em> — <em>\"Give me an Insight check; maybe your hero would have thought about it.\"</em></li><li><strong>Lore (INT).</strong> Your understanding of the history of civilization, kingdoms, and religions. Recall historical events, grasp the significance of cultural practices, and know the abilities and behavior of Celestials, Dragons, Fey, Fiends, Giants, Humanoids, and Undead.</li><li><strong>Might (STR).</strong> Your ability to apply strength effectively. Lift heavy objects, break through obstacles, climb, swim, jump, or perform feats of strength.</li><li><strong>Naturecraft (WIL).</strong> Your expertise in wilderness survival, navigation, tracking, and handling of animals. Thrive in the wild, identify flora and fauna, and track creatures. Encompasses knowledge of Beasts, Monstrosities, and Plants.</li><li><strong>Perception (WIL).</strong> Your overall ability to notice subtle details. Spot hidden objects, detect secret passages, sense subtle environmental changes, and sense when you're being followed or observed.</li><li><strong>Stealth (DEX).</strong> Your proficiency in staying unseen and moving quietly. Hide, slip past guards, evade detection, and move without drawing attention.</li></ul>"
+			},
+			"image": {
+				"caption": ""
+			},
+			"video": {
+				"controls": true,
+				"volume": 0.5
+			},
+			"src": null,
+			"sort": 200000,
+			"ownership": {
+				"default": -1
+			},
+			"flags": {},
+			"_stats": {
+				"coreVersion": "13.347",
+				"systemId": "nimble",
+				"systemVersion": "0.1.7",
+				"createdTime": null,
+				"modifiedTime": null,
+				"lastModifiedBy": null
+			}
+		},
+		{
+			"_id": "289VekaOcMF8op94",
+			"name": "Advantage & Disadvantage",
+			"type": "text",
+			"title": {
+				"show": true,
+				"level": 1
+			},
+			"text": {
+				"format": 1,
+				"content": "<p>If you are ever in a favorable situation, the GM may allow you to roll with <strong>advantage</strong>. To do this, roll 1 additional die of the same type and remove the lowest. Alternatively, if the situation is grim or your idea is a long shot, you may have to roll with <strong>disadvantage</strong> (removing the highest die instead).</p><p>If you have multiple instances of advantage or disadvantage, for each one, roll an extra die and remove the lowest (for advantage) or the highest (for disadvantage). Each instance of advantage cancels out one instance of disadvantage before you roll.</p><p><em>Example: Greataxe (2d6) with advantage — roll 3d6, remove the lowest.</em></p><p><em>Example: Greataxe (2d6) with disadvantage 2 — roll 4d6, remove the 2 highest.</em></p>"
+			},
+			"image": {
+				"caption": ""
+			},
+			"video": {
+				"controls": true,
+				"volume": 0.5
+			},
+			"src": null,
+			"sort": 300000,
+			"ownership": {
+				"default": -1
+			},
+			"flags": {},
+			"_stats": {
+				"coreVersion": "13.347",
+				"systemId": "nimble",
+				"systemVersion": "0.1.7",
+				"createdTime": null,
+				"modifiedTime": null,
+				"lastModifiedBy": null
+			}
+		},
+		{
+			"_id": "5f03XCJaVEhDVPPW",
+			"name": "Skill Checks & Saves",
+			"type": "text",
+			"title": {
+				"show": true,
+				"level": 1
+			},
+			"text": {
+				"format": 1,
+				"content": "<p>When you want to affect the world (convince an NPC, spot a trap, pick a lock, etc.), the GM may call for a <strong>skill check</strong>. Roll 1d20 and add your skill (max bonus: +12). If the total meets or exceeds the Difficulty Challenge (DC), you succeed; otherwise, you fail. A roll of 1 always fails regardless of bonuses; a roll of 20 always succeeds.</p><h3>Difficulty Challenges</h3><ul><li><strong>Easy (DC 8):</strong> Spotting a large Ogre crouched behind a small bush.</li><li><strong>Medium (DC 12):</strong> Finding a hidden doorway behind a bookcase.</li><li><strong>Challenging (DC 15):</strong> Calming an injured Owlbear stuck in a trap.</li><li><strong>Very Difficult (DC 18):</strong> Intuiting the true intentions of a trained Spy.</li><li><strong>Extremely Difficult (DC 20+):</strong> Disarming an ancient legendary trap.</li></ul><h3>Saves</h3><p>When the world affects <em>you</em>, roll a save instead. Roll 1d20 and add the relevant stat. A roll of 1 always fails, 20 always saves. You can choose to fail any save instead of rolling.</p><ul><li><strong>STR Save.</strong> When your overall fitness and physicality is tested. Helps resist forced movement, restraint, poison, and extreme temperatures.</li><li><strong>DEX Save.</strong> When your agility or speed is tested. Helps you dive for cover in an explosion or stay on your feet while running across icy terrain.</li><li><strong>INT Save.</strong> When your intelligence is tested. Helps you see through tricks and illusions.</li><li><strong>WIL Save.</strong> When your courage or personality is tested. Helps you resist charm or fear effects.</li></ul><h3>Heroes and Saves</h3><ul><li>Unless otherwise noted, the DC for effects a hero causes is <strong>10+KEY</strong>.</li><li>Each hero has 1 advantaged save (+), 1 disadvantaged save (–), and 2 neutral saves.</li></ul><p><em>Example: A Berserker (STR+, INT–) rolls all STR saves with advantage and all INT saves with disadvantage.</em></p>"
+			},
+			"image": {
+				"caption": ""
+			},
+			"video": {
+				"controls": true,
+				"volume": 0.5
+			},
+			"src": null,
+			"sort": 400000,
+			"ownership": {
+				"default": -1
+			},
+			"flags": {},
+			"_stats": {
+				"coreVersion": "13.347",
+				"systemId": "nimble",
+				"systemVersion": "0.1.7",
+				"createdTime": null,
+				"modifiedTime": null,
+				"lastModifiedBy": null
+			}
+		},
+		{
+			"_id": "Vkm1KpNl1iPZEmnd",
+			"name": "Size",
+			"type": "text",
+			"title": {
+				"show": true,
+				"level": 1
+			},
+			"text": {
+				"format": 1,
+				"content": "<p>Some spells and abilities affect differently sized objects or creatures:</p><ul><li><strong>Tiny:</strong> Can be carried in a typical pocket (many can comfortably fit in 1 space).</li><li><strong>Small:</strong> Can be carried in a backpack (2 can comfortably fit in 1 space).</li><li><strong>Medium:</strong> The average human size (1 can comfortably fit in 1 space).</li><li><strong>Large:</strong> Roughly the size of a bear (1 can comfortably fit in a 2×2 area).</li><li><strong>Huge:</strong> Roughly the size of a small house (1 can comfortably fit in a 3×3 area).</li><li><strong>Gargantuan:</strong> Can be as large as a castle keep (1 can fill a 4×4 area or greater).</li></ul>"
+			},
+			"image": {
+				"caption": ""
+			},
+			"video": {
+				"controls": true,
+				"volume": 0.5
+			},
+			"src": null,
+			"sort": 500000,
+			"ownership": {
+				"default": -1
+			},
+			"flags": {},
+			"_stats": {
+				"coreVersion": "13.347",
+				"systemId": "nimble",
+				"systemVersion": "0.1.7",
+				"createdTime": null,
+				"modifiedTime": null,
+				"lastModifiedBy": null
+			}
+		},
+		{
+			"_id": "X8pgFflL0fe1D9Gr",
+			"name": "Hit Points & Dying",
+			"type": "text",
+			"title": {
+				"show": true,
+				"level": 1
+			},
+			"text": {
+				"format": 1,
+				"content": "<p><strong>Hit Points (HP)</strong> represent your ability to endure damage. Damage reduces your HP (which can't go below 0). When reduced to 0 HP, gain 1 Wound; you also gain the <strong>Dying</strong> condition until you regain HP.</p><p>While Dying, actions are limited to 1, Concentration is broken, and you are at risk of further serious harm:</p><ul><li>Attacking or casting spells causes 1 Wound unless you make a DC 10 STR save.</li><li>Taking damage while Dying causes 2 Wounds; a crit causes 3 instead.</li></ul><h3>Wounds</h3><p>Wounds are serious injuries — a long-term gauge of how close you are to death. HP can usually be recovered quickly, but Wounds may take many days of resting to fully recover from (usually 1 per Safe Rest).</p><h3>Death</h3><p>You die when you have taken 6 Wounds (unless an ability changes this number). There are ways to revive a hero who has died, but they are rare and often come at a very steep cost.</p><h3>Temporary HP</h3><p>Some abilities or effects grant temporary HP (temp HP); these are reduced first when taking damage. Temp HP do not combine — if you have temp HP and would gain more, choose which amount to keep. They expire after a Safe Rest.</p><h3>Hit Dice</h3><p><strong>Hit Dice (HD)</strong> represent your ability to quickly recuperate from minor injuries and are spent to regain HP. Heroes start with a max of 1 Hit Die at level 1, and this limit increases by 1 each time they level up. Hit Dice are recovered during a Safe Rest.</p><blockquote><p><strong>Gritty Dying Rules (Optional):</strong> Reduce the max number of Wounds heroes have (anywhere from 5 down to 1–2 for a very lethal game). You can also have each Wound impose a cumulative –1 penalty to rolls.</p></blockquote>"
+			},
+			"image": {
+				"caption": ""
+			},
+			"video": {
+				"controls": true,
+				"volume": 0.5
+			},
+			"src": null,
+			"sort": 600000,
+			"ownership": {
+				"default": -1
+			},
+			"flags": {},
+			"_stats": {
+				"coreVersion": "13.347",
+				"systemId": "nimble",
+				"systemVersion": "0.1.7",
+				"createdTime": null,
+				"modifiedTime": null,
+				"lastModifiedBy": null
+			}
+		},
+		{
+			"_id": "k8KNiVoBdSx1bkPE",
+			"name": "Speed & Range",
+			"type": "text",
+			"title": {
+				"show": true,
+				"level": 1
+			},
+			"text": {
+				"format": 1,
+				"content": "<p>A character's <strong>Speed</strong> is how fast they can move — default is 6. Often play is done on a grid with 1-inch squares or hexagons representing roughly 5 ft. or 1 meter each. A hero with a speed of 6 can travel up to 6 spaces horizontally or diagonally.</p><p>You can move through spaces occupied by allies (or enemies as difficult terrain: half speed), as long as you don't end movement in an occupied space.</p><blockquote><p><strong>Alternate Option:</strong> For a quicker, more loose game, measure typical movement roughly from pinkie to thumb.</p></blockquote><h3>Range & Reach</h3><p>Certain abilities, weapons, and spells have a specified Range or Reach, which determines how far away targets can be affected. If none is specified, default to Reach 1.</p><ul><li><strong>In Melee.</strong> If any enemy is adjacent to you, your Ranged attacks are made with disadvantage (Reach attacks are not so affected).</li><li><strong>Long Range.</strong> You can gain disadvantage 1 to gain +2 Range on any Ranged attack (max +6).</li></ul><h3>Falling & Forced Movement</h3><p>When a character is forcibly moved but stopped by an obstacle, they take 1d6 bludgeoning damage for every space this movement is shortened. If they hit another creature, both split this damage. Falling inflicts 1d6 bludgeoning damage for every 10 ft. fallen (2 spaces).</p><blockquote><p><strong>Abstracted Distances (Optional):</strong> Use Close, Midrange, and Far instead of counting spaces. Close = Reach/Range 4; Midrange = up to 6; beyond that is Far.</p></blockquote>"
+			},
+			"image": {
+				"caption": ""
+			},
+			"video": {
+				"controls": true,
+				"volume": 0.5
+			},
+			"src": null,
+			"sort": 700000,
+			"ownership": {
+				"default": -1
+			},
+			"flags": {},
+			"_stats": {
+				"coreVersion": "13.347",
+				"systemId": "nimble",
+				"systemVersion": "0.1.7",
+				"createdTime": null,
+				"modifiedTime": null,
+				"lastModifiedBy": null
+			}
+		},
+		{
+			"_id": "X8vcz20tujVb4tIj",
+			"name": "Concentration, Cover & Grappling",
+			"type": "text",
+			"title": {
+				"show": true,
+				"level": 1
+			},
+			"text": {
+				"format": 1,
+				"content": "<h2>Concentration</h2><p>Some activities require Concentration to maintain. A character can only concentrate on one activity at a time. Whenever a character is crit while concentrating, they must make a DC 10 STR save — failing breaks Concentration. Concentration is automatically broken whenever a character drops to 0 HP or is incapacitated.</p><h2>Cover &amp; Hiding</h2><p>A creature mostly obscured from line of sight (standing behind a tree, a larger ally, a knocked over table, in poor lighting, etc.) has <strong>Cover</strong> and imposes disadvantage on attacks against them. A creature completely obscured from view has <strong>Full Cover</strong> and cannot typically be targeted by an attack.</p><p>To hide in combat, you must have Cover from the creatures you are attempting to hide from and use an action to make a DC 15 Stealth check (if you have Full Cover, you succeed automatically). The first attack you make while hidden is made with advantage, then you are no longer hidden. If this attack kills the enemy and no other enemy can see you, you may remain hidden instead.</p><h2>Grappling</h2><p>You can attempt to grab another creature provided you are within Reach and have at least 1 arm free. On a failed STR or DEX save (DC 10+STR or DEX):</p><ul><li>A target your size or smaller is <strong>Grappled</strong>.</li><li>A target larger than you gives you the <strong>Riding</strong> condition.</li></ul><p>Forced movement (pushing a grappler away), incapacitation, or spending an action and succeeding on a STR or DEX save can end it.</p><p><strong>Restrained</strong> functions like Grappled, but is caused by objects (chains, rope, roots) and ignores size restrictions. It can also be ended through any logical means, such as picking a lock or cutting/burning rope.</p>"
+			},
+			"image": {
+				"caption": ""
+			},
+			"video": {
+				"controls": true,
+				"volume": 0.5
+			},
+			"src": null,
+			"sort": 800000,
+			"ownership": {
+				"default": -1
+			},
+			"flags": {},
+			"_stats": {
+				"coreVersion": "13.347",
+				"systemId": "nimble",
+				"systemVersion": "0.1.7",
+				"createdTime": null,
+				"modifiedTime": null,
+				"lastModifiedBy": null
+			}
+		},
+		{
+			"_id": "fdNQ7XZhtGwRfokE",
+			"name": "Conditions",
+			"type": "text",
+			"title": {
+				"show": true,
+				"level": 1
+			},
+			"text": {
+				"format": 1,
+				"content": "<p>Some attacks, traps, spells, or other effects can inflict conditions — usually negative effects other than damage. Some conditions are temporary; others may last until cured; some can be ended by using an action to make an appropriate save.</p><ul><li><strong>Blinded.</strong> Can't see. Attacks against you have advantage, and your attacks have disadvantage.</li><li><strong>Bloodied.</strong> At half HP or less.</li><li><strong>Charmed.</strong> Sees the charmer as an ally. Charmer has advantage on social interactions with you.</li><li><strong>Dazed.</strong> Heroes: lose 1 action; monsters: can perform one less action on their next turn.</li><li><strong>Dying.</strong> At 0 HP. Taking damage while dying causes 2 Wounds; a crit causes 3 instead.</li><li><strong>Frightened.</strong> Disadvantage on rolls when source of fear is nearby; speed halved when moving closer to it.</li><li><strong>Grappled/Restrained.</strong> Cannot move. Attacks against you have advantage.</li><li><strong>Hampered.</strong> Any creature with their actions or movement reduced (e.g., Dazed, Grappled, Prone, Difficult Terrain).</li><li><strong>Incapacitated.</strong> Can't do anything. Attacks against you have advantage, and melee attacks that hit, crit.</li><li><strong>Invisible.</strong> Cannot be seen. Your attacks have advantage, and attacks against you have disadvantage.</li><li><strong>Petrified.</strong> Incapacitated. You have all the benefits and drawbacks of being a rock! Immune to most damage except from large explosions, picks, or similar tools.</li><li><strong>Poisoned.</strong> Disadvantage on rolls.</li><li><strong>Prone.</strong> Movement costs twice as much, and you have disadvantage on attacks. Melee attacks against you have advantage; Ranged have disadvantage. Spend 3 spaces of your Speed to stand up.</li><li><strong>Riding.</strong> You move with the creature you are riding. Any attacks that miss you strike them.</li><li><strong>Slowed.</strong> Speed halved during your next turn.</li><li><strong>Taunted.</strong> Disadvantage on attacks except against the most recent taunter.</li><li><strong>Wounded.</strong> Has any Wounds (typically 6 Wounds and a hero is dead).</li></ul><p><strong>Other Minor Statuses</strong> (Smoldering, Charged, Distracted, etc.) do nothing on their own and end whenever combat does. Some spells and abilities have additional effects against such targets.</p>"
+			},
+			"image": {
+				"caption": ""
+			},
+			"video": {
+				"controls": true,
+				"volume": 0.5
+			},
+			"src": null,
+			"sort": 900000,
+			"ownership": {
+				"default": -1
+			},
+			"flags": {},
+			"_stats": {
+				"coreVersion": "13.347",
+				"systemId": "nimble",
+				"systemVersion": "0.1.7",
+				"createdTime": null,
+				"modifiedTime": null,
+				"lastModifiedBy": null
+			}
+		}
+	],
+	"folder": null,
+	"flags": {},
+	"_stats": {
+		"coreVersion": "13.347",
+		"systemId": "nimble",
+		"systemVersion": "0.1.7",
+		"createdTime": null,
+		"modifiedTime": null,
+		"lastModifiedBy": null
+	},
+	"_id": "ZQjOBEMTFhOssTAV"
+}

--- a/packs/rules/core/equipment.json
+++ b/packs/rules/core/equipment.json
@@ -1,0 +1,186 @@
+{
+	"name": "Equipment",
+	"pages": [
+		{
+			"_id": "5k379xcPg8Zsysjl",
+			"name": "Armor",
+			"type": "text",
+			"title": {
+				"show": true,
+				"level": 1
+			},
+			"text": {
+				"format": 1,
+				"content": "<p>Armor represents your hero's ability to dodge or block damage when you use the Defend reaction. While unarmored or wearing regular clothes, your Armor is equal to your DEX. Some items may grant additional Armor while equipped.</p><p><strong>Equipment Proficiency.</strong> Heroes can use any equipment they like; however, each class has a list of weapons and armor types they are most skilled with. Weapons used without proficiency cannot crit. Defending while wearing armor worn without proficiency costs 1 additional action.</p><p><strong>Swapping Equipment.</strong> A hero can sheathe weapons or shields they are proficient with and equip a different one for free 1/round.</p><table><thead><tr><th>Armor</th><th>Armor Value</th><th>Cost</th></tr></thead><tbody><tr><td colspan=\"3\"><strong>Cloth</strong></td></tr><tr><td>Adventurer's Garb</td><td>2+DEX</td><td>10 gp</td></tr><tr><td>Minor Enchantment</td><td>3+DEX</td><td>100 gp</td></tr><tr><td>Major Enchantment</td><td>4+DEX</td><td>1,000 gp</td></tr><tr><td>Epic Enchantment</td><td>5+DEX</td><td>10,000 gp</td></tr><tr><td colspan=\"3\"><strong>Leather</strong></td></tr><tr><td>Cheap Hides</td><td>3+DEX</td><td>5 gp</td></tr><tr><td>Ox Hide</td><td>4+DEX</td><td>45 gp</td></tr><tr><td>Hard Leather (Req. 1 STR)</td><td>5+DEX</td><td>300 gp</td></tr><tr><td>Wyrmhide (Req. 1 STR)</td><td>6+DEX</td><td>2,000 gp</td></tr><tr><td colspan=\"3\"><strong>Mail</strong></td></tr><tr><td>Rusty Mail</td><td>6+DEX (max 2)</td><td>15 gp</td></tr><tr><td>Chain Shirt (Req. 2 STR)</td><td>9+DEX (max 2)</td><td>60 gp</td></tr><tr><td>Scale Mail (Req. 3 STR)</td><td>12+DEX (max 2)</td><td>700 gp</td></tr><tr><td>Dragonscale (Req. 4 STR)</td><td>15+DEX (max 2)</td><td>3,000 gp</td></tr><tr><td colspan=\"3\"><strong>Plate</strong></td></tr><tr><td>Rusty Plate (Req. 2 STR)</td><td>10</td><td>25 gp</td></tr><tr><td>Half Plate (Req. 3 STR)</td><td>14</td><td>200 gp</td></tr><tr><td>Full Plate (Req. 4 STR)</td><td>18</td><td>2,000 gp</td></tr><tr><td>Mithril Plate (Req. 5 STR)</td><td>22</td><td>5,000 gp</td></tr><tr><td colspan=\"3\"><strong>Shields</strong></td></tr><tr><td>Wooden Buckler</td><td>2</td><td>5 gp</td></tr><tr><td>Iron Shield (Req. 2 STR)</td><td>4</td><td>80 gp</td></tr><tr><td>Tower Shield (Req. 3 STR)</td><td>6</td><td>1,500 gp</td></tr><tr><td>Dragon Shield (Req. 3 STR)</td><td>8</td><td>9,000 gp</td></tr></tbody></table><blockquote><p><strong>Deflect (Optional):</strong> Instead of adding your shield's armor to your total armor as normal, you may reduce the damage of an attack by your shield's armor value for free 1/round.</p></blockquote>"
+			},
+			"image": {
+				"caption": ""
+			},
+			"video": {
+				"controls": true,
+				"volume": 0.5
+			},
+			"src": null,
+			"sort": 100000,
+			"ownership": {
+				"default": -1
+			},
+			"flags": {},
+			"_stats": {
+				"coreVersion": "13.347",
+				"systemId": "nimble",
+				"systemVersion": "0.1.7",
+				"createdTime": null,
+				"modifiedTime": null,
+				"lastModifiedBy": null
+			}
+		},
+		{
+			"_id": "koxqzkVhtXOYLWkY",
+			"name": "Weapons",
+			"type": "text",
+			"title": {
+				"show": true,
+				"level": 1
+			},
+			"text": {
+				"format": 1,
+				"content": "<h2>Weapon Properties</h2><ul><li><strong>2-handed.</strong> Can be held in a single hand, but must be wielded in 2 hands to attack with it.</li><li><strong>Load.</strong> Some weapons require extra actions to load before each shot.</li><li><strong>Reach X.</strong> How close an enemy must be to be affected by this attack. Default: Reach 1.</li><li><strong>Range X.</strong> Attacks can be made from afar. If any enemy is adjacent to you, Ranged attacks are made with disadvantage. Add 1 die of disadvantage to gain +2 Range.</li><li><strong>Thrown.</strong> Treat a melee weapon as if it had Range. Once thrown, you no longer have it!</li><li><strong>Vicious.</strong> Roll 1 additional die whenever you roll crit damage.</li></ul><h2>Melee Weapons</h2><table><thead><tr><th>Item</th><th>Damage</th><th>Properties</th><th>Cost</th></tr></thead><tbody><tr><td>Dagger</td><td>1d4+DEX Piercing</td><td>Light, Thrown 4</td><td>3 gp</td></tr><tr><td>Sickle</td><td>1d4+DEX Slashing</td><td>Vicious</td><td>10 gp</td></tr><tr><td>Club/Mace</td><td>1d6+STR Bludgeoning</td><td>—</td><td>2 gp</td></tr><tr><td>Hand Axe</td><td>1d6+STR Slashing</td><td>Thrown 4</td><td>8 gp</td></tr><tr><td>Short Sword</td><td>1d6+DEX Piercing</td><td>Light</td><td>10 gp</td></tr><tr><td>Rapier</td><td>2d4+DEX Piercing</td><td>—</td><td>60 gp</td></tr><tr><td>Staff</td><td>1d8+STR Bludgeoning</td><td>2-handed</td><td>8 gp</td></tr><tr><td>Longsword</td><td>1d8+STR Slashing</td><td>2-handed (1-handed: Req. 2 STR)</td><td>60 gp</td></tr><tr><td>Battleaxe</td><td>1d10+STR Slashing</td><td>2-handed</td><td>30 gp</td></tr><tr><td>Pole Hammer</td><td>1d10+STR Bludgeoning</td><td>2-handed, Reach 2</td><td>60 gp</td></tr><tr><td>Glaive</td><td>1d10+STR Slashing</td><td>2-handed, Reach 2</td><td>60 gp</td></tr><tr><td>Spear</td><td>1d10+STR Piercing</td><td>2-handed, Reach 2</td><td>60 gp</td></tr><tr><td>Greatmaul</td><td>1d12+STR Bludgeoning</td><td>2-handed (Req. 2 STR)</td><td>80 gp</td></tr><tr><td>Greataxe</td><td>2d6+STR Slashing</td><td>2-handed (Req. 2 STR)</td><td>100 gp</td></tr><tr><td>Greatsword</td><td>3d4+STR Slashing/Piercing</td><td>2-handed (Req. 2 STR)</td><td>120 gp</td></tr><tr><td>Unarmed</td><td>1d4 (on hit: 1+STR)</td><td>—</td><td>—</td></tr></tbody></table><h2>Ranged Weapons</h2><table><thead><tr><th>Item</th><th>Damage</th><th>Properties</th><th>Cost</th></tr></thead><tbody><tr><td>Sling</td><td>1d4+DEX Bludgeoning</td><td>2-handed, Range 12, Vicious</td><td>4 gp</td></tr><tr><td>Javelins</td><td>1d6+STR Piercing</td><td>Range 8, Stack of 4</td><td>20 gp</td></tr><tr><td>Throwing Hammers</td><td>1d8+STR Bludgeoning</td><td>Range 4, Stack of 3</td><td>25 gp</td></tr><tr><td>Shortbow</td><td>1d6+DEX Piercing</td><td>2-handed, Range 12</td><td>25 gp</td></tr><tr><td>Longbow</td><td>1d8+DEX Piercing</td><td>2-handed, Range 16 (Req. 1 STR)</td><td>30 gp</td></tr><tr><td>Crossbow</td><td>4d4+DEX Piercing</td><td>2-handed, Load: 1 action, Range 8</td><td>60 gp</td></tr><tr><td>Handheld Ballista</td><td>1d20+DEX Piercing</td><td>2-handed, Load: 2 actions, Range 8 (Req. 2 STR)</td><td>120 gp</td></tr></tbody></table><h2>Dual Wielding</h2><p>Heroes may wield 2 Light weapons at the same time. While dual wielding, you may gain advantage on an attack with those weapons, 1/round.</p><p>You may dual wield 1-handed weapons without the Light property if your STR is 3 or greater, or 1 weapon without the Light property if your STR is 2. If completely unarmed, fists/feet can be considered dual wielded.</p><p>Dual wielding different weapons? Roll dice for both weapons and choose either result (the 1/round limit still applies).</p><h2>Customizing Weapons</h2><p>Can you reflavor a staff as a greatclub? Sure! A sai instead of a dagger? Of course! Could you pay a blacksmith to make your 1d12 Greatmaul deal 2d6 or 3d4 damage instead? Since the dice all add up to 12, it won't break the game — ask your GM!</p><h2>Improvised Weapons</h2><p>Using an improvised weapon (a chair, a frying pan, a big rock), default to 1d4+STR or 1d6+STR. Your GM may allow you to use bigger dice or other properties if it makes sense. An improvised weapon may break if it lands a crit.</p>"
+			},
+			"image": {
+				"caption": ""
+			},
+			"video": {
+				"controls": true,
+				"volume": 0.5
+			},
+			"src": null,
+			"sort": 200000,
+			"ownership": {
+				"default": -1
+			},
+			"flags": {},
+			"_stats": {
+				"coreVersion": "13.347",
+				"systemId": "nimble",
+				"systemVersion": "0.1.7",
+				"createdTime": null,
+				"modifiedTime": null,
+				"lastModifiedBy": null
+			}
+		},
+		{
+			"_id": "WeKK6oE6UUrcNQ1T",
+			"name": "Adventuring Equipment",
+			"type": "text",
+			"title": {
+				"show": true,
+				"level": 1
+			},
+			"text": {
+				"format": 1,
+				"content": "<h2>Key Equipment</h2><h3>Healing Potions</h3><p>Healing potions are deep, shimmering red elixirs. Potions require one action to drink or to administer to an adjacent willing creature. Small towns may have only a few; cities offer more (but not in unlimited supply).</p><table><thead><tr><th>Item</th><th>Effect</th><th>Cost</th></tr></thead><tbody><tr><td>Healing Potion</td><td>Heal 2d4+4 HP</td><td>50 gp</td></tr><tr><td>Greater Healing Potion</td><td>Heal 3d6+6 HP</td><td>150 gp</td></tr><tr><td>Supreme Healing Potion</td><td>Heal 4d8+8 HP</td><td>450 gp</td></tr></tbody></table><h3>Torches &amp; Lanterns</h3><p>Heroes cannot typically see in the dark — fighting in the dark imposes the Blinded condition. A torch typically lasts for 1 dungeon. A lantern with oil can typically last for 1 entire outing. Torches and lanterns cast light up to 6 spaces away.</p><h3>Currency</h3><p>Currency is made up of Silver (sp) and Gold pieces (gp). 10 silver = 1 gold. 1 sp is roughly the cost of a humble meal; 1 gp, a sumptuous feast. Most small towns will have equipment and items worth 50 gp or less.</p><h2>Misc Adventuring Equipment</h2><table><thead><tr><th>Item</th><th>Notes</th><th>Cost</th></tr></thead><tbody><tr><td>Torch (stack of 2)</td><td>For when it's dark</td><td>5 sp</td></tr><tr><td>Lantern &amp; Oil</td><td>Like a torch, but refillable (refill: 1 gp)</td><td>10 gp</td></tr><tr><td>Rope (50 ft.)</td><td>You always need rope</td><td>10 gp</td></tr><tr><td>Vial of Pitch</td><td>Sticky, and VERY flammable</td><td>2 gp</td></tr><tr><td>Grappling Hook</td><td>For climbing or catching BIG fish</td><td>4 gp</td></tr><tr><td>Lock Pick</td><td>It's not mine, honest!</td><td>5 gp</td></tr><tr><td>Hunting Trap</td><td>Snap snap, don't lose a finger!</td><td>10 gp</td></tr><tr><td>Camping Supplies</td><td>Bedroll, rations, simple tent</td><td>5 gp</td></tr><tr><td>Quiver &amp; Ammo</td><td>Don't leave home without it</td><td>10 gp</td></tr><tr><td>Manacles</td><td>For when someone has been bad</td><td>3 gp</td></tr><tr><td>Chain (10 ft.)</td><td>Like rope, but stronger (and heavy)</td><td>50 gp</td></tr><tr><td>Crowbar</td><td>It's LIKE a key</td><td>2 gp</td></tr><tr><td>Shovel</td><td>Sometimes you need a hole dug</td><td>3 gp</td></tr><tr><td>Magnifying Glass</td><td>Make the small, big</td><td>5 gp</td></tr><tr><td>Telescope</td><td>Arrr</td><td>10 gp</td></tr><tr><td>Mirror</td><td>For medusas AND spinach teeth</td><td>4 gp</td></tr><tr><td>Instrument</td><td>Drums, Horn, Lyre, Flute, etc.</td><td>5–50 gp</td></tr></tbody></table><p><em>Note: These are not all of the items available — merely a sampling. If you can think of it, you can likely buy it!</em></p>"
+			},
+			"image": {
+				"caption": ""
+			},
+			"video": {
+				"controls": true,
+				"volume": 0.5
+			},
+			"src": null,
+			"sort": 300000,
+			"ownership": {
+				"default": -1
+			},
+			"flags": {},
+			"_stats": {
+				"coreVersion": "13.347",
+				"systemId": "nimble",
+				"systemVersion": "0.1.7",
+				"createdTime": null,
+				"modifiedTime": null,
+				"lastModifiedBy": null
+			}
+		},
+		{
+			"_id": "AvMvxtWjZnHnUWfZ",
+			"name": "Magical Items",
+			"type": "text",
+			"title": {
+				"show": true,
+				"level": 1
+			},
+			"text": {
+				"format": 1,
+				"content": "<p>Though some magical items can be purchased, most cannot. Some special shops may have a very small selection, but more typically these powerful items are acquired through adventuring.</p><table><thead><tr><th>Rarity</th><th>Typical Levels</th><th>Typical Cost</th></tr></thead><tbody><tr><td>Uncommon</td><td>Levels 2–6</td><td>50–500+ gp</td></tr><tr><td>Rare</td><td>Levels 5–12</td><td>500–5,000+ gp</td></tr><tr><td>Very Rare</td><td>Levels 8–18</td><td>5,000–500,000+ gp</td></tr><tr><td>Legendary</td><td>Levels 15–20</td><td>1,000,000+ gp or Priceless</td></tr></tbody></table><h3>Sample Magical Items</h3><p><strong>Weapon of Many Hands (Rarity varies).</strong> While equipped, this weapon grants the wearer additional arms. The wearer can use the extra arms to perform any task their normal hands can do but does not allow performing actions any faster. A weapon that grants 1 extra hand is likely Uncommon; 4 extra hands, Legendary.</p><p><strong>Weapon of Animosity (Rarity varies).</strong> Whenever you attack with this weapon, roll an additional animosity die. The weapon deals that much additional damage to your target on a hit. Whenever this weapon misses, you take that damage instead. A weapon adding 1d4 is likely Uncommon; 1d10 or greater, Legendary.</p><p><strong>Weapon of Slaying (Rarity varies).</strong> Whenever you attack with this weapon, it deals an additional die of damage against a particular creature type. Those creatures may try to kill you first.</p><p><strong>Weapon of Wounding (Uncommon).</strong> When you land a hit, you may suffer 1d6 damage to deal twice that much additional damage to your target.</p><p><strong>Gnatbane Weapon (Uncommon).</strong> Does not miss Small or Tiny creatures.</p><p><strong>Trinket of Ill Omen (Rare).</strong> While equipped, you have –1 to saves you roll and +1 to your save DC.</p><p><strong>Mindlink Daggers (Rare).</strong> A matched pair of slender, silver daggers with intertwining runes. Enables the sharing of thoughts between any who holds (or is stabbed by) one.</p><p><strong>Bloodstained Quill (Uncommon).</strong> If you dip this quill into the blood of a dead intelligent creature, the quill animates and writes the last words spoken by that creature.</p><p><strong>Pocket Cauldron (Rare).</strong> While Safe Resting, use this to brew your choice of 1 potion, to be consumed immediately: Elixir of Futuresight, Elixir of Requiem, or (once every 100 years) Elixir of Time.</p><p><strong>Grim Coronet (Rare).</strong> When you would die while wearing this crown, gain 3 actions and take a turn immediately. You die at the end of your turn.</p><p><strong>Key of Doors (Very Rare).</strong> Insert this key into any locked door to open it — not to the room beyond, but to any doorway you've previously walked through while holding this item.</p><p><strong>Button of Protection (Rare).</strong> When attacked, pull the button off and throw it into the air. The attacker must make a WIL save or be distracted, causing the attack to miss you. After use, the button becomes inert until a seamstress sews it back on during a Safe Rest.</p><p><strong>Eyes of the Street (Uncommon).</strong> While wearing these goggles, you can look at a rat or pigeon to see and hear through its senses for 10 minutes. After use, you must whisper a secret to the goggles before you can use them again.</p><p><strong>Skitter Shoes (Rare).</strong> While wearing these shoes, you can walk on vertical surfaces or ceilings as if they were flat ground, at half normal Speed.</p><p><strong>Handwraps of Force (Rare).</strong> Whenever you make an unarmed strike, you may push your target up to 2 spaces and yourself the same distance in the opposite direction.</p><p><strong>Resolute Fangs, Golden Bastion (Legendary Shield).</strong> +8 Armor. Reaction: When you reduce damage from a melee attack with this shield, it may Grapple the attacker regardless of its size (escape DC 20 STR, max 1 creature). Action: Speak this shield's command word to make it immovable, fixed in place, until it is spoken again.</p><p><strong>Phoenix Helm (Legendary).</strong> If you die while wearing this golden helm, your body explodes in flames and hot ash. You rise anew from the ashes...</p>"
+			},
+			"image": {
+				"caption": ""
+			},
+			"video": {
+				"controls": true,
+				"volume": 0.5
+			},
+			"src": null,
+			"sort": 400000,
+			"ownership": {
+				"default": -1
+			},
+			"flags": {},
+			"_stats": {
+				"coreVersion": "13.347",
+				"systemId": "nimble",
+				"systemVersion": "0.1.7",
+				"createdTime": null,
+				"modifiedTime": null,
+				"lastModifiedBy": null
+			}
+		},
+		{
+			"_id": "NAiNRaAhDg2fiuCD",
+			"name": "Spell Scrolls & Wands",
+			"type": "text",
+			"title": {
+				"show": true,
+				"level": 1
+			},
+			"text": {
+				"format": 1,
+				"content": "<h2>Spell Scrolls</h2><p>Spell scrolls are single-use inscribed magical spells. Casting a spell with a spell scroll does not cost mana, nor does it require magical ability. Anyone who can read the language the scroll is written in can utilize it. Reading one aloud takes the same number of actions the spell normally takes and consumes the scroll.</p><p>A character must succeed on a DC 10 Arcana check to cast it successfully if they do not already know a spell from that school; on a failure, it is wasted.</p><table><thead><tr><th>Spell Tier</th><th>Cost</th><th>Spell Tier</th><th>Cost</th></tr></thead><tbody><tr><td>Cantrip</td><td>10 gp</td><td>Tier 5</td><td>3,000 gp</td></tr><tr><td>Tier 1</td><td>35 gp</td><td>Tier 6</td><td>10,000 gp</td></tr><tr><td>Tier 2</td><td>100 gp</td><td>Tier 7</td><td>25,000+ gp</td></tr><tr><td>Tier 3</td><td>300 gp</td><td>Tier 8</td><td>75,000+ gp</td></tr><tr><td>Tier 4</td><td>1,000 gp</td><td>Tier 9</td><td>200,000+ gp</td></tr></tbody></table><h2>Wands</h2><p>Like spell scrolls, wands can be used to cast spells without consuming mana and do not require magical ability. Unlike spell scrolls, wands can be recharged and used again. Characters proficient with wands can use one from any spell school, spending only the normal number of actions to cast the spell.</p><p>Characters not proficient with wands must succeed on a DC 10+spell tier Arcana check to successfully cast the spell. Success or failure, the charge is spent.</p><table><thead><tr><th>Spell Tier</th><th>Cost</th><th>Spell Tier</th><th>Cost</th></tr></thead><tbody><tr><td>Cantrip</td><td>50 gp</td><td>Tier 5</td><td>15,000 gp</td></tr><tr><td>Tier 1</td><td>175 gp</td><td>Tier 6</td><td>50,000 gp</td></tr><tr><td>Tier 2</td><td>500 gp</td><td>Tier 7</td><td>125,000+ gp</td></tr><tr><td>Tier 3</td><td>1,500 gp</td><td>Tier 8</td><td>375,000+ gp</td></tr><tr><td>Tier 4</td><td>5,000 gp</td><td>Tier 9</td><td>1,000,000+ gp</td></tr></tbody></table><h3>Example Wands</h3><ul><li><strong>Wand of Barrier of Wind</strong> — Uncommon, Cantrip (3 charges). Recharge: Heat in a blacksmith's forge until it glows, then quench it in oil.</li><li><strong>Wand of Dread Visage</strong> — Uncommon, Tier 2 (2 charges). Recharge: Place in a freshly slain corpse. Leave it until only bones remain.</li><li><strong>Wand of Fly</strong> — Rare, Tier 2 (3 charges). Recharge: Hang with wind chimes in a breezy area. Let it ring for 3 days.</li><li><strong>Wand of Firestep</strong> — Very Rare, Tier 6 (1 charge). Recharge: Plant it in a new garden, leave it undisturbed until the flowers bloom.</li><li><strong>Wand of Ride the Lightning</strong> — Very Rare, Tier 6 (2 charges). Recharge: Place at the highest point within 1 mile. Retrieve after 3 thunderstorms.</li><li><strong>Wand of Glacier Strike</strong> — Very Rare, Tier 8 (1 charge). Recharge: Leave the wand at the bottom of a lake until it freezes over and thaws naturally.</li><li><strong>Elderwyrm's Majesty</strong> — Legendary, Tier 9 (1 charge). Casts Dragonform, turning into the type of dragon that last charged it. Recharge: Give an ancient dragon a gift it truly desires.</li><li><strong>Heartwood, Splinter of the Tree of Life</strong> — Legendary, Tier 9 (1 charge). Cast Redeem with no required components. Recharge: A sacred hymn must be sung over it ceaselessly for 100 years.</li></ul>"
+			},
+			"image": {
+				"caption": ""
+			},
+			"video": {
+				"controls": true,
+				"volume": 0.5
+			},
+			"src": null,
+			"sort": 500000,
+			"ownership": {
+				"default": -1
+			},
+			"flags": {},
+			"_stats": {
+				"coreVersion": "13.347",
+				"systemId": "nimble",
+				"systemVersion": "0.1.7",
+				"createdTime": null,
+				"modifiedTime": null,
+				"lastModifiedBy": null
+			}
+		}
+	],
+	"folder": null,
+	"flags": {},
+	"_stats": {
+		"coreVersion": "13.347",
+		"systemId": "nimble",
+		"systemVersion": "0.1.7",
+		"createdTime": null,
+		"modifiedTime": null,
+		"lastModifiedBy": null
+	},
+	"_id": "Oz9KSXS5xNFbsx3l"
+}

--- a/packs/rules/core/glossary.json
+++ b/packs/rules/core/glossary.json
@@ -1,0 +1,50 @@
+{
+	"name": "Glossary",
+	"pages": [
+		{
+			"_id": "z7qGsxoxrneQGczj",
+			"name": "Glossary",
+			"type": "text",
+			"title": {
+				"show": true,
+				"level": 1
+			},
+			"text": {
+				"format": 1,
+				"content": "<p>Quick reference for terms used throughout the Nimble rules.</p><ul><li><strong>Advantage X.</strong> Roll X additional dice and drop the X lowest dice (removing dice from left to right in the case of a tie).</li><li><strong>Ally.</strong> A friendly creature, not yourself.</li><li><strong>Assess.</strong> An action to strategically analyze the situation in combat.</li><li><strong>Attack.</strong> Any offensive action. Swinging with a weapon, casting a harmful spell, Grappling, etc.</li><li><strong>Blindsight X.</strong> You can sense creatures and obstacles normally within X spaces, ignoring Blinded, darkness, and invisibility.</li><li><strong>Cantrip.</strong> A basic spell. Costs 0 mana to cast, and their power increases as you level up.</li><li><strong>Climbing.</strong> A creature with a climbing speed can move across vertical surfaces as flat ground.</li><li><strong>Concentration.</strong> Can only Concentrate on 1 thing at a time. DC 10 STR save when crit or lose concentration.</li><li><strong>Cone X.</strong> Starts at the character and extends X spaces outward, becoming up to X spaces wide at the farthest edge.</li><li><strong>Cover.</strong> If partially obscured, incoming attacks have disadvantage. If completely obscured, cannot be targeted.</li><li><strong>d44, d66, d88.</strong> Roll 2 of the same dice; the leftmost die is the tens place, and the second is the ones. These rolls cannot miss or crit.</li><li><strong>Darkvision X.</strong> Can see normally in the dark, up to X spaces.</li><li><strong>Decrement/Increment.</strong> Use a die one size smaller or larger (d4 » d6 » d8 » d10 » d12 » d20).</li><li><strong>Difficult Terrain.</strong> Speed halved while here (e.g., moving through the space of an enemy).</li><li><strong>Disadvantage X.</strong> Roll X additional dice and drop the X highest dice.</li><li><strong>Distracted.</strong> A target is distracted if it is adjacent to or Taunted by an ally, or if it cannot see you.</li><li><strong>Encounter.</strong> An encounter begins when Initiative is rolled and ends when hostilities do.</li><li><strong>Falling.</strong> Suffer 1d6 damage per 10 ft. fallen.</li><li><strong>Field Rest/Safe Rest.</strong> Spend time to recover some of your resources.</li><li><strong>Free.</strong> Does not cost an action or any other resource (e.g., mana) unless otherwise stated.</li><li><strong>Hampered.</strong> Any creature with their actions or movement reduced (e.g., Dazed, Grappled, Prone, Difficult Terrain).</li><li><strong>KEY.</strong> Use either of your KEY attributes.</li><li><strong>Knockback/Push X.</strong> Forcibly move a creature X spaces, ignoring Difficult Terrain. Other creatures or the environment may halt movement prematurely and deal damage.</li><li><strong>Line X.</strong> A straight line extending up to X spaces in one direction.</li><li><strong>LVL.</strong> Replace this with your Hero's level.</li><li><strong>Mana.</strong> Used to fuel spellcasting. See the Heroes book for more info on how classes gain mana.</li><li><strong>Move X.</strong> Move up to that many spaces.</li><li><strong>Paralyzed, Stunned, Unconscious.</strong> Incapacitated. Can't do anything. Attacks against you have advantage, and melee attacks that hit, crit.</li><li><strong>Reach X.</strong> The area within X spaces around a character; forming your choice of a cube or sphere.</li><li><strong>Range X.</strong> Ranged attacks are made with disadvantage if ANY enemy is adjacent. Range can be extended.</li><li><strong>Resistance.</strong> Take half as much damage.</li><li><strong>Restrained.</strong> Same effect as Grappled; objects Restrain, creatures Grapple.</li><li><strong>Round.</strong> The time in combat when each Hero and enemy has a chance to act.</li><li><strong>Rushed Attacks.</strong> Attacking more than once on a turn imposes a cumulative disadvantage penalty.</li><li><strong>Skill Points.</strong> Use them to increase your skills. Start with 4 at level 1 and gain 1 each level.</li><li><strong>Spellcasting Focus.</strong> Can be used instead of an empty hand to cast spells.</li><li><strong>Stats.</strong> The core attributes of a character (STR, DEX, INT, WIL).</li><li><strong>Surprise.</strong> When combat starts before all sides are aware.</li><li><strong>Target.</strong> A selected creature or object. It must be within Range/Reach and able to be sensed.</li><li><strong>Teleport.</strong> Move instantaneously. Does not provoke opportunity attacks.</li><li><strong>Temp HP.</strong> HP that do not replenish. Expires after a Safe Rest.</li><li><strong>Turn.</strong> The primary time allotted for an individual hero or monster group to act.</li><li><strong>Unheld.</strong> Not touched, worn, or held by anyone.</li><li><strong>Vulnerable.</strong> When a creature is vulnerable to a damage type, that kind of damage ignores its armor; if unarmored, they take double the damage instead.</li><li><strong>Wound.</strong> A measure of how close a hero is to death. Typically 6 and you're dead.</li></ul>"
+			},
+			"image": {
+				"caption": ""
+			},
+			"video": {
+				"controls": true,
+				"volume": 0.5
+			},
+			"src": null,
+			"sort": 100000,
+			"ownership": {
+				"default": -1
+			},
+			"flags": {},
+			"_stats": {
+				"coreVersion": "13.347",
+				"systemId": "nimble",
+				"systemVersion": "0.1.7",
+				"createdTime": null,
+				"modifiedTime": null,
+				"lastModifiedBy": null
+			}
+		}
+	],
+	"folder": null,
+	"flags": {},
+	"_stats": {
+		"coreVersion": "13.347",
+		"systemId": "nimble",
+		"systemVersion": "0.1.7",
+		"createdTime": null,
+		"modifiedTime": null,
+		"lastModifiedBy": null
+	},
+	"_id": "ZuhDliTOf0Rp6Gng"
+}

--- a/packs/rules/core/optional-rules.json
+++ b/packs/rules/core/optional-rules.json
@@ -1,0 +1,84 @@
+{
+	"name": "Optional Rules",
+	"pages": [
+		{
+			"_id": "C4Xv5znLBXHK3QrB",
+			"name": "Optional Variant Rules",
+			"type": "text",
+			"title": {
+				"show": true,
+				"level": 1
+			},
+			"text": {
+				"format": 1,
+				"content": "<p>If your playgroup likes extra little tactical nuggets, your GM can allow you to try out some of these additional variants. You can always try out a rule for 1 session and see how you all like it before committing to it.</p><h3>Characters</h3><p><strong>Different Key Stats.</strong> Players can swap KEY or Secondary stats for a class if it makes sense (e.g., DEX and WIL for the Cheat).</p><p><strong>Complex Characters.</strong> A GM may allow heroes to pick 2 backgrounds and/or ancestry bonuses.</p><p><strong>Multiclassing.</strong> When heroes level up, they may choose any class. For example, when a level 4 Berserker levels up, they could pick Commander and take the level 1 Commander features instead of the level 5 Berserker features. A hero gains all the equipment proficiencies of all their classes but should use the advantaged/disadvantaged saves of whichever class has the highest level. <em>The GM may need to make the game substantially more challenging if multiclassing is allowed.</em></p><h3>Combat</h3><p><strong>Sucker Punch.</strong> A character standing up from Prone gives adjacent enemies the chance to take opportunity attacks (heroes and monsters alike).</p><p><strong>Playing Dead.</strong> Whenever a Hero drops to 0 HP, they can attempt to play dead by falling prone and making an Influence check (or other skill check as the situation demands).</p><p><strong>Retreat.</strong> Any hero may call for a retreat on their turn. If the party agrees, the GM allows them to flee. Each hero describes their escape. Consequences may follow, such as taking damage, suffering a Wound, or failing a quest. If the escape is particularly clever, the GM may allow the party to escape without additional consequence.</p><p><strong>Inspiration.</strong> Whenever a hero does something memorable (role-plays a great moment, makes everyone laugh, misses an attack multiple times in a row, or otherwise engages in desired behavior), the GM can grant Inspiration: the ability to reroll any single die. Inspiration expires after a Safe Rest.</p><p><strong>I Had the High Ground.</strong> Taking a crit while at a height may cause a character to fall down. A reasonable STR save may be called for, but a weak character may just fall automatically.</p><p><strong>Thrown Potions.</strong> Treat potions like Ranged attacks (Range 8). The potion misses on a 1; otherwise it heals for half as much since some splashes away and is wasted.</p><h3>Group Size</h3><p><strong>Small Groups.</strong> A GM and a single hero can play with the aid of a sidekick. Sidekicks are NPCs that the hero's player controls during combat and the GM controls outside of combat. Sidekicks get 2 actions and are always 1 level below the hero character.</p><p><strong>Large Groups.</strong> 3rd party adventures are typically balanced for parties of 3–5 players. Playing with very large groups (6–10+ heroes) can be made far more manageable simply by limiting each hero's actions to 2 instead of 3. No other rebalancing needs to be done.</p><h3>Resting</h3><p><strong>Fast Resting.</strong> For a much more heroic and fast-paced story, a Safe Rest can heal all Wounds.</p><h3>Dice</h3><p><strong>Custom Weapon Dice.</strong> For larger weapon die sizes, you can try using dice of a different size as long as they add up to the same initial die size. For example: a 1d10 glaive could be 1d4+1d6 or 1d6+1d4 (using the first die as the primary die).</p><p><strong>Critical Healing.</strong> Treat healing just like an attack roll. Rolling the max is a crit (rolling again just like an attack crit), rolling 1 is a failure to heal. Consider incrementing the die size by one step if you use this variant.</p>"
+			},
+			"image": {
+				"caption": ""
+			},
+			"video": {
+				"controls": true,
+				"volume": 0.5
+			},
+			"src": null,
+			"sort": 100000,
+			"ownership": {
+				"default": -1
+			},
+			"flags": {},
+			"_stats": {
+				"coreVersion": "13.347",
+				"systemId": "nimble",
+				"systemVersion": "0.1.7",
+				"createdTime": null,
+				"modifiedTime": null,
+				"lastModifiedBy": null
+			}
+		},
+		{
+			"_id": "DZV29AOlPmFu8mJw",
+			"name": "Measuring Spaces",
+			"type": "text",
+			"title": {
+				"show": true,
+				"level": 1
+			},
+			"text": {
+				"format": 1,
+				"content": "<p>Generally, speed is preferred above precision while playing a TTRPG — don't make other people wait unnecessarily, close enough is good enough! However, if your table prefers precise rulings, use the options below as a reference.</p><h3>Diagonal Spaces</h3><p>Treating diagonal spaces as adjacent is the default assumption, as it tends to be easier and faster (though it can cause some spatial \"weirdness\" that some may not prefer). Instead, you can treat diagonals as not adjacent at all, or count every other diagonal as adjacent (fiddly, but a good balance).</p><p>Whatever the heroes can do (moving or attacking diagonally), monsters can do as well.</p><h3>Cones &amp; Lines</h3><p><strong>Cone:</strong> Start at the character and extend X spaces outward. The cone can be up to X spaces wide at the farthest edge (you can make it narrower than X, but not wider).</p><p><strong>Line:</strong> Starting from the character, extend the area up to X spaces in a single direction (you can make it shorter, but not longer), and 1 space wide. If a space is at least halfway covered by the cone or line, it is included in the effect.</p>"
+			},
+			"image": {
+				"caption": ""
+			},
+			"video": {
+				"controls": true,
+				"volume": 0.5
+			},
+			"src": null,
+			"sort": 200000,
+			"ownership": {
+				"default": -1
+			},
+			"flags": {},
+			"_stats": {
+				"coreVersion": "13.347",
+				"systemId": "nimble",
+				"systemVersion": "0.1.7",
+				"createdTime": null,
+				"modifiedTime": null,
+				"lastModifiedBy": null
+			}
+		}
+	],
+	"folder": null,
+	"flags": {},
+	"_stats": {
+		"coreVersion": "13.347",
+		"systemId": "nimble",
+		"systemVersion": "0.1.7",
+		"createdTime": null,
+		"modifiedTime": null,
+		"lastModifiedBy": null
+	},
+	"_id": "vHuQF7yF37WYL6uR"
+}

--- a/packs/rules/core/resting-and-downtime.json
+++ b/packs/rules/core/resting-and-downtime.json
@@ -1,0 +1,118 @@
+{
+	"name": "Resting & Downtime",
+	"pages": [
+		{
+			"_id": "tDb8Kp3Vcy71IMir",
+			"name": "Field Rests",
+			"type": "text",
+			"title": {
+				"show": true,
+				"level": 1
+			},
+			"text": {
+				"format": 1,
+				"content": "<p>While out adventuring, heroes can take Field Rests to regain HP.</p><h3>Catch Breath</h3><p>Requires at least 10 minutes to tend to your injuries. Expend any number of Hit Dice one at a time (roll them and add your STR to each), and regain that many HP.</p><h3>Make Camp</h3><p>If you rest for at least 8 hours with food and sleep, take the maximum value for each Hit Die you expend instead of rolling. Add your STR to each Hit Die as usual.</p><p><em>Note: If your STR is negative, subtract it from each HD you expend instead.</em></p>"
+			},
+			"image": {
+				"caption": ""
+			},
+			"video": {
+				"controls": true,
+				"volume": 0.5
+			},
+			"src": null,
+			"sort": 100000,
+			"ownership": {
+				"default": -1
+			},
+			"flags": {},
+			"_stats": {
+				"coreVersion": "13.347",
+				"systemId": "nimble",
+				"systemVersion": "0.1.7",
+				"createdTime": null,
+				"modifiedTime": null,
+				"lastModifiedBy": null
+			}
+		},
+		{
+			"_id": "ATqyZQc94c7JVLVR",
+			"name": "Safe Rests",
+			"type": "text",
+			"title": {
+				"show": true,
+				"level": 1
+			},
+			"text": {
+				"format": 1,
+				"content": "<p>Safe Rests take place in a safe location designated by your GM — typically lodging at an inn overnight, but could also be at a secret oasis, a well-stocked cabin in the woods, near a sacred shrine, or similar. Camping in the open wilderness or in a dungeon is not sufficient for gaining the benefits of a Safe Rest.</p><p>After a Safe Rest, heroes recover:</p><ul><li>All of their HP</li><li>All Hit Dice</li><li>All mana (and other class-specific resources)</li><li>1 Wound healed</li></ul><p>Safe Rests are also a great opportunity for downtime activities.</p><h3>Lodging</h3><p>The cheapest rooms at an inn save you money but may lead to complications. Some inns may allow you to pay a premium for a nicer room and amenities, giving you a Temporary Boon. Typical prices (per person/day):</p><ul><li><strong>Poor:</strong> 5 sp</li><li><strong>Comfortable:</strong> 2 gp</li><li><strong>Lavish:</strong> 10 gp — allows players to gain one Temporary Boon the following day (see Lodging Boons table).</li></ul>"
+			},
+			"image": {
+				"caption": ""
+			},
+			"video": {
+				"controls": true,
+				"volume": 0.5
+			},
+			"src": null,
+			"sort": 200000,
+			"ownership": {
+				"default": -1
+			},
+			"flags": {},
+			"_stats": {
+				"coreVersion": "13.347",
+				"systemId": "nimble",
+				"systemVersion": "0.1.7",
+				"createdTime": null,
+				"modifiedTime": null,
+				"lastModifiedBy": null
+			}
+		},
+		{
+			"_id": "nFamYWmTTUo8HnDF",
+			"name": "Downtime Activities",
+			"type": "text",
+			"title": {
+				"show": true,
+				"level": 1
+			},
+			"text": {
+				"format": 1,
+				"content": "<p>The time you aren't out adventuring is called <strong>Downtime</strong>. You can spend Downtime to recuperate from your adventures and partake in Downtime Activities. Not every moment of Downtime needs to be narrated or roleplayed — much Downtime can be skipped over to get back to adventuring if desired.</p><h3>Example Downtime Activities</h3><ul><li><strong>Retrain.</strong> Spend time doing activities to retrain any of your chosen abilities, features, or possibly even your subclass.</li><li><strong>Gather Information.</strong> Meet NPCs, pick up news, or collect rumors and job leads.</li><li><strong>Personal Goals.</strong> Pursue goals from your backstory or other smaller quests you've chosen.</li><li><strong>Buy &amp; Sell.</strong> Get new equipment, and sell treasures you've collected while out adventuring.</li><li><strong>Perform.</strong> Play music, tell stories, compete, or perform in public to earn gold or fame.</li><li><strong>Craft.</strong> Create weapons, armor, or simple items using materials you've acquired.</li><li><strong>Socialize.</strong> Build alliances, make new friends, or make new enemies.</li><li><strong>Invest.</strong> Use your gold to invest in businesses or trade ventures for future profit.</li><li><strong>Mentor.</strong> Teach a skill or ability to another character or NPC.</li><li><strong>Research.</strong> Investigate a mystery, study ancient texts, or uncover hidden knowledge.</li><li><strong>Serve.</strong> Aid a patron or a deity in exchange for a favor, or perform charity for townsfolk.</li><li><strong>Build.</strong> Establish a home base, start a business, craft siege weapons, or build anything else you can imagine (GM and setting-permitting).</li></ul>"
+			},
+			"image": {
+				"caption": ""
+			},
+			"video": {
+				"controls": true,
+				"volume": 0.5
+			},
+			"src": null,
+			"sort": 300000,
+			"ownership": {
+				"default": -1
+			},
+			"flags": {},
+			"_stats": {
+				"coreVersion": "13.347",
+				"systemId": "nimble",
+				"systemVersion": "0.1.7",
+				"createdTime": null,
+				"modifiedTime": null,
+				"lastModifiedBy": null
+			}
+		}
+	],
+	"folder": null,
+	"flags": {},
+	"_stats": {
+		"coreVersion": "13.347",
+		"systemId": "nimble",
+		"systemVersion": "0.1.7",
+		"createdTime": null,
+		"modifiedTime": null,
+		"lastModifiedBy": null
+	},
+	"_id": "ZDLldXZlTUPQdNW0"
+}

--- a/packs/rules/core/spells.json
+++ b/packs/rules/core/spells.json
@@ -1,0 +1,288 @@
+{
+	"name": "Spells",
+	"pages": [
+		{
+			"_id": "tV1XMn64Dtl4k82H",
+			"name": "Spellcasting Rules",
+			"type": "text",
+			"title": {
+				"show": true,
+				"level": 1
+			},
+			"text": {
+				"format": 1,
+				"content": "<p>There are 6 main schools of magic. Each school has its own basic spells called <strong>cantrips</strong> and 9 tiers of progressively more powerful spells that can be unlocked as heroes level up. Heroes can cast any spell from the schools that they know within the tiers they have unlocked.</p><p><strong>Mana.</strong> Powerful tiered spells require mana to fuel them. A spell's mana cost is equal to its tier. Cantrips cost no mana.</p><p><strong>Upcasting.</strong> You can spend additional mana on tiered spells (up to the tier that you have unlocked) to make them stronger for each additional mana spent.</p><p><strong>Multi-Target/AoE.</strong> Multi-target/AoE attacks do not miss or crit, and a single roll is applied to all targets. Ignore (dis)advantage from conditions on individual targets — anything granting you (dis)advantage still applies to your roll as normal.</p><p><strong>Save Spells.</strong> A hero's save DC is typically 10+KEY.</p><p><strong>Range and Reach.</strong> Spells with \"Range\" can target creatures from a distance, but are cast with disadvantage if any enemy is adjacent to you. Add 1 die of disadvantage to gain +2 Range (max +6). Spells with \"Reach\" can't do this, but are cast normally even when in melee.</p><h3>Spell Schools Overview</h3><ul><li><strong>Fire Spells.</strong> Deal high, consistent damage at medium range. Some fire spells can inflict the Smoldering condition and gain additional destructive effects against Smoldering enemies.</li><li><strong>Ice Spells.</strong> Deal medium damage at long range, with a focus on controlling the battlefield and protecting the spellcaster. Some ice spells have additional effects against Hampered targets.</li><li><strong>Lightning Spells.</strong> Deal high damage at long range with a focus on teleporting around the battlefield and taking advantage of creatures equipped with metal. However, some lightning spells may fail to find ground and damage the spellcaster instead.</li><li><strong>Necrotic Spells.</strong> Summon horrible minions or manipulate and trap targets. Some risky necrotic spells prey upon damaged creatures, sapping their very life force — but frequently fail to distinguish between friend and foe.</li><li><strong>Radiant Spells.</strong> Can obliterate the unholy, the fearful, and those who would dare harm you or your allies. Equally effective at a distance or in melee. Other spells can protect, mend wounds, and even restore creatures back to life.</li><li><strong>Wind Spells.</strong> Aid in moving friend and foe alike around the battlefield. They can also slice and cut through entire groups of foes and viciously deal extra damage on critical hits.</li></ul><p><strong>Secret Spells.</strong> Some spells have been hidden or lost through the ages. Adventurers can sometimes stumble upon new spells (or wrench them out of the undead hands of a defeated Lich).</p>"
+			},
+			"image": {
+				"caption": ""
+			},
+			"video": {
+				"controls": true,
+				"volume": 0.5
+			},
+			"src": null,
+			"sort": 100000,
+			"ownership": {
+				"default": -1
+			},
+			"flags": {},
+			"_stats": {
+				"coreVersion": "13.347",
+				"systemId": "nimble",
+				"systemVersion": "0.1.7",
+				"createdTime": null,
+				"modifiedTime": null,
+				"lastModifiedBy": null
+			}
+		},
+		{
+			"_id": "q7CHTRpsVXteAelt",
+			"name": "Fire Spells",
+			"type": "text",
+			"title": {
+				"show": true,
+				"level": 1
+			},
+			"text": {
+				"format": 1,
+				"content": "<p><em>Deal high, consistent damage at medium range. Smoldering condition gains additional effects from some fire spells.</em></p><p><strong>Smoldering.</strong> This condition does nothing on its own, though some spells and abilities have additional effects against Smoldering creatures.</p><h3>Cantrips</h3><p><strong>Flame Dart</strong> — 1 Action, Single Target. Range: 8. Damage: 1d10. On crit: Smoldering. High Levels: +5 damage every 5 levels.</p><p><strong>Heart's Fire</strong> — 1 Action, Single Target. Range: 4. Give an ally within Range an extra action. Spend 1 mana to cast this when it is not your turn. High Levels: +1 Range every 5 levels.</p><h3>Tiered Spells</h3><p><strong>Ignite (Tier 1)</strong> — 2 Actions, Single Target. Range: 8. Damage: 4d10 to a Smoldering target, ending the condition on hit. Upcast: +10 damage.</p><p><strong>Enchant Weapon (Tier 2)</strong> — 1 Action, Single Target. Concentration: Up to 1 minute. A weapon you touch is enchanted with magical flame. It deals +KEY damage and inflicts Smoldering on crit. Upcast: +KEY damage.</p><p><strong>Flame Barrier (Tier 3)</strong> — 1 Action, Self. Reaction: When attacked, Defend for free. Until the start of your next turn, melee attackers against you take KEY damage (ignoring armor) and gain Smoldering. Upcast: +KEY damage.</p><p><strong>Pyroclasm (Tier 4)</strong> — 2 Actions, AoE. Reach: 3. Others within Reach take 2d20+10 damage (ignoring armor) on a failed DEX save. Half damage on save. Smoldering creatures fail. Upcast: +1 Reach, +2 damage.</p><p><strong>Fiery Embrace (Tier 5)</strong> — 2 Actions, AoE. Concentration: Up to 1 minute. Reach: 8. While within Reach: 1 ally gains the effects of Enchant Weapon. Enemies gain Smoldering, lose damage resistance, and their damage immunity is reduced to resistance. Upcast: +1 ally.</p><p><strong>Living Inferno (Tier 7)</strong> — 3 Actions, Self. Gain the effects of Flame Barrier until your next turn. At the end of this turn and your next turn, cast Pyroclasm for free. Upcast: Upcast Flame Barrier and Pyroclasm.</p><p><strong>Dragonform (Tier 9)</strong> — 5 Actions, Self. Transform into a Huge dragon. Gain 3 actions, a fly speed of 12, LVL Armor, 10×LVL temp HP, and:<br><em>Tooth &amp; Claw</em> (Action): Reach 2. 1d20+LVL damage (ignoring armor). Inflicts Smoldering.<br><em>Immolating Breath</em> (2 Actions): Reach: Cone 8. DC 20 DEX save, KEY d20 damage, half on save. Smoldering targets fail.<br>You can maintain this form as long as the temp HP remain (max 10 minutes). When it ends, you drop to 0 HP.</p>"
+			},
+			"image": {
+				"caption": ""
+			},
+			"video": {
+				"controls": true,
+				"volume": 0.5
+			},
+			"src": null,
+			"sort": 200000,
+			"ownership": {
+				"default": -1
+			},
+			"flags": {},
+			"_stats": {
+				"coreVersion": "13.347",
+				"systemId": "nimble",
+				"systemVersion": "0.1.7",
+				"createdTime": null,
+				"modifiedTime": null,
+				"lastModifiedBy": null
+			}
+		},
+		{
+			"_id": "XeBVfsomPVu3lxQW",
+			"name": "Ice Spells",
+			"type": "text",
+			"title": {
+				"show": true,
+				"level": 1
+			},
+			"text": {
+				"format": 1,
+				"content": "<p><em>Deal medium damage at long range, with a focus on controlling the battlefield. Some ice spells have additional effects against Hampered targets.</em></p><p><strong>Hampered.</strong> Any creature with their actions or movement reduced (e.g., Dazed, Slowed, Grappled, Restrained, Prone, in Difficult Terrain).</p><h3>Cantrips</h3><p><strong>Ice Lance</strong> — 1 Action, Single Target. Range: 12. Damage: 1d6 cold or piercing. On hit: Slowed. High Levels: +3 damage every 5 levels.</p><p><strong>Snowblind</strong> — 1 Action, Single Target. Reach: 1. Damage: 1d6. On hit: Blinded until the end of their next turn. High Levels: +3 damage every 5 levels.</p><h3>Tiered Spells</h3><p><strong>Frost Shield (Tier 1)</strong> — 1 Action, Self. Reaction: When attacked, gain 2×KEY temp HP and Defend for free. The ice melts and these temp HP are lost at the start of your next turn. Upcast: +2×KEY temp HP.</p><p><strong>Shatter (Tier 2)</strong> — 2 Actions, Single Target. Range: 12. Damage: 3d6. If any die rolls the max against a Hampered target, this counts as a crit. On crit: +20 damage. Upcast: Increase the result of ANY die by 1. +5 damage on crit.</p><p><strong>Cryosleep (Tier 3)</strong> — 2 Actions, AoE. Reach: 12. Creatures in a 2×2 area within Reach are Dazed. On a failed STR save, they fall asleep instead, becoming Incapacitated until their next two turns have passed, until damaged, or until an ally uses an action to wake them. Upcast: +1 area, +1 turn asleep.</p><p><strong>Rimeblades (Tier 4)</strong> — 3 Actions, AoE. Concentration: Up to 1 minute. Reach: 12. Conjure razor-sharp icy spikes in 5 contiguous spaces within Reach; this area is difficult terrain. Creatures that enter these spaces (or are in the area when conjured) suffer 2d6 damage for each space they touch. Upcast: +1 space, +1 damage.</p><p><strong>Arctic Blast (Tier 5)</strong> — 2 Actions, AoE. Reach: Cone 4. Damage: 4d6+10. This area is difficult terrain until the end of your next turn. Surviving creatures must make a STR save or be frozen in place (Restrained) until the end of their next turn; creatures already Hampered are Incapacitated for 1 turn instead. Upcast: +1 Reach.</p><p><strong>Glacier Strike (Tier 8)</strong> — 3 Actions, AoE. Range: 12. Damage: d66 bludgeoning to creatures in a 3×3 area. Creatures adjacent to that area take half as much. The entire area permanently becomes difficult terrain. Upcast: +1 initial area.<br><em>D66: Roll 2d6. The leftmost die is the tens place, and the second is the ones (e.g., 4 and 5 deal 45 damage).</em></p><p><strong>Arctic Annihilation (Tier 9)</strong> — 3 Actions, AoE. Reach: 12. Choose any number of objects or willing creatures within Reach to encase in ice. They are Incapacitated and immune to damage and negative effects until the start of their next turn. All other creatures and objects within Reach take d66 damage. Any surviving creature who took this damage must make a STR save or be Incapacitated for 1 round. Once cast, you must Safe Rest for 1 week before using it again.</p>"
+			},
+			"image": {
+				"caption": ""
+			},
+			"video": {
+				"controls": true,
+				"volume": 0.5
+			},
+			"src": null,
+			"sort": 300000,
+			"ownership": {
+				"default": -1
+			},
+			"flags": {},
+			"_stats": {
+				"coreVersion": "13.347",
+				"systemId": "nimble",
+				"systemVersion": "0.1.7",
+				"createdTime": null,
+				"modifiedTime": null,
+				"lastModifiedBy": null
+			}
+		},
+		{
+			"_id": "Bpwx3hGtiZ6EYbVq",
+			"name": "Lightning Spells",
+			"type": "text",
+			"title": {
+				"show": true,
+				"level": 1
+			},
+			"text": {
+				"format": 1,
+				"content": "<p><em>Deal high damage at long range with a focus on teleporting around the battlefield. Some lightning spells may fail to find ground and damage the spellcaster instead.</em></p><p><strong>Charged.</strong> Whenever you take lightning damage, you are Charged for 1 minute.</p><h3>Cantrips</h3><p><strong>Zap</strong> — 1 Action, Single Target. Range: 12. Damage: 2d8. On miss: the lightning fails to find ground, and strikes you instead. High Levels: +6 damage every 5 levels.</p><p><strong>Overload</strong> — 1 Action, AoE. Castable only if you are Charged, ending the condition. Reach: 2. Damage: 2d8 to others within Reach. High Levels: +4 damage every 5 levels.</p><h3>Tiered Spells</h3><p><strong>Arc Lightning (Tier 1)</strong> — 2 Actions, Single Target. Range: 12. Damage: 3d8. The bolt also damages the next closest creature to your target. On miss: the lightning strikes you instead. Upcast: +4 damage.<br><em>If you or an ally is the next closest, they are hit!</em></p><p><strong>Alacrity (Tier 2)</strong> — 1 Action, Self. Range: 4. Reaction: When attacked. Defend for free. After damage is dealt, you gain the Charged condition then teleport anywhere within Range. Upcast: +4 Range.</p><p><strong>Stormlash (Tier 3)</strong> — 2 Actions, AoE. Line: 12. Damage: 3d8+4 (ignoring metal armor). Surviving creatures are Dazed on a failed STR save, or Incapacitated instead for 1 of their turns if they fail by 5 or more. Creatures with a large amount of metal roll with disadvantage. Upcast: +4 damage.</p><p><strong>Electrickery (Tier 4)</strong> — 3 Actions, 2 Targets. Range: 8. Reaction: When an ally is attacked. Choose another creature within Range to swap places with your ally on a failed WIL save (they become the new target). Costs 1 Action while Charged, ending the condition. Upcast: +2 Range.</p><p><strong>Electrocharge (Tier 5)</strong> — 2 Actions, Single Target. Concentration: Up to 1 minute. A creature you touch gains the Charged condition, +1 max action, +5 armor, 2× speed, and advantage on DEX saves. Upcast: +4 Range.</p><p><strong>Ride the Lightning (Tier 6)</strong> — 3 Actions, AoE. Teleport up to 12 spaces away to a spot you can see (if a willing creature is there, swap places with them). Adjacent creatures take d88 damage. Surviving creatures must make a STR save or be hurled back 3 spaces, knocked Prone, and deafened for 1 day. Upcast: +1 DC.<br><em>D88: Roll 2d8. The leftmost die is the tens place, and the second is the ones.</em></p><p><strong>Seething Storm (Tier 9)</strong> — 3 Actions, AoE. Concentration: Up to 1 minute. Reach: 4. You become a cloud of tempestuous storm. You can fly, move for free 1/round, and attacks against you are made with disadvantage. At the end of each of your turns, strike up to 4 creatures within Reach with a bolt of lightning for d88 damage (a creature can only be struck 1/round). +2 Reach and number of bolts each round. Costs 3 actions each round to maintain. Once cast, you must Safe Rest for 1 week before using it again.</p>"
+			},
+			"image": {
+				"caption": ""
+			},
+			"video": {
+				"controls": true,
+				"volume": 0.5
+			},
+			"src": null,
+			"sort": 400000,
+			"ownership": {
+				"default": -1
+			},
+			"flags": {},
+			"_stats": {
+				"coreVersion": "13.347",
+				"systemId": "nimble",
+				"systemVersion": "0.1.7",
+				"createdTime": null,
+				"modifiedTime": null,
+				"lastModifiedBy": null
+			}
+		},
+		{
+			"_id": "oe5DFmZgmNIpWZk4",
+			"name": "Wind Spells",
+			"type": "text",
+			"title": {
+				"show": true,
+				"level": 1
+			},
+			"text": {
+				"format": 1,
+				"content": "<p><em>Aid in moving friend and foe alike around the battlefield. They can also slice and cut through entire groups of foes and viciously deal extra damage on critical hits.</em></p><h3>Cantrips</h3><p><strong>Razor Wind</strong> — 1 Action, Single Target. Range: 12. Damage: 1d4 slashing (Vicious: roll 1 additional die when you roll crit damage). Also damages up to 1 adjacent target. High Levels: +2 damage every 5 levels.</p><p><strong>Breath of Life</strong> — 1 Action, Single Target. Range: 6. Restore 1 HP to a Dying creature. High Levels: +2 Range every 5 levels.</p><h3>Tiered Spells</h3><p><strong>Blustery Gale (Tier 1)</strong> — 2 Actions, Single Target. Range: 12. Damage: 3d4 bludgeoning, advantage against flying, Small, or Tiny targets. On hit: Move a Med target 2 spaces away; Small/Tiny twice as far; Large half as far. For each die you would roll due to forced movement, deal +5 damage instead. Upcast: +1 movement.</p><p><strong>Barrier of Wind (Tier 2)</strong> — 1 Action, Self. Reaction: When attacked at Range. Defend for free. Ranged attacks have disadvantage against you this round (including the triggering attack). Upcast: +3 Armor.</p><p><strong>Fly (Tier 3)</strong> — 1 Action, Single Target+. Concentration: Up to 10 minutes. Touch a creature, grant a flying speed of 12. Upcast: +1 target.</p><p><strong>Eye of the Storm (Tier 4)</strong> — 2 Actions, AoE. Reach: 3. Damage: 4d4+10 bludgeoning to enemies within Reach. You may place surviving creatures anywhere within 1 space of the storm's Reach on a failed STR save. Upcast: +1 Reach.</p><p><strong>Updraft (Tier 5)</strong> — 3 Actions, AoE. Reach: 12. Enemies within a 5×5 area must repeat a DEX save until they succeed. For each time they failed, they suffer 1d6 falling damage and land prone. Upcast: +2 Range, +1 area.</p><p><strong>Thousand Cuts (Tier 6)</strong> — 3 Actions, AoE. Range: 12. Damage: d44 slashing damage (roll with advantage), also damages enemies within Reach 1 of your target. Upcast: +1 Reach.<br><em>D44 with advantage: Roll 3d4 and drop the lowest die. The leftmost die is the tens place, and the second is the ones.</em></p><p><strong>Boisterous Winds (Tier 7)</strong> — 2 Actions, Multi-target. Concentration: Up to 1 minute. You and up to 12 allies within Reach 12 gain: Ranged attacks have disadvantage against you, a flying speed of 12, and can move for free 1/round. Upcast: +1 minute or +2 targets.</p><p><strong>Vicious Mockery (Cantrip, Songweaver only)</strong> — 1 Action, Single Target. Range: 12. Damage: 1d4+INT psychic (ignoring armor). On hit: the target is Taunted during their next turn. High Levels: +2 damage every 5 levels.</p>"
+			},
+			"image": {
+				"caption": ""
+			},
+			"video": {
+				"controls": true,
+				"volume": 0.5
+			},
+			"src": null,
+			"sort": 500000,
+			"ownership": {
+				"default": -1
+			},
+			"flags": {},
+			"_stats": {
+				"coreVersion": "13.347",
+				"systemId": "nimble",
+				"systemVersion": "0.1.7",
+				"createdTime": null,
+				"modifiedTime": null,
+				"lastModifiedBy": null
+			}
+		},
+		{
+			"_id": "d97R8OrehaaEke9u",
+			"name": "Radiant Spells",
+			"type": "text",
+			"title": {
+				"show": true,
+				"level": 1
+			},
+			"text": {
+				"format": 1,
+				"content": "<p><em>Can obliterate the unholy, the fearful, and those who would dare harm you or your allies. Equally effective at a distance or in melee. Other spells can protect, mend wounds, and even restore creatures back to life.</em></p><h3>Cantrips</h3><p><strong>Rebuke</strong> — 1 Action, Single Target. Reach: 4. Damage: 1d6 (ignoring armor), does not miss. 2× damage against undead or cowardly (those Frightened or behind cover). High Levels: +2 damage every 5 levels.</p><p><strong>True Strike</strong> — 1 Action, Single Target. Reach: 2. Give a creature advantage on the next attack they make (until the end of their next turn). High Levels: +1 Reach every 5 levels.</p><h3>Tiered Spells</h3><p><strong>Heal (Tier 1)</strong> — 1 Action, Single Target+. Reach: 1. Heal a creature 1d6+KEY HP. Upcast: Choose one: +1 target, +4 Reach, +1d6 healing. If 5+ mana is spent, you may also heal 1 negative condition (e.g., Blind, Poisoned, 1 Wound).</p><p><strong>Warding Bond (Tier 2)</strong> — 1 Action, Single Target. Designate a willing creature as your ward for 1 minute. They take half damage from all attacks; you are attacked for the other half. Upcast: +1 creature.</p><p><strong>Shield of Justice (Tier 3)</strong> — 1 Action, Self. Reaction: When attacked, Defend for free and reflect Radiant damage back at the attacker equal to the amount blocked (ignoring armor). Upcast: +5 Armor.</p><p><strong>Condemn (Tier 4)</strong> — 2 Actions, Single Target. Reach: 4. Damage: 30. Can only target an enemy that crit you or an ally since your last turn. Cannot be reduced by any means. The next attack against that enemy is made with advantage. Upcast: +1 Reach, +1 advantage.</p><p><strong>Vengeance (Tier 5)</strong> — 2 Actions, Single Target. Reach: 1. Damage: 1d100, to a creature that attacked a Dying ally or reduced one to 0 HP since your last turn. Upcast: +1 Reach, roll with advantage.</p><p><strong>Sacrifice (Tier 6)</strong> — 1 Action, Special. Reach: 4. Reduce yourself to 0 HP. You cannot have more than 0 HP until you Safe Rest. Heal a number of HP equal to your maximum HP, divided as you choose to any other creatures within Reach. You may revive a creature that has died in the past minute if you give them at least 20 HP (also healing 2 Wounds from them), provided they have not been revived with this spell before. Upcast: +4 Reach.</p><p><strong>Redeem (Tier 9)</strong> — Casting Time: 24 hours. Requires a diamond worth at least 10,000 gp, which this spell consumes. Revive any number of deceased creatures you choose — within 1 mile — that have died in the past year, provided they have not died of old age or been revived with this spell before.</p><p><strong>Lifebinding Spirit (Tier 1, Shepherd only)</strong> — 1 Action. Summon a spirit companion that follows you and is immune to harm. It lasts until you cast this spell again, take a Safe Rest, or it heals a number of times equal to the mana spent summoning it. Action: It attacks or heals a creature within Reach 4. It attacks for 1d6+WIL radiant damage (ignoring armor), or heals for the same amount. Upcast: Increment its die size by 1 (max d12), +1 healing use.</p>"
+			},
+			"image": {
+				"caption": ""
+			},
+			"video": {
+				"controls": true,
+				"volume": 0.5
+			},
+			"src": null,
+			"sort": 600000,
+			"ownership": {
+				"default": -1
+			},
+			"flags": {},
+			"_stats": {
+				"coreVersion": "13.347",
+				"systemId": "nimble",
+				"systemVersion": "0.1.7",
+				"createdTime": null,
+				"modifiedTime": null,
+				"lastModifiedBy": null
+			}
+		},
+		{
+			"_id": "NT3yzayfU1XntNTI",
+			"name": "Necrotic Spells",
+			"type": "text",
+			"title": {
+				"show": true,
+				"level": 1
+			},
+			"text": {
+				"format": 1,
+				"content": "<p><em>Summon horrible minions or manipulate and trap targets. Some risky necrotic spells prey upon damaged creatures, sapping their very life force — but frequently fail to distinguish between friend and foe.</em></p><h3>Cantrips</h3><p><strong>Entice</strong> — 1 Action, Single Target. Range: 8. Damage: 1d4 (ignoring armor). On hit: target moves 2 spaces closer to you. High Levels: Increment die size 1 step every 5 levels (d6 » d8 » d10 » d12).</p><p><strong>Withering Touch</strong> — 1 Action, Single Target. Reach: 1. Damage: 1d12. On hit: Target is considered undead for 1 round. High Levels: +6 damage every 5 levels.</p><p><strong>Shadow Blast (Cantrip, Shadowmancer only)</strong> — 1 Action, Single Target. Range: 8. Damage: 1d12+KEY. 1/round. High Levels: +1d12 every 5 levels.</p><p><strong>Summon Shadow (Cantrip, Shadowmancer only)</strong> — 1 Action. Summon a shadow minion within Reach 1 (max INT or LVL minions, whichever is lower). Shadow minions: 1 HP, no damage bonus, cannot crit, abandon you outside of combat. Action (1/turn): Command ALL of your minions to move up to 6 then attack (Reach 1, d12 each). High Levels: +1 Reach every 5 levels.</p><h3>Tiered Spells</h3><p><strong>Shadow Trap (Tier 1)</strong> — 2 Actions, Single Target. Concentration: Up to 1 minute. The next creature to move adjacent to you suffers 3d12 damage; if Small or Tiny, it is also Restrained by shadowy tendrils for as long as you maintain concentration or until they escape. Upcast: +1 size category, +1d12 damage when they escape.</p><p><strong>Dread Visage (Tier 2)</strong> — 1 Action, Self. Reaction: When attacked, Defend for free. Melee attackers are Frightened of you and suffer 1d12 damage if they attack you this round. Costs 2 mana less while dying. Upcast: +2 damage, +2 armor.</p><p><strong>Vampiric Greed (Tier 3)</strong> — 2 Actions, AoE. Gain 1 Wound. 4d12 to all adjacent creatures, and heal HP equal to the damage done. Any surviving creatures make a STR save. Gain 1 additional Wound for each creature that saves. Upcast: +1 DC.</p><p><strong>Greater Shadow (Tier 4)</strong> — 2 Actions. Summon a 5d12 Greater Shadow minion (max 1) adjacent to you. When it dies, it explodes into 5 shadow minions (see Summon Shadow). Place them anywhere within 8 spaces. Upcast: +1d12 damage, +1 shadow minion on explosion.</p><p><strong>Gangrenous Burst (Tier 5)</strong> — 2 Actions, AoE. Reach: Up to 8. Other damaged creatures must make a STR save or take 3d20 damage (ignoring armor), half on save. The save is rolled with disadvantage while Bloodied. Upcast: +10 damage.</p><p><strong>Unspeakable Word (Tier 6)</strong> — 2 Actions, Special. Reach: 8. Damage: d66 (with advantage, ignoring armor, does not miss or crit) on a failed INT save. Target rolls with disadvantage if Bloodied or Frightened. On a success, you both take half of this damage instead. Upcast: +1 DC, +10 damage.</p><p><strong>Creeping Death (Tier 7)</strong> — 3 Actions, AoE. Reach: 8. Damage: 4d20. If this kills the creature, it violently erupts and you MUST deal the same amount of damage to another creature within 8 spaces of it that has not yet been damaged by this effect. Repeat until a creature survives this damage or no other creatures are within Reach. Upcast: +1d20 damage.</p>"
+			},
+			"image": {
+				"caption": ""
+			},
+			"video": {
+				"controls": true,
+				"volume": 0.5
+			},
+			"src": null,
+			"sort": 700000,
+			"ownership": {
+				"default": -1
+			},
+			"flags": {},
+			"_stats": {
+				"coreVersion": "13.347",
+				"systemId": "nimble",
+				"systemVersion": "0.1.7",
+				"createdTime": null,
+				"modifiedTime": null,
+				"lastModifiedBy": null
+			}
+		},
+		{
+			"_id": "Wt1t1BCorVZOvhVO",
+			"name": "Utility Spells",
+			"type": "text",
+			"title": {
+				"show": true,
+				"level": 1
+			},
+			"text": {
+				"format": 1,
+				"content": "<p><em>Some classes can choose from among these additional spells as they level up.</em></p><h3>Ice</h3><p><strong>Ice Disk (Cantrip)</strong> — Casting Time: 1 min. Conjure a disk of ice that floats just above the ground and follows you. It can carry up to 250 lbs./115 kg of weight for 1 hour or until you cast this spell again.</p><p><strong>Chillcraft (Cantrip)</strong> — 1 Action. Chill: Harmlessly freeze, thaw, or move a bath-sized amount of water near you. OR Craft: Conjure a sheet of opaque, mirror-like, or transparent ice the size of a window or small door.</p><p><strong>Wintry Scrying (Cantrip)</strong> — Casting Time: 10 min. Turn a small patch of water into a reflective icy mirror. Looking through it grants you vision of any desired location near this same body of water for 10 minutes.</p><h3>Fire</h3><p><strong>Firebrand (Cantrip)</strong> — 1 Action. Touch a surface and secretly mark it with a symbol or brief message. Speaking a chosen command word while nearby reveals it.</p><p><strong>Fire Step (Cantrip)</strong> — 1 Action, Self. Casting Time: 1 min. Teleport to a fire source you can see.</p><p><strong>Kindle (Cantrip)</strong> — 1 Action, Single Target. Ignite a small, unheld item within Range 6.</p><h3>Lightning</h3><p><strong>Spark Buddy (Cantrip)</strong> — Casting Time: 1 min. Conjure a Tiny (squirrel-sized) electrical helper for up to 1 hour. It can fetch Tiny objects (~1 lb. max), open unlocked doors, illuminate a small area, or deliver a harmless shock. If it takes damage or moves further than 6 spaces from you, it dissipates.</p><p><strong>Spark Step (Cantrip)</strong> — 1 Action, Self. Range: 4. Teleport to a metal object.</p><p><strong>Tempest's Command (Cantrip)</strong> — 1 Action. Dispel a minor magical effect, or temporarily suppress a stronger one. OR Voice of Thunder: Your eyes glow and your voice is amplified to a booming, thunder-like volume for 1 min.</p><h3>Wind</h3><p><strong>Wind Whisper (Cantrip)</strong> — 1 Action, Single Target. You whisper a message into the wind and it will be secretly carried to a specified target within 100 miles.</p><p><strong>Helpful Gust (Cantrip)</strong> — 1 Action, Single Target. Reach: 6. Gently move a Tiny unheld item within Reach in any direction. OR: Generate an illusory scent.</p><p><strong>Feather Fall (Cantrip)</strong> — 1 Action, Single Target. Reach: 6. Reaction: When a creature falls, cause them to gently float to the ground, unharmed.</p><h3>Radiant</h3><p><strong>Light (Cantrip)</strong> — 1 Action, Single Target. Cause an item to brightly glow as a torch with radiant light for as long as you hold it.</p><p><strong>Beautify (Cantrip)</strong> — 1 Action, Single Target. Clean stains or repair a small tear/break in a non-magical item, or conjure tiny beautiful things: flowers, butterflies, etc.</p><p><strong>Bond of Peace (Cantrip)</strong> — 1 Action, Single Target/Self. Bond: Telepathically communicate simple thoughts or feelings with a friendly creature you can see. OR Peace: Imbue your spoken words with calming magic, granting advantage on any check made to soothe anger or fear.</p><h3>Necrotic</h3><p><strong>Gravecraft (Cantrip)</strong> — Gravemark (Action): Soil a surface with blood, filth, or other disgusting things. OR Gravework (Casting time 1 minute): Shape/move a body-sized plot of earth.</p><p><strong>False Face (Cantrip)</strong> — Casting Time: 1 min. Change your appearance to look like someone else for 10 minutes. Requires a piece of them.</p><p><strong>Thought Leech (Cantrip)</strong> — 1 Action. Reach: 6. Read the surface thoughts of a creature within Reach. Creatures can sense you doing this and may not like it.</p>"
+			},
+			"image": {
+				"caption": ""
+			},
+			"video": {
+				"controls": true,
+				"volume": 0.5
+			},
+			"src": null,
+			"sort": 800000,
+			"ownership": {
+				"default": -1
+			},
+			"flags": {},
+			"_stats": {
+				"coreVersion": "13.347",
+				"systemId": "nimble",
+				"systemVersion": "0.1.7",
+				"createdTime": null,
+				"modifiedTime": null,
+				"lastModifiedBy": null
+			}
+		}
+	],
+	"folder": null,
+	"flags": {},
+	"_stats": {
+		"coreVersion": "13.347",
+		"systemId": "nimble",
+		"systemVersion": "0.1.7",
+		"createdTime": null,
+		"modifiedTime": null,
+		"lastModifiedBy": null
+	},
+	"_id": "vE3q1Ni1LLkfLlNK"
+}

--- a/packs/rules/core/start-here.json
+++ b/packs/rules/core/start-here.json
@@ -1,0 +1,84 @@
+{
+	"name": "Start Here",
+	"pages": [
+		{
+			"_id": "95y5zwydde7LtrMg",
+			"name": "Start Here",
+			"type": "text",
+			"title": {
+				"show": true,
+				"level": 1
+			},
+			"text": {
+				"format": 1,
+				"content": "<p>Nimble is a fast-paced, heroic fantasy TTRPG where bold choices and epic stories take center stage.</p><p>At least one player should familiarize themselves with the base rules in this book (no need for everyone to read through unless they really want to). The adventure included in the GM's Guide is designed to introduce the rules as you play.</p><p><strong>If you're new to TTRPGs</strong>, use one of the pre-made heroes (included in your digital downloads or at nimbleRPG.com/start). Level 1 for all of the classes is designed to be easy to pick up, giving a small flavor of the class and introducing the rules gradually without being overwhelming. Complexity and tactical depth is layered on as you level up and progress through an adventure.</p><p><strong>If you're experienced with RPGs</strong>, feel free to create your own hero from scratch (see @UUID[Compendium.nimble.nimble-rules.JournalEntry.jTC8Q1wHRpyfcm3Z]{Character Creation}). When building your hero, perhaps what will have the largest impact on how you interact with the world is your hero's class. Start there. Then you can flesh out other important aspects of your character's ancestry, background, and what languages you know, as well as your stats and any equipment you have. You can do these steps in any order, filling out your character sheet as you go.</p><p>Videos, digital downloads, FAQ, and more: <strong>nimbleRPG.com/start</strong></p>"
+			},
+			"image": {
+				"caption": ""
+			},
+			"video": {
+				"controls": true,
+				"volume": 0.5
+			},
+			"src": null,
+			"sort": 100000,
+			"ownership": {
+				"default": -1
+			},
+			"flags": {},
+			"_stats": {
+				"coreVersion": "13.347",
+				"systemId": "nimble",
+				"systemVersion": "0.1.7",
+				"createdTime": null,
+				"modifiedTime": null,
+				"lastModifiedBy": null
+			}
+		},
+		{
+			"_id": "ceotRQz1wScVcGWG",
+			"name": "How to Be a Good Player",
+			"type": "text",
+			"title": {
+				"show": true,
+				"level": 1
+			},
+			"text": {
+				"format": 1,
+				"content": "<p><strong>Be heroic.</strong> Create a hero eager to dive into the adventure with the party. Reluctant, anti-social loners can drag down everyone's fun. Your games will shine when you lean into the shared adventure.</p><p><strong>Pay attention. Ask questions. Take notes.</strong> The more questions you ask, the more information you'll have to work with, and you'll be able to make more interesting decisions.</p><p><strong>Be creative!</strong> Frequently, the answer to a problem isn't found on your character sheet. A hammer (or anything else) can be used in lots of ways!</p><p><strong>Embrace failure.</strong> You shouldn't try to fail, but some of the best moments in a game can come from a failed roll or bad decision. Go with it!</p><p><strong>Respect everyone else's time.</strong> Swift, suboptimal decisions are better than slow, optimal ones. They will tend to be more fun anyway! If you can't decide what to do on your turn, attack and pass. Think when everyone else isn't waiting on you. Also, arrive on time.</p><p><strong>Share the spotlight.</strong> If you've been rolling or talking more than everyone else, call on your partymates to help you; shine the spotlight on them. Sneaky characters shouldn't spend a bunch of time sneaking around a dungeon without the rest of the party.</p><p><strong>Treat the world realistically.</strong> If you insult (or kill) other characters you come across, expect consequences! If you negotiate and haggle with every merchant, your reputation as penny pinchers will likely become widespread. If you do something foolish in front of a king, expect to be jailed (or worse).</p><p><strong>Describe your actions, not mechanics.</strong> The Game Master (GM) will tell you if you need to roll any dice. If your idea is good enough, you may not need to!</p><ul><li><em>No:</em> \"Can I make an Examination check?\" — <em>Yes:</em> \"I want to search the books and paintings on the walls, looking for a secret door.\"</li><li><em>No:</em> \"I make an attack roll.\" — <em>Yes:</em> \"I smack that goblin with my sword!\"</li></ul><p><strong>Be gracious to the GM.</strong> They put a lot of effort into running the game; avoid arguing over rulings. Give them a break sometimes and offer to run a session for them! Bring snacks.</p>"
+			},
+			"image": {
+				"caption": ""
+			},
+			"video": {
+				"controls": true,
+				"volume": 0.5
+			},
+			"src": null,
+			"sort": 200000,
+			"ownership": {
+				"default": -1
+			},
+			"flags": {},
+			"_stats": {
+				"coreVersion": "13.347",
+				"systemId": "nimble",
+				"systemVersion": "0.1.7",
+				"createdTime": null,
+				"modifiedTime": null,
+				"lastModifiedBy": null
+			}
+		}
+	],
+	"folder": null,
+	"flags": {},
+	"_stats": {
+		"coreVersion": "13.347",
+		"systemId": "nimble",
+		"systemVersion": "0.1.7",
+		"createdTime": null,
+		"modifiedTime": null,
+		"lastModifiedBy": null
+	},
+	"_id": "8aZw41YGlNWJ6OOP"
+}

--- a/public/system.json
+++ b/public/system.json
@@ -208,6 +208,13 @@
 			"path": "packs/tables.db",
 			"type": "RollTable",
 			"system": "nimble"
+		},
+		{
+			"name": "nimble-rules",
+			"label": "Nimble Core Rules",
+			"path": "packs/rules.db",
+			"type": "JournalEntry",
+			"system": "nimble"
 		}
 	],
 	"background": "systems/nimble/assets/banners/manticoreFight.webp",


### PR DESCRIPTION
## Summary

- Adds a new `nimble-rules` JournalEntry compendium pack covering the full Nimble 2 Core Rules text, making the rules accessible directly inside FoundryVTT without needing the external PDF
- 10 journal entries organised by the book's own chapter structure: Start Here, Core Rules, Combat, Resting & Downtime, Character Creation, Ancestry & Background, Equipment, Spells, Optional Rules, Glossary
- Content is close-to-verbatim from the book with light HTML formatting (headings, lists, tables, bold)
- `@UUID` cross-links connect related entries (Start Here → Character Creation, Character Creation → Ancestry & Background)
- Registers the pack in `system.json` and assigns stable IDs via `packs/ids.json`

## Changes

- Added `packs/rules/core/start-here.json` — "Start Here" and "How to Be a Good Player" pages
- Added `packs/rules/core/core-rules.json` — Stats, Skills, Advantage & Disadvantage, Skill Checks & Saves, Size, Hit Points & Dying, Speed & Range, Concentration/Cover/Grappling, Conditions
- Added `packs/rules/core/combat.json` — Actions, Reactions, Starting Combat & Turn Order, Monsters & Minions
- Added `packs/rules/core/resting-and-downtime.json` — Field Rests, Safe Rests, Downtime Activities
- Added `packs/rules/core/character-creation.json` — Making a Hero, The Character Sheet, Leveling Up
- Added `packs/rules/core/ancestry-and-background.json` — Common Ancestries, Exotic Ancestries, Backgrounds, Adventuring Motivation
- Added `packs/rules/core/equipment.json` — Armor, Weapons, Adventuring Equipment, Magical Items, Spell Scrolls & Wands (with full item/price tables)
- Added `packs/rules/core/spells.json` — Spellcasting Rules, Fire, Ice, Lightning, Wind, Radiant, Necrotic, and Utility spell pages
- Added `packs/rules/core/optional-rules.json` — Optional Variant Rules, Measuring Spaces
- Added `packs/rules/core/glossary.json` — Full A–Z glossary
- Updated `public/system.json` — registered `nimble-rules` as a `JournalEntry` compendium pack
- Updated `packs/ids.json` — added stable IDs for all 10 documents

## Test Plan

- [ ] "Nimble Core Rules" compendium appears in the Compendium Packs tab
- [ ] All 10 journal entries are present and open correctly
- [ ] Page navigation works within each entry
- [ ] `@UUID` cross-links resolve correctly (Start Here → Character Creation, Character Creation → Ancestry & Background)
- [ ] Spell tables, equipment tables, and condition entries render correctly
- [ ] `pnpm build` completes without errors

## Checklist

- [x] Added or updated unit tests — N/A, this PR adds static compendium data only
- [x] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [x] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** yes
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

Closes #564

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Players and GMs can access the Nimble 2 Core Rules in FoundryVTT through the new `nimble-rules` JournalEntry pack. It contains 10 sections covering core rules, combat, character creation, ancestries, equipment, spells, resting, optional rules, and the glossary.

Homebrewers can use stable IDs for the rules sections and class feature entries.

## Engine changes

- Registered `nimble-rules` at `packs/rules.db`.
- Added 10 core rules documents under `packs/rules/core/`.
- Added `rules.core` mappings and 14 class feature identifiers in `packs/ids.json`.
- Added no migrations.
- Added no settings.
- Added no new rule types.
- Added no `en.json` keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->