### PR TITLE
fix: clean up level-up/level-down dialog state and grant logic

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -26,6 +26,13 @@ const abilityScores: Record<AbilityKeyType, string> = {
 	will: 'NIMBLE.abilityScores.will',
 };
 
+const abilities: Record<AbilityKeyType, { label: string }> = {
+	strength: { label: 'NIMBLE.abilityScores.strength' },
+	dexterity: { label: 'NIMBLE.abilityScores.dexterity' },
+	intelligence: { label: 'NIMBLE.abilityScores.intelligence' },
+	will: { label: 'NIMBLE.abilityScores.will' },
+};
+
 const abilityScoreAbbreviations: Record<AbilityKeyType, string> = {
 	strength: 'NIMBLE.abilityScoreAbbreviations.strength',
 	dexterity: 'NIMBLE.abilityScoreAbbreviations.dexterity',
@@ -849,6 +856,7 @@ const NIMBLE = {
 	ROLL_MODE,
 
 	// Config
+	abilities,
 	abilityScoreAbbreviations,
 	abilityScoreControls,
 	abilityScores,

--- a/src/documents/actor/character.ts
+++ b/src/documents/actor/character.ts
@@ -1240,42 +1240,36 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 			}
 		}
 
-		// Create feature documents from autoGrant and selected features
-		let grantedFeatureIds: string[] = [];
+		// Build a single list of items to grant (class features + epic boon)
+		const itemsToGrant: { toObject(): object; uuid: string }[] = [];
 
 		if (typedDialogData.classFeatures) {
-			const featuresToGrant: NimbleFeatureItem[] = [
+			itemsToGrant.push(
 				...typedDialogData.classFeatures.autoGrant,
 				...typedDialogData.classFeatures.selected.values(),
-			];
-
-			if (featuresToGrant.length > 0) {
-				const featureDocumentSources = featuresToGrant.map((feature) => {
-					const featureData = feature.toObject();
-					(featureData as { _stats: { compendiumSource?: string } })._stats.compendiumSource =
-						feature.uuid;
-					return featureData;
-				});
-
-				const createdFeatures = await this.createEmbeddedDocuments('Item', featureDocumentSources);
-				grantedFeatureIds = (createdFeatures ?? [])
-					.map((f) => f.id)
-					.filter((id): id is string => id !== null);
-			}
+			);
 		}
 
-		// Grant epic boon at level 19
-		const epicBoon = typedDialogData.selectedEpicBoon;
-		if (epicBoon) {
-			const boonData = epicBoon.toObject();
-			(boonData as { _stats: { compendiumSource?: string } })._stats.compendiumSource =
-				epicBoon.uuid;
+		if (typedDialogData.selectedEpicBoon) {
+			itemsToGrant.push(typedDialogData.selectedEpicBoon);
+		}
 
-			const createdBoons = await this.createEmbeddedDocuments('Item', [boonData]);
-			const boonIds = (createdBoons ?? [])
-				.map((b) => b.id)
+		let grantedFeatureIds: string[] = [];
+
+		if (itemsToGrant.length > 0) {
+			const documentSources = itemsToGrant.map((item) => {
+				const data = item.toObject();
+				(data as { _stats: { compendiumSource?: string } })._stats.compendiumSource = item.uuid;
+				return data;
+			});
+
+			const created = await this.createEmbeddedDocuments(
+				'Item',
+				documentSources as Parameters<typeof this.createEmbeddedDocuments>[1],
+			);
+			grantedFeatureIds = (created ?? [])
+				.map((item) => item.id)
 				.filter((id): id is string => id !== null);
-			grantedFeatureIds = [...grantedFeatureIds, ...boonIds];
 		}
 
 		// Record level up history

--- a/src/utils/generateBlankSkillSet.ts
+++ b/src/utils/generateBlankSkillSet.ts
@@ -6,6 +6,6 @@ export default function generateBlankSkillSet() {
 			acc[skillKey] = null;
 			return acc;
 		},
-		{} as Record<string, null>,
+		{} as Record<string, number | null>,
 	);
 }

--- a/src/utils/getEpicBoons.ts
+++ b/src/utils/getEpicBoons.ts
@@ -18,7 +18,7 @@ export default async function getEpicBoons(): Promise<EpicBoonChoice[]> {
 	for (const item of game.items) {
 		if (item.type !== 'boon') continue;
 
-		const boon = item as object as NimbleBoonItem;
+		const boon = item as unknown as NimbleBoonItem;
 		if (boon.system.boonType !== 'epic') continue;
 
 		epicBoons.push({
@@ -36,14 +36,14 @@ export default async function getEpicBoons(): Promise<EpicBoonChoice[]> {
 	for (const pack of game.packs) {
 		// Skip packs that have no boon-type entries in the index
 		const hasBoons = [...pack.index].some(
-			(entry) => (entry as object as { type?: string }).type === 'boon',
+			(entry) => (entry as unknown as { type?: string }).type === 'boon',
 		);
 		if (!hasBoons) continue;
 
 		try {
 			const documents = (await pack.getDocuments({
 				type: 'boon',
-			})) as object as NimbleBoonItem[];
+			})) as unknown as NimbleBoonItem[];
 
 			for (const boon of documents) {
 				if (boon.system.boonType !== 'epic') continue;

--- a/src/view/dialogs/CharacterLevelDownDialogState.svelte.ts
+++ b/src/view/dialogs/CharacterLevelDownDialogState.svelte.ts
@@ -62,8 +62,7 @@ export function createLevelDownState(
 		Object.entries(lastHistory?.abilityIncreases ?? {})
 			.filter(([, value]) => (value as number) > 0)
 			.map(([key, value]) => ({
-				// @ts-expect-error — abilities config exists at runtime but isn't in the type declarations
-				name: (CONFIG.NIMBLE.abilities[key]?.label as string) ?? key,
+				name: CONFIG.NIMBLE.abilities[key]?.label ?? key,
 				points: value as number,
 			})),
 	);

--- a/src/view/dialogs/CharacterLevelUpDialogState.svelte.ts
+++ b/src/view/dialogs/CharacterLevelUpDialogState.svelte.ts
@@ -99,7 +99,10 @@ export function createLevelUpState(
 
 	// Load class features when dialog opens
 	$effect(() => {
-		if (!characterClass) return;
+		if (!characterClass) {
+			featuresLoading = false;
+			return;
+		}
 
 		featuresLoading = true;
 		buildClassFeatureIndex()
@@ -165,7 +168,9 @@ export function createLevelUpState(
 	});
 
 	const skillPointChangesAssigned = $derived.by(() => {
-		return Object.values(skillPointChanges).reduce((acc, change) => acc + (change ?? 0), 0) === 1;
+		return (
+			Object.values(skillPointChanges).reduce<number>((acc, change) => acc + (change ?? 0), 0) === 1
+		);
 	});
 
 	// Reset skills when ability score selection changes
@@ -312,7 +317,7 @@ export function createLevelUpState(
 		get skillPointChanges() {
 			return skillPointChanges;
 		},
-		set skillPointChanges(v: Record<string, null>) {
+		set skillPointChanges(v: Record<string, number | null>) {
 			skillPointChanges = v;
 		},
 		get hasStatIncrease() {


### PR DESCRIPTION
## Summary
- Fix `skillPointChanges` setter type from `Record<string, null>` to `Record<string, number | null>` (and `generateBlankSkillSet` return type)
- Fix `featuresLoading` stuck `true` when `characterClass` is undefined, which left the dialog permanently incomplete
- Consolidate feature + epic boon creation into a single `createEmbeddedDocuments` call, removing duplicated pattern
- Replace non-idiomatic `as object as X` double casts with `as unknown as X` in `getEpicBoons.ts`
- Add `abilities` config to `CONFIG.NIMBLE`, removing `@ts-expect-error` in `CharacterLevelDownDialogState`

## Test plan
- [x] `pnpm check` passes (format, lint, circular deps, types, 712 tests)