### PR TITLE
fix(dialogs): restore advantage/disadvantage on checks and initiative

### DIFF
--- a/src/view/dialogs/CheckRollDialog.svelte
+++ b/src/view/dialogs/CheckRollDialog.svelte
@@ -9,18 +9,17 @@
 	const { skillCheckDialog } = CONFIG.NIMBLE;
 
 	let { actor, dialog, type = 'abilityCheck', ...data }: CheckRollDialogProps = $props();
-	let selectedRollMode = $state(untrack(() => [Math.clamp(Number(data.rollMode ?? 0), -6, 6)]));
+	let selectedRollMode = $state(untrack(() => Math.clamp(Number(data.rollMode ?? 0), -6, 6)));
 	let shouldRollBeHidden = $state(Boolean(game.settings.get('nimble', 'hideRolls')));
 
-	let selectedRollModeValue = $derived(selectedRollMode[0] ?? 0);
 	let rollFormula = $derived.by(() => {
 		if (type === 'initiative') {
-			return actor._getInitiativeFormula({ rollMode: selectedRollModeValue });
+			return actor._getInitiativeFormula({ rollMode: selectedRollMode });
 		}
 
 		return getRollFormula(actor as Parameters<typeof getRollFormula>[0], {
 			...data,
-			rollMode: selectedRollModeValue,
+			rollMode: selectedRollMode,
 			type,
 		});
 	});
@@ -45,7 +44,7 @@
 		data-button-variant="basic"
 		onclick={() =>
 			dialog.submitRoll({
-				rollMode: selectedRollModeValue,
+				rollMode: selectedRollMode,
 				rollFormula,
 				visibilityMode: shouldRollBeHidden ? 'blindroll' : 'publicroll',
 			})}


### PR DESCRIPTION
## Summary

Fixes a regression where advantage/disadvantage on saves, ability checks, skill checks, and initiative had no effect — the roll always came out as `1d20` instead of `2d20kh` / `2d20kl`. Reported by DorgaJohn on Discord after the 0.8.2 release.

## Root cause

PR #547 changed `CheckRollDialog.svelte` to wrap `selectedRollMode` in an array (`[value]`), then extract it via `selectedRollMode[0]`. But `RollModeConfig` binds `selectedRollMode` to `RangeSlider`'s `value` prop (a number, per svelte-range-slider-pips). On mount the slider runs `checkValueIsNumber()`, sees an array, coerces it to `0`, and the `bind:` propagates that back — so `selectedRollMode` becomes a plain number. `selectedRollMode[0] ?? 0` then resolves to `0` forever, regardless of slider position, so `rollFormula` is always built with `rollMode: 0`.

`ItemActivationConfigDialog` and `SpellUpcastDialog` already used a plain number, so damage rolls were unaffected.

## Fix

Drop the array wrapper — keep `selectedRollMode` as a plain number and use it directly. Matches the pattern in the other dialogs.

## Test plan

- [ ] Roll a saving throw with advantage — formula shows `2d20kh + ...`, two dice are rolled.
- [ ] Roll a saving throw with disadvantage — formula shows `2d20kl + ...`, two dice are rolled.
- [ ] Roll an ability check / skill check with advantage/disadvantage — same behavior.
- [ ] Roll initiative with advantage/disadvantage from the initiative enricher — same behavior.
- [ ] Straight roll (no advantage) still rolls `1d20`.
- [ ] Damage rolls with advantage/disadvantage still work (regression check on the untouched dialogs).