### PR TITLE
feat(rules): applyCondition rule type with event-time dispatch

### DIFF
--- a/packs/monsters/core/cultists/doomsayer.json
+++ b/packs/monsters/core/cultists/doomsayer.json
@@ -144,7 +144,14 @@
 			"system": {
 				"macro": "",
 				"identifier": "",
-				"rules": [],
+				"rules": [
+					{
+						"type": "applyCondition",
+						"condition": "despair",
+						"trigger": "onCrit",
+						"label": "Fanatical Zeal: Despair on crit"
+					}
+				],
 				"activation": {
 					"acquireTargetsFromTemplate": false,
 					"cost": {

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -1487,7 +1487,7 @@
 			},
 			"autoApplyConditions": {
 				"name": "Auto-Apply Conditions from Rules",
-				"hint": "When enabled, features and items with applyCondition rules will automatically apply the configured condition when their trigger fires (e.g. on crit, on turn start). When disabled, rules that would apply conditions are ignored."
+				"hint": "Automatically apply conditions from feature rules when their trigger fires. When off, rules still surface on the chat card for manual GM application."
 			},
 			"ncswEnabled": {
 				"name": "Enable Combat System",

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -534,6 +534,7 @@
 		},
 		"ruleTypes": {
 			"abilityBonus": "Stat Bonus",
+			"applyCondition": "Apply Condition",
 			"armorClass": "Armor Class",
 			"combatMana": "Combat Mana",
 			"grantItem": "Item",

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -1484,6 +1484,10 @@
 				"name": "Adjacency Includes Diagonals",
 				"hint": "When enabled, tokens that share only a corner are considered adjacent (diagonal adjacency). When disabled, only tokens sharing a full edge are adjacent (orthogonal only)."
 			},
+			"autoApplyConditions": {
+				"name": "Auto-Apply Conditions from Rules",
+				"hint": "When enabled, features and items with applyCondition rules will automatically apply the configured condition when their trigger fires (e.g. on crit, on turn start). When disabled, rules that would apply conditions are ignored."
+			},
 			"ncswEnabled": {
 				"name": "Enable Combat System",
 				"hint": "Show the Combat System panel during combat. Helps GMs quickly target heroes and roll attacks for minions, monsters, and legendary monsters."

--- a/src/config/registerRulesConfig.ts
+++ b/src/config/registerRulesConfig.ts
@@ -1,4 +1,5 @@
 import { AbilityBonusRule } from '../models/rules/abilityBonus.js';
+import { ApplyConditionRule } from '../models/rules/applyCondition.js';
 import { ArmorClassRule } from '../models/rules/armorClass.js';
 import { CombatManaRule } from '../models/rules/combatMana.js';
 import { ItemGrantRule } from '../models/rules/grantItem.js';
@@ -25,6 +26,7 @@ import { UnarmedDamageRule } from '../models/rules/unarmedDamage.js';
 export default function registerRulesConfig() {
 	const ruleTypes = {
 		abilityBonus: 'NIMBLE.ruleTypes.abilityBonus',
+		applyCondition: 'NIMBLE.ruleTypes.applyCondition',
 		armorClass: 'NIMBLE.ruleTypes.armorClass',
 		combatMana: 'NIMBLE.ruleTypes.combatMana',
 		grantItem: 'NIMBLE.ruleTypes.grantItem',
@@ -51,6 +53,7 @@ export default function registerRulesConfig() {
 
 	const ruleDataModels = {
 		abilityBonus: AbilityBonusRule,
+		applyCondition: ApplyConditionRule,
 		armorClass: ArmorClassRule,
 		combatMana: CombatManaRule,
 		grantItem: ItemGrantRule,

--- a/src/documents/actor/base.svelte.ts
+++ b/src/documents/actor/base.svelte.ts
@@ -679,7 +679,18 @@ class NimbleBaseActor<ActorType extends SystemActorTypes = SystemActorTypes> ext
 
 		ChatMessage.applyRollMode(chatData as Record<string, unknown>, visibilityMode);
 
-		return (await ChatMessage.create(chatData)) ?? null;
+		const message = (await ChatMessage.create(chatData)) ?? null;
+
+		const combatant = game.combat?.getCombatantByActor(this.id ?? '') ?? null;
+		if (combatant) {
+			// @ts-expect-error - nimble.initiativeRolled is a custom Nimble hook consumed by ruleEventDispatch
+			Hooks.callAll('nimble.initiativeRolled', {
+				actor: this,
+				combatant,
+			});
+		}
+
+		return message;
 	}
 
 	async rollSavingThrow(saveKey: SaveKeyType, options: ActorRollOptions = {}) {

--- a/src/documents/actor/character.ts
+++ b/src/documents/actor/character.ts
@@ -1521,6 +1521,12 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 			restData,
 		);
 		await manager.rest();
+
+		// @ts-expect-error - nimble.rest is a custom Nimble hook consumed by ruleEventDispatch
+		Hooks.callAll('nimble.rest', {
+			actor: this,
+			restType: restData.restType,
+		});
 	}
 
 	/** ------------------------------------------------------ */

--- a/src/documents/chatMessage.ts
+++ b/src/documents/chatMessage.ts
@@ -363,7 +363,35 @@ class NimbleChatMessage extends ChatMessage {
 			}
 		}
 
+		// Let rules on the speaker actor contribute nodes to the card. Each rule
+		// decides independently what (if anything) to surface — chat card rendering
+		// stays rule-type-agnostic.
+		const ruleNodes = this.#collectRuleActivationCardNodes({
+			isCritical: systemData.isCritical,
+			isMiss: systemData.isMiss,
+		});
+		if (ruleNodes.length > 0) {
+			nodes.push(ruleNodes);
+		}
+
 		return nodes;
+	}
+
+	#collectRuleActivationCardNodes(context: { isCritical: boolean; isMiss: boolean }): EffectNode[] {
+		const actorId = this.speaker?.actor;
+		const actor = actorId ? game.actors?.get(actorId) : null;
+		const rules = (
+			actor as unknown as {
+				rules?: Array<{ getActivationCardNodes?: (ctx: typeof context) => EffectNode[] }>;
+			} | null
+		)?.rules;
+		if (!rules || rules.length === 0) return [];
+
+		const contributed: EffectNode[] = [];
+		for (const rule of rules) {
+			contributed.push(...(rule.getActivationCardNodes?.(context) ?? []));
+		}
+		return contributed;
 	}
 
 	/** ------------------------------------------------------ */
@@ -448,8 +476,23 @@ class NimbleChatMessage extends ChatMessage {
 			return;
 		}
 
+		const sourceActorId = this.speaker?.actor;
+		const sourceActor = sourceActorId ? (game.actors?.get(sourceActorId) ?? null) : null;
+		const sourceItemId = (this.flags as Record<string, { itemId?: string } | undefined>)?.nimble
+			?.itemId;
+		const sourceItem = sourceItemId ? (sourceActor?.items?.get(sourceItemId) ?? null) : null;
+
 		for (const target of damageApplicationPlan.applicableTargets) {
 			await target.actor.applyDamage(target.adjustedDamage);
+			// @ts-expect-error - nimble.damageApplied is a custom Nimble hook consumed by ruleEventDispatch
+			Hooks.callAll('nimble.damageApplied', {
+				sourceItem,
+				sourceActor,
+				targetActor: target.actor,
+				card: this,
+				isCritical: systemData.isCritical,
+				isMiss: systemData.isMiss,
+			});
 		}
 
 		for (const tokenName of damageApplicationPlan.zeroDamageTargetNames) {

--- a/src/hooks/combatantHooks/combatantDefeatSync.ts
+++ b/src/hooks/combatantHooks/combatantDefeatSync.ts
@@ -1,3 +1,8 @@
+import {
+	ACTOR_HP_PATHS,
+	ACTOR_WOUNDS_PATHS,
+	hasAnyActorChangeAt,
+} from '../../utils/actorHpChangePaths.js';
 import { getActorHpValue, getActorWoundsValueAndMax } from '../../utils/actorResources.js';
 import { isCombatantDead } from '../../utils/isCombatantDead.js';
 
@@ -219,11 +224,8 @@ export default function registerCombatantDefeatSync() {
 	didRegisterCombatantDefeatSync = true;
 
 	Hooks.on('updateActor', (actor: Actor.Implementation, changes: Record<string, unknown>) => {
-		const hpChanged = foundry.utils.hasProperty(changes, 'system.attributes.hp.value');
-		const woundsChanged =
-			foundry.utils.hasProperty(changes, 'system.attributes.wounds.value') ||
-			foundry.utils.hasProperty(changes, 'system.attributes.wounds.max');
-		if (!hpChanged && !woundsChanged) return;
+		const watched = [ACTOR_HP_PATHS.value, ACTOR_WOUNDS_PATHS.value, ACTOR_WOUNDS_PATHS.max];
+		if (!hasAnyActorChangeAt(changes, watched)) return;
 
 		void syncActorCombatantDeathState(actor);
 	});

--- a/src/hooks/combatantHooks/combatantHealthStateSync.ts
+++ b/src/hooks/combatantHooks/combatantHealthStateSync.ts
@@ -1,4 +1,5 @@
 import { getActorHealthState } from '../../utils/actorHealthState.js';
+import { ACTOR_HP_PATHS, hasAnyActorChangeAt } from '../../utils/actorHpChangePaths.js';
 
 const BLOODIED_STATUS_ID = 'bloodied';
 const LAST_STAND_STATUS_ID = 'lastStand';
@@ -48,11 +49,8 @@ export default function registerCombatantHealthStateSync() {
 	didRegisterCombatantHealthStateSync = true;
 
 	Hooks.on('updateActor', (actor: Actor.Implementation, changes: Record<string, unknown>) => {
-		const hpChanged =
-			foundry.utils.hasProperty(changes, 'system.attributes.hp.value') ||
-			foundry.utils.hasProperty(changes, 'system.attributes.hp.max') ||
-			foundry.utils.hasProperty(changes, 'system.attributes.hp.lastStandThreshold');
-		if (!hpChanged) return;
+		const watched = [ACTOR_HP_PATHS.value, ACTOR_HP_PATHS.max, ACTOR_HP_PATHS.lastStandThreshold];
+		if (!hasAnyActorChangeAt(changes, watched)) return;
 
 		void syncActorHealthState(actor);
 	});

--- a/src/hooks/ruleEventDispatch.test.ts
+++ b/src/hooks/ruleEventDispatch.test.ts
@@ -1,0 +1,276 @@
+import type { Mock } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Track the hook event handlers registered during module import.
+const handlers = new Map<string, (...args: unknown[]) => void>();
+const hooksOn = vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+	handlers.set(event, handler);
+	return 1;
+});
+
+vi.stubGlobal('Hooks', {
+	on: hooksOn,
+	once: vi.fn(),
+	off: vi.fn(),
+	call: vi.fn(),
+	callAll: vi.fn(),
+});
+
+const settingsGet = vi.fn().mockReturnValue(false);
+vi.stubGlobal('game', {
+	settings: { get: settingsGet },
+});
+
+vi.stubGlobal('foundry', {
+	utils: {
+		hasProperty: (target: unknown, path: string) => {
+			const segments = path.split('.');
+			let cursor: unknown = target;
+			for (const segment of segments) {
+				if (cursor === null || typeof cursor !== 'object') return false;
+				if (!(segment in (cursor as Record<string, unknown>))) return false;
+				cursor = (cursor as Record<string, unknown>)[segment];
+			}
+			return true;
+		},
+	},
+});
+
+vi.mock('../utils/actorHealthState.js', () => ({
+	getActorHealthState: vi.fn(() => 'normal'),
+}));
+
+import { getActorHealthState } from '../utils/actorHealthState.js';
+import registerRuleEventDispatch from './ruleEventDispatch.js';
+
+interface RuleLike {
+	onItemUsed: Mock;
+	onTurnStart: Mock;
+	onTurnEnd: Mock;
+	onActorKilled: Mock;
+	onActorWounded: Mock;
+	onSaveResolved: Mock;
+	onRest: Mock;
+	onInitiativeRolled: Mock;
+}
+
+function createMockRule(): RuleLike {
+	return {
+		onItemUsed: vi.fn().mockResolvedValue(undefined),
+		onTurnStart: vi.fn().mockResolvedValue(undefined),
+		onTurnEnd: vi.fn().mockResolvedValue(undefined),
+		onActorKilled: vi.fn().mockResolvedValue(undefined),
+		onActorWounded: vi.fn().mockResolvedValue(undefined),
+		onSaveResolved: vi.fn().mockResolvedValue(undefined),
+		onRest: vi.fn().mockResolvedValue(undefined),
+		onInitiativeRolled: vi.fn().mockResolvedValue(undefined),
+	};
+}
+
+describe('ruleEventDispatch', () => {
+	beforeAll(() => {
+		// Register once — the dispatcher has an internal idempotency latch.
+		registerRuleEventDispatch();
+	});
+
+	beforeEach(() => {
+		settingsGet.mockReset();
+		settingsGet.mockReturnValue(true);
+		(getActorHealthState as unknown as Mock).mockReset();
+		(getActorHealthState as unknown as Mock).mockReturnValue('normal');
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('registers the expected hook event names', () => {
+		expect(handlers.has('nimble.damageApplied')).toBe(true);
+		expect(handlers.has('combatTurn')).toBe(true);
+		expect(handlers.has('updateActor')).toBe(true);
+		expect(handlers.has('nimble.saveResolved')).toBe(true);
+		expect(handlers.has('nimble.rest')).toBe(true);
+		expect(handlers.has('nimble.initiativeRolled')).toBe(true);
+	});
+
+	describe('automation.autoApplyConditions gating', () => {
+		it('skips dispatch when setting is disabled', async () => {
+			settingsGet.mockReturnValue(false);
+			const rule = createMockRule();
+			const sourceActor = { rules: [rule] };
+			const targetActor = { rules: [] };
+
+			const handler = handlers.get('nimble.damageApplied');
+			expect(handler).toBeDefined();
+			handler?.({
+				sourceItem: {},
+				sourceActor,
+				targetActor,
+				card: null,
+				isCritical: true,
+				isMiss: false,
+			});
+
+			await Promise.resolve();
+			expect(rule.onItemUsed).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('nimble.damageApplied → onItemUsed', () => {
+		it('calls onItemUsed on each rule of the source actor with the target', async () => {
+			const rule = createMockRule();
+			const sourceActor = { rules: [rule] };
+			const targetActor = { rules: [] };
+
+			const handler = handlers.get('nimble.damageApplied');
+			handler?.({
+				sourceItem: { name: 'Shadow Blast' },
+				sourceActor,
+				targetActor,
+				card: null,
+				isCritical: true,
+				isMiss: false,
+			});
+			await Promise.resolve();
+			await Promise.resolve();
+
+			expect(rule.onItemUsed).toHaveBeenCalledTimes(1);
+			const ctx = rule.onItemUsed.mock.calls[0]?.[0];
+			expect(ctx).toMatchObject({
+				isCritical: true,
+				isMiss: false,
+				sourceActor,
+				targetActor,
+			});
+		});
+
+		it('no-ops when sourceActor or targetActor is missing', async () => {
+			const handler = handlers.get('nimble.damageApplied');
+			expect(() =>
+				handler?.({
+					sourceItem: {},
+					sourceActor: null,
+					targetActor: null,
+					card: null,
+					isCritical: true,
+					isMiss: false,
+				}),
+			).not.toThrow();
+			await Promise.resolve();
+		});
+	});
+
+	describe('combatTurn → onTurnStart/onTurnEnd', () => {
+		it('fires onTurnEnd on the previous combatant and onTurnStart on the next', async () => {
+			const previousRule = createMockRule();
+			const nextRule = createMockRule();
+			const previousActor = { rules: [previousRule] };
+			const nextActor = { rules: [nextRule] };
+			const previousCombatant = { actor: previousActor } as unknown as Combatant;
+			const nextCombatant = { actor: nextActor } as unknown as Combatant;
+			const combat = {
+				combatant: previousCombatant,
+				turns: [nextCombatant],
+			} as unknown as Combat;
+
+			const handler = handlers.get('combatTurn');
+			handler?.(combat, { round: 1, turn: 0 }, { advanceTime: 0, direction: 1 });
+			await Promise.resolve();
+			await Promise.resolve();
+
+			expect(previousRule.onTurnEnd).toHaveBeenCalledTimes(1);
+			expect(nextRule.onTurnStart).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('updateActor → onActorKilled/onActorWounded', () => {
+		it('fires onActorKilled when HP changed and current HP ≤ 0', async () => {
+			const rule = createMockRule();
+			const actor = {
+				rules: [rule],
+				system: { attributes: { hp: { value: 0, max: 20 } } },
+			};
+			const changes = { system: { attributes: { hp: { value: 0 } } } };
+
+			const handler = handlers.get('updateActor');
+			handler?.(actor, changes);
+			await Promise.resolve();
+			await Promise.resolve();
+
+			expect(rule.onActorKilled).toHaveBeenCalledTimes(1);
+			expect(rule.onActorWounded).not.toHaveBeenCalled();
+		});
+
+		it('fires onActorWounded when HP changed and state is bloodied', async () => {
+			(getActorHealthState as unknown as Mock).mockReturnValue('bloodied');
+			const rule = createMockRule();
+			const actor = {
+				rules: [rule],
+				system: { attributes: { hp: { value: 5, max: 20 } } },
+			};
+			const changes = { system: { attributes: { hp: { value: 5 } } } };
+
+			const handler = handlers.get('updateActor');
+			handler?.(actor, changes);
+			await Promise.resolve();
+			await Promise.resolve();
+
+			expect(rule.onActorWounded).toHaveBeenCalledTimes(1);
+			expect(rule.onActorKilled).not.toHaveBeenCalled();
+		});
+
+		it('does nothing when HP was not part of the update', async () => {
+			const rule = createMockRule();
+			const actor = {
+				rules: [rule],
+				system: { attributes: { hp: { value: 10, max: 20 } } },
+			};
+			const changes = { name: 'Renamed' };
+
+			const handler = handlers.get('updateActor');
+			handler?.(actor, changes);
+			await Promise.resolve();
+
+			expect(rule.onActorKilled).not.toHaveBeenCalled();
+			expect(rule.onActorWounded).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('nimble.rest / nimble.initiativeRolled / nimble.saveResolved', () => {
+		it('dispatches onRest', async () => {
+			const rule = createMockRule();
+			const actor = { rules: [rule] };
+
+			const handler = handlers.get('nimble.rest');
+			handler?.({ actor, restType: 'safe' });
+			await Promise.resolve();
+			await Promise.resolve();
+
+			expect(rule.onRest).toHaveBeenCalledTimes(1);
+		});
+
+		it('dispatches onInitiativeRolled', async () => {
+			const rule = createMockRule();
+			const actor = { rules: [rule] };
+
+			const handler = handlers.get('nimble.initiativeRolled');
+			handler?.({ actor, combatant: {} });
+			await Promise.resolve();
+			await Promise.resolve();
+
+			expect(rule.onInitiativeRolled).toHaveBeenCalledTimes(1);
+		});
+
+		it('dispatches onSaveResolved', async () => {
+			const rule = createMockRule();
+			const actor = { rules: [rule] };
+
+			const handler = handlers.get('nimble.saveResolved');
+			handler?.({ actor, saveType: 'strength', outcome: 'fail' });
+			await Promise.resolve();
+			await Promise.resolve();
+
+			expect(rule.onSaveResolved).toHaveBeenCalledTimes(1);
+		});
+	});
+});

--- a/src/hooks/ruleEventDispatch.ts
+++ b/src/hooks/ruleEventDispatch.ts
@@ -1,0 +1,195 @@
+import type {
+	ActorHealthContext,
+	InitiativeRolledContext,
+	ItemUsedContext,
+	NimbleBaseRule,
+	RestContext,
+	SaveResolvedContext,
+	TurnContext,
+} from '../models/rules/base.js';
+import { getActorHealthState } from '../utils/actorHealthState.js';
+import { ACTOR_HP_PATHS, hasAnyActorChangeAt } from '../utils/actorHpChangePaths.js';
+
+const AUTO_APPLY_CONDITIONS_SETTING = 'automation.autoApplyConditions';
+
+interface ActorWithRules {
+	rules?: NimbleBaseRule[];
+}
+
+interface NimbleDamageAppliedPayload {
+	sourceItem: unknown;
+	sourceActor: ActorWithRules;
+	targetActor: ActorWithRules;
+	card: ChatMessage | null;
+	isCritical: boolean;
+	isMiss: boolean;
+}
+
+interface NimbleSavePayload {
+	actor: ActorWithRules;
+	saveType: string;
+	outcome: 'pass' | 'fail';
+}
+
+interface NimbleRestPayload {
+	actor: ActorWithRules;
+	restType: 'safe' | 'field';
+}
+
+interface NimbleInitiativePayload {
+	actor: ActorWithRules;
+	combatant: Combatant;
+}
+
+function isAutoApplyEnabled(): boolean {
+	try {
+		return Boolean(
+			game.settings?.get('nimble' as 'core', AUTO_APPLY_CONDITIONS_SETTING as 'rollMode'),
+		);
+	} catch {
+		return false;
+	}
+}
+
+async function dispatch<TContext>(
+	actor: ActorWithRules | null | undefined,
+	methodName: keyof NimbleBaseRule,
+	context: TContext,
+): Promise<void> {
+	if (!actor?.rules) return;
+	for (const rule of actor.rules) {
+		const method = rule[methodName] as ((ctx: TContext) => Promise<void>) | undefined;
+		if (typeof method !== 'function') continue;
+		try {
+			await method.call(rule, context);
+		} catch (error) {
+			// eslint-disable-next-line no-console
+			console.warn(`Nimble | ruleEventDispatch ${String(methodName)} failed`, error);
+		}
+	}
+}
+
+function handleDamageApplied(payload: NimbleDamageAppliedPayload): void {
+	if (!isAutoApplyEnabled()) return;
+	if (!payload.sourceActor || !payload.targetActor) return;
+	const context: ItemUsedContext = {
+		sourceItem: payload.sourceItem as unknown as ItemUsedContext['sourceItem'],
+		sourceActor: payload.sourceActor as unknown as ItemUsedContext['sourceActor'],
+		targetActor: payload.targetActor as unknown as ItemUsedContext['targetActor'],
+		card: payload.card,
+		isCritical: payload.isCritical,
+		isMiss: payload.isMiss,
+	};
+	void dispatch(payload.sourceActor, 'onItemUsed', context);
+}
+
+function handleCombatTurn(
+	combat: Combat,
+	updateData: { round: number; turn: number },
+	_updateOptions: { advanceTime: number; direction: number },
+): void {
+	if (!isAutoApplyEnabled()) return;
+	if (!combat?.turns?.length) return;
+
+	const previousCombatant = combat.combatant ?? null;
+	const previousActor = (previousCombatant?.actor ?? null) as ActorWithRules | null;
+	if (previousCombatant && previousActor) {
+		const endContext: TurnContext = {
+			combat,
+			combatant: previousCombatant,
+			actor: previousActor as unknown as TurnContext['actor'],
+		};
+		void dispatch(previousActor, 'onTurnEnd', endContext);
+	}
+
+	const nextCombatant = combat.turns[updateData.turn] ?? null;
+	const nextActor = (nextCombatant?.actor ?? null) as ActorWithRules | null;
+	if (nextCombatant && nextActor) {
+		const startContext: TurnContext = {
+			combat,
+			combatant: nextCombatant,
+			actor: nextActor as unknown as TurnContext['actor'],
+		};
+		void dispatch(nextActor, 'onTurnStart', startContext);
+	}
+}
+
+function handleActorUpdate(actor: Actor.Implementation, changes: Record<string, unknown>): void {
+	if (!isAutoApplyEnabled()) return;
+	if (!hasAnyActorChangeAt(changes, [ACTOR_HP_PATHS.value])) return;
+
+	const typedActor = actor as unknown as Actor.Implementation & {
+		system: { attributes: { hp: { value: number } } };
+	};
+	const currentHp = typedActor.system.attributes.hp.value ?? 0;
+
+	const actorWithRules = actor as unknown as ActorWithRules;
+	const healthContext: ActorHealthContext = {
+		actor: actor as unknown as ActorHealthContext['actor'],
+		previousHp: currentHp,
+		currentHp,
+	};
+
+	if (currentHp <= 0) {
+		void dispatch(actorWithRules, 'onActorKilled', healthContext);
+		return;
+	}
+
+	const healthState = getActorHealthState(actor);
+	if (healthState === 'bloodied' || healthState === 'lastStand') {
+		void dispatch(actorWithRules, 'onActorWounded', healthContext);
+	}
+}
+
+function handleSaveResolved(payload: NimbleSavePayload): void {
+	if (!isAutoApplyEnabled()) return;
+	const context: SaveResolvedContext = {
+		actor: payload.actor as unknown as SaveResolvedContext['actor'],
+		saveType: payload.saveType,
+		outcome: payload.outcome,
+	};
+	void dispatch(payload.actor, 'onSaveResolved', context);
+}
+
+function handleRest(payload: NimbleRestPayload): void {
+	if (!isAutoApplyEnabled()) return;
+	const context: RestContext = {
+		actor: payload.actor as unknown as RestContext['actor'],
+		restType: payload.restType,
+	};
+	void dispatch(payload.actor, 'onRest', context);
+}
+
+function handleInitiativeRolled(payload: NimbleInitiativePayload): void {
+	if (!isAutoApplyEnabled()) return;
+	const context: InitiativeRolledContext = {
+		actor: payload.actor as unknown as InitiativeRolledContext['actor'],
+		combatant: payload.combatant,
+	};
+	void dispatch(payload.actor, 'onInitiativeRolled', context);
+}
+
+let didRegister = false;
+
+type HookFn = (...args: unknown[]) => void;
+const onHook = (event: string, handler: HookFn): number =>
+	(Hooks.on as (ev: string, fn: HookFn) => number)(event, handler);
+
+export default function registerRuleEventDispatch(): void {
+	if (didRegister) return;
+	didRegister = true;
+
+	onHook('nimble.damageApplied', handleDamageApplied as HookFn);
+	onHook('combatTurn', handleCombatTurn as HookFn);
+	onHook('updateActor', handleActorUpdate as HookFn);
+	onHook('nimble.saveResolved', handleSaveResolved as HookFn);
+	onHook('nimble.rest', handleRest as HookFn);
+	onHook('nimble.initiativeRolled', handleInitiativeRolled as HookFn);
+}
+
+export {
+	AUTO_APPLY_CONDITIONS_SETTING,
+	type NimbleSavePayload,
+	type NimbleRestPayload,
+	type NimbleInitiativePayload,
+};

--- a/src/models/rules/applyCondition.test.ts
+++ b/src/models/rules/applyCondition.test.ts
@@ -1,0 +1,385 @@
+import type { Mock } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApplyConditionRule, type ApplyConditionTrigger } from './applyCondition.js';
+
+interface MockActiveEffect {
+	update: Mock<(data: Record<string, unknown>) => Promise<unknown>>;
+}
+
+interface MockActor {
+	statuses: Set<string>;
+	toggleStatusEffect: Mock<
+		(
+			statusId: string,
+			options?: { active?: boolean },
+		) => Promise<MockActiveEffect | boolean | undefined>
+	>;
+}
+
+interface MockItem {
+	actor: MockActor;
+	isEmbedded: boolean;
+	name: string;
+	uuid: string;
+}
+
+interface ApplyConditionSource {
+	condition: string;
+	trigger: ApplyConditionTrigger;
+	duration?: { rounds?: number | null; turns?: number | null; seconds?: number | null };
+	disabled?: boolean;
+	label?: string;
+	id?: string;
+	identifier?: string;
+	priority?: number;
+	predicate?: Record<string, unknown>;
+	type?: string;
+}
+
+interface ApplyConditionRuleTestInstance extends ApplyConditionRule {
+	condition: string;
+	trigger: ApplyConditionTrigger;
+	duration: { rounds: number | null; turns: number | null; seconds: number | null };
+	disabled: boolean;
+	label: string;
+}
+
+function createMockActor(): MockActor {
+	return {
+		statuses: new Set<string>(),
+		toggleStatusEffect: vi.fn().mockResolvedValue(true),
+	};
+}
+
+function createMockActorWithAppliedEffect(effectUpdate: Mock): MockActor {
+	return {
+		statuses: new Set<string>(),
+		toggleStatusEffect: vi.fn().mockResolvedValue({ update: effectUpdate }),
+	};
+}
+
+function createMockItem(actor: MockActor): MockItem {
+	return { actor, isEmbedded: true, name: 'Test Feature', uuid: 'test-item-uuid' };
+}
+
+function createApplyConditionRule(
+	config: ApplyConditionSource,
+	actor: MockActor,
+): ApplyConditionRuleTestInstance {
+	const item = createMockItem(actor);
+	const sourceData = {
+		condition: config.condition,
+		trigger: config.trigger,
+		duration: {
+			rounds: config.duration?.rounds ?? null,
+			turns: config.duration?.turns ?? null,
+			seconds: config.duration?.seconds ?? null,
+		},
+		disabled: config.disabled ?? false,
+		label: config.label ?? 'Test Apply Condition',
+		id: config.id ?? 'test-apply-condition-id',
+		identifier: config.identifier ?? '',
+		priority: config.priority ?? 1,
+		predicate: config.predicate ?? {},
+		type: 'applyCondition',
+	};
+
+	const rule = new ApplyConditionRule(
+		sourceData as foundry.data.fields.SchemaField.CreateData<
+			ApplyConditionRule['schema']['fields']
+		>,
+		{ parent: item as unknown as foundry.abstract.DataModel.Any, strict: false },
+	) as ApplyConditionRuleTestInstance;
+
+	rule.condition = config.condition;
+	rule.trigger = config.trigger;
+	rule.duration = sourceData.duration;
+	rule.disabled = config.disabled ?? false;
+	rule.label = config.label ?? 'Test Apply Condition';
+
+	Object.defineProperty(rule, 'item', { get: () => item, configurable: true });
+	Object.defineProperty(rule, '_predicate', {
+		get: () => ({ size: 0 }),
+		configurable: true,
+	});
+
+	return rule;
+}
+
+function buildItemUsedContext(
+	sourceActor: MockActor,
+	targetActor: MockActor | null,
+	overrides: {
+		isCritical?: boolean;
+		isMiss?: boolean;
+	} = {},
+) {
+	const item = createMockItem(sourceActor);
+	type Ctx = Parameters<ApplyConditionRule['onItemUsed']>[0];
+	return {
+		sourceItem: item as unknown as Ctx['sourceItem'],
+		sourceActor: sourceActor as unknown as Ctx['sourceActor'],
+		targetActor: targetActor as unknown as Ctx['targetActor'],
+		card: null,
+		isCritical: overrides.isCritical ?? false,
+		isMiss: overrides.isMiss ?? false,
+	};
+}
+
+describe('ApplyConditionRule', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe('schema', () => {
+		it('defines the expected fields', () => {
+			const schema = ApplyConditionRule.defineSchema();
+			expect(schema).toHaveProperty('type');
+			expect(schema).toHaveProperty('condition');
+			expect(schema).toHaveProperty('trigger');
+			expect(schema).toHaveProperty('duration');
+		});
+	});
+
+	describe('onItemUsed (fires per target on damage-apply)', () => {
+		it('fires onCrit trigger only when context.isCritical is true', async () => {
+			const attackerActor = createMockActor();
+			const targetActor = createMockActor();
+			const rule = createApplyConditionRule(
+				{ condition: 'smoldering', trigger: 'onCrit' },
+				attackerActor,
+			);
+
+			await rule.onItemUsed(buildItemUsedContext(attackerActor, targetActor));
+			expect(targetActor.toggleStatusEffect).not.toHaveBeenCalled();
+
+			await rule.onItemUsed(buildItemUsedContext(attackerActor, targetActor, { isCritical: true }));
+			expect(targetActor.toggleStatusEffect).toHaveBeenCalledWith('smoldering', { active: true });
+		});
+
+		it('fires onHit trigger only when not critical', async () => {
+			const attackerActor = createMockActor();
+			const targetActor = createMockActor();
+			const rule = createApplyConditionRule(
+				{ condition: 'dazed', trigger: 'onHit' },
+				attackerActor,
+			);
+
+			await rule.onItemUsed(buildItemUsedContext(attackerActor, targetActor, { isCritical: true }));
+			expect(targetActor.toggleStatusEffect).not.toHaveBeenCalled();
+
+			await rule.onItemUsed(buildItemUsedContext(attackerActor, targetActor));
+			expect(targetActor.toggleStatusEffect).toHaveBeenCalledWith('dazed', { active: true });
+		});
+
+		it('ignores events where the source actor is not the rule owner', async () => {
+			const ownerActor = createMockActor();
+			const otherActor = createMockActor();
+			const targetActor = createMockActor();
+			const rule = createApplyConditionRule(
+				{ condition: 'smoldering', trigger: 'onCrit' },
+				ownerActor,
+			);
+
+			// Event comes from a different actor's item — rule should not fire.
+			await rule.onItemUsed(buildItemUsedContext(otherActor, targetActor, { isCritical: true }));
+
+			expect(targetActor.toggleStatusEffect).not.toHaveBeenCalled();
+		});
+
+		it('no-ops gracefully when targetActor is null', async () => {
+			const attackerActor = createMockActor();
+			const rule = createApplyConditionRule(
+				{ condition: 'blinded', trigger: 'onCrit' },
+				attackerActor,
+			);
+
+			await expect(
+				rule.onItemUsed(buildItemUsedContext(attackerActor, null, { isCritical: true })),
+			).resolves.not.toThrow();
+		});
+	});
+
+	describe('self-target triggers', () => {
+		it('fires onTurnStart only when the combatant actor owns the rule', async () => {
+			const ownerActor = createMockActor();
+			const otherActor = createMockActor();
+			const rule = createApplyConditionRule(
+				{ condition: 'focused', trigger: 'onTurnStart' },
+				ownerActor,
+			);
+
+			await rule.onTurnStart({
+				combat: {} as Combat,
+				combatant: {} as Combatant,
+				actor: otherActor as unknown as Parameters<ApplyConditionRule['onTurnStart']>[0]['actor'],
+			});
+			expect(ownerActor.toggleStatusEffect).not.toHaveBeenCalled();
+
+			await rule.onTurnStart({
+				combat: {} as Combat,
+				combatant: {} as Combatant,
+				actor: ownerActor as unknown as Parameters<ApplyConditionRule['onTurnStart']>[0]['actor'],
+			});
+			expect(ownerActor.toggleStatusEffect).toHaveBeenCalledWith('focused', { active: true });
+		});
+
+		it('does not fire onTurnStart for a rule with a different trigger', async () => {
+			const ownerActor = createMockActor();
+			const rule = createApplyConditionRule(
+				{ condition: 'focused', trigger: 'onTurnEnd' },
+				ownerActor,
+			);
+
+			await rule.onTurnStart({
+				combat: {} as Combat,
+				combatant: {} as Combatant,
+				actor: ownerActor as unknown as Parameters<ApplyConditionRule['onTurnStart']>[0]['actor'],
+			});
+
+			expect(ownerActor.toggleStatusEffect).not.toHaveBeenCalled();
+		});
+
+		it('fires onSaveFail only on failing outcome', async () => {
+			const ownerActor = createMockActor();
+			const rule = createApplyConditionRule(
+				{ condition: 'prone', trigger: 'onSaveFail' },
+				ownerActor,
+			);
+
+			await rule.onSaveResolved({
+				actor: ownerActor as unknown as Parameters<
+					ApplyConditionRule['onSaveResolved']
+				>[0]['actor'],
+				saveType: 'strength',
+				outcome: 'pass',
+			});
+			expect(ownerActor.toggleStatusEffect).not.toHaveBeenCalled();
+
+			await rule.onSaveResolved({
+				actor: ownerActor as unknown as Parameters<
+					ApplyConditionRule['onSaveResolved']
+				>[0]['actor'],
+				saveType: 'strength',
+				outcome: 'fail',
+			});
+			expect(ownerActor.toggleStatusEffect).toHaveBeenCalledWith('prone', { active: true });
+		});
+	});
+
+	describe('duration pass-through', () => {
+		it('patches the ActiveEffect returned by toggleStatusEffect when duration is configured', async () => {
+			const attackerActor = createMockActor();
+			const effectUpdate = vi.fn().mockResolvedValue(undefined);
+			const targetActor = createMockActorWithAppliedEffect(effectUpdate);
+
+			const rule = createApplyConditionRule(
+				{
+					condition: 'smoldering',
+					trigger: 'onCrit',
+					duration: { rounds: 2 },
+				},
+				attackerActor,
+			);
+
+			await rule.onItemUsed(buildItemUsedContext(attackerActor, targetActor, { isCritical: true }));
+
+			expect(effectUpdate).toHaveBeenCalledWith({ duration: { rounds: 2 } });
+		});
+
+		it('skips the update when no duration fields are set', async () => {
+			const attackerActor = createMockActor();
+			const effectUpdate = vi.fn().mockResolvedValue(undefined);
+			const targetActor = createMockActorWithAppliedEffect(effectUpdate);
+
+			const rule = createApplyConditionRule(
+				{ condition: 'smoldering', trigger: 'onCrit' },
+				attackerActor,
+			);
+
+			await rule.onItemUsed(buildItemUsedContext(attackerActor, targetActor, { isCritical: true }));
+
+			expect(effectUpdate).not.toHaveBeenCalled();
+		});
+
+		it('skips the update when toggleStatusEffect returns true (effect already existed)', async () => {
+			const attackerActor = createMockActor();
+			const targetActor = createMockActor();
+			targetActor.toggleStatusEffect.mockResolvedValue(true);
+
+			const rule = createApplyConditionRule(
+				{ condition: 'smoldering', trigger: 'onCrit', duration: { rounds: 2 } },
+				attackerActor,
+			);
+
+			await expect(
+				rule.onItemUsed(buildItemUsedContext(attackerActor, targetActor, { isCritical: true })),
+			).resolves.not.toThrow();
+		});
+	});
+
+	describe('predicate gating', () => {
+		it('skips application when disabled', async () => {
+			const attackerActor = createMockActor();
+			const targetActor = createMockActor();
+			const rule = createApplyConditionRule(
+				{ condition: 'smoldering', trigger: 'onCrit', disabled: true },
+				attackerActor,
+			);
+
+			await rule.onItemUsed(buildItemUsedContext(attackerActor, targetActor, { isCritical: true }));
+
+			expect(targetActor.toggleStatusEffect).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('getActivationCardNodes', () => {
+		it('returns a condition node when the trigger matches the context', () => {
+			const actor = createMockActor();
+			const rule = createApplyConditionRule({ condition: 'smoldering', trigger: 'onCrit' }, actor);
+
+			const nodes = rule.getActivationCardNodes({ isCritical: true, isMiss: false });
+
+			expect(nodes).toHaveLength(1);
+			const first = nodes[0] as { type: string; condition: string; id: string } | undefined;
+			expect(first?.type).toBe('condition');
+			expect(first?.condition).toBe('smoldering');
+			expect(first?.id).toContain('apply-condition-');
+		});
+
+		it('returns nothing when the trigger does not match the context', () => {
+			const actor = createMockActor();
+			const rule = createApplyConditionRule({ condition: 'smoldering', trigger: 'onCrit' }, actor);
+
+			expect(rule.getActivationCardNodes({ isCritical: false, isMiss: false })).toEqual([]);
+			expect(rule.getActivationCardNodes({ isCritical: false, isMiss: true })).toEqual([]);
+		});
+
+		it('returns nothing for non-attack triggers', () => {
+			const actor = createMockActor();
+			const rule = createApplyConditionRule(
+				{ condition: 'smoldering', trigger: 'onTurnStart' },
+				actor,
+			);
+
+			expect(rule.getActivationCardNodes({ isCritical: true, isMiss: false })).toEqual([]);
+		});
+	});
+
+	describe('dedupe against existing condition', () => {
+		it('does not re-apply when target already has the condition', async () => {
+			const attackerActor = createMockActor();
+			const targetActor = createMockActor();
+			targetActor.statuses.add('smoldering');
+
+			const rule = createApplyConditionRule(
+				{ condition: 'smoldering', trigger: 'onCrit' },
+				attackerActor,
+			);
+
+			await rule.onItemUsed(buildItemUsedContext(attackerActor, targetActor, { isCritical: true }));
+
+			expect(targetActor.toggleStatusEffect).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/src/models/rules/applyCondition.test.ts
+++ b/src/models/rules/applyCondition.test.ts
@@ -1,5 +1,10 @@
 import type { Mock } from 'vitest';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hooksCall = vi.fn().mockReturnValue(true);
+const hooksCallAll = vi.fn();
+vi.stubGlobal('Hooks', { call: hooksCall, callAll: hooksCallAll });
+
 import { ApplyConditionRule, type ApplyConditionTrigger } from './applyCondition.js';
 
 interface MockActiveEffect {
@@ -129,6 +134,7 @@ function buildItemUsedContext(
 describe('ApplyConditionRule', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		hooksCall.mockReturnValue(true);
 	});
 
 	describe('schema', () => {
@@ -380,6 +386,97 @@ describe('ApplyConditionRule', () => {
 			await rule.onItemUsed(buildItemUsedContext(attackerActor, targetActor, { isCritical: true }));
 
 			expect(targetActor.toggleStatusEffect).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('nimble.preApplyCondition hook', () => {
+		it('calls Hooks.call before applying the condition', async () => {
+			const attackerActor = createMockActor();
+			const targetActor = createMockActor();
+			const rule = createApplyConditionRule(
+				{ condition: 'dazed', trigger: 'onCrit' },
+				attackerActor,
+			);
+
+			await rule.onItemUsed(buildItemUsedContext(attackerActor, targetActor, { isCritical: true }));
+
+			expect(hooksCall).toHaveBeenCalledWith(
+				'nimble.preApplyCondition',
+				expect.objectContaining({ target: targetActor, condition: 'dazed' }),
+			);
+			expect(targetActor.toggleStatusEffect).toHaveBeenCalled();
+		});
+
+		it('skips application when a listener returns false', async () => {
+			hooksCall.mockReturnValue(false);
+			const attackerActor = createMockActor();
+			const targetActor = createMockActor();
+			const rule = createApplyConditionRule(
+				{ condition: 'dazed', trigger: 'onCrit' },
+				attackerActor,
+			);
+
+			await rule.onItemUsed(buildItemUsedContext(attackerActor, targetActor, { isCritical: true }));
+
+			expect(hooksCall).toHaveBeenCalledWith(
+				'nimble.preApplyCondition',
+				expect.objectContaining({ condition: 'dazed' }),
+			);
+			expect(targetActor.toggleStatusEffect).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('nimble.conditionApplied hook', () => {
+		it('fires Hooks.callAll after successfully applying a condition', async () => {
+			const attackerActor = createMockActor();
+			const effectUpdate = vi.fn().mockResolvedValue(undefined);
+			const targetActor = createMockActorWithAppliedEffect(effectUpdate);
+			const rule = createApplyConditionRule(
+				{ condition: 'smoldering', trigger: 'onCrit' },
+				attackerActor,
+			);
+
+			await rule.onItemUsed(buildItemUsedContext(attackerActor, targetActor, { isCritical: true }));
+
+			expect(hooksCallAll).toHaveBeenCalledWith(
+				'nimble.conditionApplied',
+				expect.objectContaining({
+					target: targetActor,
+					condition: 'smoldering',
+					effect: expect.objectContaining({ update: effectUpdate }),
+				}),
+			);
+		});
+
+		it('passes null effect when toggleStatusEffect returns true', async () => {
+			const attackerActor = createMockActor();
+			const targetActor = createMockActor();
+			targetActor.toggleStatusEffect.mockResolvedValue(true);
+			const rule = createApplyConditionRule(
+				{ condition: 'dazed', trigger: 'onCrit' },
+				attackerActor,
+			);
+
+			await rule.onItemUsed(buildItemUsedContext(attackerActor, targetActor, { isCritical: true }));
+
+			expect(hooksCallAll).toHaveBeenCalledWith(
+				'nimble.conditionApplied',
+				expect.objectContaining({ condition: 'dazed', effect: null }),
+			);
+		});
+
+		it('does not fire when preApplyCondition blocks application', async () => {
+			hooksCall.mockReturnValue(false);
+			const attackerActor = createMockActor();
+			const targetActor = createMockActor();
+			const rule = createApplyConditionRule(
+				{ condition: 'dazed', trigger: 'onCrit' },
+				attackerActor,
+			);
+
+			await rule.onItemUsed(buildItemUsedContext(attackerActor, targetActor, { isCritical: true }));
+
+			expect(hooksCallAll).not.toHaveBeenCalledWith('nimble.conditionApplied', expect.anything());
 		});
 	});
 });

--- a/src/models/rules/applyCondition.ts
+++ b/src/models/rules/applyCondition.ts
@@ -183,8 +183,30 @@ class ApplyConditionRule extends NimbleBaseRule<ApplyConditionRule.Schema> {
 		// dedupe only works for status effects with a static _id, which Nimble only
 		// assigns to conditions with linked statuses (see ConditionManager.ts).
 		if (target.statuses?.has(this.condition)) return;
+
+		// Blocking hook — listeners can return false to prevent condition application
+		// (e.g. condition immunity, resistance, or redirect).
+		// @ts-expect-error - nimble.preApplyCondition is a custom Nimble hook
+		const allowed = Hooks.call('nimble.preApplyCondition', {
+			target,
+			condition: this.condition,
+			source: this.item,
+			rule: this,
+		});
+		if (allowed === false) return;
+
 		const result = await target.toggleStatusEffect(this.condition, { active: true });
 		await this.#maybePatchDuration(result);
+
+		// Notify listeners that a condition was successfully applied.
+		// @ts-expect-error - nimble.conditionApplied is a custom Nimble hook
+		Hooks.callAll('nimble.conditionApplied', {
+			target,
+			condition: this.condition,
+			effect: typeof result === 'object' ? result : null,
+			source: this.item,
+			rule: this,
+		});
 	}
 
 	async #maybePatchDuration(result: ActiveEffectLike | boolean | undefined): Promise<void> {

--- a/src/models/rules/applyCondition.ts
+++ b/src/models/rules/applyCondition.ts
@@ -1,0 +1,206 @@
+import type { ConditionNode, EffectNode } from '#types/effectTree.js';
+import {
+	type ActivationCardContext,
+	type ActorHealthContext,
+	type InitiativeRolledContext,
+	type ItemUsedContext,
+	NimbleBaseRule,
+	type RestContext,
+	type SaveResolvedContext,
+	type TurnContext,
+} from './base.js';
+
+const ATTACK_OUTCOME_TRIGGERS = ['onHit', 'onCrit', 'onMiss'] as const;
+const SELF_TRIGGERS = [
+	'onTurnStart',
+	'onTurnEnd',
+	'onKill',
+	'onWound',
+	'onSaveFail',
+	'onRest',
+	'onInitiative',
+] as const;
+
+const TRIGGER_CHOICES = [...ATTACK_OUTCOME_TRIGGERS, ...SELF_TRIGGERS] as const;
+
+type ApplyConditionTrigger = (typeof TRIGGER_CHOICES)[number];
+
+function schema() {
+	const { fields } = foundry.data;
+
+	return {
+		type: new fields.StringField({ required: true, nullable: false, initial: 'applyCondition' }),
+		condition: new fields.StringField({ required: true, nullable: false, initial: '' }),
+		trigger: new fields.StringField({
+			required: true,
+			nullable: false,
+			initial: 'onCrit',
+			choices: TRIGGER_CHOICES as unknown as string[],
+		}),
+		duration: new fields.SchemaField({
+			rounds: new fields.NumberField({ required: false, nullable: true, initial: null }),
+			turns: new fields.NumberField({ required: false, nullable: true, initial: null }),
+			seconds: new fields.NumberField({ required: false, nullable: true, initial: null }),
+		}),
+	};
+}
+
+declare namespace ApplyConditionRule {
+	type Schema = NimbleBaseRule.Schema & ReturnType<typeof schema>;
+}
+
+interface ActiveEffectLike {
+	update(data: Record<string, unknown>): Promise<unknown>;
+}
+
+interface ActorWithStatusEffect {
+	statuses?: Set<string>;
+	toggleStatusEffect(
+		statusId: string,
+		options?: { active?: boolean; overlay?: boolean },
+	): Promise<ActiveEffectLike | boolean | undefined>;
+}
+
+class ApplyConditionRule extends NimbleBaseRule<ApplyConditionRule.Schema> {
+	declare condition: string;
+	declare trigger: ApplyConditionTrigger;
+	declare duration: { rounds: number | null; turns: number | null; seconds: number | null };
+
+	static override defineSchema(): ApplyConditionRule.Schema {
+		return {
+			...NimbleBaseRule.defineSchema(),
+			...schema(),
+		};
+	}
+
+	override tooltipInfo(): string {
+		return super.tooltipInfo(
+			new Map([
+				['condition', 'string'],
+				[
+					'trigger',
+					TRIGGER_CHOICES.map((t) => `'${t}'`).join(
+						' <span class="nimble-type-summary__operator">|</span> ',
+					),
+				],
+				['duration', '{ rounds?, turns?, seconds? } | null'],
+			]),
+		);
+	}
+
+	override async onItemUsed(context: ItemUsedContext): Promise<void> {
+		if (!this.#shouldFireOnItemUsed(context)) return;
+		const targetActor = context.targetActor as unknown as ActorWithStatusEffect | null;
+		if (!targetActor) return;
+		await this.#applyConditionTo(targetActor);
+	}
+
+	override getActivationCardNodes(context: ActivationCardContext): EffectNode[] {
+		if (!this.#isAttackTrigger()) return [];
+		if (!this.#matchesAttackContext(context)) return [];
+		if (!this.condition) return [];
+		const node: ConditionNode = {
+			id: `apply-condition-${this.id}`,
+			type: 'condition',
+			condition: this.condition,
+			parentContext: null,
+			parentNode: null,
+		};
+		return [node];
+	}
+
+	override async onTurnStart(context: TurnContext): Promise<void> {
+		if (this.trigger !== 'onTurnStart') return;
+		if (context.actor !== this.item.actor) return;
+		await this.#applyConditionToSelf();
+	}
+
+	override async onTurnEnd(context: TurnContext): Promise<void> {
+		if (this.trigger !== 'onTurnEnd') return;
+		if (context.actor !== this.item.actor) return;
+		await this.#applyConditionToSelf();
+	}
+
+	override async onActorKilled(context: ActorHealthContext): Promise<void> {
+		if (this.trigger !== 'onKill') return;
+		if (context.actor !== this.item.actor) return;
+		await this.#applyConditionToSelf();
+	}
+
+	override async onActorWounded(context: ActorHealthContext): Promise<void> {
+		if (this.trigger !== 'onWound') return;
+		if (context.actor !== this.item.actor) return;
+		await this.#applyConditionToSelf();
+	}
+
+	override async onSaveResolved(context: SaveResolvedContext): Promise<void> {
+		if (this.trigger !== 'onSaveFail') return;
+		if (context.actor !== this.item.actor) return;
+		if (context.outcome !== 'fail') return;
+		await this.#applyConditionToSelf();
+	}
+
+	override async onRest(context: RestContext): Promise<void> {
+		if (this.trigger !== 'onRest') return;
+		if (context.actor !== this.item.actor) return;
+		await this.#applyConditionToSelf();
+	}
+
+	override async onInitiativeRolled(context: InitiativeRolledContext): Promise<void> {
+		if (this.trigger !== 'onInitiative') return;
+		if (context.actor !== this.item.actor) return;
+		await this.#applyConditionToSelf();
+	}
+
+	#shouldFireOnItemUsed(context: ItemUsedContext): boolean {
+		if (!this.test()) return false;
+		if (context.sourceActor !== this.item.actor) return false;
+		return this.#matchesAttackContext(context);
+	}
+
+	#matchesAttackContext(context: { isCritical: boolean; isMiss: boolean }): boolean {
+		if (this.trigger === 'onHit') return !context.isCritical && !context.isMiss;
+		if (this.trigger === 'onCrit') return context.isCritical;
+		if (this.trigger === 'onMiss') return context.isMiss;
+		return false;
+	}
+
+	#isAttackTrigger(): boolean {
+		return this.trigger === 'onHit' || this.trigger === 'onCrit' || this.trigger === 'onMiss';
+	}
+
+	async #applyConditionToSelf(): Promise<void> {
+		if (!this.test()) return;
+		const selfActor = this.item.actor as unknown as ActorWithStatusEffect | null;
+		if (!selfActor) return;
+		await this.#applyConditionTo(selfActor);
+	}
+
+	async #applyConditionTo(target: ActorWithStatusEffect): Promise<void> {
+		if (!this.condition) return;
+		// Short-circuit if the target already has the condition. Mirrors the pattern in
+		// src/view/chat/components/ConditionNode.svelte — Foundry's toggleStatusEffect
+		// dedupe only works for status effects with a static _id, which Nimble only
+		// assigns to conditions with linked statuses (see ConditionManager.ts).
+		if (target.statuses?.has(this.condition)) return;
+		const result = await target.toggleStatusEffect(this.condition, { active: true });
+		await this.#maybePatchDuration(result);
+	}
+
+	async #maybePatchDuration(result: ActiveEffectLike | boolean | undefined): Promise<void> {
+		const durationUpdate: Record<string, number | null> = {};
+		if (this.duration.rounds !== null) durationUpdate.rounds = this.duration.rounds;
+		if (this.duration.turns !== null) durationUpdate.turns = this.duration.turns;
+		if (this.duration.seconds !== null) durationUpdate.seconds = this.duration.seconds;
+		if (Object.keys(durationUpdate).length === 0) return;
+
+		// Foundry's toggleStatusEffect returns:
+		//   ActiveEffect — newly created effect (patch its duration)
+		//   true        — effect already existed (nothing to patch)
+		//   false / undefined — no-op
+		if (!result || typeof result !== 'object') return;
+		await result.update({ duration: durationUpdate });
+	}
+}
+
+export { ApplyConditionRule, type ApplyConditionTrigger, TRIGGER_CHOICES };

--- a/src/models/rules/base.ts
+++ b/src/models/rules/base.ts
@@ -1,3 +1,4 @@
+import type { EffectNode } from '#types/effectTree.js';
 import type { NimbleRollData } from '#types/rollData.d.ts';
 import getDeterministicBonus from '../../dice/getDeterministicBonus.js';
 import type { Predicate } from '../../etc/Predicate.js';
@@ -44,6 +45,52 @@ interface PreCreateArgs {
 	pendingItems: Array<foundry.data.fields.SchemaField.AssignmentData<Item.Schema>>;
 	tempItems: Item[];
 	operation: { keepId?: boolean };
+}
+
+// Context passed to onItemUsed — fires per target when damage from an item's
+// use is actually applied to that target (NOT when the roll lands). This
+// ensures rules don't trigger on a hit the GM later voids.
+interface ItemUsedContext {
+	sourceItem: NimbleBaseItem;
+	sourceActor: NimbleBaseActor;
+	targetActor: NimbleBaseActor;
+	card: ChatMessage | null;
+	isCritical: boolean;
+	isMiss: boolean;
+}
+
+// Context passed to getActivationCardNodes when a chat card renders.
+interface ActivationCardContext {
+	isCritical: boolean;
+	isMiss: boolean;
+}
+
+interface TurnContext {
+	combat: Combat;
+	combatant: Combatant;
+	actor: NimbleBaseActor;
+}
+
+interface ActorHealthContext {
+	actor: NimbleBaseActor;
+	previousHp: number;
+	currentHp: number;
+}
+
+interface SaveResolvedContext {
+	actor: NimbleBaseActor;
+	saveType: string;
+	outcome: 'pass' | 'fail';
+}
+
+interface RestContext {
+	actor: NimbleBaseActor;
+	restType: 'safe' | 'field';
+}
+
+interface InitiativeRolledContext {
+	actor: NimbleBaseActor;
+	combatant: Combatant;
 }
 
 abstract class NimbleBaseRule<
@@ -188,10 +235,74 @@ abstract class NimbleBaseRule<
 		// Default implementation does nothing
 	}
 
+	/**
+	 * Hook called after an item is used and a chat card is produced.
+	 * Dispatched by ruleEventDispatch for attack-outcome triggers (onHit/onCrit/onMiss).
+	 */
+	async onItemUsed(_context: ItemUsedContext): Promise<void> {
+		// Default implementation does nothing
+	}
+
+	/** Hook called at the start of a combatant's turn. */
+	async onTurnStart(_context: TurnContext): Promise<void> {
+		// Default implementation does nothing
+	}
+
+	/** Hook called at the end of a combatant's turn. */
+	async onTurnEnd(_context: TurnContext): Promise<void> {
+		// Default implementation does nothing
+	}
+
+	/** Hook called when an actor's HP drops to 0 or below. */
+	async onActorKilled(_context: ActorHealthContext): Promise<void> {
+		// Default implementation does nothing
+	}
+
+	/** Hook called when an actor takes a wound (bloodied / lastStand transition). */
+	async onActorWounded(_context: ActorHealthContext): Promise<void> {
+		// Default implementation does nothing
+	}
+
+	/** Hook called when a saving throw resolves. */
+	async onSaveResolved(_context: SaveResolvedContext): Promise<void> {
+		// Default implementation does nothing
+	}
+
+	/** Hook called when an actor completes a rest. */
+	async onRest(_context: RestContext): Promise<void> {
+		// Default implementation does nothing
+	}
+
+	/** Hook called when an actor rolls initiative. */
+	async onInitiativeRolled(_context: InitiativeRolledContext): Promise<void> {
+		// Default implementation does nothing
+	}
+
+	/**
+	 * Called by the chat card renderer when an activation card resolves, for every
+	 * rule on the speaker actor. Returns zero or more EffectNode entries to inject
+	 * into the card's render tree — surfaces rule-driven outcomes (e.g. a
+	 * rule-derived ConditionNode) in the card regardless of automation settings.
+	 */
+	getActivationCardNodes(_context: ActivationCardContext): EffectNode[] {
+		// Default implementation contributes no nodes
+		return [];
+	}
+
 	override toString() {
 		const data = this.toJSON();
 		return JSON.stringify(data, null, 2);
 	}
 }
 
-export { NimbleBaseRule, type PreCreateArgs };
+export {
+	NimbleBaseRule,
+	type PreCreateArgs,
+	type ItemUsedContext,
+	type TurnContext,
+	type ActorHealthContext,
+	type SaveResolvedContext,
+	type RestContext,
+	type InitiativeRolledContext,
+	type ActivationCardContext,
+};

--- a/src/nimble.ts
+++ b/src/nimble.ts
@@ -12,6 +12,7 @@ import ready from './hooks/ready.js';
 import renderChatMessageHTML from './hooks/renderChatMessage.js';
 import renderCompendium from './hooks/renderCompendium.js';
 import renderNimbleTokenHUD from './hooks/renderNimbleTokenHUD.js';
+import registerRuleEventDispatch from './hooks/ruleEventDispatch.js';
 import setup from './hooks/setup.js';
 import './scss/main.scss';
 import { getCombatManaGrantForCombat, getCombatManaGrantMap } from './utils/combatManaRules.js';
@@ -91,6 +92,7 @@ registerCombatantHealthStateSync();
 registerMinionGroupTokenBadges();
 registerMinionGroupTokenActions();
 registerTokenCombatantSync();
+registerRuleEventDispatch();
 
 // Refresh tokens when combat ends to remove turn indicators
 Hooks.on('deleteCombat', async (combat: Combat) => {

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -47,6 +47,21 @@ export default function registerSystemSettings() {
 	);
 
 	registerAdjacencySettings();
+
+	game.settings.register(
+		'nimble' as 'core',
+		'automation.autoApplyConditions' as 'rollMode',
+		{
+			name: 'NIMBLE.settings.autoApplyConditions.name',
+			hint: 'NIMBLE.settings.autoApplyConditions.hint',
+			scope: 'world',
+			config: true,
+			type: Boolean,
+			default: false,
+			requiresReload: true,
+		} as unknown as Parameters<typeof game.settings.register>[2],
+	);
+
 	registerCombatTrackerSettings();
 	registerNcswSettings();
 

--- a/src/utils/actorHpChangePaths.ts
+++ b/src/utils/actorHpChangePaths.ts
@@ -1,0 +1,26 @@
+/**
+ * Canonical property paths for actor HP / wound fields that `updateActor` hook
+ * handlers need to watch. Centralizing these keeps listeners consistent when
+ * the system data shape changes.
+ */
+export const ACTOR_HP_PATHS = {
+	value: 'system.attributes.hp.value',
+	max: 'system.attributes.hp.max',
+	lastStandThreshold: 'system.attributes.hp.lastStandThreshold',
+} as const;
+
+export const ACTOR_WOUNDS_PATHS = {
+	value: 'system.attributes.wounds.value',
+	max: 'system.attributes.wounds.max',
+} as const;
+
+/**
+ * Returns true if any of the provided dot-notation paths appears in the
+ * `changes` diff emitted by Foundry's `updateActor` hook.
+ */
+export function hasAnyActorChangeAt(
+	changes: Record<string, unknown>,
+	paths: readonly string[],
+): boolean {
+	return paths.some((path) => foundry.utils.hasProperty(changes, path));
+}


### PR DESCRIPTION
## Summary

Adds the `applyCondition` foundation rule type plus the event-time rule dispatcher it runs on. Rules declared on a feature, skill, or item can now apply a Nimble condition to the owner or the current attack's target when a trigger fires — without writing macros or relying on GMs clicking a chat-card button.

## Changes

- New `ApplyConditionRule` data model in `src/models/rules/applyCondition.ts`. Schema `{ type, condition, trigger, duration? }`. Applies only registered Nimble conditions (`CONFIG.NIMBLE.conditions`) — never arbitrary `ActiveEffect`s (those belong in #577 `toggleEffect`).
- New event-time lifecycle hooks on `NimbleBaseRule`: `onItemUsed`, `onTurnStart`/`End`, `onActorKilled`/`Wounded`, `onSaveResolved`, `onRest`, `onInitiativeRolled`, `getActivationCardNodes`. Pattern mirrors `SpeedBonusRule`'s existing `prePrepareData`/`afterPrepareData` overrides.
- New shared dispatcher `src/hooks/ruleEventDispatch.ts` that subscribes to upstream signals and iterates `actor.rules`. Attack-outcome triggers fire from `nimble.damageApplied` (new, emitted per-target in `chatMessage.applyDamage`) — **not** `nimble.useItem` — so GMs can void a hit without the condition already being stuck on the target.
- New upstream emits: `nimble.damageApplied` (per-target in `chatMessage.applyDamage`), `nimble.rest` (in `character.triggerRest`), `nimble.initiativeRolled` (in `actor.rollInitiativeToChat`). `nimble.saveResolved` is subscribed but not yet emitted (deferred — needs wiring at the save resolution site).
- New world setting `automation.autoApplyConditions` (boolean, default **OFF**, `requiresReload: true`) gates all rule-driven condition dispatch.
- `chatMessage.ts:effectNodes` getter now delegates to `rule.getActivationCardNodes()` on every rule of the speaker actor, letting rules contribute synthetic nodes to the chat card. `ApplyConditionRule` uses this to render a compact `ConditionNode` pill on the card — visible (and clickable for manual apply) regardless of whether the automation setting is on.
- Dedupe pre-check (`actor.statuses.has(condition)` before `toggleStatusEffect`) mirrors the existing pattern in `ConditionNode.svelte:40`. Foundry's native dedupe is unreliable for status effects without a static `_id`.
- New shared helper `src/utils/actorHpChangePaths.ts` centralizes the HP-change property paths used by three `updateActor` listeners (`combatantDefeatSync`, `combatantHealthStateSync`, and the new dispatcher).
- New content: `Fanatical Zeal` on `packs/monsters/core/cultists/doomsayer.json` now has an `applyCondition` rule wiring the "your crits also inflict Despair" clause. Previously pure description text with no mechanical backing.
- 24 new unit tests across `applyCondition.test.ts` and `ruleEventDispatch.test.ts`. Full suite 785/785 green.

## Test Plan

Reviewer steps using the shipped Doomsayer content:

1. Pull the branch and launch Foundry against the worktree (or install the built bundle).
2. In **Settings → Configure Settings → System Settings**, enable **Auto-Apply Conditions from Rules**. Accept the reload prompt.
3. Drop a **Doomsayer** from the Monsters compendium onto a scene.
4. Target any player token and fire **Ecstatic Ravings** from the Doomsayer's sheet.
5. Force or roll a crit (set primary die to max). Expected:
   - Chat card shows the `Despair` pill under the effects section.
   - Clicking **Apply Damage** applies damage **and** the Despair condition to the targeted token.
6. Toggle **Auto-Apply Conditions from Rules** OFF (reload again). Repeat step 4:
   - Chat card still shows the `Despair` pill.
   - The GM can click the pill to apply Despair manually — nothing fires automatically.
7. With automation ON, crit a target that is already Despair-afflicted → **no duplicate effect** (dedupe pre-check).
8. With automation ON, crit a target but **don't** click Apply Damage → **no condition applied** (rule fires at damage-apply, not card post, so the GM can void the hit cleanly).

## Checklist

- [x] Added or updated unit tests
- [x] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [x] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** yes
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues

Closes #575.

Related but out of scope for this PR:

- #577 `toggleEffect` — arbitrary `ActiveEffect` application (not conditions).
- `onSaveFail` trigger upstream wiring — schema value is valid but dormant until a follow-up emits `nimble.saveResolved` at the save resolution site.
- `onMiss` trigger upstream wiring — no natural damage-application equivalent; the right upstream signal wasn't designed here.
- Conditional roll-modifier rule for Fanatical Zeal's "advantage while not at max HP" clause — needs a different rule type.
