### PR TITLE
feat: multi-select class features & level-up feature selection

### DIFF
--- a/packs/classFeatures/core/commander/commanders-order/face-me.json
+++ b/packs/classFeatures/core/commander/commanders-order/face-me.json
@@ -48,7 +48,8 @@
 		"subclass": false,
 		"gainedAtLevels": [
 			2
-		]
+		],
+		"maxSelections": 2
 	},
 	"effects": [],
 	"folder": "406c4e162069a4a8",

--- a/packs/classFeatures/core/commander/commanders-order/hold-the-line.json
+++ b/packs/classFeatures/core/commander/commanders-order/hold-the-line.json
@@ -63,7 +63,8 @@
 		"subclass": false,
 		"gainedAtLevels": [
 			2
-		]
+		],
+		"maxSelections": 2
 	},
 	"effects": [],
 	"folder": "406c4e162069a4a8",

--- a/packs/classFeatures/core/commander/commanders-order/i-can-do-this-all-day.json
+++ b/packs/classFeatures/core/commander/commanders-order/i-can-do-this-all-day.json
@@ -68,7 +68,8 @@
 		"subclass": false,
 		"gainedAtLevels": [
 			2
-		]
+		],
+		"maxSelections": 2
 	},
 	"effects": [],
 	"folder": "406c4e162069a4a8",

--- a/packs/classFeatures/core/commander/commanders-order/move-it-move-it.json
+++ b/packs/classFeatures/core/commander/commanders-order/move-it-move-it.json
@@ -70,7 +70,8 @@
 		"subclass": false,
 		"gainedAtLevels": [
 			2
-		]
+		],
+		"maxSelections": 2
 	},
 	"effects": [],
 	"folder": "406c4e162069a4a8",

--- a/packs/classFeatures/core/commander/commanders-order/reposition.json
+++ b/packs/classFeatures/core/commander/commanders-order/reposition.json
@@ -40,7 +40,8 @@
 		"subclass": false,
 		"gainedAtLevels": [
 			2
-		]
+		],
+		"maxSelections": 2
 	},
 	"effects": [],
 	"folder": "406c4e162069a4a8",

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -1303,6 +1303,7 @@
 			"editSelection": "Edit Class Feature Selection",
 			"hint": "The following features are available at level 1 for your class. Some features are automatically granted, while others require you to make a choice.",
 			"chooseOne": "(Choose one)",
+			"chooseN": "(Choose {count})",
 			"noDescriptionAvailable": "No description available.",
 			"selected": "Selected",
 			"confirmSelection": "Confirm Selection",

--- a/src/documents/actor/character.ts
+++ b/src/documents/actor/character.ts
@@ -73,7 +73,7 @@ interface LevelUpDialogData {
 	selectedEpicBoon: NimbleBoonItem | null;
 	classFeatures: {
 		autoGrant: NimbleFeatureItem[];
-		selected: Map<string, NimbleFeatureItem>;
+		selected: Map<string, NimbleFeatureItem[]>;
 	} | null;
 }
 
@@ -1244,10 +1244,10 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 		const itemsToGrant: { toObject(): object; uuid: string }[] = [];
 
 		if (typedDialogData.classFeatures) {
-			itemsToGrant.push(
-				...typedDialogData.classFeatures.autoGrant,
-				...typedDialogData.classFeatures.selected.values(),
-			);
+			itemsToGrant.push(...typedDialogData.classFeatures.autoGrant);
+			for (const features of typedDialogData.classFeatures.selected.values()) {
+				itemsToGrant.push(...features);
+			}
 		}
 
 		if (typedDialogData.selectedEpicBoon) {

--- a/src/documents/dialogs/CharacterCreationDialog.svelte.ts
+++ b/src/documents/dialogs/CharacterCreationDialog.svelte.ts
@@ -97,7 +97,7 @@ export default class CharacterCreationDialog extends SvelteApplicationMixin(Appl
 		};
 		classFeatures?: {
 			autoGrant: string[];
-			selected: Map<string, NimbleFeatureItem>;
+			selected: Map<string, NimbleFeatureItem[]>;
 		};
 		spells?: {
 			autoGrant: string[];
@@ -250,10 +250,12 @@ export default class CharacterCreationDialog extends SvelteApplicationMixin(Appl
 		}
 
 		// Add selected features
-		for (const [_group, feature] of results.classFeatures?.selected ?? []) {
-			const source = feature.toObject();
-			source._stats.compendiumSource = feature.uuid;
-			featureDocumentSources.push(source as object as Item.CreateData);
+		for (const [_group, features] of results.classFeatures?.selected ?? []) {
+			for (const feature of features) {
+				const source = feature.toObject();
+				source._stats.compendiumSource = feature.uuid;
+				featureDocumentSources.push(source as object as Item.CreateData);
+			}
 		}
 
 		// Create all features

--- a/src/models/item/FeatureDataModel.ts
+++ b/src/models/item/FeatureDataModel.ts
@@ -35,6 +35,13 @@ const schema = () => ({
 			initial: [],
 		},
 	),
+	maxSelections: new fields.NumberField({
+		required: true,
+		nullable: false,
+		initial: 1,
+		integer: true,
+		min: 1,
+	}),
 });
 
 declare namespace NimbleFeatureData {
@@ -63,6 +70,8 @@ class NimbleFeatureData extends NimbleBaseItemData<
 	declare gainedAtLevel: number | null;
 
 	declare gainedAtLevels: number[];
+
+	declare maxSelections: number;
 
 	declare activation: {
 		showDescription: boolean;

--- a/src/utils/getClassFeatures.ts
+++ b/src/utils/getClassFeatures.ts
@@ -152,6 +152,7 @@ export default async function getClassFeaturesFromIndex(
 	const result: ClassFeatureResult = {
 		autoGrant: [],
 		selectionGroups: new Map(),
+		selectionCounts: new Map(),
 	};
 
 	if (!classIdentifier || level < 1) {
@@ -194,6 +195,16 @@ export default async function getClassFeaturesFromIndex(
 		} else {
 			result.selectionGroups.set(groupName, groupFeatures);
 		}
+	}
+
+	// Derive selection counts from maxSelections on features (take the max per group)
+	for (const [groupName, groupFeatures] of result.selectionGroups) {
+		let maxSel = 1;
+		for (const feature of groupFeatures) {
+			const featureMax = (feature.system as { maxSelections?: number }).maxSelections ?? 1;
+			if (featureMax > maxSel) maxSel = featureMax;
+		}
+		result.selectionCounts.set(groupName, maxSel);
 	}
 
 	return result;

--- a/src/view/dialogs/CharacterLevelUpDialogState.svelte.ts
+++ b/src/view/dialogs/CharacterLevelUpDialogState.svelte.ts
@@ -94,7 +94,7 @@ export function createLevelUpState(
 
 	// Class features state
 	let classFeatures: ClassFeatureResult | null = $state(null);
-	let selectedClassFeatures: Map<string, NimbleFeatureItem> = $state(new Map());
+	let selectedClassFeatures: Map<string, NimbleFeatureItem[]> = $state(new Map());
 	let featuresLoading = $state(true);
 
 	// Load class features when dialog opens
@@ -145,6 +145,7 @@ export function createLevelUpState(
 				classFeatures = {
 					autoGrant: filteredAutoGrant,
 					selectionGroups: filteredSelectionGroups,
+					selectionCounts: rawFeatures.selectionCounts,
 				};
 				featuresLoading = false;
 			})
@@ -160,9 +161,9 @@ export function createLevelUpState(
 		if (!classFeatures) return true;
 
 		for (const groupName of classFeatures.selectionGroups.keys()) {
-			if (!selectedClassFeatures.has(groupName)) {
-				return false;
-			}
+			const required = classFeatures.selectionCounts?.get(groupName) ?? 1;
+			const selected = selectedClassFeatures.get(groupName)?.length ?? 0;
+			if (selected < required) return false;
 		}
 		return true;
 	});
@@ -335,7 +336,7 @@ export function createLevelUpState(
 		get selectedClassFeatures() {
 			return selectedClassFeatures;
 		},
-		set selectedClassFeatures(v: Map<string, NimbleFeatureItem>) {
+		set selectedClassFeatures(v: Map<string, NimbleFeatureItem[]>) {
 			selectedClassFeatures = v;
 		},
 		submit,

--- a/src/view/dialogs/characterCreation/state.svelte.test.ts
+++ b/src/view/dialogs/characterCreation/state.svelte.test.ts
@@ -108,6 +108,7 @@ function createClassFeaturesResult(
 	return {
 		autoGrant,
 		selectionGroups: new Map(),
+		selectionCounts: new Map(),
 	};
 }
 

--- a/src/view/dialogs/characterCreation/state.svelte.ts
+++ b/src/view/dialogs/characterCreation/state.svelte.ts
@@ -137,12 +137,14 @@ function ancestryOptionsComplete(
 
 function classFeaturesComplete(
 	features: ClassFeatureResult | null,
-	selections: Map<string, NimbleFeatureItem>,
+	selections: Map<string, NimbleFeatureItem[]>,
 ): boolean {
 	if (!features) return true;
 
 	for (const groupName of features.selectionGroups.keys()) {
-		if (!selections.has(groupName)) {
+		const required = features.selectionCounts?.get(groupName) ?? 1;
+		const selected = selections.get(groupName)?.length ?? 0;
+		if (selected < required) {
 			return false;
 		}
 	}
@@ -188,7 +190,7 @@ interface GetCurrentStageParams {
 	remainingSkillPoints: number;
 	bonusLanguages: string[];
 	classFeatures: ClassFeatureResult | null;
-	selectedClassFeatures: Map<string, NimbleFeatureItem>;
+	selectedClassFeatures: Map<string, NimbleFeatureItem[]>;
 	spellGrants: SpellGrantResult | null;
 	selectedSchools: Map<string, string[]>;
 	selectedSpells: Map<string, string[]>;
@@ -347,7 +349,7 @@ export function createCharacterCreationState(params: CharacterCreationStateParam
 
 	// Class features state
 	let classFeatures = $state<ClassFeatureResult | null>(null);
-	let selectedClassFeatures = $state<Map<string, NimbleFeatureItem>>(new Map());
+	let selectedClassFeatures = $state<Map<string, NimbleFeatureItem[]>>(new Map());
 
 	// Spell grants state
 	let spellGrants = $state<SpellGrantResult | null>(null);
@@ -831,7 +833,7 @@ export function createCharacterCreationState(params: CharacterCreationStateParam
 		get selectedClassFeatures() {
 			return selectedClassFeatures;
 		},
-		set selectedClassFeatures(value: Map<string, NimbleFeatureItem>) {
+		set selectedClassFeatures(value: Map<string, NimbleFeatureItem[]>) {
 			selectedClassFeatures = value;
 		},
 		get spellGrants() {

--- a/src/view/dialogs/characterCreation/types.ts
+++ b/src/view/dialogs/characterCreation/types.ts
@@ -108,7 +108,7 @@ export interface CharacterCreationResults {
 	};
 	classFeatures?: {
 		autoGrant: string[];
-		selected: Map<string, NimbleFeatureItem>;
+		selected: Map<string, NimbleFeatureItem[]>;
 	};
 	spells?: {
 		autoGrant: string[];

--- a/src/view/dialogs/components/characterCreator/ClassFeatureSelection.svelte
+++ b/src/view/dialogs/components/characterCreator/ClassFeatureSelection.svelte
@@ -54,7 +54,8 @@
 				<FeatureGroupSelection
 					{groupName}
 					{features}
-					selectedFeature={selectedFeatures.get(groupName) ?? null}
+					selectedFeatures={selectedFeatures.get(groupName) ?? []}
+					maxSelections={classFeatures?.selectionCounts?.get(groupName) ?? 1}
 					onSelect={(feature) => state.handleFeatureSelect(groupName, feature)}
 				/>
 			{/each}

--- a/src/view/dialogs/components/characterCreator/ClassFeatureSelection.svelte.ts
+++ b/src/view/dialogs/components/characterCreator/ClassFeatureSelection.svelte.ts
@@ -3,7 +3,7 @@ import type { ClassFeatureResult } from '#types/components/ClassFeatureSelection
 
 export interface ClassFeatureSelectionState {
 	classFeatures: ClassFeatureResult | null;
-	selectedFeatures: Map<string, NimbleFeatureItem>;
+	selectedFeatures: Map<string, NimbleFeatureItem[]>;
 }
 
 /**
@@ -15,9 +15,9 @@ export interface ClassFeatureSelectionState {
  */
 export function createClassFeatureSelectionState(
 	getState: () => ClassFeatureSelectionState,
-	setSelectedFeatures: (features: Map<string, NimbleFeatureItem>) => void,
+	setSelectedFeatures: (features: Map<string, NimbleFeatureItem[]>) => void,
 ) {
-	// Auto-select features for groups that only have one option
+	// Auto-select features for groups where available options equal the required count
 	$effect(() => {
 		const { classFeatures, selectedFeatures } = getState();
 		if (!classFeatures?.selectionGroups) return;
@@ -26,8 +26,9 @@ export function createClassFeatureSelectionState(
 		let hasChanges = false;
 
 		for (const [groupName, features] of classFeatures.selectionGroups) {
-			if (features.length === 1 && !newSelections.has(groupName)) {
-				newSelections.set(groupName, features[0]);
+			const maxSelections = classFeatures.selectionCounts?.get(groupName) ?? 1;
+			if (features.length <= maxSelections && !newSelections.has(groupName)) {
+				newSelections.set(groupName, [...features]);
 				hasChanges = true;
 			}
 		}
@@ -38,13 +39,22 @@ export function createClassFeatureSelectionState(
 	});
 
 	function handleFeatureSelect(groupName: string, feature: NimbleFeatureItem) {
-		const { selectedFeatures } = getState();
+		const { selectedFeatures, classFeatures } = getState();
 		const newSelections = new Map(selectedFeatures);
+		const current = [...(newSelections.get(groupName) ?? [])];
+		const maxSelections = classFeatures?.selectionCounts?.get(groupName) ?? 1;
 
-		if (newSelections.get(groupName)?.uuid === feature.uuid) {
+		const existingIndex = current.findIndex((f) => f.uuid === feature.uuid);
+		if (existingIndex >= 0) {
+			current.splice(existingIndex, 1);
+		} else if (current.length < maxSelections) {
+			current.push(feature);
+		}
+
+		if (current.length === 0) {
 			newSelections.delete(groupName);
 		} else {
-			newSelections.set(groupName, feature);
+			newSelections.set(groupName, current);
 		}
 
 		setSelectedFeatures(newSelections);

--- a/src/view/dialogs/components/characterCreator/FeatureGroupSelection.svelte
+++ b/src/view/dialogs/components/characterCreator/FeatureGroupSelection.svelte
@@ -5,17 +5,36 @@
 	import FeatureCard from './FeatureCard.svelte';
 	import localize from '#utils/localize.js';
 
-	let { groupName, features, selectedFeature, onSelect }: FeatureGroupSelectionProps = $props();
+	let {
+		groupName,
+		features,
+		selectedFeatures,
+		maxSelections,
+		onSelect,
+	}: FeatureGroupSelectionProps = $props();
 
-	const state = createFeatureGroupSelectionState(() => ({ groupName, features }));
+	const state = createFeatureGroupSelectionState(() => ({ groupName, features, maxSelections }));
 
-	// Selection is complete when a feature is selected and it's not a single-option group
-	const isSelectionComplete = $derived(!!selectedFeature && !state.isSingleOption);
+	function isFeatureSelected(featureUuid: string): boolean {
+		return selectedFeatures.some((f) => f.uuid === featureUuid);
+	}
 
-	// Filter to show only selected feature when selection is complete
-	const displayedFeatures = $derived(
-		isSelectionComplete ? features.filter((f) => f.uuid === selectedFeature?.uuid) : features,
+	// Selection is complete when all required selections are made
+	const isSelectionComplete = $derived(
+		selectedFeatures.length >= maxSelections && !state.isSingleOption,
 	);
+
+	// Filter to show only selected features when selection is complete
+	const displayedFeatures = $derived(
+		isSelectionComplete
+			? features.filter((f) => selectedFeatures.some((s) => s.uuid === f.uuid))
+			: features,
+	);
+
+	function getHintText(): string {
+		if (maxSelections === 1) return localize('NIMBLE.classFeatureSelection.chooseOne');
+		return localize('NIMBLE.classFeatureSelection.chooseN', { count: String(maxSelections) });
+	}
 </script>
 
 <div class="feature-group">
@@ -24,7 +43,7 @@
 			{state.formattedGroupName}
 		</h4>
 		{#if !state.isSingleOption && !isSelectionComplete}
-			<span class="feature-group__hint">{localize('NIMBLE.classFeatureSelection.chooseOne')}</span>
+			<span class="feature-group__hint">{getHintText()}</span>
 		{/if}
 	</header>
 
@@ -32,7 +51,7 @@
 		{#each displayedFeatures as feature (feature.uuid)}
 			<FeatureCard
 				{feature}
-				isSelected={state.isSingleOption ? false : selectedFeature?.uuid === feature.uuid}
+				isSelected={state.isSingleOption ? false : isFeatureSelected(feature.uuid)}
 				onSelect={state.isSingleOption ? undefined : () => onSelect(feature)}
 			/>
 		{/each}

--- a/src/view/dialogs/components/characterCreator/FeatureGroupSelection.svelte.ts
+++ b/src/view/dialogs/components/characterCreator/FeatureGroupSelection.svelte.ts
@@ -18,14 +18,15 @@ export function formatGroupName(name: string): string {
  * @returns Object containing derived state
  */
 export function createFeatureGroupSelectionState(
-	getProps: () => { groupName: string; features: NimbleFeatureItem[] },
+	getProps: () => { groupName: string; features: NimbleFeatureItem[]; maxSelections: number },
 ) {
 	return {
 		get formattedGroupName() {
 			return formatGroupName(getProps().groupName);
 		},
 		get isSingleOption() {
-			return getProps().features.length === 1;
+			const { features, maxSelections } = getProps();
+			return features.length <= maxSelections;
 		},
 	};
 }

--- a/src/view/dialogs/components/levelUpHelper/LevelUpClassFeatureSelection.svelte
+++ b/src/view/dialogs/components/levelUpHelper/LevelUpClassFeatureSelection.svelte
@@ -59,7 +59,8 @@
 				<FeatureGroupSelection
 					{groupName}
 					{features}
-					selectedFeature={selectedFeatures.get(groupName) ?? null}
+					selectedFeatures={selectedFeatures.get(groupName) ?? []}
+					maxSelections={classFeatures?.selectionCounts?.get(groupName) ?? 1}
 					onSelect={(feature) => handleFeatureSelect(groupName, feature)}
 				/>
 			{/each}

--- a/src/view/dialogs/components/levelUpHelper/LevelUpClassFeatureSelection.svelte.ts
+++ b/src/view/dialogs/components/levelUpHelper/LevelUpClassFeatureSelection.svelte.ts
@@ -9,10 +9,10 @@ import type { ClassFeatureResult } from '#types/components/ClassFeatureSelection
  */
 export function createClassFeatureSelectionState(
 	getClassFeatures: () => ClassFeatureResult | null,
-	getSelectedFeatures: () => Map<string, NimbleFeatureItem>,
-	setSelectedFeatures: (features: Map<string, NimbleFeatureItem>) => void,
+	getSelectedFeatures: () => Map<string, NimbleFeatureItem[]>,
+	setSelectedFeatures: (features: Map<string, NimbleFeatureItem[]>) => void,
 ) {
-	// Auto-select features for groups that only have one option
+	// Auto-select features for groups where available options equal the required count
 	$effect(() => {
 		const classFeatures = getClassFeatures();
 		if (!classFeatures?.selectionGroups) return;
@@ -21,8 +21,9 @@ export function createClassFeatureSelectionState(
 		let hasChanges = false;
 
 		for (const [groupName, features] of classFeatures.selectionGroups) {
-			if (features.length === 1 && !newSelections.has(groupName)) {
-				newSelections.set(groupName, features[0]);
+			const maxSelections = classFeatures.selectionCounts?.get(groupName) ?? 1;
+			if (features.length <= maxSelections && !newSelections.has(groupName)) {
+				newSelections.set(groupName, [...features]);
 				hasChanges = true;
 			}
 		}
@@ -33,12 +34,22 @@ export function createClassFeatureSelectionState(
 	});
 
 	function handleFeatureSelect(groupName: string, feature: NimbleFeatureItem) {
+		const classFeatures = getClassFeatures();
 		const newSelections = new Map(getSelectedFeatures());
+		const current = [...(newSelections.get(groupName) ?? [])];
+		const maxSelections = classFeatures?.selectionCounts?.get(groupName) ?? 1;
 
-		if (newSelections.get(groupName)?.uuid === feature.uuid) {
+		const existingIndex = current.findIndex((f) => f.uuid === feature.uuid);
+		if (existingIndex >= 0) {
+			current.splice(existingIndex, 1);
+		} else if (current.length < maxSelections) {
+			current.push(feature);
+		}
+
+		if (current.length === 0) {
 			newSelections.delete(groupName);
 		} else {
-			newSelections.set(groupName, feature);
+			newSelections.set(groupName, current);
 		}
 
 		setSelectedFeatures(newSelections);

--- a/types/components/ClassFeatureSelection.d.ts
+++ b/types/components/ClassFeatureSelection.d.ts
@@ -3,12 +3,13 @@ import type { NimbleFeatureItem } from '#documents/item/feature.js';
 export interface ClassFeatureResult {
 	autoGrant: NimbleFeatureItem[];
 	selectionGroups: Map<string, NimbleFeatureItem[]>;
+	selectionCounts: Map<string, number>;
 }
 
 export interface ClassFeatureSelectionProps {
 	active: boolean;
 	classFeatures: ClassFeatureResult | null;
-	selectedFeatures: Map<string, NimbleFeatureItem>;
+	selectedFeatures: Map<string, NimbleFeatureItem[]>;
 }
 
 export interface FeatureCardProps {
@@ -20,13 +21,14 @@ export interface FeatureCardProps {
 export interface FeatureGroupSelectionProps {
 	groupName: string;
 	features: NimbleFeatureItem[];
-	selectedFeature: NimbleFeatureItem | null;
+	selectedFeatures: NimbleFeatureItem[];
+	maxSelections: number;
 	onSelect: (feature: NimbleFeatureItem) => void;
 }
 
 export interface LevelUpClassFeatureSelectionProps {
 	classFeatures: ClassFeatureResult | null;
-	selectedFeatures: Map<string, NimbleFeatureItem>;
+	selectedFeatures: Map<string, NimbleFeatureItem[]>;
 	loading?: boolean;
 }
 


### PR DESCRIPTION
## Summary
- Adds `groupSelectionCounts` to the class data model so classes can configure how many features are selectable per group per level (e.g., Commander's Orders: choose 2 at level 2)
- Upgrades feature selection UI from single-select to multi-select with dynamic "(Choose N)" hints
- Integrates class feature selection into the level-up dialog with full grant/revert support via `grantedFeatureIds` in level-up history

## Test plan
- [ ] Create a Commander character, level up to 2 — verify 5 Commander's Orders shown with "(Choose 2)" hint
- [ ] Select 2 orders, complete level-up — verify both appear on the character sheet
- [ ] Level down from 2 → 1 — verify both orders are removed and shown in the revert preview
- [ ] Create a new character (any class) — verify character creation feature selection still works for single-select groups
- [ ] Level up a class with no features at the target level — verify no feature section appears