### PR TITLE
feat: grant subclass features on level up

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -468,7 +468,8 @@
 			"hitDiceLabel": "Hit Dice:",
 			"rollHitDice": "Roll Hit Dice",
 			"rollHitDiceTooltip": "Roll your Hit Die with advantage and increase your max HP by that much.",
-			"takeAverage": "Take Average ({average})"
+			"takeAverage": "Take Average ({average})",
+			"subclassFeatures": "Subclass Features"
 		},
 		"levelDownDialog": {
 			"level": "Level",
@@ -479,6 +480,7 @@
 			"point": "point",
 			"points": "points",
 			"subclass": "Subclass",
+			"feature": "Feature",
 			"removed": "removed",
 			"warningMessage": "This action will permanently revert the last level up. This cannot be undone.",
 			"confirmLevelDown": "Confirm Level Down",

--- a/src/config.ts
+++ b/src/config.ts
@@ -673,6 +673,7 @@ const levelUpDialog = {
 	rollHitDice: 'NIMBLE.levelUpDialog.rollHitDice',
 	rollHitDiceTooltip: 'NIMBLE.levelUpDialog.rollHitDiceTooltip',
 	takeAverage: 'NIMBLE.levelUpDialog.takeAverage',
+	subclassFeatures: 'NIMBLE.levelUpDialog.subclassFeatures',
 };
 
 const skillCheckDialog = {
@@ -688,6 +689,7 @@ const levelDownDialog = {
 	point: 'NIMBLE.levelDownDialog.point',
 	points: 'NIMBLE.levelDownDialog.points',
 	subclass: 'NIMBLE.levelDownDialog.subclass',
+	feature: 'NIMBLE.levelDownDialog.feature',
 	removed: 'NIMBLE.levelDownDialog.removed',
 	warningMessage: 'NIMBLE.levelDownDialog.warningMessage',
 	confirmLevelDown: 'NIMBLE.levelDownDialog.confirmLevelDown',

--- a/src/documents/actor/character.ts
+++ b/src/documents/actor/character.ts
@@ -1,6 +1,7 @@
 import type { NimbleAncestryItem } from '#documents/item/ancestry.js';
 import type { NimbleBackgroundItem } from '#documents/item/background.js';
 import type { NimbleClassItem } from '#documents/item/class.js';
+import type { NimbleFeatureItem } from '#documents/item/feature.js';
 import type { NimbleSubclassItem } from '#documents/item/subclass.js';
 import type { SkillKeyType } from '#types/skillKey.js';
 import { getHighestSpellTier } from '#utils/spell/getHighestSpellTier.ts';
@@ -68,6 +69,7 @@ interface LevelUpDialogData {
 	selectedAbilityScore: string | null;
 	skillPointChanges: Record<string, number>;
 	selectedSubclass: NimbleSubclassItem | null;
+	grantedFeatures: NimbleFeatureItem[];
 }
 
 export class NimbleCharacter extends NimbleBaseActor<'character'> {
@@ -1216,6 +1218,26 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 			}
 		}
 
+		// Grant subclass features
+		const featuresToGrant = typedDialogData.grantedFeatures ?? [];
+		const grantedFeatureIds: string[] = [];
+
+		if (featuresToGrant.length > 0) {
+			const featureDocumentSources: Item.CreateData[] = [];
+			for (const feature of featuresToGrant) {
+				const source = (feature as NimbleFeatureItem).toObject();
+				(source as { _stats: { compendiumSource?: string } })._stats.compendiumSource =
+					feature.uuid;
+				featureDocumentSources.push(source as object as Item.CreateData);
+			}
+			const created = await this.createEmbeddedDocuments('Item', featureDocumentSources);
+			if (created) {
+				for (const doc of created) {
+					if (doc.id) grantedFeatureIds.push(doc.id);
+				}
+			}
+		}
+
 		// Record level up history
 		const historyEntry = {
 			level: nextClassLevel,
@@ -1224,6 +1246,7 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 			skillIncreases: typedDialogData.skillPointChanges,
 			hitDieAdded: true,
 			classIdentifier: characterClass.identifier,
+			grantedFeatureIds,
 		};
 
 		actorUpdates['system.levelUpHistory'] = [...this.system.levelUpHistory, historyEntry];
@@ -1320,6 +1343,15 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 				actorUpdates[path] = current - change;
 			}
 		});
+
+		// Remove granted subclass features
+		const grantedFeatureIds = lastHistory.grantedFeatureIds ?? [];
+		if (grantedFeatureIds.length > 0) {
+			const validIds = grantedFeatureIds.filter((id) => this.items.get(id));
+			if (validIds.length > 0) {
+				await this.deleteEmbeddedDocuments('Item', validIds);
+			}
+		}
 
 		// Remove all subclasses if reverting from level 3
 		if (lastHistory.level <= 3) {

--- a/src/models/actor/CharacterDataModel.ts
+++ b/src/models/actor/CharacterDataModel.ts
@@ -384,6 +384,10 @@ const characterSchema = () => ({
 				initial: '',
 				nullable: false,
 			}),
+			grantedFeatureIds: new fields.ArrayField(
+				new fields.StringField({ required: true, nullable: false }),
+				{ required: true, nullable: false, initial: () => [] },
+			),
 		}),
 		{ required: true, nullable: false, initial: () => [] },
 	),
@@ -480,6 +484,7 @@ interface LevelUpHistoryEntry {
 	skillIncreases: Record<string, number>;
 	hitDieAdded: boolean;
 	classIdentifier: string;
+	grantedFeatureIds: string[];
 }
 
 declare namespace NimbleCharacterData {

--- a/src/utils/getSubclassFeatures.ts
+++ b/src/utils/getSubclassFeatures.ts
@@ -1,0 +1,98 @@
+import type { NimbleFeatureItem } from '#documents/item/feature.js';
+
+/**
+ * Shape of a feature's indexed fields in a compendium pack.
+ */
+interface FeatureIndexEntry {
+	_id: string;
+	uuid: string;
+	type: string;
+	name: string;
+	system?: {
+		class?: string;
+		subclass?: boolean;
+		gainedAtLevel?: number;
+		gainedAtLevels?: number[];
+		group?: string;
+	};
+}
+
+/**
+ * Get subclass features for a given class, subclass, and set of levels.
+ * Scans world items and compendium packs for features where
+ * subclass is true, class and group match, and gainedAtLevel is in the requested levels.
+ */
+export default async function getSubclassFeatures(
+	classIdentifier: string,
+	subclassIdentifier: string,
+	levels: number[],
+): Promise<NimbleFeatureItem[]> {
+	const seen = new Set<string>();
+	const uuids: string[] = [];
+
+	function matchesLevel(system: {
+		gainedAtLevel?: number | null;
+		gainedAtLevels?: number[];
+	}): boolean {
+		if (system.gainedAtLevel && levels.includes(system.gainedAtLevel)) return true;
+		if (system.gainedAtLevels) {
+			for (const level of system.gainedAtLevels) {
+				if (levels.includes(level)) return true;
+			}
+		}
+		return false;
+	}
+
+	function addUuid(uuid: string): void {
+		if (seen.has(uuid)) return;
+		seen.add(uuid);
+		uuids.push(uuid);
+	}
+
+	// Process world items
+	for (const item of game.items) {
+		if (item.type !== 'feature') continue;
+		const featureItem = item as NimbleFeatureItem;
+		const system = featureItem.system;
+
+		if (!system.subclass) continue;
+		if (system.class !== classIdentifier) continue;
+		if (system.group !== subclassIdentifier) continue;
+		if (!matchesLevel(system)) continue;
+
+		addUuid(featureItem.uuid);
+	}
+
+	// Process compendium packs
+	const indexFields = [
+		'system.class',
+		'system.subclass',
+		'system.gainedAtLevel',
+		'system.gainedAtLevels',
+		'system.group',
+	] as string[];
+
+	for (const pack of game.packs) {
+		if (pack.documentName !== 'Item') continue;
+
+		// @ts-expect-error - Foundry types don't include custom index fields, but the API accepts them
+		const packIndex = await pack.getIndex({ fields: indexFields });
+		for (const indexEntry of packIndex) {
+			const entry = indexEntry as FeatureIndexEntry;
+			if (entry.type !== 'feature') continue;
+
+			const system = entry.system;
+			if (!system?.subclass) continue;
+			if (system.class !== classIdentifier) continue;
+			if (system.group !== subclassIdentifier) continue;
+			if (!matchesLevel(system)) continue;
+
+			addUuid(entry.uuid);
+		}
+	}
+
+	// Load full feature documents
+	const features = await Promise.all(uuids.map((uuid) => fromUuid(uuid as `Item.${string}`)));
+
+	return features.filter((f): f is NimbleFeatureItem => f != null);
+}

--- a/src/view/dialogs/CharacterLevelDownDialog.svelte
+++ b/src/view/dialogs/CharacterLevelDownDialog.svelte
@@ -50,6 +50,13 @@
 	const willRemoveSubclass = $derived(lastHistory?.level <= 3);
 	const subclasses = $derived(actor.items.filter((i) => i.type === 'subclass'));
 	const hasSubclass = $derived(subclasses.length > 0);
+
+	// Get features that will be removed
+	const grantedFeatures = $derived(
+		(lastHistory?.grantedFeatureIds ?? [])
+			.map((id: string) => actor.items.get(id))
+			.filter((item: unknown): item is { id: string; name: string } => item != null),
+	);
 </script>
 
 <article class="nimble-sheet__body">
@@ -142,6 +149,21 @@
 						</span>
 						<span class="nimble-level-down-preview__value">
 							{subclass.name}
+							{CONFIG.NIMBLE.levelDownDialog.removed}
+						</span>
+					</li>
+				{/each}
+			{/if}
+
+			{#if grantedFeatures.length > 0}
+				{#each grantedFeatures as feature}
+					<li class="nimble-level-down-preview__item nimble-level-down-preview__item--loss">
+						<span class="nimble-level-down-preview__label">
+							<i class="fa-solid fa-scroll"></i>
+							{CONFIG.NIMBLE.levelDownDialog.feature}
+						</span>
+						<span class="nimble-level-down-preview__value">
+							{feature.name}
 							{CONFIG.NIMBLE.levelDownDialog.removed}
 						</span>
 					</li>

--- a/src/view/dialogs/CharacterLevelUpDialog.svelte
+++ b/src/view/dialogs/CharacterLevelUpDialog.svelte
@@ -1,13 +1,16 @@
 <script lang="ts">
 	import type { NimbleClassItem } from '../../documents/item/class.js';
+	import type { NimbleFeatureItem } from '../../documents/item/feature.js';
 	import generateBlankSkillSet from '../../utils/generateBlankSkillSet.js';
 	import getChoicesFromCompendium from '../../utils/getChoicesFromCompendium.js';
+	import getSubclassFeatures from '../../utils/getSubclassFeatures.js';
 
 	import getSubclassChoices from '../../utils/getSubclassChoices.js';
 
 	import AbilityScoreIncrease from './components/levelUpHelper/AbilityScoreIncrease.svelte';
 	import HitPointSelection from './components/levelUpHelper/HitPointSelection.svelte';
 	import SkillPointAssignment from './components/levelUpHelper/SkillPointAssignment.svelte';
+	import SubclassFeatureDisplay from './components/levelUpHelper/SubclassFeatureDisplay.svelte';
 	import SubclassSelection from './components/levelUpHelper/SubclassSelection.svelte';
 
 	const { forms, levelUpDialog } = CONFIG.NIMBLE;
@@ -18,6 +21,7 @@
 			selectedSubclass,
 			skillPointChanges,
 			takeAverageHp: hitPointRollSelection === 'average',
+			grantedFeatures: subclassFeatures,
 		});
 	}
 
@@ -70,6 +74,39 @@
 			getSubclassChoices(characterClass.identifier).then((choices) => {
 				subclasses = choices;
 			});
+		}
+	});
+
+	let subclassFeatures: NimbleFeatureItem[] = $state([]);
+
+	// Fetch subclass features at level 3 reactively when a subclass is selected
+	$effect(() => {
+		if (hasSubclassSelection && selectedSubclass && characterClass) {
+			const subclassIdentifier = (selectedSubclass as { name: string }).name.slugify({
+				strict: true,
+			});
+			getSubclassFeatures(characterClass.identifier, subclassIdentifier, [1, 2, 3]).then(
+				(features) => {
+					subclassFeatures = features;
+				},
+			);
+		} else if (hasSubclassSelection && !selectedSubclass) {
+			subclassFeatures = [];
+		}
+	});
+
+	// Fetch subclass features for levels after 3 from the character's existing subclass
+	$effect(() => {
+		if (!hasSubclassSelection && characterClass) {
+			const existingSubclass = document.items?.find((i: { type: string }) => i.type === 'subclass');
+			if (existingSubclass) {
+				const subclassIdentifier = existingSubclass.name.slugify({ strict: true });
+				getSubclassFeatures(characterClass.identifier, subclassIdentifier, [levelingTo]).then(
+					(features) => {
+						subclassFeatures = features;
+					},
+				);
+			}
 		}
 	});
 
@@ -148,6 +185,10 @@
 
 	{#if levelingTo === 3 && subclasses.length}
 		<SubclassSelection {subclasses} bind:selectedSubclass />
+	{/if}
+
+	{#if subclassFeatures.length > 0}
+		<SubclassFeatureDisplay features={subclassFeatures} />
 	{/if}
 </section>
 

--- a/src/view/dialogs/components/levelUpHelper/SubclassFeatureDisplay.svelte
+++ b/src/view/dialogs/components/levelUpHelper/SubclassFeatureDisplay.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+	import type { NimbleFeatureItem } from '#documents/item/feature.js';
+
+	import FeatureCard from '../characterCreator/FeatureCard.svelte';
+	import localize from '#utils/localize.js';
+
+	let { features }: { features: NimbleFeatureItem[] } = $props();
+</script>
+
+<section class="subclass-features">
+	<header class="nimble-section-header">
+		<h3 class="nimble-heading" data-heading-variant="section">
+			{localize('NIMBLE.levelUpDialog.subclassFeatures')}
+		</h3>
+	</header>
+
+	<ul class="subclass-features__list">
+		{#each features as feature (feature.uuid)}
+			<FeatureCard {feature} />
+		{/each}
+	</ul>
+</section>
+
+<style lang="scss">
+	.subclass-features__list {
+		display: flex;
+		flex-direction: column;
+		margin: 0.5rem 0 0 0;
+		padding: 0;
+	}
+</style>


### PR DESCRIPTION
## Summary
- When leveling to 3 and selecting a subclass, all subclass features for levels 1-3 are fetched and granted to the character
- At subsequent subclass feature levels (7, 11, 15), features are automatically granted based on the character's existing subclass
- Features are displayed in the level-up dialog before confirmation so the player knows what they're getting
- Granted feature IDs are tracked in `levelUpHistory` for clean removal on level-down
- The level-down dialog shows which features will be removed

## Changes
- **New**: `src/utils/getSubclassFeatures.ts` — scans world items and compendium packs for matching subclass features
- **New**: `SubclassFeatureDisplay.svelte` — reuses the existing `FeatureCard` component to display auto-granted features
- **Modified**: `CharacterDataModel.ts` — added `grantedFeatureIds` to `levelUpHistory` schema (backward-compatible)
- **Modified**: `character.ts` — embeds features in `triggerLevelUp()`, removes them in `revertLastLevelUp()`
- **Modified**: `CharacterLevelUpDialog.svelte` — fetches and displays subclass features reactively
- **Modified**: `CharacterLevelDownDialog.svelte` — shows features that will be removed on revert

## Test plan
- [ ] Level a character to 3, select a subclass → verify subclass features (levels 1-3) appear in dialog and are granted
- [ ] Level to 7 → verify subclass features for level 7 appear and are granted
- [ ] Level-down from 7 → verify level 7 features are removed
- [ ] Level-down from 3 → verify subclass + all subclass features are removed
- [ ] Level to 4 (no subclass features at this level) → verify dialog works normally with no feature section
- [ ] Test with Beastmaster (has level 1-2 features) to verify all early-level features are picked up at level 3