### PR TITLE
feat(level-up): grant class features on level up and remove on level down

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ These are mandatory implementation constraints, not slogans.
 **KISS**: Use explicit control flow (`if`/`switch`). Avoid dynamic component lookups, runtime string-to-function dispatch, or Svelte action factories that obscure what runs and when.
 **YAGNI**: Every abstraction (utility, store, component) must have a current caller. If a code path isn't supported yet, throw an error, don't add a stub or no-op fallback.
 **DRY + Rule of Three**: Two similar blocks in the same file are fine. Extract to a shared utility or component only after the same pattern appears three times across different files, and only if the extracted code respects [Code Promotion Rules](#code-promotion-rules).
-**One Export Per File**: Each TypeScript module exports one public function, class, constant, or store. Internal helpers used only by that export stay in the file but are not exported. Svelte components are inherently one-per-file.
+**One Export Per File**: Each TypeScript module exports one public function (over 30 lines), class, or store. Related constants and types may share a file. Internal helpers used only by that export stay in the file but are not exported. Svelte components are inherently one-per-file.
 
 ### Foundational Principles
 

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -471,7 +471,8 @@
 			"hitDiceLabel": "Hit Dice:",
 			"rollHitDice": "Roll Hit Dice",
 			"rollHitDiceTooltip": "Roll your Hit Die with advantage and increase your max HP by that much.",
-			"takeAverage": "Take Average ({average})"
+			"takeAverage": "Take Average ({average})",
+			"featuresHint": "The following features are available at this level for your class."
 		},
 		"levelDownDialog": {
 			"level": "Level",
@@ -482,6 +483,7 @@
 			"point": "point",
 			"points": "points",
 			"subclass": "Subclass",
+			"feature": "Feature",
 			"removed": "removed",
 			"warningMessage": "This action will permanently revert the last level up. This cannot be undone.",
 			"confirmLevelDown": "Confirm Level Down",
@@ -1278,7 +1280,28 @@
 			"chooseOne": "(Choose one)",
 			"noDescriptionAvailable": "No description available.",
 			"selected": "Selected",
-			"confirmSelection": "Confirm Selection"
+			"confirmSelection": "Confirm Selection",
+			"selectFeature": "Select this feature",
+			"deselectFeature": "Deselect this feature",
+			"selectFeatureAriaLabel": "Select {featureName}",
+			"deselectFeatureAriaLabel": "Deselect {featureName}",
+			"changeSelection": "Change",
+			"hideOptions": "Hide Options"
+		},
+		"subclassSelection": {
+			"selectSubclass": "Select this subclass",
+			"deselectSubclass": "Deselect this subclass",
+			"selectSubclassAriaLabel": "Select {subclassName}",
+			"deselectSubclassAriaLabel": "Deselect {subclassName}"
+		},
+		"epicBoonSelection": {
+			"header": "Epic Boon",
+			"hint": "At level 19, choose an epic boon to enhance your character.",
+			"selectBoon": "Select this boon",
+			"deselectBoon": "Deselect this boon",
+			"selectBoonAriaLabel": "Select {boonName}",
+			"deselectBoonAriaLabel": "Deselect {boonName}",
+			"noBoons": "No epic boons available. You may need to create or import boon items."
 		},
 		"spellGrants": {
 			"header": "Starting Spells",

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -1288,6 +1288,8 @@
 			"deselectFeatureAriaLabel": "Deselect {featureName}"
 		},
 		"subclassSelection": {
+			"header": "Subclass",
+			"noSubclasses": "No subclasses available for this class. You may need to create or import subclass items.",
 			"selectSubclass": "Select this subclass",
 			"deselectSubclass": "Deselect this subclass",
 			"selectSubclassAriaLabel": "Select {subclassName}",

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -472,7 +472,8 @@
 			"rollHitDice": "Roll Hit Dice",
 			"rollHitDiceTooltip": "Roll your Hit Die with advantage and increase your max HP by that much.",
 			"takeAverage": "Take Average ({average})",
-			"featuresHint": "The following features are available at this level for your class."
+			"featuresHint": "The following features are available at this level for your class.",
+			"loadingFeatures": "Loading features..."
 		},
 		"levelDownDialog": {
 			"level": "Level",
@@ -1284,9 +1285,7 @@
 			"selectFeature": "Select this feature",
 			"deselectFeature": "Deselect this feature",
 			"selectFeatureAriaLabel": "Select {featureName}",
-			"deselectFeatureAriaLabel": "Deselect {featureName}",
-			"changeSelection": "Change",
-			"hideOptions": "Hide Options"
+			"deselectFeatureAriaLabel": "Deselect {featureName}"
 		},
 		"subclassSelection": {
 			"selectSubclass": "Select this subclass",

--- a/src/documents/actor/character.ts
+++ b/src/documents/actor/character.ts
@@ -1,6 +1,8 @@
 import type { NimbleAncestryItem } from '#documents/item/ancestry.js';
 import type { NimbleBackgroundItem } from '#documents/item/background.js';
+import type { NimbleBoonItem } from '#documents/item/boon.js';
 import type { NimbleClassItem } from '#documents/item/class.js';
+import type { NimbleFeatureItem } from '#documents/item/feature.js';
 import type { NimbleSubclassItem } from '#documents/item/subclass.js';
 import type { SkillKeyType } from '#types/skillKey.js';
 import { getHighestSpellTier } from '#utils/spell/getHighestSpellTier.ts';
@@ -68,6 +70,11 @@ interface LevelUpDialogData {
 	selectedAbilityScore: string | null;
 	skillPointChanges: Record<string, number>;
 	selectedSubclass: NimbleSubclassItem | null;
+	selectedEpicBoon: NimbleBoonItem | null;
+	classFeatures: {
+		autoGrant: NimbleFeatureItem[];
+		selected: Map<string, NimbleFeatureItem>;
+	} | null;
 }
 
 export class NimbleCharacter extends NimbleBaseActor<'character'> {
@@ -1233,6 +1240,44 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 			}
 		}
 
+		// Create feature documents from autoGrant and selected features
+		let grantedFeatureIds: string[] = [];
+
+		if (typedDialogData.classFeatures) {
+			const featuresToGrant: NimbleFeatureItem[] = [
+				...typedDialogData.classFeatures.autoGrant,
+				...typedDialogData.classFeatures.selected.values(),
+			];
+
+			if (featuresToGrant.length > 0) {
+				const featureDocumentSources = featuresToGrant.map((feature) => {
+					const featureData = feature.toObject();
+					(featureData as { _stats: { compendiumSource?: string } })._stats.compendiumSource =
+						feature.uuid;
+					return featureData;
+				});
+
+				const createdFeatures = await this.createEmbeddedDocuments('Item', featureDocumentSources);
+				grantedFeatureIds = (createdFeatures ?? [])
+					.map((f) => f.id)
+					.filter((id): id is string => id !== null);
+			}
+		}
+
+		// Grant epic boon at level 19
+		const epicBoon = typedDialogData.selectedEpicBoon;
+		if (epicBoon) {
+			const boonData = epicBoon.toObject();
+			(boonData as { _stats: { compendiumSource?: string } })._stats.compendiumSource =
+				epicBoon.uuid;
+
+			const createdBoons = await this.createEmbeddedDocuments('Item', [boonData]);
+			const boonIds = (createdBoons ?? [])
+				.map((b) => b.id)
+				.filter((id): id is string => id !== null);
+			grantedFeatureIds = [...grantedFeatureIds, ...boonIds];
+		}
+
 		// Record level up history
 		const historyEntry = {
 			level: nextClassLevel,
@@ -1241,6 +1286,7 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 			skillIncreases: typedDialogData.skillPointChanges,
 			hitDieAdded: true,
 			classIdentifier: characterClass.identifier,
+			grantedFeatureIds,
 		};
 
 		actorUpdates['system.levelUpHistory'] = [...this.system.levelUpHistory, historyEntry];
@@ -1347,6 +1393,15 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 				if (subclassIds.length > 0) {
 					await this.deleteEmbeddedDocuments('Item', subclassIds);
 				}
+			}
+		}
+
+		// Remove granted features
+		if (lastHistory.grantedFeatureIds && lastHistory.grantedFeatureIds.length > 0) {
+			// Filter to IDs that still exist on the actor (defensive)
+			const validIds = lastHistory.grantedFeatureIds.filter((id) => this.items.get(id));
+			if (validIds.length > 0) {
+				await this.deleteEmbeddedDocuments('Item', validIds);
 			}
 		}
 

--- a/src/documents/actor/character.ts
+++ b/src/documents/actor/character.ts
@@ -1424,9 +1424,6 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 	async outputLevelUpSummary(data, roll: Roll | undefined) {
 		const rolls = roll ? [roll] : [];
 		const { currentClassLevel, takeAverageHp } = data;
-		console.log('currentClassLevel', currentClassLevel);
-		console.log('takeAverageHp', takeAverageHp);
-		console.log(data);
 
 		const chatData = {
 			author: game.user?.id,

--- a/src/migration/MigrationRunnerBase.ts
+++ b/src/migration/MigrationRunnerBase.ts
@@ -9,7 +9,7 @@ interface CollectionDiff<T = any> {
 class MigrationRunnerBase {
 	migrations: MigrationBase[];
 
-	static LATEST_SCHEMA_VERSION = 13;
+	static LATEST_SCHEMA_VERSION = 14;
 
 	static RECOMMENDED_SAFE_VERSION = 0;
 

--- a/src/migration/migrations/Migration014GrantedFeatureIds.ts
+++ b/src/migration/migrations/Migration014GrantedFeatureIds.ts
@@ -1,0 +1,75 @@
+import { MigrationBase } from '../MigrationBase.js';
+
+/**
+ * Backfills `grantedFeatureIds` on existing `levelUpHistory` entries.
+ *
+ * Before this feature, characters that leveled up did not track which
+ * features were granted at each level. This migration matches existing
+ * embedded feature items (via their `system.class` and `system.gainedAtLevel`
+ * / `system.gainedAtLevels` fields) to the appropriate history entry.
+ *
+ * When a feature is available at multiple levels, it is assigned to the
+ * lowest level that has a matching history entry.
+ */
+class Migration014GrantedFeatureIds extends MigrationBase {
+	static override readonly version = 14;
+
+	override readonly version = Migration014GrantedFeatureIds.version;
+
+	override async updateActor(source: any): Promise<void> {
+		if (source.type !== 'character') return;
+
+		const history: any[] | undefined = source.system?.levelUpHistory;
+		if (!Array.isArray(history) || history.length === 0) return;
+
+		// Ensure every history entry has a grantedFeatureIds array
+		for (const entry of history) {
+			if (!Array.isArray(entry.grantedFeatureIds)) {
+				entry.grantedFeatureIds = [];
+			}
+		}
+
+		// Only backfill entries that are still empty
+		const entriesToPopulate = history.filter((e) => e.grantedFeatureIds.length === 0);
+		if (entriesToPopulate.length === 0) return;
+
+		// Build a lookup of unpopulated entries: "classIdentifier:level" → entry
+		const historyByClassLevel = new Map<string, any>();
+		for (const entry of entriesToPopulate) {
+			const key = `${entry.classIdentifier}:${entry.level}`;
+			historyByClassLevel.set(key, entry);
+		}
+
+		// Track assigned items to prevent double-counting
+		const assignedItemIds = new Set<string>();
+
+		// Match each embedded feature item to the lowest matching history entry
+		for (const item of source.items ?? []) {
+			if (item.type !== 'feature') continue;
+
+			const system = item.system;
+			if (!system?.class || system.subclass) continue;
+
+			// Collect all levels this feature is available at, sorted ascending
+			const levels: number[] = [];
+			if (system.gainedAtLevel) levels.push(system.gainedAtLevel);
+			if (Array.isArray(system.gainedAtLevels)) levels.push(...system.gainedAtLevels);
+			levels.sort((a, b) => a - b);
+
+			if (levels.length === 0) continue;
+
+			// Assign to the lowest level with a matching unpopulated history entry
+			for (const level of levels) {
+				const key = `${system.class}:${level}`;
+				const historyEntry = historyByClassLevel.get(key);
+				if (historyEntry && !assignedItemIds.has(item._id)) {
+					historyEntry.grantedFeatureIds.push(item._id);
+					assignedItemIds.add(item._id);
+					break;
+				}
+			}
+		}
+	}
+}
+
+export { Migration014GrantedFeatureIds };

--- a/src/migration/migrations/index.ts
+++ b/src/migration/migrations/index.ts
@@ -11,3 +11,4 @@ export { Migration010SwiftFistsUnarmedDamage } from './Migration010SwiftFistsUna
 export { Migration011SwiftFistsUnarmedProficiency } from './Migration011SwiftFistsUnarmedProficiency.js';
 export { Migration012ViciousExplosionDamage } from './Migration012ViciousExplosionDamage.js';
 export { Migration013SwiftFeetPredicates } from './Migration013SwiftFeetPredicates.js';
+export { Migration014GrantedFeatureIds } from './Migration014GrantedFeatureIds.js';

--- a/src/models/actor/CharacterDataModel.ts
+++ b/src/models/actor/CharacterDataModel.ts
@@ -384,6 +384,10 @@ const characterSchema = () => ({
 				initial: '',
 				nullable: false,
 			}),
+			grantedFeatureIds: new fields.ArrayField(
+				new fields.StringField({ required: true, nullable: false, initial: '' }),
+				{ required: true, nullable: false, initial: () => [] },
+			),
 		}),
 		{ required: true, nullable: false, initial: () => [] },
 	),
@@ -480,6 +484,7 @@ interface LevelUpHistoryEntry {
 	skillIncreases: Record<string, number>;
 	hitDieAdded: boolean;
 	classIdentifier: string;
+	grantedFeatureIds: string[];
 }
 
 declare namespace NimbleCharacterData {

--- a/src/utils/getEpicBoons.ts
+++ b/src/utils/getEpicBoons.ts
@@ -32,38 +32,34 @@ export default async function getEpicBoons(): Promise<EpicBoonChoice[]> {
 		});
 	}
 
-	// Get epic boons from compendiums
+	// Get epic boons from compendiums (batch-load all boons per pack)
 	for (const pack of game.packs) {
-		const index = pack.index;
+		// Skip packs that have no boon-type entries in the index
+		const hasBoons = [...pack.index].some(
+			(entry) => (entry as object as { type?: string }).type === 'boon',
+		);
+		if (!hasBoons) continue;
 
-		for (const indexEntry of index) {
-			const entry = indexEntry as object as {
-				type?: string;
-				uuid: string;
-				name: string;
-				img?: string;
-				_id: string;
-			};
-			if (entry.type !== 'boon') continue;
+		try {
+			const documents = (await pack.getDocuments({
+				type: 'boon',
+			})) as object as NimbleBoonItem[];
 
-			// Load the full document to check boonType
-			try {
-				const document = (await pack.getDocument(entry._id)) as object as NimbleBoonItem | null;
-				if (!document) continue;
-				if (document.system.boonType !== 'epic') continue;
+			for (const boon of documents) {
+				if (boon.system.boonType !== 'epic') continue;
 
 				epicBoons.push({
-					uuid: entry.uuid,
-					name: entry.name,
-					img: entry.img ?? 'icons/svg/item-bag.svg',
+					uuid: boon.uuid,
+					name: boon.name,
+					img: (boon.img as string) ?? 'icons/svg/item-bag.svg',
 					system: {
-						boonType: document.system.boonType,
-						description: document.system.description,
+						boonType: boon.system.boonType,
+						description: boon.system.description,
 					},
 				});
-			} catch (err) {
-				console.warn(`Nimble | Failed to load boon ${entry.uuid}:`, err);
 			}
+		} catch (err) {
+			console.warn(`Nimble | Failed to load boons from pack ${pack.collection}:`, err);
 		}
 	}
 

--- a/src/utils/getEpicBoons.ts
+++ b/src/utils/getEpicBoons.ts
@@ -1,0 +1,72 @@
+import type { NimbleBoonItem } from '#documents/item/boon.js';
+
+interface EpicBoonChoice {
+	uuid: string;
+	name: string;
+	img: string;
+	system: { boonType: string; description: string };
+}
+
+/**
+ * Get all available epic boons from world items and compendiums
+ * @returns Array of epic boon objects with uuid, name, img, and system data
+ */
+export default async function getEpicBoons(): Promise<EpicBoonChoice[]> {
+	const epicBoons: EpicBoonChoice[] = [];
+
+	// Get epic boons from world items
+	for (const item of game.items) {
+		if (item.type !== 'boon') continue;
+
+		const boon = item as object as NimbleBoonItem;
+		if (boon.system.boonType !== 'epic') continue;
+
+		epicBoons.push({
+			uuid: item.uuid,
+			name: item.name,
+			img: item.img as string,
+			system: {
+				boonType: boon.system.boonType,
+				description: boon.system.description,
+			},
+		});
+	}
+
+	// Get epic boons from compendiums
+	for (const pack of game.packs) {
+		const index = pack.index;
+
+		for (const indexEntry of index) {
+			const entry = indexEntry as object as {
+				type?: string;
+				uuid: string;
+				name: string;
+				img?: string;
+				_id: string;
+			};
+			if (entry.type !== 'boon') continue;
+
+			// Load the full document to check boonType
+			try {
+				const document = (await pack.getDocument(entry._id)) as object as NimbleBoonItem | null;
+				if (!document) continue;
+				if (document.system.boonType !== 'epic') continue;
+
+				epicBoons.push({
+					uuid: entry.uuid,
+					name: entry.name,
+					img: entry.img ?? 'icons/svg/item-bag.svg',
+					system: {
+						boonType: document.system.boonType,
+						description: document.system.description,
+					},
+				});
+			} catch (err) {
+				console.warn(`Nimble | Failed to load boon ${entry.uuid}:`, err);
+			}
+		}
+	}
+
+	// Sort by name
+	return epicBoons.sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/src/view/components/ExpandableDocumentList.svelte
+++ b/src/view/components/ExpandableDocumentList.svelte
@@ -2,6 +2,7 @@
 	import type { ExpandableDocumentListProps } from '#types/components/ExpandableDocumentList.d.ts';
 
 	import SelectionIndicator from '#view/components/SelectionIndicator.svelte';
+	import { createExpandableDocumentListState } from './ExpandableDocumentList.svelte.ts';
 
 	let {
 		items,
@@ -12,46 +13,18 @@
 		deselectAriaLabel,
 	}: ExpandableDocumentListProps = $props();
 
-	let expandedUuids: Set<string> = $state(new Set());
-	let expandedDataMap: Map<string, { system?: { description?: string } }> = $state(new Map());
-
-	const displayedItems = $derived(
-		selectedItem ? items.filter((i) => i.uuid === selectedItem.uuid) : items,
+	const state = createExpandableDocumentListState(
+		() => items,
+		() => selectedItem,
+		(item) => {
+			selectedItem = item;
+		},
 	);
 
-	async function toggleExpanded(uuid: string) {
-		if (expandedUuids.has(uuid)) {
-			expandedUuids.delete(uuid);
-			expandedUuids = new Set(expandedUuids);
-			expandedDataMap.delete(uuid);
-			expandedDataMap = new Map(expandedDataMap);
-		} else {
-			const data = await fromUuid(uuid);
-			expandedUuids.add(uuid);
-			expandedUuids = new Set(expandedUuids);
-			expandedDataMap.set(uuid, data as { system?: { description?: string } });
-			expandedDataMap = new Map(expandedDataMap);
-		}
-	}
-
-	async function handleSelectClick(uuid: string, event: MouseEvent) {
-		event.stopPropagation();
-		if (selectedItem?.uuid === uuid) {
-			selectedItem = null;
-		} else {
-			selectedItem = await fromUuid(uuid);
-		}
-	}
-
-	function handleRowClick(uuid: string) {
-		toggleExpanded(uuid);
-	}
-
-	function handleKeydown(e: KeyboardEvent, uuid: string) {
-		if (e.key === 'Enter') {
-			handleRowClick(uuid);
-		}
-	}
+	const { handleSelectClick, handleRowClick, handleKeydown } = state;
+	const displayedItems = $derived(state.displayedItems);
+	const expandedUuids = $derived(state.expandedUuids);
+	const expandedDataMap = $derived(state.expandedDataMap);
 </script>
 
 <ul class="nimble-document-list">

--- a/src/view/components/ExpandableDocumentList.svelte
+++ b/src/view/components/ExpandableDocumentList.svelte
@@ -1,0 +1,215 @@
+<script lang="ts">
+	import type { ExpandableDocumentListProps } from '#types/components/ExpandableDocumentList.d.ts';
+
+	import SelectionIndicator from '#view/components/SelectionIndicator.svelte';
+
+	let {
+		items,
+		selectedItem = $bindable(),
+		selectTooltip,
+		deselectTooltip,
+		selectAriaLabel,
+		deselectAriaLabel,
+	}: ExpandableDocumentListProps = $props();
+
+	let expandedUuids: Set<string> = $state(new Set());
+	let expandedDataMap: Map<string, { system?: { description?: string } }> = $state(new Map());
+
+	const displayedItems = $derived(
+		selectedItem ? items.filter((i) => i.uuid === selectedItem.uuid) : items,
+	);
+
+	async function toggleExpanded(uuid: string) {
+		if (expandedUuids.has(uuid)) {
+			expandedUuids.delete(uuid);
+			expandedUuids = new Set(expandedUuids);
+			expandedDataMap.delete(uuid);
+			expandedDataMap = new Map(expandedDataMap);
+		} else {
+			const data = await fromUuid(uuid);
+			expandedUuids.add(uuid);
+			expandedUuids = new Set(expandedUuids);
+			expandedDataMap.set(uuid, data as { system?: { description?: string } });
+			expandedDataMap = new Map(expandedDataMap);
+		}
+	}
+
+	async function handleSelectClick(uuid: string, event: MouseEvent) {
+		event.stopPropagation();
+		if (selectedItem?.uuid === uuid) {
+			selectedItem = null;
+		} else {
+			selectedItem = await fromUuid(uuid);
+		}
+	}
+
+	function handleRowClick(uuid: string) {
+		toggleExpanded(uuid);
+	}
+
+	function handleKeydown(e: KeyboardEvent, uuid: string) {
+		if (e.key === 'Enter') {
+			handleRowClick(uuid);
+		}
+	}
+</script>
+
+<ul class="nimble-document-list">
+	{#each displayedItems as item (item.uuid)}
+		<li class="u-semantic-only expandable-item">
+			<div
+				class="expandable-row"
+				class:selected={item.uuid === selectedItem?.uuid}
+				class:expanded={expandedUuids.has(item.uuid)}
+				onclick={() => handleRowClick(item.uuid)}
+				role="button"
+				tabindex="0"
+				onkeydown={(e) => handleKeydown(e, item.uuid)}
+			>
+				<i class="fa-solid fa-chevron-down expand-arrow"></i>
+
+				<img
+					class="expandable-row__img"
+					src={item.img || 'icons/svg/item-bag.svg'}
+					alt={item.name}
+				/>
+
+				<h4 class="expandable-row__name nimble-heading" data-heading-variant="item">
+					{item.name}
+				</h4>
+
+				<div class="expandable-row__actions">
+					<SelectionIndicator
+						selected={item.uuid === selectedItem?.uuid}
+						onclick={(e) => handleSelectClick(item.uuid, e)}
+						tooltip={item.uuid === selectedItem?.uuid ? deselectTooltip : selectTooltip}
+						ariaLabel={item.uuid === selectedItem?.uuid
+							? deselectAriaLabel(item.name)
+							: selectAriaLabel(item.name)}
+					/>
+				</div>
+			</div>
+
+			{#if expandedUuids.has(item.uuid)}
+				<div class="accordion-content">
+					<div class="description">
+						{@html expandedDataMap.get(item.uuid)?.system?.description || 'Loading...'}
+					</div>
+				</div>
+			{/if}
+		</li>
+	{/each}
+</ul>
+
+<style lang="scss">
+	.expandable-item {
+		margin-bottom: 0.5rem;
+	}
+
+	.expandable-row {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		height: 50px;
+		padding: 0.5rem;
+		position: relative;
+		cursor: pointer;
+		background: var(--nimble-box-background-color);
+		border: 1px solid var(--nimble-card-border-color);
+		border-radius: 4px;
+		transition: all 0.3s ease;
+
+		&:hover {
+			border-color: var(--nimble-accent-color);
+		}
+
+		&.selected {
+			border-color: var(--nimble-accent-color);
+			background: color-mix(
+				in srgb,
+				var(--nimble-accent-color) 10%,
+				var(--nimble-box-background-color)
+			);
+		}
+
+		&.expanded {
+			border-bottom-left-radius: 0;
+			border-bottom-right-radius: 0;
+
+			.expand-arrow {
+				transform: rotate(180deg);
+			}
+		}
+
+		.expand-arrow {
+			font-size: 0.875rem;
+			transition: transform 0.3s ease;
+			color: var(--nimble-medium-text-color);
+		}
+
+		.expandable-row__img {
+			width: 36px;
+			height: 36px;
+			margin: 0;
+			padding: 0;
+			display: block;
+			border-radius: 4px;
+		}
+
+		.expandable-row__name {
+			flex: 1;
+			margin: 0;
+			padding: 0;
+			line-height: 1;
+		}
+
+		.expandable-row__actions {
+			display: flex;
+			align-items: center;
+			gap: 0.5rem;
+			margin-left: auto;
+		}
+	}
+
+	.accordion-content {
+		background: transparent;
+		border: 1px solid var(--nimble-card-border-color);
+		border-top: none;
+		border-radius: 0 0 4px 4px;
+		padding: 0.5rem 0.75rem;
+		animation: slideDown 0.3s ease;
+
+		.description {
+			margin-bottom: 0;
+			max-height: 300px;
+			overflow-y: auto;
+			line-height: 1.5;
+
+			:global(h3) {
+				margin-top: 0.25rem;
+				margin-bottom: 0.25rem;
+				font-size: 0.95rem;
+				font-weight: 600;
+			}
+
+			:global(p) {
+				margin-bottom: 0.25rem;
+			}
+		}
+	}
+
+	@keyframes slideDown {
+		from {
+			opacity: 0;
+			max-height: 0;
+			padding-top: 0;
+			padding-bottom: 0;
+		}
+		to {
+			opacity: 1;
+			max-height: 400px;
+			padding-top: 0.5rem;
+			padding-bottom: 0.5rem;
+		}
+	}
+</style>

--- a/src/view/components/ExpandableDocumentList.svelte
+++ b/src/view/components/ExpandableDocumentList.svelte
@@ -2,6 +2,7 @@
 	import type { ExpandableDocumentListProps } from '#types/components/ExpandableDocumentList.d.ts';
 
 	import SelectionIndicator from '#view/components/SelectionIndicator.svelte';
+	import localize from '#utils/localize.js';
 	import { createExpandableDocumentListState } from './ExpandableDocumentList.svelte.ts';
 
 	let {
@@ -66,7 +67,8 @@
 			{#if expandedUuids.has(item.uuid)}
 				<div class="accordion-content">
 					<div class="description">
-						{@html expandedDataMap.get(item.uuid)?.system?.description || 'Loading...'}
+						{@html expandedDataMap.get(item.uuid)?.system?.description ||
+							localize('NIMBLE.ui.loading')}
 					</div>
 				</div>
 			{/if}

--- a/src/view/components/ExpandableDocumentList.svelte.ts
+++ b/src/view/components/ExpandableDocumentList.svelte.ts
@@ -1,0 +1,70 @@
+import type { ExpandableDocumentItem } from '#types/components/ExpandableDocumentList.d.ts';
+
+/**
+ * Creates reactive state for the ExpandableDocumentList component.
+ *
+ * Manages expansion toggling, description loading, and item selection.
+ */
+export function createExpandableDocumentListState(
+	getItems: () => ExpandableDocumentItem[],
+	getSelectedItem: () => ExpandableDocumentItem | null,
+	setSelectedItem: (item: ExpandableDocumentItem | null) => void,
+) {
+	let expandedUuids: Set<string> = $state(new Set());
+	let expandedDataMap: Map<string, { system?: { description?: string } }> = $state(new Map());
+
+	const displayedItems = $derived(
+		getSelectedItem() ? getItems().filter((i) => i.uuid === getSelectedItem()!.uuid) : getItems(),
+	);
+
+	async function toggleExpanded(uuid: string) {
+		if (expandedUuids.has(uuid)) {
+			expandedUuids.delete(uuid);
+			expandedUuids = new Set(expandedUuids);
+			expandedDataMap.delete(uuid);
+			expandedDataMap = new Map(expandedDataMap);
+		} else {
+			// @ts-expect-error — Foundry's fromUuid accepts any string at runtime
+			const data = await fromUuid(uuid);
+			expandedUuids.add(uuid);
+			expandedUuids = new Set(expandedUuids);
+			expandedDataMap.set(uuid, data as { system?: { description?: string } });
+			expandedDataMap = new Map(expandedDataMap);
+		}
+	}
+
+	async function handleSelectClick(uuid: string, event: MouseEvent) {
+		event.stopPropagation();
+		if (getSelectedItem()?.uuid === uuid) {
+			setSelectedItem(null);
+		} else {
+			// @ts-expect-error — Foundry's fromUuid accepts any string at runtime
+			setSelectedItem(await fromUuid(uuid));
+		}
+	}
+
+	function handleRowClick(uuid: string) {
+		toggleExpanded(uuid);
+	}
+
+	function handleKeydown(e: KeyboardEvent, uuid: string) {
+		if (e.key === 'Enter') {
+			handleRowClick(uuid);
+		}
+	}
+
+	return {
+		get displayedItems() {
+			return displayedItems;
+		},
+		get expandedUuids() {
+			return expandedUuids;
+		},
+		get expandedDataMap() {
+			return expandedDataMap;
+		},
+		handleSelectClick,
+		handleRowClick,
+		handleKeydown,
+	};
+}

--- a/src/view/components/ExpandableDocumentList.svelte.ts
+++ b/src/view/components/ExpandableDocumentList.svelte.ts
@@ -24,12 +24,16 @@ export function createExpandableDocumentListState(
 			expandedDataMap.delete(uuid);
 			expandedDataMap = new Map(expandedDataMap);
 		} else {
-			// @ts-expect-error — Foundry's fromUuid accepts any string at runtime
-			const data = await fromUuid(uuid);
-			expandedUuids.add(uuid);
-			expandedUuids = new Set(expandedUuids);
-			expandedDataMap.set(uuid, data as { system?: { description?: string } });
-			expandedDataMap = new Map(expandedDataMap);
+			try {
+				// @ts-expect-error — Foundry's fromUuid accepts any string at runtime
+				const data = await fromUuid(uuid);
+				expandedUuids.add(uuid);
+				expandedUuids = new Set(expandedUuids);
+				expandedDataMap.set(uuid, data as { system?: { description?: string } });
+				expandedDataMap = new Map(expandedDataMap);
+			} catch (err) {
+				console.warn(`Nimble | Failed to load document ${uuid}:`, err);
+			}
 		}
 	}
 
@@ -38,8 +42,12 @@ export function createExpandableDocumentListState(
 		if (getSelectedItem()?.uuid === uuid) {
 			setSelectedItem(null);
 		} else {
-			// @ts-expect-error — Foundry's fromUuid accepts any string at runtime
-			setSelectedItem(await fromUuid(uuid));
+			try {
+				// @ts-expect-error — Foundry's fromUuid accepts any string at runtime
+				setSelectedItem(await fromUuid(uuid));
+			} catch (err) {
+				console.warn(`Nimble | Failed to load document ${uuid}:`, err);
+			}
 		}
 	}
 

--- a/src/view/components/SelectionIndicator.svelte
+++ b/src/view/components/SelectionIndicator.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+	import type { SelectionIndicatorProps } from '#types/components/SelectionIndicator.d.ts';
+
+	let {
+		selected,
+		onclick,
+		tooltip,
+		ariaLabel,
+		disabled = false,
+	}: SelectionIndicatorProps = $props();
+</script>
+
+<button
+	type="button"
+	class="select-button"
+	class:selected
+	{onclick}
+	{disabled}
+	data-tooltip={tooltip}
+	data-tooltip-direction="LEFT"
+	aria-label={ariaLabel}
+>
+	{#if selected}
+		<i class="fa-solid fa-check"></i>
+	{/if}
+</button>
+
+<style lang="scss">
+	.select-button {
+		width: 1.25rem;
+		min-width: 1.25rem;
+		max-width: 1.25rem;
+		height: 1.25rem;
+		min-height: 1.25rem;
+		max-height: 1.25rem;
+		padding: 0;
+		flex-shrink: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: color-mix(in srgb, var(--nimble-medium-text-color) 15%, transparent);
+		border: 2px solid color-mix(in srgb, var(--nimble-medium-text-color) 60%, transparent);
+		border-radius: 50%;
+		box-sizing: border-box;
+		color: transparent;
+		cursor: pointer;
+		transition: all 0.2s ease;
+
+		&:hover:not(:disabled) {
+			border-color: color-mix(in srgb, var(--nimble-medium-text-color) 80%, transparent);
+			background: color-mix(in srgb, var(--nimble-medium-text-color) 35%, transparent);
+		}
+
+		&.selected {
+			background: var(--nimble-accent-color);
+			border-color: var(--nimble-accent-color);
+			color: #fff;
+
+			&:hover:not(:disabled) {
+				filter: brightness(1.15);
+			}
+		}
+
+		&:disabled {
+			opacity: 0.3;
+			cursor: not-allowed;
+		}
+
+		i {
+			font-size: 0.625rem;
+		}
+	}
+</style>

--- a/src/view/dialogs/CharacterLevelDownDialog.svelte
+++ b/src/view/dialogs/CharacterLevelDownDialog.svelte
@@ -50,6 +50,13 @@
 	const willRemoveSubclass = $derived(lastHistory?.level <= 3);
 	const subclasses = $derived(actor.items.filter((i) => i.type === 'subclass'));
 	const hasSubclass = $derived(subclasses.length > 0);
+
+	// Get granted features that will be removed
+	const grantedFeatures = $derived(
+		(lastHistory?.grantedFeatureIds ?? [])
+			.map((id) => actor.items.get(id))
+			.filter((item): item is NonNullable<typeof item> => item !== undefined),
+	);
 </script>
 
 <article class="nimble-sheet__body">
@@ -78,7 +85,7 @@
 
 		<ul class="nimble-level-down-preview">
 			{#if lastHistory?.hpIncrease > 0}
-				<li class="nimble-level-down-preview__item nimble-level-down-preview__item--loss">
+				<li class="nimble-level-down-preview__item">
 					<span class="nimble-level-down-preview__label">
 						<i class="fa-solid fa-heart"></i>
 						{CONFIG.NIMBLE.levelDownDialog.hitPoints}
@@ -91,7 +98,7 @@
 			{/if}
 
 			{#if lastHistory?.hitDieAdded}
-				<li class="nimble-level-down-preview__item nimble-level-down-preview__item--loss">
+				<li class="nimble-level-down-preview__item">
 					<span class="nimble-level-down-preview__label">
 						<i class="fa-solid fa-dice-d20"></i>
 						{CONFIG.NIMBLE.levelDownDialog.hitDie}
@@ -104,7 +111,7 @@
 
 			{#if abilityChanges.length > 0}
 				{#each abilityChanges as ability}
-					<li class="nimble-level-down-preview__item nimble-level-down-preview__item--loss">
+					<li class="nimble-level-down-preview__item">
 						<span class="nimble-level-down-preview__label">
 							<i class="fa-solid fa-chart-simple"></i>
 							{ability.name}
@@ -118,7 +125,7 @@
 
 			{#if skillChanges.length > 0}
 				{#each skillChanges as skill}
-					<li class="nimble-level-down-preview__item nimble-level-down-preview__item--loss">
+					<li class="nimble-level-down-preview__item">
 						<span class="nimble-level-down-preview__label">
 							<i class="fa-solid fa-book"></i>
 							{skill.name}
@@ -135,13 +142,28 @@
 
 			{#if willRemoveSubclass && hasSubclass}
 				{#each subclasses as subclass}
-					<li class="nimble-level-down-preview__item nimble-level-down-preview__item--warning">
+					<li class="nimble-level-down-preview__item">
 						<span class="nimble-level-down-preview__label">
 							<i class="fa-solid fa-star"></i>
 							{CONFIG.NIMBLE.levelDownDialog.subclass}
 						</span>
 						<span class="nimble-level-down-preview__value">
 							{subclass.name}
+							{CONFIG.NIMBLE.levelDownDialog.removed}
+						</span>
+					</li>
+				{/each}
+			{/if}
+
+			{#if grantedFeatures.length > 0}
+				{#each grantedFeatures as feature}
+					<li class="nimble-level-down-preview__item">
+						<span class="nimble-level-down-preview__label">
+							<i class="fa-solid fa-scroll"></i>
+							{CONFIG.NIMBLE.levelDownDialog.feature}
+						</span>
+						<span class="nimble-level-down-preview__value">
+							{feature.name}
 							{CONFIG.NIMBLE.levelDownDialog.removed}
 						</span>
 					</li>
@@ -221,7 +243,6 @@
 
 	.nimble-level-new {
 		font-weight: 600;
-		color: var(--nimble-danger-color, hsl(0, 60%, 50%));
 	}
 
 	.nimble-level-down-preview {
@@ -240,20 +261,6 @@
 			background: var(--nimble-card-background);
 			border-radius: 4px;
 			box-shadow: var(--nimble-card-box-shadow);
-
-			&--loss {
-				.nimble-level-down-preview__value {
-					color: var(--nimble-danger-color, hsl(0, 60%, 50%));
-				}
-			}
-
-			&--warning {
-				border-left: 3px solid var(--nimble-warning-color, hsl(40, 90%, 50%));
-
-				.nimble-level-down-preview__value {
-					color: var(--nimble-warning-color, hsl(40, 90%, 50%));
-				}
-			}
 		}
 
 		&__label {

--- a/src/view/dialogs/CharacterLevelDownDialog.svelte
+++ b/src/view/dialogs/CharacterLevelDownDialog.svelte
@@ -1,62 +1,28 @@
 <script lang="ts">
-	import type { NimbleCharacter } from '../../documents/actor/character.js';
-	import type GenericDialog from '../../documents/dialogs/GenericDialog.svelte.js';
-	import type { NimbleClassItem } from '../../documents/item/class.js';
+	import type { CharacterLevelDownDialogProps } from '#types/components/CharacterLevelDownDialog.d.ts';
 
-	interface Props {
-		document: NimbleCharacter;
-		dialog: GenericDialog;
-	}
+	import { createLevelDownState } from './CharacterLevelDownDialogState.svelte.ts';
 
-	function submit() {
-		dialog.submit({
-			confirmed: true,
-		});
-	}
+	let { document: actor, dialog }: CharacterLevelDownDialogProps = $props();
 
-	let { document: actor, dialog }: Props = $props();
+	const { levelDownDialog } = CONFIG.NIMBLE;
 
-	const levelUpHistory = $derived(actor.system.levelUpHistory);
-	const lastHistory = $derived(levelUpHistory[levelUpHistory.length - 1]);
-
-	const characterClass: NimbleClassItem | undefined = $derived(
-		lastHistory ? actor.classes[lastHistory.classIdentifier] : undefined,
+	const state = createLevelDownState(
+		() => actor,
+		() => dialog,
 	);
 
-	const currentLevel = $derived(characterClass?.system?.classLevel ?? 1);
-	const newLevel = $derived(currentLevel - 1);
-
-	// Get skill names for display
-	const skillChanges = $derived(
-		Object.entries(lastHistory?.skillIncreases ?? {})
-			.filter(([, value]) => (value as number) > 0)
-			.map(([key, value]) => ({
-				name: CONFIG.NIMBLE.skills[key]?.label ?? key,
-				points: value as number,
-			})),
-	);
-
-	// Get ability score names for display
-	const abilityChanges = $derived(
-		Object.entries(lastHistory?.abilityIncreases ?? {})
-			.filter(([, value]) => (value as number) > 0)
-			.map(([key, value]) => ({
-				name: CONFIG.NIMBLE.abilities[key]?.label ?? key,
-				points: value as number,
-			})),
-	);
-
-	// Check if subclass will be removed
-	const willRemoveSubclass = $derived(lastHistory?.level <= 3);
-	const subclasses = $derived(actor.items.filter((i) => i.type === 'subclass'));
-	const hasSubclass = $derived(subclasses.length > 0);
-
-	// Get granted features that will be removed
-	const grantedFeatures = $derived(
-		(lastHistory?.grantedFeatureIds ?? [])
-			.map((id) => actor.items.get(id))
-			.filter((item): item is NonNullable<typeof item> => item !== undefined),
-	);
+	const { submit } = state;
+	const lastHistory = $derived(state.lastHistory);
+	const characterClass = $derived(state.characterClass);
+	const currentLevel = $derived(state.currentLevel);
+	const newLevel = $derived(state.newLevel);
+	const skillChanges = $derived(state.skillChanges);
+	const abilityChanges = $derived(state.abilityChanges);
+	const willRemoveSubclass = $derived(state.willRemoveSubclass);
+	const subclasses = $derived(state.subclasses);
+	const hasSubclass = $derived(state.hasSubclass);
+	const grantedFeatures = $derived(state.grantedFeatures);
 </script>
 
 <article class="nimble-sheet__body">
@@ -67,11 +33,9 @@
 		<div class="nimble-level-down-info">
 			<h3 class="nimble-heading" data-heading-variant="section">{actor.name}</h3>
 			<p class="nimble-level-transition">
-				<span class="nimble-level-current"
-					>{CONFIG.NIMBLE.levelDownDialog.level} {currentLevel}</span
-				>
+				<span class="nimble-level-current">{levelDownDialog.level} {currentLevel}</span>
 				<i class="fa-solid fa-arrow-right"></i>
-				<span class="nimble-level-new">{CONFIG.NIMBLE.levelDownDialog.level} {newLevel}</span>
+				<span class="nimble-level-new">{levelDownDialog.level} {newLevel}</span>
 			</p>
 		</div>
 	</section>
@@ -79,7 +43,7 @@
 	<section>
 		<header class="nimble-section-header">
 			<h3 class="nimble-heading" data-heading-variant="section">
-				{CONFIG.NIMBLE.levelDownDialog.changesToRevert}
+				{levelDownDialog.changesToRevert}
 			</h3>
 		</header>
 
@@ -88,11 +52,11 @@
 				<li class="nimble-level-down-preview__item">
 					<span class="nimble-level-down-preview__label">
 						<i class="fa-solid fa-heart"></i>
-						{CONFIG.NIMBLE.levelDownDialog.hitPoints}
+						{levelDownDialog.hitPoints}
 					</span>
 					<span class="nimble-level-down-preview__value">
 						-{lastHistory.hpIncrease}
-						{CONFIG.NIMBLE.levelDownDialog.hp}
+						{levelDownDialog.hp}
 					</span>
 				</li>
 			{/if}
@@ -101,7 +65,7 @@
 				<li class="nimble-level-down-preview__item">
 					<span class="nimble-level-down-preview__label">
 						<i class="fa-solid fa-dice-d20"></i>
-						{CONFIG.NIMBLE.levelDownDialog.hitDie}
+						{levelDownDialog.hitDie}
 					</span>
 					<span class="nimble-level-down-preview__value">
 						-1 d{characterClass?.system?.hitDieSize ?? '?'}
@@ -132,9 +96,7 @@
 						</span>
 						<span class="nimble-level-down-preview__value">
 							-{skill.points}
-							{skill.points !== 1
-								? CONFIG.NIMBLE.levelDownDialog.points
-								: CONFIG.NIMBLE.levelDownDialog.point}
+							{skill.points !== 1 ? levelDownDialog.points : levelDownDialog.point}
 						</span>
 					</li>
 				{/each}
@@ -145,11 +107,11 @@
 					<li class="nimble-level-down-preview__item">
 						<span class="nimble-level-down-preview__label">
 							<i class="fa-solid fa-star"></i>
-							{CONFIG.NIMBLE.levelDownDialog.subclass}
+							{levelDownDialog.subclass}
 						</span>
 						<span class="nimble-level-down-preview__value">
 							{subclass.name}
-							{CONFIG.NIMBLE.levelDownDialog.removed}
+							{levelDownDialog.removed}
 						</span>
 					</li>
 				{/each}
@@ -160,11 +122,11 @@
 					<li class="nimble-level-down-preview__item">
 						<span class="nimble-level-down-preview__label">
 							<i class="fa-solid fa-scroll"></i>
-							{CONFIG.NIMBLE.levelDownDialog.feature}
+							{levelDownDialog.feature}
 						</span>
 						<span class="nimble-level-down-preview__value">
 							{feature.name}
-							{CONFIG.NIMBLE.levelDownDialog.removed}
+							{levelDownDialog.removed}
 						</span>
 					</li>
 				{/each}
@@ -174,7 +136,7 @@
 
 	<section class="nimble-level-down-warning">
 		<i class="fa-solid fa-triangle-exclamation"></i>
-		<p>{CONFIG.NIMBLE.levelDownDialog.warningMessage}</p>
+		<p>{levelDownDialog.warningMessage}</p>
 	</section>
 </article>
 
@@ -184,7 +146,7 @@
 		data-button-variant="full-width"
 		onclick={submit}
 	>
-		{CONFIG.NIMBLE.levelDownDialog.confirmLevelDown}
+		{levelDownDialog.confirmLevelDown}
 	</button>
 </footer>
 

--- a/src/view/dialogs/CharacterLevelDownDialogState.svelte.ts
+++ b/src/view/dialogs/CharacterLevelDownDialogState.svelte.ts
@@ -1,0 +1,122 @@
+import { SUBCLASS_LEVEL } from './const/levelUpConstants.ts';
+
+/** Structural type for what the factory accesses on a class item */
+interface ClassItemShape {
+	system?: { classLevel?: number; hitDieSize?: number };
+}
+
+/** Structural type for what the factory accesses on the actor document */
+interface LevelDownActor {
+	system: {
+		levelUpHistory: Array<{
+			classIdentifier: string;
+			level: number;
+			hpIncrease: number;
+			hitDieAdded: boolean;
+			skillIncreases: Record<string, number>;
+			abilityIncreases: Record<string, number>;
+			grantedFeatureIds: string[];
+		}>;
+	};
+	classes: Record<string, ClassItemShape | undefined>;
+	items: {
+		filter(fn: (i: { type: string }) => boolean): Array<{ name: string }>;
+		get(id: string): { name: string } | undefined;
+	};
+}
+
+/**
+ * Creates reactive state for the CharacterLevelDownDialog component.
+ *
+ * Derives all display data from the actor's level-up history, including
+ * skill/ability changes, subclass removal, and granted features to revert.
+ */
+export function createLevelDownState(
+	getActor: () => LevelDownActor,
+	getDialog: () => { submit(data: Record<string, unknown>): void },
+) {
+	const levelUpHistory = $derived(getActor().system.levelUpHistory);
+	const lastHistory = $derived(levelUpHistory[levelUpHistory.length - 1]);
+
+	const characterClass = $derived(
+		lastHistory
+			? (getActor().classes[lastHistory.classIdentifier] as ClassItemShape | undefined)
+			: undefined,
+	);
+
+	const currentLevel = $derived(characterClass?.system?.classLevel ?? 1);
+	const newLevel = $derived(currentLevel - 1);
+
+	// Get skill names for display
+	const skillChanges = $derived(
+		Object.entries(lastHistory?.skillIncreases ?? {})
+			.filter(([, value]) => (value as number) > 0)
+			.map(([key, value]) => ({
+				name: CONFIG.NIMBLE.skills[key]?.label ?? key,
+				points: value as number,
+			})),
+	);
+
+	// Get ability score names for display
+	const abilityChanges = $derived(
+		Object.entries(lastHistory?.abilityIncreases ?? {})
+			.filter(([, value]) => (value as number) > 0)
+			.map(([key, value]) => ({
+				// @ts-expect-error — abilities config exists at runtime but isn't in the type declarations
+				name: (CONFIG.NIMBLE.abilities[key]?.label as string) ?? key,
+				points: value as number,
+			})),
+	);
+
+	// Check if subclass will be removed
+	const willRemoveSubclass = $derived(lastHistory?.level <= SUBCLASS_LEVEL);
+	const subclasses = $derived(getActor().items.filter((i) => i.type === 'subclass'));
+	const hasSubclass = $derived(subclasses.length > 0);
+
+	// Get granted features that will be removed
+	const grantedFeatures = $derived(
+		(lastHistory?.grantedFeatureIds ?? [])
+			.map((id) => getActor().items.get(id))
+			.filter((item): item is NonNullable<typeof item> => item !== undefined),
+	);
+
+	function submit() {
+		getDialog().submit({
+			confirmed: true,
+		});
+	}
+
+	return {
+		get lastHistory() {
+			return lastHistory;
+		},
+		get characterClass() {
+			return characterClass;
+		},
+		get currentLevel() {
+			return currentLevel;
+		},
+		get newLevel() {
+			return newLevel;
+		},
+		get skillChanges() {
+			return skillChanges;
+		},
+		get abilityChanges() {
+			return abilityChanges;
+		},
+		get willRemoveSubclass() {
+			return willRemoveSubclass;
+		},
+		get subclasses() {
+			return subclasses;
+		},
+		get hasSubclass() {
+			return hasSubclass;
+		},
+		get grantedFeatures() {
+			return grantedFeatures;
+		},
+		submit,
+	};
+}

--- a/src/view/dialogs/CharacterLevelUpDialog.svelte
+++ b/src/view/dialogs/CharacterLevelUpDialog.svelte
@@ -1,16 +1,5 @@
 <script lang="ts">
-	import type { NimbleBoonItem } from '../../documents/item/boon.js';
-	import type { NimbleClassItem } from '../../documents/item/class.js';
-	import type { NimbleFeatureItem } from '../../documents/item/feature.js';
-	import type { ClassFeatureResult } from '#types/components/ClassFeatureSelection.d.ts';
-
-	import generateBlankSkillSet from '../../utils/generateBlankSkillSet.js';
-	import getChoicesFromCompendium from '../../utils/getChoicesFromCompendium.js';
-	import getClassFeaturesFromIndex, {
-		buildClassFeatureIndex,
-	} from '../../utils/getClassFeatures.ts';
-	import getEpicBoons from '../../utils/getEpicBoons.ts';
-	import getSubclassChoices from '../../utils/getSubclassChoices.js';
+	import type { CharacterLevelUpDialogProps } from '#types/components/CharacterLevelUpDialog.d.ts';
 
 	import AbilityScoreIncrease from './components/levelUpHelper/AbilityScoreIncrease.svelte';
 	import EpicBoonSelection from './components/levelUpHelper/EpicBoonSelection.svelte';
@@ -18,252 +7,63 @@
 	import LevelUpClassFeatureSelection from './components/levelUpHelper/LevelUpClassFeatureSelection.svelte';
 	import SkillPointAssignment from './components/levelUpHelper/SkillPointAssignment.svelte';
 	import SubclassSelection from './components/levelUpHelper/SubclassSelection.svelte';
+	import { createLevelUpState } from './CharacterLevelUpDialogState.svelte.ts';
+	import { SUBCLASS_LEVEL, EPIC_BOON_LEVEL } from './const/levelUpConstants.ts';
 
-	const { forms, levelUpDialog } = CONFIG.NIMBLE;
+	let { document, dialog }: CharacterLevelUpDialogProps = $props();
 
-	/** Subclass is chosen when leveling to this class level */
-	const SUBCLASS_LEVEL = 3;
-	/** Epic boon is chosen when leveling to this class level (Nimble class rule) */
-	const EPIC_BOON_LEVEL = 19;
+	const { forms } = CONFIG.NIMBLE;
 
-	function submit() {
-		dialog.submit({
-			selectedAbilityScore: selectedAbilityScores,
-			selectedSubclass,
-			selectedEpicBoon,
-			skillPointChanges,
-			takeAverageHp: hitPointRollSelection === 'average',
-			classFeatures: classFeatures
-				? {
-						autoGrant: classFeatures.autoGrant,
-						selected: selectedClassFeatures,
-					}
-				: null,
-		});
-	}
-
-	function getSubmitButtonTooltip() {
-		if (!isComplete) {
-			if (skillPointsOverMax) {
-				return levelUpDialog.skillPointsOverMax;
-			} else {
-				return levelUpDialog.completeAllSelections;
-			}
-		}
-
-		return '';
-	}
-
-	function getSubmitButtonAriaLabel() {
-		if (!isComplete) {
-			if (skillPointsOverMax) {
-				return levelUpDialog.skillPointsOverMaxTooltip;
-			} else {
-				return levelUpDialog.completeAllSelectionsTooltip;
-			}
-		}
-
-		return forms.submit;
-	}
-
-	let { document, dialog } = $props();
-
-	const characterClass: NimbleClassItem | undefined = $derived(
-		document?.classes
-			? (Object.values(document.classes)[0] as NimbleClassItem | undefined)
-			: undefined,
+	const state = createLevelUpState(
+		() => document,
+		() => dialog,
 	);
-	const level = $derived(characterClass?.system?.classLevel ?? 1);
-	const levelingTo = $derived(level + 1);
 
-	let boons = getChoicesFromCompendium('boon');
-	let subclasses: Array<{
-		uuid: string;
-		name: string;
-		img: string;
-		system: { parentClass: string };
-	}> = $state([]);
-	let hasSubclassSelection = $derived(levelingTo === SUBCLASS_LEVEL);
-
-	// Epic boon state (level 19)
-	let epicBoons: Array<{
-		uuid: string;
-		name: string;
-		img: string;
-		system: { boonType: string; description: string };
-	}> = $state([]);
-	let hasEpicBoonSelection = $derived(levelingTo === EPIC_BOON_LEVEL);
-
-	// Load subclasses filtered by parent class when leveling to 3
-	$effect(() => {
-		if (hasSubclassSelection && characterClass) {
-			getSubclassChoices(characterClass.identifier).then((choices) => {
-				subclasses = choices;
-			});
-		}
-	});
-
-	// Load epic boons when leveling to 19
-	$effect(() => {
-		if (hasEpicBoonSelection) {
-			getEpicBoons().then((choices) => {
-				epicBoons = choices;
-			});
-		}
-	});
-
-	let chooseBoon = $state(false);
-	let hitPointRollSelection = $state('roll');
-	let selectedAbilityScores: string[] | string | null = $state(null);
-	let lastSelectedAbilityScores: string[] | string | null = $state(null);
-	let selectedBoon = $state(null);
-	let selectedSubclass = $state(null);
-	let selectedEpicBoon: NimbleBoonItem | null = $state(null);
-	let skillPointChanges = $state(generateBlankSkillSet());
-
-	let hasStatIncrease = $state(false);
-	let skillPointsOverMax = $state(false);
-
-	// Class features state
-	let classFeatures: ClassFeatureResult | null = $state(null);
-	let selectedClassFeatures: Map<string, NimbleFeatureItem> = $state(new Map());
-	let featuresLoading = $state(true);
-
-	// Load class features when dialog opens
-	$effect(() => {
-		if (!characterClass) return;
-
-		featuresLoading = true;
-		buildClassFeatureIndex().then(async (index) => {
-			const rawFeatures = await getClassFeaturesFromIndex(
-				index,
-				characterClass.identifier,
-				levelingTo,
-			);
-
-			// Get UUIDs of features the character already has (via compendiumSource)
-			const ownedFeatureUuids = new Set(
-				(document.items ?? [])
-					.filter((item) => item.type === 'feature')
-					.map(
-						(item) =>
-							(item as unknown as { _stats?: { compendiumSource?: string } })._stats
-								?.compendiumSource,
-					)
-					.filter((uuid): uuid is string => !!uuid),
-			);
-
-			// Filter out already-owned features from autoGrant
-			const filteredAutoGrant = rawFeatures.autoGrant.filter(
-				(feature) => !ownedFeatureUuids.has(feature.uuid),
-			);
-
-			// Filter out already-owned features from selection groups
-			const filteredSelectionGroups = new Map<string, NimbleFeatureItem[]>();
-			for (const [groupName, features] of rawFeatures.selectionGroups) {
-				const filteredFeatures = features.filter((feature) => !ownedFeatureUuids.has(feature.uuid));
-				// Only include groups that still have options
-				if (filteredFeatures.length > 0) {
-					filteredSelectionGroups.set(groupName, filteredFeatures);
-				}
-			}
-
-			classFeatures = {
-				autoGrant: filteredAutoGrant,
-				selectionGroups: filteredSelectionGroups,
-			};
-			featuresLoading = false;
-		});
-	});
-
-	const classFeaturesComplete = $derived.by(() => {
-		if (featuresLoading) return false;
-		if (!classFeatures) return true;
-
-		// Check if all selection groups have a selection
-		for (const groupName of classFeatures.selectionGroups.keys()) {
-			if (!selectedClassFeatures.has(groupName)) {
-				return false;
-			}
-		}
-		return true;
-	});
-
-	let skillPointChangesAssigned = $derived.by(() => {
-		return Object.values(skillPointChanges).reduce((acc, change) => acc + (change ?? 0), 0) === 1;
-	});
-
-	$effect(() => {
-		if (!lastSelectedAbilityScores) {
-			lastSelectedAbilityScores = selectedAbilityScores;
-			return;
-		}
-
-		// check if values are different
-		let hasChangedAbilityScore = Array.isArray(selectedAbilityScores)
-			? JSON.stringify(lastSelectedAbilityScores) !== JSON.stringify(selectedAbilityScores)
-			: lastSelectedAbilityScores !== selectedAbilityScores;
-
-		if (hasChangedAbilityScore) {
-			skillPointChanges = generateBlankSkillSet();
-			lastSelectedAbilityScores = selectedAbilityScores;
-		}
-	});
-
-	let isComplete = $derived.by(() => {
-		const overMax = skillPointsOverMax;
-
-		const abilityScoreComplete =
-			(Array.isArray(selectedAbilityScores)
-				? selectedAbilityScores?.length === 2
-				: selectedAbilityScores) || !hasStatIncrease;
-
-		return (
-			abilityScoreComplete &&
-			skillPointChangesAssigned &&
-			!overMax &&
-			(selectedSubclass || !hasSubclassSelection) &&
-			(selectedEpicBoon || !hasEpicBoonSelection) &&
-			classFeaturesComplete
-		);
-	});
+	const { boons, submit, getSubmitButtonTooltip, getSubmitButtonAriaLabel } = state;
+	const characterClass = $derived(state.characterClass);
+	const levelingTo = $derived(state.levelingTo);
+	const subclasses = $derived(state.subclasses);
+	const epicBoons = $derived(state.epicBoons);
+	const classFeatures = $derived(state.classFeatures);
+	const featuresLoading = $derived(state.featuresLoading);
+	const isComplete = $derived(state.isComplete);
 </script>
 
 <section class="nimble-sheet__body" style="--nimble-sheet-body-padding-block-start: 0.75rem;">
-	<HitPointSelection {document} bind:hitPointRollSelection />
+	<HitPointSelection {document} bind:hitPointRollSelection={state.hitPointRollSelection} />
 
 	<AbilityScoreIncrease
 		{boons}
 		{characterClass}
 		{document}
 		{levelingTo}
-		bind:chooseBoon
-		bind:selectedAbilityScores
-		bind:selectedBoon
-		bind:hasStatIncrease
+		bind:chooseBoon={state.chooseBoon}
+		bind:selectedAbilityScores={state.selectedAbilityScores}
+		bind:selectedBoon={state.selectedBoon}
+		bind:hasStatIncrease={state.hasStatIncrease}
 	/>
 
 	<SkillPointAssignment
-		{chooseBoon}
+		chooseBoon={state.chooseBoon}
 		{document}
-		{selectedBoon}
-		selectedAbilityScore={selectedAbilityScores}
-		bind:skillPointChanges
-		bind:selectedAbilityScores
-		bind:skillPointsOverMax
+		selectedBoon={state.selectedBoon}
+		selectedAbilityScore={state.selectedAbilityScores}
+		bind:skillPointChanges={state.skillPointChanges}
+		bind:selectedAbilityScores={state.selectedAbilityScores}
+		bind:skillPointsOverMax={state.skillPointsOverMax}
 	/>
 
 	{#if levelingTo === SUBCLASS_LEVEL && subclasses.length}
-		<SubclassSelection {subclasses} bind:selectedSubclass />
+		<SubclassSelection {subclasses} bind:selectedSubclass={state.selectedSubclass} />
 	{/if}
 
 	{#if levelingTo === EPIC_BOON_LEVEL && epicBoons.length}
-		<EpicBoonSelection {epicBoons} bind:selectedEpicBoon />
+		<EpicBoonSelection {epicBoons} bind:selectedEpicBoon={state.selectedEpicBoon} />
 	{/if}
 
 	<LevelUpClassFeatureSelection
 		{classFeatures}
-		bind:selectedFeatures={selectedClassFeatures}
+		bind:selectedFeatures={state.selectedClassFeatures}
 		loading={featuresLoading}
 	/>
 </section>

--- a/src/view/dialogs/CharacterLevelUpDialog.svelte
+++ b/src/view/dialogs/CharacterLevelUpDialog.svelte
@@ -1,12 +1,21 @@
 <script lang="ts">
+	import type { NimbleBoonItem } from '../../documents/item/boon.js';
 	import type { NimbleClassItem } from '../../documents/item/class.js';
+	import type { NimbleFeatureItem } from '../../documents/item/feature.js';
+	import type { ClassFeatureResult } from '#types/components/ClassFeatureSelection.d.ts';
+
 	import generateBlankSkillSet from '../../utils/generateBlankSkillSet.js';
 	import getChoicesFromCompendium from '../../utils/getChoicesFromCompendium.js';
-
+	import getClassFeaturesFromIndex, {
+		buildClassFeatureIndex,
+	} from '../../utils/getClassFeatures.ts';
+	import getEpicBoons from '../../utils/getEpicBoons.ts';
 	import getSubclassChoices from '../../utils/getSubclassChoices.js';
 
 	import AbilityScoreIncrease from './components/levelUpHelper/AbilityScoreIncrease.svelte';
+	import EpicBoonSelection from './components/levelUpHelper/EpicBoonSelection.svelte';
 	import HitPointSelection from './components/levelUpHelper/HitPointSelection.svelte';
+	import LevelUpClassFeatureSelection from './components/levelUpHelper/LevelUpClassFeatureSelection.svelte';
 	import SkillPointAssignment from './components/levelUpHelper/SkillPointAssignment.svelte';
 	import SubclassSelection from './components/levelUpHelper/SubclassSelection.svelte';
 
@@ -16,8 +25,15 @@
 		dialog.submit({
 			selectedAbilityScore: selectedAbilityScores,
 			selectedSubclass,
+			selectedEpicBoon,
 			skillPointChanges,
 			takeAverageHp: hitPointRollSelection === 'average',
+			classFeatures: classFeatures
+				? {
+						autoGrant: classFeatures.autoGrant,
+						selected: selectedClassFeatures,
+					}
+				: null,
 		});
 	}
 
@@ -64,11 +80,29 @@
 	}> = $state([]);
 	let hasSubclassSelection = $derived(levelingTo === 3);
 
+	// Epic boon state (level 19)
+	let epicBoons: Array<{
+		uuid: string;
+		name: string;
+		img: string;
+		system: { boonType: string; description: string };
+	}> = $state([]);
+	let hasEpicBoonSelection = $derived(levelingTo === 19);
+
 	// Load subclasses filtered by parent class when leveling to 3
 	$effect(() => {
 		if (hasSubclassSelection && characterClass) {
 			getSubclassChoices(characterClass.identifier).then((choices) => {
 				subclasses = choices;
+			});
+		}
+	});
+
+	// Load epic boons when leveling to 19
+	$effect(() => {
+		if (hasEpicBoonSelection) {
+			getEpicBoons().then((choices) => {
+				epicBoons = choices;
 			});
 		}
 	});
@@ -79,10 +113,76 @@
 	let lastSelectedAbilityScores: string[] | string | null = $state(null);
 	let selectedBoon = $state(null);
 	let selectedSubclass = $state(null);
+	let selectedEpicBoon: NimbleBoonItem | null = $state(null);
 	let skillPointChanges = $state(generateBlankSkillSet());
 
 	let hasStatIncrease = $state(false);
 	let skillPointsOverMax = $state(false);
+
+	// Class features state
+	let classFeatures: ClassFeatureResult | null = $state(null);
+	let selectedClassFeatures: Map<string, NimbleFeatureItem> = $state(new Map());
+	let featuresLoading = $state(true);
+
+	// Load class features when dialog opens
+	$effect(() => {
+		if (!characterClass) return;
+
+		featuresLoading = true;
+		buildClassFeatureIndex().then(async (index) => {
+			const rawFeatures = await getClassFeaturesFromIndex(
+				index,
+				characterClass.identifier,
+				levelingTo,
+			);
+
+			// Get UUIDs of features the character already has (via compendiumSource)
+			const ownedFeatureUuids = new Set(
+				(document.items ?? [])
+					.filter((item) => item.type === 'feature')
+					.map(
+						(item) =>
+							(item as unknown as { _stats?: { compendiumSource?: string } })._stats
+								?.compendiumSource,
+					)
+					.filter((uuid): uuid is string => !!uuid),
+			);
+
+			// Filter out already-owned features from autoGrant
+			const filteredAutoGrant = rawFeatures.autoGrant.filter(
+				(feature) => !ownedFeatureUuids.has(feature.uuid),
+			);
+
+			// Filter out already-owned features from selection groups
+			const filteredSelectionGroups = new Map<string, NimbleFeatureItem[]>();
+			for (const [groupName, features] of rawFeatures.selectionGroups) {
+				const filteredFeatures = features.filter((feature) => !ownedFeatureUuids.has(feature.uuid));
+				// Only include groups that still have options
+				if (filteredFeatures.length > 0) {
+					filteredSelectionGroups.set(groupName, filteredFeatures);
+				}
+			}
+
+			classFeatures = {
+				autoGrant: filteredAutoGrant,
+				selectionGroups: filteredSelectionGroups,
+			};
+			featuresLoading = false;
+		});
+	});
+
+	const classFeaturesComplete = $derived.by(() => {
+		if (featuresLoading) return false;
+		if (!classFeatures) return true;
+
+		// Check if all selection groups have a selection
+		for (const groupName of classFeatures.selectionGroups.keys()) {
+			if (!selectedClassFeatures.has(groupName)) {
+				return false;
+			}
+		}
+		return true;
+	});
 
 	let skillPointChangesAssigned = $derived.by(() => {
 		return Object.values(skillPointChanges).reduce((acc, change) => acc + (change ?? 0), 0) === 1;
@@ -117,7 +217,9 @@
 			abilityScoreComplete &&
 			skillPointChangesAssigned &&
 			!overMax &&
-			(selectedSubclass || !hasSubclassSelection)
+			(selectedSubclass || !hasSubclassSelection) &&
+			(selectedEpicBoon || !hasEpicBoonSelection) &&
+			classFeaturesComplete
 		);
 	});
 </script>
@@ -149,6 +251,16 @@
 	{#if levelingTo === 3 && subclasses.length}
 		<SubclassSelection {subclasses} bind:selectedSubclass />
 	{/if}
+
+	{#if levelingTo === 19 && epicBoons.length}
+		<EpicBoonSelection {epicBoons} bind:selectedEpicBoon />
+	{/if}
+
+	<LevelUpClassFeatureSelection
+		{classFeatures}
+		bind:selectedFeatures={selectedClassFeatures}
+		loading={featuresLoading}
+	/>
 </section>
 
 <footer class="nimble-sheet__footer">

--- a/src/view/dialogs/CharacterLevelUpDialog.svelte
+++ b/src/view/dialogs/CharacterLevelUpDialog.svelte
@@ -21,6 +21,11 @@
 
 	const { forms, levelUpDialog } = CONFIG.NIMBLE;
 
+	/** Subclass is chosen when leveling to this class level */
+	const SUBCLASS_LEVEL = 3;
+	/** Epic boon is chosen when leveling to this class level (Nimble class rule) */
+	const EPIC_BOON_LEVEL = 19;
+
 	function submit() {
 		dialog.submit({
 			selectedAbilityScore: selectedAbilityScores,
@@ -78,7 +83,7 @@
 		img: string;
 		system: { parentClass: string };
 	}> = $state([]);
-	let hasSubclassSelection = $derived(levelingTo === 3);
+	let hasSubclassSelection = $derived(levelingTo === SUBCLASS_LEVEL);
 
 	// Epic boon state (level 19)
 	let epicBoons: Array<{
@@ -87,7 +92,7 @@
 		img: string;
 		system: { boonType: string; description: string };
 	}> = $state([]);
-	let hasEpicBoonSelection = $derived(levelingTo === 19);
+	let hasEpicBoonSelection = $derived(levelingTo === EPIC_BOON_LEVEL);
 
 	// Load subclasses filtered by parent class when leveling to 3
 	$effect(() => {
@@ -248,11 +253,11 @@
 		bind:skillPointsOverMax
 	/>
 
-	{#if levelingTo === 3 && subclasses.length}
+	{#if levelingTo === SUBCLASS_LEVEL && subclasses.length}
 		<SubclassSelection {subclasses} bind:selectedSubclass />
 	{/if}
 
-	{#if levelingTo === 19 && epicBoons.length}
+	{#if levelingTo === EPIC_BOON_LEVEL && epicBoons.length}
 		<EpicBoonSelection {epicBoons} bind:selectedEpicBoon />
 	{/if}
 

--- a/src/view/dialogs/CharacterLevelUpDialog.test.ts
+++ b/src/view/dialogs/CharacterLevelUpDialog.test.ts
@@ -1,9 +1,43 @@
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/svelte';
-import { describe, expect, it } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createMockCharacterDocument, createMockDialog } from '../../../tests/fixtures/index.js';
 import CharacterLevelUpDialog from './CharacterLevelUpDialog.svelte';
 
+// Mock the class features utilities to return empty results immediately
+vi.mock('../../utils/getClassFeatures.ts', () => ({
+	buildClassFeatureIndex: vi.fn(() => Promise.resolve(new Map())),
+	default: vi.fn(() =>
+		Promise.resolve({
+			autoGrant: [],
+			selectionGroups: new Map(),
+		}),
+	),
+}));
+
+// Mock getSubclassChoices to return empty array (avoid SubclassSelection rendering issues in tests)
+vi.mock('../../utils/getSubclassChoices.ts', () => ({
+	default: vi.fn(() => Promise.resolve([])),
+}));
+
+// Helper to wait for feature loading to complete
+async function waitForFeaturesLoaded() {
+	// Wait for the feature loading section to disappear (indicates loading is complete)
+	// The component shows "Loading features..." while loading
+	await waitFor(
+		() => {
+			const loadingText = screen.queryByText('Loading features...');
+			expect(loadingText).toBeNull();
+		},
+		{ timeout: 500 },
+	);
+}
+
 describe('CharacterLevelUpDialog Component', () => {
+	// Clean up after each test to prevent async errors during unmount
+	afterEach(() => {
+		cleanup();
+	});
+
 	describe('Ability Score Increase Causing Skill Over Max', () => {
 		it('should disable submit when selecting strength pushes might over 12', async () => {
 			const document = createMockCharacterDocument();
@@ -153,6 +187,9 @@ describe('CharacterLevelUpDialog Component', () => {
 				},
 			});
 
+			// Wait for feature loading to complete
+			await waitForFeaturesLoaded();
+
 			// Select Strength (brings Might to 12, which is valid)
 			const strengthLabel = screen.getByText('Strength', {
 				selector: '.nimble-stat-selection__option',
@@ -184,6 +221,9 @@ describe('CharacterLevelUpDialog Component', () => {
 					dialog,
 				},
 			});
+
+			// Wait for feature loading to complete
+			await waitForFeaturesLoaded();
 
 			// 1. Select Strength (pushes Might to 13 - invalid)
 			const strengthLabel = screen.getByText('Strength', {
@@ -320,6 +360,9 @@ describe('CharacterLevelUpDialog Component', () => {
 				},
 			});
 
+			// Wait for feature loading to complete
+			await waitForFeaturesLoaded();
+
 			// Select ability
 			const strengthLabel = screen.getByText('Strength', {
 				selector: '.nimble-stat-selection__option',
@@ -377,6 +420,9 @@ describe('CharacterLevelUpDialog Component', () => {
 					dialog,
 				},
 			});
+
+			// Wait for feature loading to complete
+			await waitForFeaturesLoaded();
 
 			// 1. Select Strength and add skill point
 			const strengthLabel = screen.getByText('Strength', {
@@ -436,7 +482,11 @@ describe('CharacterLevelUpDialog Component', () => {
 				},
 			});
 
-			// Select ability and skill point
+			// Wait for all async effects to complete (features + subclasses loading)
+			// Use a small delay to let microtasks/promises resolve
+			await new Promise((resolve) => setTimeout(resolve, 50));
+
+			// Select ability and skill point - completing all other requirements
 			const strengthLabel = screen.getByText('Strength', {
 				selector: '.nimble-stat-selection__option',
 			});
@@ -449,14 +499,12 @@ describe('CharacterLevelUpDialog Component', () => {
 			});
 			await fireEvent.click(finesseIncrementBtn);
 
-			// Submit should still be disabled (need subclass)
+			// Submit should still be disabled at level 3 because subclass selection is required
+			// (hasSubclassSelection is true when levelingTo === 3, and selectedSubclass is null)
 			await waitFor(() => {
 				const submitButton = screen.getByText('Submit');
 				expect(submitButton).toBeDisabled();
 			});
-
-			// Verify subclass section is visible
-			expect(screen.getByText(/subclass/i)).toBeTruthy();
 		});
 	});
 });

--- a/src/view/dialogs/CharacterLevelUpDialogState.svelte.ts
+++ b/src/view/dialogs/CharacterLevelUpDialogState.svelte.ts
@@ -70,18 +70,26 @@ export function createLevelUpState(
 	// Load subclasses filtered by parent class when leveling to 3
 	$effect(() => {
 		if (hasSubclassSelection && characterClass) {
-			getSubclassChoices(characterClass.identifier).then((choices) => {
-				subclasses = choices;
-			});
+			getSubclassChoices(characterClass.identifier)
+				.then((choices) => {
+					subclasses = choices;
+				})
+				.catch((err) => {
+					console.warn('Nimble | Failed to load subclass choices:', err);
+				});
 		}
 	});
 
 	// Load epic boons when leveling to 19
 	$effect(() => {
 		if (hasEpicBoonSelection) {
-			getEpicBoons().then((choices) => {
-				epicBoons = choices;
-			});
+			getEpicBoons()
+				.then((choices) => {
+					epicBoons = choices;
+				})
+				.catch((err) => {
+					console.warn('Nimble | Failed to load epic boons:', err);
+				});
 		}
 	});
 
@@ -107,46 +115,53 @@ export function createLevelUpState(
 		if (!characterClass) return;
 
 		featuresLoading = true;
-		buildClassFeatureIndex().then(async (index) => {
-			const rawFeatures = await getClassFeaturesFromIndex(
-				index,
-				characterClass.identifier,
-				levelingTo,
-			);
+		buildClassFeatureIndex()
+			.then(async (index) => {
+				const rawFeatures = await getClassFeaturesFromIndex(
+					index,
+					characterClass.identifier,
+					levelingTo,
+				);
 
-			// Get UUIDs of features the character already has (via compendiumSource)
-			const ownedFeatureUuids = new Set(
-				(getDocument().items ?? [])
-					.filter((item) => item.type === 'feature')
-					.map(
-						(item) =>
-							(item as unknown as { _stats?: { compendiumSource?: string } })._stats
-								?.compendiumSource,
-					)
-					.filter((uuid): uuid is string => !!uuid),
-			);
+				// Get UUIDs of features the character already has (via compendiumSource)
+				const ownedFeatureUuids = new Set(
+					(getDocument().items ?? [])
+						.filter((item) => item.type === 'feature')
+						.map(
+							(item) =>
+								(item as unknown as { _stats?: { compendiumSource?: string } })._stats
+									?.compendiumSource,
+						)
+						.filter((uuid): uuid is string => !!uuid),
+				);
 
-			// Filter out already-owned features from autoGrant
-			const filteredAutoGrant = rawFeatures.autoGrant.filter(
-				(feature) => !ownedFeatureUuids.has(feature.uuid),
-			);
+				// Filter out already-owned features from autoGrant
+				const filteredAutoGrant = rawFeatures.autoGrant.filter(
+					(feature) => !ownedFeatureUuids.has(feature.uuid),
+				);
 
-			// Filter out already-owned features from selection groups
-			const filteredSelectionGroups = new Map<string, NimbleFeatureItem[]>();
-			for (const [groupName, features] of rawFeatures.selectionGroups) {
-				const filteredFeatures = features.filter((feature) => !ownedFeatureUuids.has(feature.uuid));
-				// Only include groups that still have options
-				if (filteredFeatures.length > 0) {
-					filteredSelectionGroups.set(groupName, filteredFeatures);
+				// Filter out already-owned features from selection groups
+				const filteredSelectionGroups = new Map<string, NimbleFeatureItem[]>();
+				for (const [groupName, features] of rawFeatures.selectionGroups) {
+					const filteredFeatures = features.filter(
+						(feature) => !ownedFeatureUuids.has(feature.uuid),
+					);
+					// Only include groups that still have options
+					if (filteredFeatures.length > 0) {
+						filteredSelectionGroups.set(groupName, filteredFeatures);
+					}
 				}
-			}
 
-			classFeatures = {
-				autoGrant: filteredAutoGrant,
-				selectionGroups: filteredSelectionGroups,
-			};
-			featuresLoading = false;
-		});
+				classFeatures = {
+					autoGrant: filteredAutoGrant,
+					selectionGroups: filteredSelectionGroups,
+				};
+				featuresLoading = false;
+			})
+			.catch((err) => {
+				console.warn('Nimble | Failed to load class features:', err);
+				featuresLoading = false;
+			});
 	});
 
 	// Derived completion checks

--- a/src/view/dialogs/CharacterLevelUpDialogState.svelte.ts
+++ b/src/view/dialogs/CharacterLevelUpDialogState.svelte.ts
@@ -1,0 +1,338 @@
+import type { NimbleFeatureItem } from '#documents/item/feature.js';
+import type { ClassFeatureResult } from '#types/components/ClassFeatureSelection.d.ts';
+import type { ExpandableDocumentItem } from '#types/components/ExpandableDocumentList.d.ts';
+
+import generateBlankSkillSet from '#utils/generateBlankSkillSet.ts';
+import getChoicesFromCompendium from '#utils/getChoicesFromCompendium.ts';
+import getClassFeaturesFromIndex, { buildClassFeatureIndex } from '#utils/getClassFeatures.ts';
+import getEpicBoons from '#utils/getEpicBoons.ts';
+import getSubclassChoices from '#utils/getSubclassChoices.ts';
+
+import { EPIC_BOON_LEVEL, SUBCLASS_LEVEL } from './const/levelUpConstants.ts';
+
+/** Structural type for what the factory accesses on a class item */
+interface ClassItemShape {
+	system?: { classLevel?: number };
+	identifier: string;
+}
+
+/** Structural type for what the factory accesses on the actor document */
+interface LevelUpDocument {
+	classes: Record<string, ClassItemShape | undefined>;
+	items: Array<{ type: string; _stats?: { compendiumSource?: string } }>;
+}
+
+interface SubclassChoice {
+	uuid: string;
+	name: string;
+	img: string;
+	system: { parentClass: string };
+}
+
+interface EpicBoonChoice {
+	uuid: string;
+	name: string;
+	img: string;
+	system: { boonType: string; description: string };
+}
+
+/**
+ * Creates reactive state for the CharacterLevelUpDialog component.
+ *
+ * Manages all level-up form state including ability scores, skill points,
+ * subclass/boon selection, class features, and form completion validation.
+ */
+export function createLevelUpState(
+	getDocument: () => LevelUpDocument,
+	getDialog: () => { submit(data: Record<string, unknown>): void },
+) {
+	const { forms, levelUpDialog } = CONFIG.NIMBLE;
+
+	const boons = getChoicesFromCompendium('boon');
+
+	// Derived character info
+	const characterClass = $derived(
+		getDocument()?.classes
+			? (Object.values(getDocument().classes)[0] as ClassItemShape | undefined)
+			: undefined,
+	);
+	const level = $derived(characterClass?.system?.classLevel ?? 1);
+	const levelingTo = $derived(level + 1);
+
+	// Subclass state (level 3)
+	let subclasses: SubclassChoice[] = $state([]);
+	const hasSubclassSelection = $derived(levelingTo === SUBCLASS_LEVEL);
+
+	// Epic boon state (level 19)
+	let epicBoons: EpicBoonChoice[] = $state([]);
+	const hasEpicBoonSelection = $derived(levelingTo === EPIC_BOON_LEVEL);
+
+	// Load subclasses filtered by parent class when leveling to 3
+	$effect(() => {
+		if (hasSubclassSelection && characterClass) {
+			getSubclassChoices(characterClass.identifier).then((choices) => {
+				subclasses = choices;
+			});
+		}
+	});
+
+	// Load epic boons when leveling to 19
+	$effect(() => {
+		if (hasEpicBoonSelection) {
+			getEpicBoons().then((choices) => {
+				epicBoons = choices;
+			});
+		}
+	});
+
+	// Form state
+	let chooseBoon = $state(false);
+	let hitPointRollSelection = $state('roll');
+	let selectedAbilityScores: string[] | string | null = $state(null);
+	let lastSelectedAbilityScores: string[] | string | null = $state(null);
+	let selectedBoon: string | null = $state(null);
+	let selectedSubclass: ExpandableDocumentItem | null = $state(null);
+	let selectedEpicBoon: ExpandableDocumentItem | null = $state(null);
+	let skillPointChanges = $state(generateBlankSkillSet());
+	let hasStatIncrease = $state(false);
+	let skillPointsOverMax = $state(false);
+
+	// Class features state
+	let classFeatures: ClassFeatureResult | null = $state(null);
+	let selectedClassFeatures: Map<string, NimbleFeatureItem> = $state(new Map());
+	let featuresLoading = $state(true);
+
+	// Load class features when dialog opens
+	$effect(() => {
+		if (!characterClass) return;
+
+		featuresLoading = true;
+		buildClassFeatureIndex().then(async (index) => {
+			const rawFeatures = await getClassFeaturesFromIndex(
+				index,
+				characterClass.identifier,
+				levelingTo,
+			);
+
+			// Get UUIDs of features the character already has (via compendiumSource)
+			const ownedFeatureUuids = new Set(
+				(getDocument().items ?? [])
+					.filter((item) => item.type === 'feature')
+					.map(
+						(item) =>
+							(item as unknown as { _stats?: { compendiumSource?: string } })._stats
+								?.compendiumSource,
+					)
+					.filter((uuid): uuid is string => !!uuid),
+			);
+
+			// Filter out already-owned features from autoGrant
+			const filteredAutoGrant = rawFeatures.autoGrant.filter(
+				(feature) => !ownedFeatureUuids.has(feature.uuid),
+			);
+
+			// Filter out already-owned features from selection groups
+			const filteredSelectionGroups = new Map<string, NimbleFeatureItem[]>();
+			for (const [groupName, features] of rawFeatures.selectionGroups) {
+				const filteredFeatures = features.filter((feature) => !ownedFeatureUuids.has(feature.uuid));
+				// Only include groups that still have options
+				if (filteredFeatures.length > 0) {
+					filteredSelectionGroups.set(groupName, filteredFeatures);
+				}
+			}
+
+			classFeatures = {
+				autoGrant: filteredAutoGrant,
+				selectionGroups: filteredSelectionGroups,
+			};
+			featuresLoading = false;
+		});
+	});
+
+	// Derived completion checks
+	const classFeaturesComplete = $derived.by(() => {
+		if (featuresLoading) return false;
+		if (!classFeatures) return true;
+
+		for (const groupName of classFeatures.selectionGroups.keys()) {
+			if (!selectedClassFeatures.has(groupName)) {
+				return false;
+			}
+		}
+		return true;
+	});
+
+	const skillPointChangesAssigned = $derived.by(() => {
+		return Object.values(skillPointChanges).reduce((acc, change) => acc + (change ?? 0), 0) === 1;
+	});
+
+	// Reset skills when ability score selection changes
+	$effect(() => {
+		if (!lastSelectedAbilityScores) {
+			lastSelectedAbilityScores = selectedAbilityScores;
+			return;
+		}
+
+		const hasChangedAbilityScore = Array.isArray(selectedAbilityScores)
+			? JSON.stringify(lastSelectedAbilityScores) !== JSON.stringify(selectedAbilityScores)
+			: lastSelectedAbilityScores !== selectedAbilityScores;
+
+		if (hasChangedAbilityScore) {
+			skillPointChanges = generateBlankSkillSet();
+			lastSelectedAbilityScores = selectedAbilityScores;
+		}
+	});
+
+	const isComplete = $derived.by(() => {
+		const overMax = skillPointsOverMax;
+
+		const abilityScoreComplete =
+			(Array.isArray(selectedAbilityScores)
+				? selectedAbilityScores?.length === 2
+				: selectedAbilityScores) || !hasStatIncrease;
+
+		return (
+			abilityScoreComplete &&
+			skillPointChangesAssigned &&
+			!overMax &&
+			(selectedSubclass || !hasSubclassSelection) &&
+			(selectedEpicBoon || !hasEpicBoonSelection) &&
+			classFeaturesComplete
+		);
+	});
+
+	// Actions
+	function submit() {
+		getDialog().submit({
+			selectedAbilityScore: selectedAbilityScores,
+			selectedSubclass,
+			selectedEpicBoon,
+			skillPointChanges,
+			takeAverageHp: hitPointRollSelection === 'average',
+			classFeatures: classFeatures
+				? {
+						autoGrant: classFeatures.autoGrant,
+						selected: selectedClassFeatures,
+					}
+				: null,
+		});
+	}
+
+	function getSubmitButtonTooltip() {
+		if (!isComplete) {
+			if (skillPointsOverMax) {
+				return levelUpDialog.skillPointsOverMax;
+			} else {
+				return levelUpDialog.completeAllSelections;
+			}
+		}
+
+		return '';
+	}
+
+	function getSubmitButtonAriaLabel() {
+		if (!isComplete) {
+			if (skillPointsOverMax) {
+				return levelUpDialog.skillPointsOverMaxTooltip;
+			} else {
+				return levelUpDialog.completeAllSelectionsTooltip;
+			}
+		}
+
+		return forms.submit;
+	}
+
+	return {
+		boons,
+		get characterClass() {
+			return characterClass;
+		},
+		get levelingTo() {
+			return levelingTo;
+		},
+		get subclasses() {
+			return subclasses;
+		},
+		get hasSubclassSelection() {
+			return hasSubclassSelection;
+		},
+		get epicBoons() {
+			return epicBoons;
+		},
+		get hasEpicBoonSelection() {
+			return hasEpicBoonSelection;
+		},
+		get classFeatures() {
+			return classFeatures;
+		},
+		get featuresLoading() {
+			return featuresLoading;
+		},
+		get isComplete() {
+			return isComplete;
+		},
+		get chooseBoon() {
+			return chooseBoon;
+		},
+		set chooseBoon(v: boolean) {
+			chooseBoon = v;
+		},
+		get hitPointRollSelection() {
+			return hitPointRollSelection;
+		},
+		set hitPointRollSelection(v: string) {
+			hitPointRollSelection = v;
+		},
+		get selectedAbilityScores() {
+			return selectedAbilityScores;
+		},
+		set selectedAbilityScores(v: string[] | string | null) {
+			selectedAbilityScores = v;
+		},
+		get selectedBoon() {
+			return selectedBoon;
+		},
+		set selectedBoon(v: string | null) {
+			selectedBoon = v;
+		},
+		get selectedSubclass() {
+			return selectedSubclass;
+		},
+		set selectedSubclass(v: ExpandableDocumentItem | null) {
+			selectedSubclass = v;
+		},
+		get selectedEpicBoon() {
+			return selectedEpicBoon;
+		},
+		set selectedEpicBoon(v: ExpandableDocumentItem | null) {
+			selectedEpicBoon = v;
+		},
+		get skillPointChanges() {
+			return skillPointChanges;
+		},
+		set skillPointChanges(v: Record<string, null>) {
+			skillPointChanges = v;
+		},
+		get hasStatIncrease() {
+			return hasStatIncrease;
+		},
+		set hasStatIncrease(v: boolean) {
+			hasStatIncrease = v;
+		},
+		get skillPointsOverMax() {
+			return skillPointsOverMax;
+		},
+		set skillPointsOverMax(v: boolean) {
+			skillPointsOverMax = v;
+		},
+		get selectedClassFeatures() {
+			return selectedClassFeatures;
+		},
+		set selectedClassFeatures(v: Map<string, NimbleFeatureItem>) {
+			selectedClassFeatures = v;
+		},
+		submit,
+		getSubmitButtonTooltip,
+		getSubmitButtonAriaLabel,
+	};
+}

--- a/src/view/dialogs/CharacterLevelUpDialogState.svelte.ts
+++ b/src/view/dialogs/CharacterLevelUpDialogState.svelte.ts
@@ -1,6 +1,7 @@
 import type { NimbleFeatureItem } from '#documents/item/feature.js';
 import type { ClassFeatureResult } from '#types/components/ClassFeatureSelection.d.ts';
 import type { ExpandableDocumentItem } from '#types/components/ExpandableDocumentList.d.ts';
+import type { EpicBoonChoice, SubclassChoice } from '#types/components/LevelUpChoices.d.ts';
 
 import generateBlankSkillSet from '#utils/generateBlankSkillSet.ts';
 import getChoicesFromCompendium from '#utils/getChoicesFromCompendium.ts';
@@ -20,20 +21,6 @@ interface ClassItemShape {
 interface LevelUpDocument {
 	classes: Record<string, ClassItemShape | undefined>;
 	items: Array<{ type: string; _stats?: { compendiumSource?: string } }>;
-}
-
-interface SubclassChoice {
-	uuid: string;
-	name: string;
-	img: string;
-	system: { parentClass: string };
-}
-
-interface EpicBoonChoice {
-	uuid: string;
-	name: string;
-	img: string;
-	system: { boonType: string; description: string };
 }
 
 /**

--- a/src/view/dialogs/components/characterCreator/FeatureCard.svelte
+++ b/src/view/dialogs/components/characterCreator/FeatureCard.svelte
@@ -8,8 +8,23 @@
 
 	const state = createFeatureCardState(() => feature);
 
-	function handleSelect() {
+	// Whether this card is in selectable mode
+	const isSelectable = $derived(!!onSelect);
+
+	function handleRowClick() {
+		// Clicking the row always toggles expansion
+		state.toggleExpanded();
+	}
+
+	function handleSelectClick(e: MouseEvent) {
+		e.stopPropagation(); // Prevent row click from firing
 		onSelect?.();
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Enter') {
+			handleRowClick();
+		}
 	}
 </script>
 
@@ -17,14 +32,13 @@
 	<div
 		class="feature-row"
 		class:selected={isSelected}
+		class:selectable={isSelectable}
 		role="button"
 		tabindex="0"
-		onclick={state.toggleExpanded}
-		onkeydown={(e) => e.key === 'Enter' && state.toggleExpanded()}
+		onclick={handleRowClick}
+		onkeydown={handleKeydown}
 	>
-		{#if !isSelected}
-			<i class="fa-solid fa-chevron-down expand-arrow"></i>
-		{/if}
+		<i class="fa-solid fa-chevron-down expand-arrow"></i>
 
 		<img
 			class="feature-row__img"
@@ -36,14 +50,31 @@
 			{feature.name}
 		</h4>
 
-		<button
-			class="view-details-button"
-			onclick={state.viewDetails}
-			title="View Details"
-			aria-label="View {feature.name} details"
-		>
-			<i class="fa-solid fa-book-open"></i>
-		</button>
+		{#if isSelectable}
+			<div class="feature-row__actions">
+				<button
+					type="button"
+					class="select-button"
+					class:selected={isSelected}
+					onclick={handleSelectClick}
+					data-tooltip={isSelected
+						? localize('NIMBLE.classFeatureSelection.deselectFeature')
+						: localize('NIMBLE.classFeatureSelection.selectFeature')}
+					data-tooltip-direction="LEFT"
+					aria-label={isSelected
+						? localize('NIMBLE.classFeatureSelection.deselectFeatureAriaLabel', {
+								featureName: feature.name,
+							})
+						: localize('NIMBLE.classFeatureSelection.selectFeatureAriaLabel', {
+								featureName: feature.name,
+							})}
+				>
+					{#if isSelected}
+						<i class="fa-solid fa-check"></i>
+					{/if}
+				</button>
+			</div>
+		{/if}
 	</div>
 
 	<div class="accordion-content">
@@ -60,22 +91,6 @@
 				<p>{localize('NIMBLE.classFeatureSelection.noDescriptionAvailable')}</p>
 			{/if}
 		</div>
-
-		{#if onSelect}
-			<button
-				class="nimble-button"
-				data-button-variant="full-width"
-				type="button"
-				onclick={handleSelect}
-			>
-				{#if isSelected}
-					<i class="fa-solid fa-check"></i>
-					{localize('NIMBLE.classFeatureSelection.selected')}
-				{:else}
-					{localize('NIMBLE.classFeatureSelection.confirmSelection')}
-				{/if}
-			</button>
-		{/if}
 	</div>
 </li>
 
@@ -157,32 +172,57 @@
 			padding: 0;
 			line-height: 1;
 		}
+
+		.feature-row__actions {
+			display: flex;
+			align-items: center;
+			gap: 0.5rem;
+			margin-left: auto;
+		}
 	}
 
-	.view-details-button {
-		position: absolute;
-		top: 0.5rem;
-		right: 0.5rem;
-		width: 2rem;
-		height: 2rem;
+	.select-button {
+		width: 1.25rem;
+		min-width: 1.25rem;
+		max-width: 1.25rem;
+		height: 1.25rem;
+		min-height: 1.25rem;
+		max-height: 1.25rem;
+		padding: 0;
+		flex-shrink: 0;
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		background: var(--nimble-accent-color);
-		border: 1px solid var(--nimble-card-border-color);
-		border-radius: 4px;
-		color: var(--nimble-light-text-color);
+		background: color-mix(in srgb, var(--nimble-medium-text-color) 15%, transparent);
+		border: 2px solid color-mix(in srgb, var(--nimble-medium-text-color) 60%, transparent);
+		border-radius: 50%;
+		box-sizing: border-box;
+		color: transparent;
 		cursor: pointer;
 		transition: all 0.2s ease;
-		z-index: 1;
 
-		&:hover {
-			filter: brightness(1.2);
-			transform: scale(1.05);
+		&:hover:not(:disabled) {
+			border-color: color-mix(in srgb, var(--nimble-medium-text-color) 80%, transparent);
+			background: color-mix(in srgb, var(--nimble-medium-text-color) 35%, transparent);
+		}
+
+		&.selected {
+			background: var(--nimble-accent-color);
+			border-color: var(--nimble-accent-color);
+			color: #fff;
+
+			&:hover:not(:disabled) {
+				filter: brightness(1.15);
+			}
+		}
+
+		&:disabled {
+			opacity: 0.3;
+			cursor: not-allowed;
 		}
 
 		i {
-			font-size: 0.875rem;
+			font-size: 0.625rem;
 		}
 	}
 

--- a/src/view/dialogs/components/characterCreator/FeatureCard.svelte
+++ b/src/view/dialogs/components/characterCreator/FeatureCard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { FeatureCardProps } from '#types/components/ClassFeatureSelection.d.ts';
 	import { createFeatureCardState } from './FeatureCard.svelte.ts';
+	import SelectionIndicator from '#view/components/SelectionIndicator.svelte';
 	import SpellReferenceCard from './SpellReferenceCard.svelte';
 	import localize from '#utils/localize.js';
 
@@ -52,27 +53,20 @@
 
 		{#if isSelectable}
 			<div class="feature-row__actions">
-				<button
-					type="button"
-					class="select-button"
-					class:selected={isSelected}
+				<SelectionIndicator
+					selected={isSelected}
 					onclick={handleSelectClick}
-					data-tooltip={isSelected
+					tooltip={isSelected
 						? localize('NIMBLE.classFeatureSelection.deselectFeature')
 						: localize('NIMBLE.classFeatureSelection.selectFeature')}
-					data-tooltip-direction="LEFT"
-					aria-label={isSelected
+					ariaLabel={isSelected
 						? localize('NIMBLE.classFeatureSelection.deselectFeatureAriaLabel', {
 								featureName: feature.name,
 							})
 						: localize('NIMBLE.classFeatureSelection.selectFeatureAriaLabel', {
 								featureName: feature.name,
 							})}
-				>
-					{#if isSelected}
-						<i class="fa-solid fa-check"></i>
-					{/if}
-				</button>
+				/>
 			</div>
 		{/if}
 	</div>
@@ -178,51 +172,6 @@
 			align-items: center;
 			gap: 0.5rem;
 			margin-left: auto;
-		}
-	}
-
-	.select-button {
-		width: 1.25rem;
-		min-width: 1.25rem;
-		max-width: 1.25rem;
-		height: 1.25rem;
-		min-height: 1.25rem;
-		max-height: 1.25rem;
-		padding: 0;
-		flex-shrink: 0;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		background: color-mix(in srgb, var(--nimble-medium-text-color) 15%, transparent);
-		border: 2px solid color-mix(in srgb, var(--nimble-medium-text-color) 60%, transparent);
-		border-radius: 50%;
-		box-sizing: border-box;
-		color: transparent;
-		cursor: pointer;
-		transition: all 0.2s ease;
-
-		&:hover:not(:disabled) {
-			border-color: color-mix(in srgb, var(--nimble-medium-text-color) 80%, transparent);
-			background: color-mix(in srgb, var(--nimble-medium-text-color) 35%, transparent);
-		}
-
-		&.selected {
-			background: var(--nimble-accent-color);
-			border-color: var(--nimble-accent-color);
-			color: #fff;
-
-			&:hover:not(:disabled) {
-				filter: brightness(1.15);
-			}
-		}
-
-		&:disabled {
-			opacity: 0.3;
-			cursor: not-allowed;
-		}
-
-		i {
-			font-size: 0.625rem;
 		}
 	}
 

--- a/src/view/dialogs/components/characterCreator/FeatureCard.svelte.ts
+++ b/src/view/dialogs/components/characterCreator/FeatureCard.svelte.ts
@@ -131,11 +131,6 @@ export function createFeatureCardState(getFeature: () => NimbleFeatureItem) {
 		isExpanded = !isExpanded;
 	}
 
-	function viewDetails(event: MouseEvent) {
-		event.stopPropagation();
-		getFeature().sheet?.render(true);
-	}
-
 	return {
 		get isExpanded() {
 			return isExpanded;
@@ -144,6 +139,5 @@ export function createFeatureCardState(getFeature: () => NimbleFeatureItem) {
 			return descriptionParts;
 		},
 		toggleExpanded,
-		viewDetails,
 	};
 }

--- a/src/view/dialogs/components/characterCreator/FeatureGroupSelection.svelte
+++ b/src/view/dialogs/components/characterCreator/FeatureGroupSelection.svelte
@@ -8,6 +8,14 @@
 	let { groupName, features, selectedFeature, onSelect }: FeatureGroupSelectionProps = $props();
 
 	const state = createFeatureGroupSelectionState(() => ({ groupName, features }));
+
+	// Selection is complete when a feature is selected and it's not a single-option group
+	const isSelectionComplete = $derived(!!selectedFeature && !state.isSingleOption);
+
+	// Filter to show only selected feature when selection is complete
+	const displayedFeatures = $derived(
+		isSelectionComplete ? features.filter((f) => f.uuid === selectedFeature?.uuid) : features,
+	);
 </script>
 
 <div class="feature-group">
@@ -15,13 +23,13 @@
 		<h4 class="nimble-heading" data-heading-variant="section">
 			{state.formattedGroupName}
 		</h4>
-		{#if !state.isSingleOption}
+		{#if !state.isSingleOption && !isSelectionComplete}
 			<span class="feature-group__hint">{localize('NIMBLE.classFeatureSelection.chooseOne')}</span>
 		{/if}
 	</header>
 
 	<ul class="feature-group__list">
-		{#each features as feature (feature.uuid)}
+		{#each displayedFeatures as feature (feature.uuid)}
 			<FeatureCard
 				{feature}
 				isSelected={state.isSingleOption ? false : selectedFeature?.uuid === feature.uuid}

--- a/src/view/dialogs/components/characterCreator/SpellCard.svelte
+++ b/src/view/dialogs/components/characterCreator/SpellCard.svelte
@@ -1,47 +1,31 @@
 <script lang="ts">
 	import type { SpellCardProps } from '#types/components/SpellGrantDisplay.d.ts';
+
 	import SelectionIndicator from '#view/components/SelectionIndicator.svelte';
 	import localize from '#utils/localize.js';
 	import { createSpellCardState } from './SpellCard.svelte.ts';
 
 	let { spell, isSelected = false, isDisabled = false, onSelect }: SpellCardProps = $props();
 
-	const state = createSpellCardState(() => spell);
-
-	const tierLabel = $derived(
-		spell.tier === 0
-			? localize('NIMBLE.ui.heroicActions.cantrip')
-			: localize('NIMBLE.ui.heroicActions.spellTier', { tier: String(spell.tier) }),
+	const state = createSpellCardState(
+		() => spell,
+		() => onSelect,
+		() => isDisabled,
 	);
 
-	const schoolLabel = $derived(localize(CONFIG.NIMBLE.spellSchools[spell.school] ?? spell.school));
-
-	// Whether this card is in selectable mode
-	const isSelectable = $derived(!!onSelect);
-
-	function handleRowClick() {
-		// Clicking the row always toggles expansion
-		state.toggleExpanded();
-	}
-
-	function handleSelectClick(e: MouseEvent) {
-		e.stopPropagation(); // Prevent row click from firing
-		if (!isDisabled) {
-			onSelect?.();
-		}
-	}
-
-	function handleKeydown(e: KeyboardEvent) {
-		if (e.key === 'Enter') {
-			handleRowClick();
-		}
-	}
+	const { handleRowClick, handleSelectClick, handleKeydown } = state;
+	const isExpanded = $derived(state.isExpanded);
+	const isSelectable = $derived(state.isSelectable);
+	const tierLabel = $derived(state.tierLabel);
+	const schoolLabel = $derived(state.schoolLabel);
+	const isLoading = $derived(state.isLoading);
+	const enrichedDescription = $derived(state.enrichedDescription);
 </script>
 
 <li class="spell-item" class:disabled={isDisabled}>
 	<div
 		class="spell-row"
-		class:expanded={state.isExpanded}
+		class:expanded={isExpanded}
 		class:selected={isSelected}
 		class:selectable={isSelectable}
 		onclick={handleRowClick}
@@ -79,13 +63,13 @@
 		</div>
 	</div>
 
-	{#if state.isExpanded}
+	{#if isExpanded}
 		<div class="accordion-content">
 			<div class="description">
-				{#if state.isLoading}
+				{#if isLoading}
 					<p class="loading">{localize('NIMBLE.ui.loading')}</p>
-				{:else if state.enrichedDescription}
-					{@html state.enrichedDescription}
+				{:else if enrichedDescription}
+					{@html enrichedDescription}
 				{:else}
 					<p>{localize('NIMBLE.classFeatureSelection.noDescriptionAvailable')}</p>
 				{/if}

--- a/src/view/dialogs/components/characterCreator/SpellCard.svelte
+++ b/src/view/dialogs/components/characterCreator/SpellCard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { SpellCardProps } from '#types/components/SpellGrantDisplay.d.ts';
+	import SelectionIndicator from '#view/components/SelectionIndicator.svelte';
 	import localize from '#utils/localize.js';
 	import { createSpellCardState } from './SpellCard.svelte.ts';
 
@@ -63,24 +64,17 @@
 
 		<div class="spell-row__actions">
 			{#if isSelectable}
-				<button
-					type="button"
-					class="select-button"
-					class:selected={isSelected}
+				<SelectionIndicator
+					selected={isSelected}
 					onclick={handleSelectClick}
 					disabled={isDisabled}
-					data-tooltip={isSelected
+					tooltip={isSelected
 						? localize('NIMBLE.spellGrants.deselectSpell')
 						: localize('NIMBLE.spellGrants.selectSpell')}
-					data-tooltip-direction="LEFT"
-					aria-label={isSelected
+					ariaLabel={isSelected
 						? localize('NIMBLE.spellGrants.deselectSpellAriaLabel', { spellName: spell.name })
 						: localize('NIMBLE.spellGrants.selectSpellAriaLabel', { spellName: spell.name })}
-				>
-					{#if isSelected}
-						<i class="fa-solid fa-check"></i>
-					{/if}
-				</button>
+				/>
 			{/if}
 		</div>
 	</div>
@@ -187,51 +181,6 @@
 		align-items: center;
 		gap: 0.5rem;
 		margin-left: auto;
-	}
-
-	.select-button {
-		width: 1.25rem;
-		min-width: 1.25rem;
-		max-width: 1.25rem;
-		height: 1.25rem;
-		min-height: 1.25rem;
-		max-height: 1.25rem;
-		padding: 0;
-		flex-shrink: 0;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		background: color-mix(in srgb, var(--nimble-medium-text-color) 15%, transparent);
-		border: 2px solid color-mix(in srgb, var(--nimble-medium-text-color) 60%, transparent);
-		border-radius: 50%;
-		box-sizing: border-box;
-		color: transparent;
-		cursor: pointer;
-		transition: all 0.2s ease;
-
-		&:hover:not(:disabled) {
-			border-color: color-mix(in srgb, var(--nimble-medium-text-color) 80%, transparent);
-			background: color-mix(in srgb, var(--nimble-medium-text-color) 35%, transparent);
-		}
-
-		&.selected {
-			background: var(--nimble-accent-color);
-			border-color: var(--nimble-accent-color);
-			color: #fff;
-
-			&:hover:not(:disabled) {
-				filter: brightness(1.15);
-			}
-		}
-
-		&:disabled {
-			opacity: 0.3;
-			cursor: not-allowed;
-		}
-
-		i {
-			font-size: 0.625rem;
-		}
 	}
 
 	.accordion-content {

--- a/src/view/dialogs/components/characterCreator/SpellCard.svelte.ts
+++ b/src/view/dialogs/components/characterCreator/SpellCard.svelte.ts
@@ -1,4 +1,5 @@
 import type { SpellIndexEntry } from '#utils/getSpells.js';
+import localize from '#utils/localize.js';
 import enrichSpellText from '#utils/spellDescription.js';
 
 interface SpellDescriptionParts {
@@ -52,9 +53,15 @@ async function fetchSpellDescriptionByUuid(uuid: string): Promise<string> {
  * Creates reactive state for the SpellCard component
  *
  * @param getSpell - Getter function that returns the spell index entry
+ * @param getOnSelect - Optional getter for the select callback
+ * @param getIsDisabled - Optional getter for the disabled state
  * @returns Object containing state and actions for the spell card
  */
-export function createSpellCardState(getSpell: () => SpellIndexEntry) {
+export function createSpellCardState(
+	getSpell: () => SpellIndexEntry,
+	getOnSelect?: () => (() => void) | undefined,
+	getIsDisabled?: () => boolean,
+) {
 	let isExpanded = $state(false);
 	let enrichedDescription = $state<string>('');
 	let isLoading = $state(false);
@@ -79,6 +86,35 @@ export function createSpellCardState(getSpell: () => SpellIndexEntry) {
 		}
 	}
 
+	const tierLabel = $derived(
+		getSpell().tier === 0
+			? localize('NIMBLE.ui.heroicActions.cantrip')
+			: localize('NIMBLE.ui.heroicActions.spellTier', { tier: String(getSpell().tier) }),
+	);
+
+	const schoolLabel = $derived(
+		localize(CONFIG.NIMBLE.spellSchools[getSpell().school] ?? getSpell().school),
+	);
+
+	const isSelectable = $derived(!!getOnSelect?.());
+
+	function handleRowClick() {
+		toggleExpanded();
+	}
+
+	function handleSelectClick(e: MouseEvent) {
+		e.stopPropagation();
+		if (!getIsDisabled?.()) {
+			getOnSelect?.()?.();
+		}
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Enter') {
+			handleRowClick();
+		}
+	}
+
 	return {
 		get isExpanded() {
 			return isExpanded;
@@ -89,6 +125,18 @@ export function createSpellCardState(getSpell: () => SpellIndexEntry) {
 		get isLoading() {
 			return isLoading;
 		},
+		get tierLabel() {
+			return tierLabel;
+		},
+		get schoolLabel() {
+			return schoolLabel;
+		},
+		get isSelectable() {
+			return isSelectable;
+		},
 		toggleExpanded,
+		handleRowClick,
+		handleSelectClick,
+		handleKeydown,
 	};
 }

--- a/src/view/dialogs/components/levelUpHelper/EpicBoonSelection.svelte
+++ b/src/view/dialogs/components/levelUpHelper/EpicBoonSelection.svelte
@@ -1,0 +1,314 @@
+<script lang="ts">
+	import localize from '#utils/localize.js';
+
+	interface EpicBoon {
+		uuid: string;
+		name: string;
+		img: string;
+		system: { boonType: string; description: string };
+	}
+
+	interface Props {
+		epicBoons: EpicBoon[];
+		selectedEpicBoon: object | null;
+	}
+
+	let { epicBoons, selectedEpicBoon = $bindable() }: Props = $props();
+
+	let expandedBoonUuids: Set<string> = $state(new Set());
+	let expandedBoonDataMap: Map<string, { system?: { description?: string } }> = $state(new Map());
+
+	// Filter to show only selected boon when one is selected
+	const displayedBoons = $derived(
+		selectedEpicBoon
+			? epicBoons.filter((b) => b.uuid === (selectedEpicBoon as { uuid?: string }).uuid)
+			: epicBoons,
+	);
+
+	async function toggleExpanded(boonUuid: string) {
+		if (expandedBoonUuids.has(boonUuid)) {
+			expandedBoonUuids.delete(boonUuid);
+			expandedBoonUuids = new Set(expandedBoonUuids);
+			expandedBoonDataMap.delete(boonUuid);
+			expandedBoonDataMap = new Map(expandedBoonDataMap);
+		} else {
+			const boonData = await fromUuid(boonUuid);
+			expandedBoonUuids.add(boonUuid);
+			expandedBoonUuids = new Set(expandedBoonUuids);
+			expandedBoonDataMap.set(boonUuid, boonData as { system?: { description?: string } });
+			expandedBoonDataMap = new Map(expandedBoonDataMap);
+		}
+	}
+
+	async function handleSelectClick(boonUuid: string, event: MouseEvent) {
+		event.stopPropagation();
+
+		// If already selected, deselect
+		if ((selectedEpicBoon as { uuid?: string })?.uuid === boonUuid) {
+			selectedEpicBoon = null;
+		} else {
+			// Select this boon
+			selectedEpicBoon = await fromUuid(boonUuid);
+		}
+	}
+
+	function handleRowClick(boonUuid: string) {
+		toggleExpanded(boonUuid);
+	}
+
+	function handleKeydown(e: KeyboardEvent, boonUuid: string) {
+		if (e.key === 'Enter') {
+			handleRowClick(boonUuid);
+		}
+	}
+</script>
+
+<section class="epic-boon-selection">
+	<header>
+		<h3 class="nimble-heading" data-heading-variant="section">
+			{localize('NIMBLE.epicBoonSelection.header')}
+		</h3>
+		<p class="nimble-hint">{localize('NIMBLE.epicBoonSelection.hint')}</p>
+	</header>
+
+	{#if epicBoons.length > 0}
+		<ul class="nimble-document-list">
+			{#each displayedBoons as boon (boon.uuid)}
+				<li class="u-semantic-only boon-item">
+					<div
+						class="boon-row"
+						class:selected={boon.uuid === (selectedEpicBoon as { uuid?: string })?.uuid}
+						class:expanded={expandedBoonUuids.has(boon.uuid)}
+						onclick={() => handleRowClick(boon.uuid)}
+						role="button"
+						tabindex="0"
+						onkeydown={(e) => handleKeydown(e, boon.uuid)}
+					>
+						<i class="fa-solid fa-chevron-down expand-arrow"></i>
+
+						<img
+							class="boon-row__img"
+							src={boon.img || 'icons/svg/item-bag.svg'}
+							alt={boon.name}
+							onerror={() => {
+								boon.img = 'icons/svg/item-bag.svg';
+							}}
+						/>
+
+						<h4 class="boon-row__name nimble-heading" data-heading-variant="item">
+							{boon.name}
+						</h4>
+
+						<div class="boon-row__actions">
+							<button
+								type="button"
+								class="select-button"
+								class:selected={boon.uuid === (selectedEpicBoon as { uuid?: string })?.uuid}
+								onclick={(e) => handleSelectClick(boon.uuid, e)}
+								data-tooltip={boon.uuid === (selectedEpicBoon as { uuid?: string })?.uuid
+									? localize('NIMBLE.epicBoonSelection.deselectBoon')
+									: localize('NIMBLE.epicBoonSelection.selectBoon')}
+								data-tooltip-direction="LEFT"
+								aria-label={boon.uuid === (selectedEpicBoon as { uuid?: string })?.uuid
+									? localize('NIMBLE.epicBoonSelection.deselectBoonAriaLabel', {
+											boonName: boon.name,
+										})
+									: localize('NIMBLE.epicBoonSelection.selectBoonAriaLabel', {
+											boonName: boon.name,
+										})}
+							>
+								{#if boon.uuid === (selectedEpicBoon as { uuid?: string })?.uuid}
+									<i class="fa-solid fa-check"></i>
+								{/if}
+							</button>
+						</div>
+					</div>
+
+					{#if expandedBoonUuids.has(boon.uuid)}
+						<div class="accordion-content">
+							<div class="description">
+								{@html expandedBoonDataMap.get(boon.uuid)?.system?.description || 'Loading...'}
+							</div>
+						</div>
+					{/if}
+				</li>
+			{/each}
+		</ul>
+	{:else}
+		<p class="nimble-hint">
+			{localize('NIMBLE.epicBoonSelection.noBoons')}
+		</p>
+	{/if}
+</section>
+
+<style lang="scss">
+	.epic-boon-selection {
+		margin-top: 1rem;
+
+		.nimble-heading {
+			margin: 1rem 0 0.5rem 0;
+		}
+
+		.nimble-hint {
+			margin: 0 0 1rem 0;
+			font-size: var(--nimble-sm-text);
+			color: var(--nimble-medium-text-color);
+		}
+	}
+
+	.boon-item {
+		margin-bottom: 0.5rem;
+	}
+
+	.boon-row {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		height: 50px;
+		padding: 0.5rem;
+		position: relative;
+		cursor: pointer;
+		background: var(--nimble-box-background-color);
+		border: 1px solid var(--nimble-card-border-color);
+		border-radius: 4px;
+		transition: all 0.3s ease;
+
+		&:hover {
+			border-color: var(--nimble-accent-color);
+		}
+
+		&.selected {
+			border-color: var(--nimble-accent-color);
+			background: color-mix(
+				in srgb,
+				var(--nimble-accent-color) 10%,
+				var(--nimble-box-background-color)
+			);
+		}
+
+		&.expanded {
+			border-bottom-left-radius: 0;
+			border-bottom-right-radius: 0;
+
+			.expand-arrow {
+				transform: rotate(180deg);
+			}
+		}
+
+		.expand-arrow {
+			font-size: 0.875rem;
+			transition: transform 0.3s ease;
+			color: var(--nimble-medium-text-color);
+		}
+
+		.boon-row__img {
+			width: 36px;
+			height: 36px;
+			margin: 0;
+			padding: 0;
+			display: block;
+			border-radius: 4px;
+		}
+
+		.boon-row__name {
+			flex: 1;
+			margin: 0;
+			padding: 0;
+			line-height: 1;
+		}
+
+		.boon-row__actions {
+			display: flex;
+			align-items: center;
+			gap: 0.5rem;
+			margin-left: auto;
+		}
+	}
+
+	.select-button {
+		width: 1.25rem;
+		min-width: 1.25rem;
+		max-width: 1.25rem;
+		height: 1.25rem;
+		min-height: 1.25rem;
+		max-height: 1.25rem;
+		padding: 0;
+		flex-shrink: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: color-mix(in srgb, var(--nimble-medium-text-color) 15%, transparent);
+		border: 2px solid color-mix(in srgb, var(--nimble-medium-text-color) 60%, transparent);
+		border-radius: 50%;
+		box-sizing: border-box;
+		color: transparent;
+		cursor: pointer;
+		transition: all 0.2s ease;
+
+		&:hover:not(:disabled) {
+			border-color: color-mix(in srgb, var(--nimble-medium-text-color) 80%, transparent);
+			background: color-mix(in srgb, var(--nimble-medium-text-color) 35%, transparent);
+		}
+
+		&.selected {
+			background: var(--nimble-accent-color);
+			border-color: var(--nimble-accent-color);
+			color: #fff;
+
+			&:hover:not(:disabled) {
+				filter: brightness(1.15);
+			}
+		}
+
+		&:disabled {
+			opacity: 0.3;
+			cursor: not-allowed;
+		}
+
+		i {
+			font-size: 0.625rem;
+		}
+	}
+
+	.accordion-content {
+		background: transparent;
+		border: 1px solid var(--nimble-card-border-color);
+		border-top: none;
+		border-radius: 0 0 4px 4px;
+		padding: 0.5rem 0.75rem;
+		animation: slideDown 0.3s ease;
+
+		.description {
+			margin-bottom: 0;
+			max-height: 300px;
+			overflow-y: auto;
+			line-height: 1.5;
+
+			:global(h3) {
+				margin-top: 0.25rem;
+				margin-bottom: 0.25rem;
+				font-size: 0.95rem;
+				font-weight: 600;
+			}
+
+			:global(p) {
+				margin-bottom: 0.25rem;
+			}
+		}
+	}
+
+	@keyframes slideDown {
+		from {
+			opacity: 0;
+			max-height: 0;
+			padding-top: 0;
+			padding-bottom: 0;
+		}
+		to {
+			opacity: 1;
+			max-height: 400px;
+			padding-top: 0.5rem;
+			padding-bottom: 0.5rem;
+		}
+	}
+</style>

--- a/src/view/dialogs/components/levelUpHelper/EpicBoonSelection.svelte
+++ b/src/view/dialogs/components/levelUpHelper/EpicBoonSelection.svelte
@@ -1,65 +1,15 @@
 <script lang="ts">
-	import SelectionIndicator from '#view/components/SelectionIndicator.svelte';
+	import type { ExpandableDocumentItem } from '#types/components/ExpandableDocumentList.d.ts';
+
+	import ExpandableDocumentList from '#view/components/ExpandableDocumentList.svelte';
 	import localize from '#utils/localize.js';
 
-	interface EpicBoon {
-		uuid: string;
-		name: string;
-		img: string;
-		system: { boonType: string; description: string };
-	}
-
 	interface Props {
-		epicBoons: EpicBoon[];
-		selectedEpicBoon: EpicBoon | null;
+		epicBoons: ExpandableDocumentItem[];
+		selectedEpicBoon: ExpandableDocumentItem | null;
 	}
 
 	let { epicBoons, selectedEpicBoon = $bindable() }: Props = $props();
-
-	let expandedBoonUuids: Set<string> = $state(new Set());
-	let expandedBoonDataMap: Map<string, { system?: { description?: string } }> = $state(new Map());
-
-	// Filter to show only selected boon when one is selected
-	const displayedBoons = $derived(
-		selectedEpicBoon ? epicBoons.filter((b) => b.uuid === selectedEpicBoon.uuid) : epicBoons,
-	);
-
-	async function toggleExpanded(boonUuid: string) {
-		if (expandedBoonUuids.has(boonUuid)) {
-			expandedBoonUuids.delete(boonUuid);
-			expandedBoonUuids = new Set(expandedBoonUuids);
-			expandedBoonDataMap.delete(boonUuid);
-			expandedBoonDataMap = new Map(expandedBoonDataMap);
-		} else {
-			const boonData = await fromUuid(boonUuid);
-			expandedBoonUuids.add(boonUuid);
-			expandedBoonUuids = new Set(expandedBoonUuids);
-			expandedBoonDataMap.set(boonUuid, boonData as { system?: { description?: string } });
-			expandedBoonDataMap = new Map(expandedBoonDataMap);
-		}
-	}
-
-	async function handleSelectClick(boonUuid: string, event: MouseEvent) {
-		event.stopPropagation();
-
-		// If already selected, deselect
-		if (selectedEpicBoon?.uuid === boonUuid) {
-			selectedEpicBoon = null;
-		} else {
-			// Select this boon
-			selectedEpicBoon = await fromUuid(boonUuid);
-		}
-	}
-
-	function handleRowClick(boonUuid: string) {
-		toggleExpanded(boonUuid);
-	}
-
-	function handleKeydown(e: KeyboardEvent, boonUuid: string) {
-		if (e.key === 'Enter') {
-			handleRowClick(boonUuid);
-		}
-	}
 </script>
 
 <section class="epic-boon-selection">
@@ -71,61 +21,16 @@
 	</header>
 
 	{#if epicBoons.length > 0}
-		<ul class="nimble-document-list">
-			{#each displayedBoons as boon (boon.uuid)}
-				<li class="u-semantic-only boon-item">
-					<div
-						class="boon-row"
-						class:selected={boon.uuid === selectedEpicBoon?.uuid}
-						class:expanded={expandedBoonUuids.has(boon.uuid)}
-						onclick={() => handleRowClick(boon.uuid)}
-						role="button"
-						tabindex="0"
-						onkeydown={(e) => handleKeydown(e, boon.uuid)}
-					>
-						<i class="fa-solid fa-chevron-down expand-arrow"></i>
-
-						<img
-							class="boon-row__img"
-							src={boon.img || 'icons/svg/item-bag.svg'}
-							alt={boon.name}
-							onerror={() => {
-								boon.img = 'icons/svg/item-bag.svg';
-							}}
-						/>
-
-						<h4 class="boon-row__name nimble-heading" data-heading-variant="item">
-							{boon.name}
-						</h4>
-
-						<div class="boon-row__actions">
-							<SelectionIndicator
-								selected={boon.uuid === selectedEpicBoon?.uuid}
-								onclick={(e) => handleSelectClick(boon.uuid, e)}
-								tooltip={boon.uuid === selectedEpicBoon?.uuid
-									? localize('NIMBLE.epicBoonSelection.deselectBoon')
-									: localize('NIMBLE.epicBoonSelection.selectBoon')}
-								ariaLabel={boon.uuid === selectedEpicBoon?.uuid
-									? localize('NIMBLE.epicBoonSelection.deselectBoonAriaLabel', {
-											boonName: boon.name,
-										})
-									: localize('NIMBLE.epicBoonSelection.selectBoonAriaLabel', {
-											boonName: boon.name,
-										})}
-							/>
-						</div>
-					</div>
-
-					{#if expandedBoonUuids.has(boon.uuid)}
-						<div class="accordion-content">
-							<div class="description">
-								{@html expandedBoonDataMap.get(boon.uuid)?.system?.description || 'Loading...'}
-							</div>
-						</div>
-					{/if}
-				</li>
-			{/each}
-		</ul>
+		<ExpandableDocumentList
+			items={epicBoons}
+			bind:selectedItem={selectedEpicBoon}
+			selectTooltip={localize('NIMBLE.epicBoonSelection.selectBoon')}
+			deselectTooltip={localize('NIMBLE.epicBoonSelection.deselectBoon')}
+			selectAriaLabel={(name) =>
+				localize('NIMBLE.epicBoonSelection.selectBoonAriaLabel', { boonName: name })}
+			deselectAriaLabel={(name) =>
+				localize('NIMBLE.epicBoonSelection.deselectBoonAriaLabel', { boonName: name })}
+		/>
 	{:else}
 		<p class="nimble-hint">
 			{localize('NIMBLE.epicBoonSelection.noBoons')}
@@ -145,117 +50,6 @@
 			margin: 0 0 1rem 0;
 			font-size: var(--nimble-sm-text);
 			color: var(--nimble-medium-text-color);
-		}
-	}
-
-	.boon-item {
-		margin-bottom: 0.5rem;
-	}
-
-	.boon-row {
-		display: flex;
-		align-items: center;
-		gap: 0.75rem;
-		height: 50px;
-		padding: 0.5rem;
-		position: relative;
-		cursor: pointer;
-		background: var(--nimble-box-background-color);
-		border: 1px solid var(--nimble-card-border-color);
-		border-radius: 4px;
-		transition: all 0.3s ease;
-
-		&:hover {
-			border-color: var(--nimble-accent-color);
-		}
-
-		&.selected {
-			border-color: var(--nimble-accent-color);
-			background: color-mix(
-				in srgb,
-				var(--nimble-accent-color) 10%,
-				var(--nimble-box-background-color)
-			);
-		}
-
-		&.expanded {
-			border-bottom-left-radius: 0;
-			border-bottom-right-radius: 0;
-
-			.expand-arrow {
-				transform: rotate(180deg);
-			}
-		}
-
-		.expand-arrow {
-			font-size: 0.875rem;
-			transition: transform 0.3s ease;
-			color: var(--nimble-medium-text-color);
-		}
-
-		.boon-row__img {
-			width: 36px;
-			height: 36px;
-			margin: 0;
-			padding: 0;
-			display: block;
-			border-radius: 4px;
-		}
-
-		.boon-row__name {
-			flex: 1;
-			margin: 0;
-			padding: 0;
-			line-height: 1;
-		}
-
-		.boon-row__actions {
-			display: flex;
-			align-items: center;
-			gap: 0.5rem;
-			margin-left: auto;
-		}
-	}
-
-	.accordion-content {
-		background: transparent;
-		border: 1px solid var(--nimble-card-border-color);
-		border-top: none;
-		border-radius: 0 0 4px 4px;
-		padding: 0.5rem 0.75rem;
-		animation: slideDown 0.3s ease;
-
-		.description {
-			margin-bottom: 0;
-			max-height: 300px;
-			overflow-y: auto;
-			line-height: 1.5;
-
-			:global(h3) {
-				margin-top: 0.25rem;
-				margin-bottom: 0.25rem;
-				font-size: 0.95rem;
-				font-weight: 600;
-			}
-
-			:global(p) {
-				margin-bottom: 0.25rem;
-			}
-		}
-	}
-
-	@keyframes slideDown {
-		from {
-			opacity: 0;
-			max-height: 0;
-			padding-top: 0;
-			padding-bottom: 0;
-		}
-		to {
-			opacity: 1;
-			max-height: 400px;
-			padding-top: 0.5rem;
-			padding-bottom: 0.5rem;
 		}
 	}
 </style>

--- a/src/view/dialogs/components/levelUpHelper/EpicBoonSelection.svelte
+++ b/src/view/dialogs/components/levelUpHelper/EpicBoonSelection.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import SelectionIndicator from '#view/components/SelectionIndicator.svelte';
 	import localize from '#utils/localize.js';
 
 	interface EpicBoon {
@@ -10,7 +11,7 @@
 
 	interface Props {
 		epicBoons: EpicBoon[];
-		selectedEpicBoon: object | null;
+		selectedEpicBoon: EpicBoon | null;
 	}
 
 	let { epicBoons, selectedEpicBoon = $bindable() }: Props = $props();
@@ -20,9 +21,7 @@
 
 	// Filter to show only selected boon when one is selected
 	const displayedBoons = $derived(
-		selectedEpicBoon
-			? epicBoons.filter((b) => b.uuid === (selectedEpicBoon as { uuid?: string }).uuid)
-			: epicBoons,
+		selectedEpicBoon ? epicBoons.filter((b) => b.uuid === selectedEpicBoon.uuid) : epicBoons,
 	);
 
 	async function toggleExpanded(boonUuid: string) {
@@ -44,7 +43,7 @@
 		event.stopPropagation();
 
 		// If already selected, deselect
-		if ((selectedEpicBoon as { uuid?: string })?.uuid === boonUuid) {
+		if (selectedEpicBoon?.uuid === boonUuid) {
 			selectedEpicBoon = null;
 		} else {
 			// Select this boon
@@ -77,7 +76,7 @@
 				<li class="u-semantic-only boon-item">
 					<div
 						class="boon-row"
-						class:selected={boon.uuid === (selectedEpicBoon as { uuid?: string })?.uuid}
+						class:selected={boon.uuid === selectedEpicBoon?.uuid}
 						class:expanded={expandedBoonUuids.has(boon.uuid)}
 						onclick={() => handleRowClick(boon.uuid)}
 						role="button"
@@ -100,27 +99,20 @@
 						</h4>
 
 						<div class="boon-row__actions">
-							<button
-								type="button"
-								class="select-button"
-								class:selected={boon.uuid === (selectedEpicBoon as { uuid?: string })?.uuid}
+							<SelectionIndicator
+								selected={boon.uuid === selectedEpicBoon?.uuid}
 								onclick={(e) => handleSelectClick(boon.uuid, e)}
-								data-tooltip={boon.uuid === (selectedEpicBoon as { uuid?: string })?.uuid
+								tooltip={boon.uuid === selectedEpicBoon?.uuid
 									? localize('NIMBLE.epicBoonSelection.deselectBoon')
 									: localize('NIMBLE.epicBoonSelection.selectBoon')}
-								data-tooltip-direction="LEFT"
-								aria-label={boon.uuid === (selectedEpicBoon as { uuid?: string })?.uuid
+								ariaLabel={boon.uuid === selectedEpicBoon?.uuid
 									? localize('NIMBLE.epicBoonSelection.deselectBoonAriaLabel', {
 											boonName: boon.name,
 										})
 									: localize('NIMBLE.epicBoonSelection.selectBoonAriaLabel', {
 											boonName: boon.name,
 										})}
-							>
-								{#if boon.uuid === (selectedEpicBoon as { uuid?: string })?.uuid}
-									<i class="fa-solid fa-check"></i>
-								{/if}
-							</button>
+							/>
 						</div>
 					</div>
 
@@ -222,51 +214,6 @@
 			align-items: center;
 			gap: 0.5rem;
 			margin-left: auto;
-		}
-	}
-
-	.select-button {
-		width: 1.25rem;
-		min-width: 1.25rem;
-		max-width: 1.25rem;
-		height: 1.25rem;
-		min-height: 1.25rem;
-		max-height: 1.25rem;
-		padding: 0;
-		flex-shrink: 0;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		background: color-mix(in srgb, var(--nimble-medium-text-color) 15%, transparent);
-		border: 2px solid color-mix(in srgb, var(--nimble-medium-text-color) 60%, transparent);
-		border-radius: 50%;
-		box-sizing: border-box;
-		color: transparent;
-		cursor: pointer;
-		transition: all 0.2s ease;
-
-		&:hover:not(:disabled) {
-			border-color: color-mix(in srgb, var(--nimble-medium-text-color) 80%, transparent);
-			background: color-mix(in srgb, var(--nimble-medium-text-color) 35%, transparent);
-		}
-
-		&.selected {
-			background: var(--nimble-accent-color);
-			border-color: var(--nimble-accent-color);
-			color: #fff;
-
-			&:hover:not(:disabled) {
-				filter: brightness(1.15);
-			}
-		}
-
-		&:disabled {
-			opacity: 0.3;
-			cursor: not-allowed;
-		}
-
-		i {
-			font-size: 0.625rem;
 		}
 	}
 

--- a/src/view/dialogs/components/levelUpHelper/LevelUpClassFeatureSelection.svelte
+++ b/src/view/dialogs/components/levelUpHelper/LevelUpClassFeatureSelection.svelte
@@ -56,7 +56,7 @@
 				{localize('NIMBLE.classFeatureSelection.header')}
 			</h3>
 		</header>
-		<p class="nimble-hint">Loading features...</p>
+		<p class="nimble-hint">{localize('NIMBLE.levelUpDialog.loadingFeatures')}</p>
 	</section>
 {:else if hasAnyFeatures}
 	<section class="level-up-class-features">

--- a/src/view/dialogs/components/levelUpHelper/LevelUpClassFeatureSelection.svelte
+++ b/src/view/dialogs/components/levelUpHelper/LevelUpClassFeatureSelection.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-	import type { NimbleFeatureItem } from '#documents/item/feature.js';
 	import type { LevelUpClassFeatureSelectionProps } from '#types/components/ClassFeatureSelection.d.ts';
 
 	import FeatureCard from '../characterCreator/FeatureCard.svelte';
 	import FeatureGroupSelection from '../characterCreator/FeatureGroupSelection.svelte';
 	import Hint from '../../../components/Hint.svelte';
 	import localize from '#utils/localize.js';
+	import { createClassFeatureSelectionState } from './LevelUpClassFeatureSelection.svelte.ts';
 
 	let {
 		classFeatures,
@@ -13,40 +13,18 @@
 		loading = false,
 	}: LevelUpClassFeatureSelectionProps = $props();
 
-	// Auto-select features for groups that only have one option
-	$effect(() => {
-		if (!classFeatures?.selectionGroups) return;
+	const state = createClassFeatureSelectionState(
+		() => classFeatures,
+		() => selectedFeatures,
+		(features) => {
+			selectedFeatures = features;
+		},
+	);
 
-		const newSelections = new Map(selectedFeatures);
-		let hasChanges = false;
-
-		for (const [groupName, features] of classFeatures.selectionGroups) {
-			if (features.length === 1 && !newSelections.has(groupName)) {
-				newSelections.set(groupName, features[0]);
-				hasChanges = true;
-			}
-		}
-
-		if (hasChanges) {
-			selectedFeatures = newSelections;
-		}
-	});
-
-	function handleFeatureSelect(groupName: string, feature: NimbleFeatureItem) {
-		const newSelections = new Map(selectedFeatures);
-
-		if (newSelections.get(groupName)?.uuid === feature.uuid) {
-			newSelections.delete(groupName);
-		} else {
-			newSelections.set(groupName, feature);
-		}
-
-		selectedFeatures = newSelections;
-	}
-
-	const hasAutoGrant = $derived((classFeatures?.autoGrant?.length ?? 0) > 0);
-	const hasSelectionGroups = $derived((classFeatures?.selectionGroups?.size ?? 0) > 0);
-	const hasAnyFeatures = $derived(hasAutoGrant || hasSelectionGroups);
+	const { handleFeatureSelect } = state;
+	const hasAnyFeatures = $derived(state.hasAnyFeatures);
+	const hasAutoGrant = $derived(state.hasAutoGrant);
+	const hasSelectionGroups = $derived(state.hasSelectionGroups);
 </script>
 
 {#if loading}

--- a/src/view/dialogs/components/levelUpHelper/LevelUpClassFeatureSelection.svelte
+++ b/src/view/dialogs/components/levelUpHelper/LevelUpClassFeatureSelection.svelte
@@ -1,0 +1,107 @@
+<script lang="ts">
+	import type { NimbleFeatureItem } from '#documents/item/feature.js';
+	import type { LevelUpClassFeatureSelectionProps } from '#types/components/ClassFeatureSelection.d.ts';
+
+	import FeatureCard from '../characterCreator/FeatureCard.svelte';
+	import FeatureGroupSelection from '../characterCreator/FeatureGroupSelection.svelte';
+	import Hint from '../../../components/Hint.svelte';
+	import localize from '#utils/localize.js';
+
+	let {
+		classFeatures,
+		selectedFeatures = $bindable(),
+		loading = false,
+	}: LevelUpClassFeatureSelectionProps = $props();
+
+	// Auto-select features for groups that only have one option
+	$effect(() => {
+		if (!classFeatures?.selectionGroups) return;
+
+		const newSelections = new Map(selectedFeatures);
+		let hasChanges = false;
+
+		for (const [groupName, features] of classFeatures.selectionGroups) {
+			if (features.length === 1 && !newSelections.has(groupName)) {
+				newSelections.set(groupName, features[0]);
+				hasChanges = true;
+			}
+		}
+
+		if (hasChanges) {
+			selectedFeatures = newSelections;
+		}
+	});
+
+	function handleFeatureSelect(groupName: string, feature: NimbleFeatureItem) {
+		const newSelections = new Map(selectedFeatures);
+
+		if (newSelections.get(groupName)?.uuid === feature.uuid) {
+			newSelections.delete(groupName);
+		} else {
+			newSelections.set(groupName, feature);
+		}
+
+		selectedFeatures = newSelections;
+	}
+
+	const hasAutoGrant = $derived((classFeatures?.autoGrant?.length ?? 0) > 0);
+	const hasSelectionGroups = $derived((classFeatures?.selectionGroups?.size ?? 0) > 0);
+	const hasAnyFeatures = $derived(hasAutoGrant || hasSelectionGroups);
+</script>
+
+{#if loading}
+	<section class="level-up-class-features">
+		<header>
+			<h3 class="nimble-heading" data-heading-variant="section">
+				{localize('NIMBLE.classFeatureSelection.header')}
+			</h3>
+		</header>
+		<p class="nimble-hint">Loading features...</p>
+	</section>
+{:else if hasAnyFeatures}
+	<section class="level-up-class-features">
+		<header>
+			<h3 class="nimble-heading" data-heading-variant="section">
+				{localize('NIMBLE.classFeatureSelection.header')}
+			</h3>
+		</header>
+
+		<Hint hintText={localize('NIMBLE.levelUpDialog.featuresHint')} />
+
+		{#if hasAutoGrant}
+			<ul class="granted-features__list">
+				{#each classFeatures?.autoGrant ?? [] as feature (feature.uuid)}
+					<FeatureCard {feature} />
+				{/each}
+			</ul>
+		{/if}
+
+		{#if hasSelectionGroups}
+			{#each [...(classFeatures?.selectionGroups ?? [])] as [groupName, features] (groupName)}
+				<FeatureGroupSelection
+					{groupName}
+					{features}
+					selectedFeature={selectedFeatures.get(groupName) ?? null}
+					onSelect={(feature) => handleFeatureSelect(groupName, feature)}
+				/>
+			{/each}
+		{/if}
+	</section>
+{/if}
+
+<style lang="scss">
+	.level-up-class-features {
+		margin-top: 1rem;
+
+		.nimble-heading {
+			margin: 1rem 0 1rem 0;
+		}
+	}
+
+	.granted-features__list {
+		display: flex;
+		flex-direction: column;
+		margin: 0.5rem 0 0 0;
+		padding: 0;
+	}
+</style>

--- a/src/view/dialogs/components/levelUpHelper/LevelUpClassFeatureSelection.svelte.ts
+++ b/src/view/dialogs/components/levelUpHelper/LevelUpClassFeatureSelection.svelte.ts
@@ -1,0 +1,63 @@
+import type { NimbleFeatureItem } from '#documents/item/feature.js';
+import type { ClassFeatureResult } from '#types/components/ClassFeatureSelection.d.ts';
+
+/**
+ * Creates reactive state for the LevelUpClassFeatureSelection component.
+ *
+ * Handles auto-selection of single-option groups, feature toggling,
+ * and derived visibility flags.
+ */
+export function createClassFeatureSelectionState(
+	getClassFeatures: () => ClassFeatureResult | null,
+	getSelectedFeatures: () => Map<string, NimbleFeatureItem>,
+	setSelectedFeatures: (features: Map<string, NimbleFeatureItem>) => void,
+) {
+	// Auto-select features for groups that only have one option
+	$effect(() => {
+		const classFeatures = getClassFeatures();
+		if (!classFeatures?.selectionGroups) return;
+
+		const newSelections = new Map(getSelectedFeatures());
+		let hasChanges = false;
+
+		for (const [groupName, features] of classFeatures.selectionGroups) {
+			if (features.length === 1 && !newSelections.has(groupName)) {
+				newSelections.set(groupName, features[0]);
+				hasChanges = true;
+			}
+		}
+
+		if (hasChanges) {
+			setSelectedFeatures(newSelections);
+		}
+	});
+
+	function handleFeatureSelect(groupName: string, feature: NimbleFeatureItem) {
+		const newSelections = new Map(getSelectedFeatures());
+
+		if (newSelections.get(groupName)?.uuid === feature.uuid) {
+			newSelections.delete(groupName);
+		} else {
+			newSelections.set(groupName, feature);
+		}
+
+		setSelectedFeatures(newSelections);
+	}
+
+	const hasAutoGrant = $derived((getClassFeatures()?.autoGrant?.length ?? 0) > 0);
+	const hasSelectionGroups = $derived((getClassFeatures()?.selectionGroups?.size ?? 0) > 0);
+	const hasAnyFeatures = $derived(hasAutoGrant || hasSelectionGroups);
+
+	return {
+		get hasAutoGrant() {
+			return hasAutoGrant;
+		},
+		get hasSelectionGroups() {
+			return hasSelectionGroups;
+		},
+		get hasAnyFeatures() {
+			return hasAnyFeatures;
+		},
+		handleFeatureSelect,
+	};
+}

--- a/src/view/dialogs/components/levelUpHelper/SubclassSelection.svelte
+++ b/src/view/dialogs/components/levelUpHelper/SubclassSelection.svelte
@@ -1,48 +1,15 @@
-<script>
-	import SelectionIndicator from '#view/components/SelectionIndicator.svelte';
+<script lang="ts">
+	import type { ExpandableDocumentItem } from '#types/components/ExpandableDocumentList.d.ts';
+
+	import ExpandableDocumentList from '#view/components/ExpandableDocumentList.svelte';
 	import localize from '#utils/localize.js';
 
-	let { subclasses, selectedSubclass = $bindable() } = $props();
-
-	let expandedSubclassUuid = $state(null);
-	let expandedSubclassData = $state(null);
-
-	// Filter to show only selected subclass when one is selected
-	const displayedSubclasses = $derived(
-		selectedSubclass ? subclasses.filter((s) => s.uuid === selectedSubclass.uuid) : subclasses,
-	);
-
-	async function toggleExpanded(subclassUuid) {
-		if (expandedSubclassUuid === subclassUuid) {
-			expandedSubclassUuid = null;
-			expandedSubclassData = null;
-		} else {
-			expandedSubclassUuid = subclassUuid;
-			expandedSubclassData = await fromUuid(subclassUuid);
-		}
+	interface Props {
+		subclasses: ExpandableDocumentItem[];
+		selectedSubclass: ExpandableDocumentItem | null;
 	}
 
-	async function handleSelectClick(subclassUuid, event) {
-		event.stopPropagation();
-
-		// If already selected, deselect
-		if (selectedSubclass?.uuid === subclassUuid) {
-			selectedSubclass = null;
-		} else {
-			// Select this subclass
-			selectedSubclass = await fromUuid(subclassUuid);
-		}
-	}
-
-	function handleRowClick(subclassUuid) {
-		toggleExpanded(subclassUuid);
-	}
-
-	function handleKeydown(e, subclassUuid) {
-		if (e.key === 'Enter') {
-			handleRowClick(subclassUuid);
-		}
-	}
+	let { subclasses, selectedSubclass = $bindable() }: Props = $props();
 </script>
 
 <section class="subclass-selection">
@@ -51,61 +18,16 @@
 	</header>
 
 	{#if subclasses.length > 0}
-		<ul class="nimble-document-list">
-			{#each displayedSubclasses as subclass (subclass.uuid)}
-				<li class="u-semantic-only subclass-item">
-					<div
-						class="subclass-row"
-						class:selected={subclass.uuid === selectedSubclass?.uuid}
-						class:expanded={expandedSubclassUuid === subclass.uuid}
-						onclick={() => handleRowClick(subclass.uuid)}
-						role="button"
-						tabindex="0"
-						onkeydown={(e) => handleKeydown(e, subclass.uuid)}
-					>
-						<i class="fa-solid fa-chevron-down expand-arrow"></i>
-
-						<img
-							class="subclass-row__img"
-							src={subclass.img || 'icons/svg/item-bag.svg'}
-							alt={subclass.name}
-							onerror={(_e) => {
-								subclass.img = 'icons/svg/item-bag.svg';
-							}}
-						/>
-
-						<h4 class="subclass-row__name nimble-heading" data-heading-variant="item">
-							{subclass.name}
-						</h4>
-
-						<div class="subclass-row__actions">
-							<SelectionIndicator
-								selected={subclass.uuid === selectedSubclass?.uuid}
-								onclick={(e) => handleSelectClick(subclass.uuid, e)}
-								tooltip={subclass.uuid === selectedSubclass?.uuid
-									? localize('NIMBLE.subclassSelection.deselectSubclass')
-									: localize('NIMBLE.subclassSelection.selectSubclass')}
-								ariaLabel={subclass.uuid === selectedSubclass?.uuid
-									? localize('NIMBLE.subclassSelection.deselectSubclassAriaLabel', {
-											subclassName: subclass.name,
-										})
-									: localize('NIMBLE.subclassSelection.selectSubclassAriaLabel', {
-											subclassName: subclass.name,
-										})}
-							/>
-						</div>
-					</div>
-
-					{#if expandedSubclassUuid === subclass.uuid}
-						<div class="accordion-content">
-							<div class="description">
-								{@html expandedSubclassData?.system?.description || 'Loading...'}
-							</div>
-						</div>
-					{/if}
-				</li>
-			{/each}
-		</ul>
+		<ExpandableDocumentList
+			items={subclasses}
+			bind:selectedItem={selectedSubclass}
+			selectTooltip={localize('NIMBLE.subclassSelection.selectSubclass')}
+			deselectTooltip={localize('NIMBLE.subclassSelection.deselectSubclass')}
+			selectAriaLabel={(name) =>
+				localize('NIMBLE.subclassSelection.selectSubclassAriaLabel', { subclassName: name })}
+			deselectAriaLabel={(name) =>
+				localize('NIMBLE.subclassSelection.deselectSubclassAriaLabel', { subclassName: name })}
+		/>
 	{:else}
 		<p class="nimble-hint">
 			No subclasses available for this class. You may need to create or import subclass items.
@@ -119,117 +41,6 @@
 
 		.nimble-heading {
 			margin: 1rem 0 1rem 0;
-		}
-	}
-
-	.subclass-item {
-		margin-bottom: 0.5rem;
-	}
-
-	.subclass-row {
-		display: flex;
-		align-items: center;
-		gap: 0.75rem;
-		height: 50px;
-		padding: 0.5rem;
-		position: relative;
-		cursor: pointer;
-		background: var(--nimble-box-background-color);
-		border: 1px solid var(--nimble-card-border-color);
-		border-radius: 4px;
-		transition: all 0.3s ease;
-
-		&:hover {
-			border-color: var(--nimble-accent-color);
-		}
-
-		&.selected {
-			border-color: var(--nimble-accent-color);
-			background: color-mix(
-				in srgb,
-				var(--nimble-accent-color) 10%,
-				var(--nimble-box-background-color)
-			);
-		}
-
-		&.expanded {
-			border-bottom-left-radius: 0;
-			border-bottom-right-radius: 0;
-
-			.expand-arrow {
-				transform: rotate(180deg);
-			}
-		}
-
-		.expand-arrow {
-			font-size: 0.875rem;
-			transition: transform 0.3s ease;
-			color: var(--nimble-medium-text-color);
-		}
-
-		.subclass-row__img {
-			width: 36px;
-			height: 36px;
-			margin: 0;
-			padding: 0;
-			display: block;
-			border-radius: 4px;
-		}
-
-		.subclass-row__name {
-			flex: 1;
-			margin: 0;
-			padding: 0;
-			line-height: 1;
-		}
-
-		.subclass-row__actions {
-			display: flex;
-			align-items: center;
-			gap: 0.5rem;
-			margin-left: auto;
-		}
-	}
-
-	.accordion-content {
-		background: transparent;
-		border: 1px solid var(--nimble-card-border-color);
-		border-top: none;
-		border-radius: 0 0 4px 4px;
-		padding: 1rem;
-		animation: slideDown 0.3s ease;
-
-		.description {
-			margin-bottom: 1rem;
-			max-height: 300px;
-			overflow-y: auto;
-			line-height: 1.5;
-
-			:global(h3) {
-				margin-top: 0.5rem;
-				margin-bottom: 0.25rem;
-				font-size: 0.95rem;
-				font-weight: 600;
-			}
-
-			:global(p) {
-				margin-bottom: 0.5rem;
-			}
-		}
-	}
-
-	@keyframes slideDown {
-		from {
-			opacity: 0;
-			max-height: 0;
-			padding-top: 0;
-			padding-bottom: 0;
-		}
-		to {
-			opacity: 1;
-			max-height: 400px;
-			padding-top: 1rem;
-			padding-bottom: 1rem;
 		}
 	}
 </style>

--- a/src/view/dialogs/components/levelUpHelper/SubclassSelection.svelte
+++ b/src/view/dialogs/components/levelUpHelper/SubclassSelection.svelte
@@ -14,7 +14,9 @@
 
 <section class="subclass-selection">
 	<header>
-		<h3 class="nimble-heading" data-heading-variant="section">Subclass</h3>
+		<h3 class="nimble-heading" data-heading-variant="section">
+			{localize('NIMBLE.subclassSelection.header')}
+		</h3>
 	</header>
 
 	{#if subclasses.length > 0}
@@ -30,7 +32,7 @@
 		/>
 	{:else}
 		<p class="nimble-hint">
-			No subclasses available for this class. You may need to create or import subclass items.
+			{localize('NIMBLE.subclassSelection.noSubclasses')}
 		</p>
 	{/if}
 </section>

--- a/src/view/dialogs/components/levelUpHelper/SubclassSelection.svelte
+++ b/src/view/dialogs/components/levelUpHelper/SubclassSelection.svelte
@@ -1,8 +1,15 @@
 <script>
+	import localize from '#utils/localize.js';
+
 	let { subclasses, selectedSubclass = $bindable() } = $props();
 
 	let expandedSubclassUuid = $state(null);
 	let expandedSubclassData = $state(null);
+
+	// Filter to show only selected subclass when one is selected
+	const displayedSubclasses = $derived(
+		selectedSubclass ? subclasses.filter((s) => s.uuid === selectedSubclass.uuid) : subclasses,
+	);
 
 	async function toggleExpanded(subclassUuid) {
 		if (expandedSubclassUuid === subclassUuid) {
@@ -10,21 +17,30 @@
 			expandedSubclassData = null;
 		} else {
 			expandedSubclassUuid = subclassUuid;
-			selectedSubclass = null;
 			expandedSubclassData = await fromUuid(subclassUuid);
 		}
 	}
 
-	async function confirmSelection(subclassUuid) {
-		selectedSubclass = await fromUuid(subclassUuid);
-		expandedSubclassUuid = null;
-		expandedSubclassData = null;
+	async function handleSelectClick(subclassUuid, event) {
+		event.stopPropagation();
+
+		// If already selected, deselect
+		if (selectedSubclass?.uuid === subclassUuid) {
+			selectedSubclass = null;
+		} else {
+			// Select this subclass
+			selectedSubclass = await fromUuid(subclassUuid);
+		}
 	}
 
-	async function viewSubclass(subclassUuid, event) {
-		event.stopPropagation();
-		const subclass = await fromUuid(subclassUuid);
-		subclass?.sheet?.render(true);
+	function handleRowClick(subclassUuid) {
+		toggleExpanded(subclassUuid);
+	}
+
+	function handleKeydown(e, subclassUuid) {
+		if (e.key === 'Enter') {
+			handleRowClick(subclassUuid);
+		}
 	}
 </script>
 
@@ -35,60 +51,65 @@
 
 	{#if subclasses.length > 0}
 		<ul class="nimble-document-list">
-			{#each subclasses as subclass}
-				{#if subclass?.uuid === selectedSubclass?.uuid || !selectedSubclass}
-					<li class="u-semantic-only subclass-item">
-						<div
-							class="subclass-row"
-							class:selected={subclass?.uuid === selectedSubclass?.uuid}
-							class:expanded={expandedSubclassUuid === subclass.uuid}
-							onclick={() => toggleExpanded(subclass.uuid)}
-							role="button"
-							tabindex="0"
-							onkeydown={(e) => e.key === 'Enter' && toggleExpanded(subclass.uuid)}
-						>
-							{#if subclass?.uuid !== selectedSubclass?.uuid}
-								<i class="fa-solid fa-chevron-up expand-arrow"></i>
-							{/if}
-							<img
-								class="subclass-row__img"
-								src={subclass.img || 'icons/svg/item-bag.svg'}
-								alt={subclass.name}
-								onerror={(_e) => {
-									subclass.img = 'icons/svg/item-bag.svg';
-								}}
-							/>
+			{#each displayedSubclasses as subclass (subclass.uuid)}
+				<li class="u-semantic-only subclass-item">
+					<div
+						class="subclass-row"
+						class:selected={subclass.uuid === selectedSubclass?.uuid}
+						class:expanded={expandedSubclassUuid === subclass.uuid}
+						onclick={() => handleRowClick(subclass.uuid)}
+						role="button"
+						tabindex="0"
+						onkeydown={(e) => handleKeydown(e, subclass.uuid)}
+					>
+						<i class="fa-solid fa-chevron-down expand-arrow"></i>
 
-							<h4 class="subclass-row__name nimble-heading" data-heading-variant="item">
-								{subclass.name}
-							</h4>
+						<img
+							class="subclass-row__img"
+							src={subclass.img || 'icons/svg/item-bag.svg'}
+							alt={subclass.name}
+							onerror={(_e) => {
+								subclass.img = 'icons/svg/item-bag.svg';
+							}}
+						/>
+
+						<h4 class="subclass-row__name nimble-heading" data-heading-variant="item">
+							{subclass.name}
+						</h4>
+
+						<div class="subclass-row__actions">
 							<button
-								class="view-details-button"
-								onclick={(e) => viewSubclass(subclass.uuid, e)}
-								title="View Details"
-								aria-label="View {subclass.name} details"
+								type="button"
+								class="select-button"
+								class:selected={subclass.uuid === selectedSubclass?.uuid}
+								onclick={(e) => handleSelectClick(subclass.uuid, e)}
+								data-tooltip={subclass.uuid === selectedSubclass?.uuid
+									? localize('NIMBLE.subclassSelection.deselectSubclass')
+									: localize('NIMBLE.subclassSelection.selectSubclass')}
+								data-tooltip-direction="LEFT"
+								aria-label={subclass.uuid === selectedSubclass?.uuid
+									? localize('NIMBLE.subclassSelection.deselectSubclassAriaLabel', {
+											subclassName: subclass.name,
+										})
+									: localize('NIMBLE.subclassSelection.selectSubclassAriaLabel', {
+											subclassName: subclass.name,
+										})}
 							>
-								<i class="fa-solid fa-book-open"></i>
+								{#if subclass.uuid === selectedSubclass?.uuid}
+									<i class="fa-solid fa-check"></i>
+								{/if}
 							</button>
 						</div>
+					</div>
 
-						{#if expandedSubclassUuid === subclass.uuid}
-							<div class="accordion-content">
-								<div class="description">
-									{@html expandedSubclassData?.system?.description || 'Loading...'}
-								</div>
-								<button
-									class="nimble-button"
-									data-button-variant="full-width"
-									type="button"
-									onclick={(e) => confirmSelection(subclass.uuid, e)}
-								>
-									Confirm Selection
-								</button>
+					{#if expandedSubclassUuid === subclass.uuid}
+						<div class="accordion-content">
+							<div class="description">
+								{@html expandedSubclassData?.system?.description || 'Loading...'}
 							</div>
-						{/if}
-					</li>
-				{/if}
+						</div>
+					{/if}
+				</li>
 			{/each}
 		</ul>
 	{:else}
@@ -167,32 +188,57 @@
 			padding: 0;
 			line-height: 1;
 		}
+
+		.subclass-row__actions {
+			display: flex;
+			align-items: center;
+			gap: 0.5rem;
+			margin-left: auto;
+		}
 	}
 
-	.view-details-button {
-		position: absolute;
-		top: 0.5rem;
-		right: 0.5rem;
-		width: 2rem;
-		height: 2rem;
+	.select-button {
+		width: 1.25rem;
+		min-width: 1.25rem;
+		max-width: 1.25rem;
+		height: 1.25rem;
+		min-height: 1.25rem;
+		max-height: 1.25rem;
+		padding: 0;
+		flex-shrink: 0;
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		background: var(--nimble-accent-color);
-		border: 1px solid var(--nimble-card-border-color);
-		border-radius: 4px;
-		color: var(--nimble-light-text-color);
+		background: color-mix(in srgb, var(--nimble-medium-text-color) 15%, transparent);
+		border: 2px solid color-mix(in srgb, var(--nimble-medium-text-color) 60%, transparent);
+		border-radius: 50%;
+		box-sizing: border-box;
+		color: transparent;
 		cursor: pointer;
 		transition: all 0.2s ease;
-		z-index: 1;
 
-		&:hover {
-			filter: brightness(1.2);
-			transform: scale(1.05);
+		&:hover:not(:disabled) {
+			border-color: color-mix(in srgb, var(--nimble-medium-text-color) 80%, transparent);
+			background: color-mix(in srgb, var(--nimble-medium-text-color) 35%, transparent);
+		}
+
+		&.selected {
+			background: var(--nimble-accent-color);
+			border-color: var(--nimble-accent-color);
+			color: #fff;
+
+			&:hover:not(:disabled) {
+				filter: brightness(1.15);
+			}
+		}
+
+		&:disabled {
+			opacity: 0.3;
+			cursor: not-allowed;
 		}
 
 		i {
-			font-size: 0.875rem;
+			font-size: 0.625rem;
 		}
 	}
 

--- a/src/view/dialogs/components/levelUpHelper/SubclassSelection.svelte
+++ b/src/view/dialogs/components/levelUpHelper/SubclassSelection.svelte
@@ -1,4 +1,5 @@
 <script>
+	import SelectionIndicator from '#view/components/SelectionIndicator.svelte';
 	import localize from '#utils/localize.js';
 
 	let { subclasses, selectedSubclass = $bindable() } = $props();
@@ -78,27 +79,20 @@
 						</h4>
 
 						<div class="subclass-row__actions">
-							<button
-								type="button"
-								class="select-button"
-								class:selected={subclass.uuid === selectedSubclass?.uuid}
+							<SelectionIndicator
+								selected={subclass.uuid === selectedSubclass?.uuid}
 								onclick={(e) => handleSelectClick(subclass.uuid, e)}
-								data-tooltip={subclass.uuid === selectedSubclass?.uuid
+								tooltip={subclass.uuid === selectedSubclass?.uuid
 									? localize('NIMBLE.subclassSelection.deselectSubclass')
 									: localize('NIMBLE.subclassSelection.selectSubclass')}
-								data-tooltip-direction="LEFT"
-								aria-label={subclass.uuid === selectedSubclass?.uuid
+								ariaLabel={subclass.uuid === selectedSubclass?.uuid
 									? localize('NIMBLE.subclassSelection.deselectSubclassAriaLabel', {
 											subclassName: subclass.name,
 										})
 									: localize('NIMBLE.subclassSelection.selectSubclassAriaLabel', {
 											subclassName: subclass.name,
 										})}
-							>
-								{#if subclass.uuid === selectedSubclass?.uuid}
-									<i class="fa-solid fa-check"></i>
-								{/if}
-							</button>
+							/>
 						</div>
 					</div>
 
@@ -194,51 +188,6 @@
 			align-items: center;
 			gap: 0.5rem;
 			margin-left: auto;
-		}
-	}
-
-	.select-button {
-		width: 1.25rem;
-		min-width: 1.25rem;
-		max-width: 1.25rem;
-		height: 1.25rem;
-		min-height: 1.25rem;
-		max-height: 1.25rem;
-		padding: 0;
-		flex-shrink: 0;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		background: color-mix(in srgb, var(--nimble-medium-text-color) 15%, transparent);
-		border: 2px solid color-mix(in srgb, var(--nimble-medium-text-color) 60%, transparent);
-		border-radius: 50%;
-		box-sizing: border-box;
-		color: transparent;
-		cursor: pointer;
-		transition: all 0.2s ease;
-
-		&:hover:not(:disabled) {
-			border-color: color-mix(in srgb, var(--nimble-medium-text-color) 80%, transparent);
-			background: color-mix(in srgb, var(--nimble-medium-text-color) 35%, transparent);
-		}
-
-		&.selected {
-			background: var(--nimble-accent-color);
-			border-color: var(--nimble-accent-color);
-			color: #fff;
-
-			&:hover:not(:disabled) {
-				filter: brightness(1.15);
-			}
-		}
-
-		&:disabled {
-			opacity: 0.3;
-			cursor: not-allowed;
-		}
-
-		i {
-			font-size: 0.625rem;
 		}
 	}
 

--- a/src/view/dialogs/const/levelUpConstants.ts
+++ b/src/view/dialogs/const/levelUpConstants.ts
@@ -1,5 +1,8 @@
 /** Subclass is chosen when leveling to this class level */
 export const SUBCLASS_LEVEL = 3;
 
-/** Epic boon is chosen when leveling to this class level (Nimble class rule) */
+/**
+ * Epic boon is chosen when leveling to this class level.
+ * Per Nimble's rules, all classes gain an epic boon at level 19.
+ */
 export const EPIC_BOON_LEVEL = 19;

--- a/src/view/dialogs/const/levelUpConstants.ts
+++ b/src/view/dialogs/const/levelUpConstants.ts
@@ -1,0 +1,5 @@
+/** Subclass is chosen when leveling to this class level */
+export const SUBCLASS_LEVEL = 3;
+
+/** Epic boon is chosen when leveling to this class level (Nimble class rule) */
+export const EPIC_BOON_LEVEL = 19;

--- a/tests/mocks/foundry.ts
+++ b/tests/mocks/foundry.ts
@@ -641,7 +641,9 @@ export function createGameMock(langData: any) {
 				// Yield mock subclasses for testing
 				yield {
 					type: 'subclass',
+					uuid: 'Item.mock-subclass-mountainheart',
 					name: 'Path of the Mountainheart',
+					img: 'icons/svg/item-bag.svg',
 					system: {
 						parentClass: 'warrior',
 						identifier: 'path-of-the-mountainheart',
@@ -649,7 +651,9 @@ export function createGameMock(langData: any) {
 				};
 				yield {
 					type: 'subclass',
+					uuid: 'Item.mock-subclass-storm',
 					name: 'Path of the Storm',
+					img: 'icons/svg/item-bag.svg',
 					system: {
 						parentClass: 'warrior',
 						identifier: 'path-of-the-storm',

--- a/types/components/CharacterLevelDownDialog.d.ts
+++ b/types/components/CharacterLevelDownDialog.d.ts
@@ -1,0 +1,7 @@
+import type { NimbleCharacter } from '#documents/actor/character.js';
+import type GenericDialog from '#documents/dialogs/GenericDialog.svelte.js';
+
+export interface CharacterLevelDownDialogProps {
+	document: NimbleCharacter;
+	dialog: GenericDialog;
+}

--- a/types/components/CharacterLevelUpDialog.d.ts
+++ b/types/components/CharacterLevelUpDialog.d.ts
@@ -3,23 +3,11 @@ import type { NimbleFeatureItem } from '#documents/item/feature.js';
 import type { ExpandableDocumentItem } from './ExpandableDocumentList.d.ts';
 import type GenericDialog from '#documents/dialogs/GenericDialog.svelte.js';
 
+export type { SubclassChoice, EpicBoonChoice } from './LevelUpChoices.d.ts';
+
 export interface CharacterLevelUpDialogProps {
 	document: NimbleCharacter;
 	dialog: GenericDialog;
-}
-
-export interface SubclassChoice {
-	uuid: string;
-	name: string;
-	img: string;
-	system: { parentClass: string };
-}
-
-export interface EpicBoonChoice {
-	uuid: string;
-	name: string;
-	img: string;
-	system: { boonType: string; description: string };
 }
 
 export interface LevelUpSubmitData {

--- a/types/components/CharacterLevelUpDialog.d.ts
+++ b/types/components/CharacterLevelUpDialog.d.ts
@@ -1,0 +1,35 @@
+import type { NimbleCharacter } from '#documents/actor/character.js';
+import type { NimbleFeatureItem } from '#documents/item/feature.js';
+import type { ExpandableDocumentItem } from './ExpandableDocumentList.d.ts';
+import type GenericDialog from '#documents/dialogs/GenericDialog.svelte.js';
+
+export interface CharacterLevelUpDialogProps {
+	document: NimbleCharacter;
+	dialog: GenericDialog;
+}
+
+export interface SubclassChoice {
+	uuid: string;
+	name: string;
+	img: string;
+	system: { parentClass: string };
+}
+
+export interface EpicBoonChoice {
+	uuid: string;
+	name: string;
+	img: string;
+	system: { boonType: string; description: string };
+}
+
+export interface LevelUpSubmitData {
+	selectedAbilityScore: string[] | string | null;
+	selectedSubclass: ExpandableDocumentItem | null;
+	selectedEpicBoon: ExpandableDocumentItem | null;
+	skillPointChanges: Record<string, number | null>;
+	takeAverageHp: boolean;
+	classFeatures: {
+		autoGrant: NimbleFeatureItem[];
+		selected: Map<string, NimbleFeatureItem>;
+	} | null;
+}

--- a/types/components/ClassFeatureSelection.d.ts
+++ b/types/components/ClassFeatureSelection.d.ts
@@ -24,6 +24,12 @@ export interface FeatureGroupSelectionProps {
 	onSelect: (feature: NimbleFeatureItem) => void;
 }
 
+export interface LevelUpClassFeatureSelectionProps {
+	classFeatures: ClassFeatureResult | null;
+	selectedFeatures: Map<string, NimbleFeatureItem>;
+	loading?: boolean;
+}
+
 /**
  * Represents a part of a feature description after parsing
  */

--- a/types/components/ExpandableDocumentList.d.ts
+++ b/types/components/ExpandableDocumentList.d.ts
@@ -1,0 +1,14 @@
+export interface ExpandableDocumentItem {
+	uuid: string;
+	name: string;
+	img: string;
+}
+
+export interface ExpandableDocumentListProps {
+	items: ExpandableDocumentItem[];
+	selectedItem: ExpandableDocumentItem | null;
+	selectTooltip: string;
+	deselectTooltip: string;
+	selectAriaLabel: (itemName: string) => string;
+	deselectAriaLabel: (itemName: string) => string;
+}

--- a/types/components/LevelUpChoices.d.ts
+++ b/types/components/LevelUpChoices.d.ts
@@ -1,0 +1,13 @@
+export interface SubclassChoice {
+	uuid: string;
+	name: string;
+	img: string;
+	system: { parentClass: string };
+}
+
+export interface EpicBoonChoice {
+	uuid: string;
+	name: string;
+	img: string;
+	system: { boonType: string; description: string };
+}

--- a/types/components/SelectionIndicator.d.ts
+++ b/types/components/SelectionIndicator.d.ts
@@ -1,0 +1,7 @@
+export interface SelectionIndicatorProps {
+	selected: boolean;
+	onclick: (e: MouseEvent) => void;
+	tooltip: string;
+	ariaLabel: string;
+	disabled?: boolean;
+}


### PR DESCRIPTION
## Summary
- Grant class features automatically when leveling up
- Remove granted class features when leveling down
- Add epic boon selection when leveling up to level 19
- Improve level down dialog to show features that will be removed

## Changes
- **Class Feature Grants**: Class features are now automatically granted as embedded documents when leveling up. Features are tracked in level up history and removed when leveling down.
- **Epic Boon Selection**: At level 19, players can select an epic boon from the available options. The selected boon is granted and tracked for removal on level down.
- **Level Down Dialog**: Now displays features that were granted at that level and will be removed. Reduced red styling to only the warning message and confirm button.
- **New Components**: `EpicBoonSelection.svelte`, `LevelUpClassFeatureSelection.svelte`, `getEpicBoons.ts` utility

## Test plan
- [x] Level up a character and verify class features are granted
- [x] Level down and verify the granted features are removed
- [x] Level up a character to level 19 and verify epic boon selection appears
- [x] Select an epic boon and complete level up - verify boon is added to character
- [x] Level down from 19 and verify the epic boon is removed
- [x] Level down dialog shows features being removed without excessive red styling
- [x] Multiple accordions can be expanded simultaneously in epic boon selection