### PR TITLE
fix(packs): Commander combat tactics levels & Rat Prince type

### DIFF
--- a/packs/classFeatures/core/commander/combat-tactics/commanding-presence.json
+++ b/packs/classFeatures/core/commander/combat-tactics/commanding-presence.json
@@ -88,13 +88,15 @@
 		"featureType": "class",
 		"class": "commander",
 		"group": "combat-tactics",
-		"gainedAtLevel": 5,
+		"gainedAtLevel": 4,
 		"subclass": false,
 		"gainedAtLevels": [
-			5,
-			9,
-			13,
-			17
+			4,
+			6,
+			8,
+			10,
+			12,
+			16
 		]
 	},
 	"effects": [],

--- a/packs/classFeatures/core/commander/combat-tactics/heavy-strike.json
+++ b/packs/classFeatures/core/commander/combat-tactics/heavy-strike.json
@@ -59,13 +59,15 @@
 		"featureType": "class",
 		"class": "commander",
 		"group": "combat-tactics",
-		"gainedAtLevel": 5,
+		"gainedAtLevel": 4,
 		"subclass": false,
 		"gainedAtLevels": [
-			5,
-			9,
-			13,
-			17
+			4,
+			6,
+			8,
+			10,
+			12,
+			16
 		]
 	},
 	"effects": [],

--- a/packs/classFeatures/core/commander/combat-tactics/inerrant-strike.json
+++ b/packs/classFeatures/core/commander/combat-tactics/inerrant-strike.json
@@ -59,13 +59,15 @@
 		"featureType": "class",
 		"class": "commander",
 		"group": "combat-tactics",
-		"gainedAtLevel": 5,
+		"gainedAtLevel": 4,
 		"subclass": false,
 		"gainedAtLevels": [
-			5,
-			9,
-			13,
-			17
+			4,
+			6,
+			8,
+			10,
+			12,
+			16
 		]
 	},
 	"effects": [],

--- a/packs/classFeatures/core/commander/combat-tactics/lunging-strike.json
+++ b/packs/classFeatures/core/commander/combat-tactics/lunging-strike.json
@@ -59,13 +59,15 @@
 		"featureType": "class",
 		"class": "commander",
 		"group": "combat-tactics",
-		"gainedAtLevel": 5,
+		"gainedAtLevel": 4,
 		"subclass": false,
 		"gainedAtLevels": [
-			5,
-			9,
-			13,
-			17
+			4,
+			6,
+			8,
+			10,
+			12,
+			16
 		]
 	},
 	"effects": [],

--- a/packs/classFeatures/core/commander/combat-tactics/sweeping-strike.json
+++ b/packs/classFeatures/core/commander/combat-tactics/sweeping-strike.json
@@ -59,13 +59,15 @@
 		"featureType": "class",
 		"class": "commander",
 		"group": "combat-tactics",
-		"gainedAtLevel": 5,
+		"gainedAtLevel": 4,
 		"subclass": false,
 		"gainedAtLevels": [
-			5,
-			9,
-			13,
-			17
+			4,
+			6,
+			8,
+			10,
+			12,
+			16
 		]
 	},
 	"effects": [],

--- a/packs/ids.json
+++ b/packs/ids.json
@@ -768,7 +768,6 @@
 			"pudge-the-blunderer": "nAew89tkjzZNnnac",
 			"queen-aranya-broodmother": "m5BJajp8f7TGj3QU",
 			"queen-aranyas-spiderling-minion": "RW07GUkU1QLtRbrV",
-			"rat-prince": "XQOBiTP8L3Yac9Up",
 			"ravager-of-the-lowlands": "zCcpMXbxzzyFzKsz",
 			"scorpion-queen": "zaM78FA829bAaDmR",
 			"thorn-quickblade": "lgul04YrKU0RjG0F",
@@ -1006,6 +1005,7 @@
 				"giant-spider": "ML3WomiwkHKUfTnO",
 				"great-worm": "lQ83gZRlm3bTgsbp",
 				"nestweaver": "zDKPmCy5DbGdkJLU",
+				"rat-prince": "XQOBiTP8L3Yac9Up",
 				"rat-swarm": "xx6ELqMvhFA8qVfN",
 				"umber-hulk": "UqUuKtAWlOrDkAFy",
 				"wax-golem": "7f3ZENlslRDMVcEf"

--- a/packs/monsters/core/underground/rat-prince.json
+++ b/packs/monsters/core/underground/rat-prince.json
@@ -1,8 +1,8 @@
 {
 	"name": "Rat Prince",
-	"type": "soloMonster",
-	"folder": null,
-	"img": "icons/creatures/mammals/rodent-rat-diseaed-gray.webp",
+	"type": "npc",
+	"folder": "1e695c5c5b1b3293",
+	"img": "icons/svg/mystery-man.svg",
 	"system": {
 		"attributes": {
 			"armor": "none",
@@ -19,6 +19,7 @@
 		"description": "",
 		"details": {
 			"creatureType": "Ratfolk",
+			"isFlunky": false,
 			"level": "1"
 		},
 		"savingThrows": {


### PR DESCRIPTION
## Summary
- **Commander Combat Tactics**: All 5 combat tactic options (Commanding Presence, Heavy Strike, Inerrant Strike, Lunging Strike, Sweeping Strike) were incorrectly tied to "Combat Tactics" feature levels `[5, 9, 13, 17]` instead of "Fit for Any Battlefield" levels `[4, 6, 8, 10, 12, 16]`
- **Rat Prince**: Reclassified from `soloMonster` to `npc` per GMG stat block, moved from `legendaryMonsters` pack to `monsters/underground`

## Test plan
- [ ] Load a Commander character and verify combat tactic options appear at level 4 (not 5)
- [ ] Verify additional combat tactics are offered at levels 6, 8, 10, 12, 16
- [ ] Verify Rat Prince appears in the Monsters compendium under Underground, not in Legendary Monsters
- [ ] Verify Rat Prince renders correctly as an NPC sheet