### PR TITLE
fix(test): add missing spellIndex prop to CharacterCreationDialog test

### DIFF
--- a/src/view/dialogs/CharacterCreationDialog.test.ts
+++ b/src/view/dialogs/CharacterCreationDialog.test.ts
@@ -13,6 +13,7 @@ function createProps(overrides: Record<string, unknown> = {}) {
 			id: 'test-dialog',
 			submitCharacterCreation: vi.fn(),
 		},
+		spellIndex: Promise.resolve(new Map()),
 		statArrayOptions: [],
 		...overrides,
 	};


### PR DESCRIPTION
## Summary
- Adds missing `spellIndex` prop to the test's `createProps()` function
- Fixes test failure caused by character creation state initialization expecting `spellIndex` to be a Promise

## Test plan
- [x] All 712 tests pass
- [x] Type check passes