### PR TITLE
chore(compendium): fix broken image references

### DIFF
--- a/packs/legendaryMonsters/core/kelebek-entomancer.json
+++ b/packs/legendaryMonsters/core/kelebek-entomancer.json
@@ -2,7 +2,7 @@
 	"name": "Kelebek, Entomancer",
 	"type": "soloMonster",
 	"folder": null,
-	"img": "icons/creatures/invertebrates/swarm-bees.webp",
+	"img": "icons/creatures/invertebrates/wasp-swarm-tan.webp",
 	"system": {
 		"attributes": {
 			"armor": "medium",
@@ -47,7 +47,7 @@
 		"width": 1,
 		"height": 1,
 		"texture": {
-			"src": "icons/creatures/invertebrates/swarm-bees.webp",
+			"src": "icons/creatures/invertebrates/wasp-swarm-tan.webp",
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"offsetX": 0,

--- a/packs/legendaryMonsters/core/poppy-giant-stinkbug.json
+++ b/packs/legendaryMonsters/core/poppy-giant-stinkbug.json
@@ -2,7 +2,7 @@
 	"name": "Poppy, Giant Stinkbug",
 	"type": "soloMonster",
 	"folder": null,
-	"img": "icons/creatures/invertebrates/beetle-scarab-green.webp",
+	"img": "icons/creatures/invertebrates/beetle-stag-yellow-green.webp",
 	"system": {
 		"attributes": {
 			"armor": "heavy",
@@ -47,7 +47,7 @@
 		"width": 1,
 		"height": 1,
 		"texture": {
-			"src": "icons/creatures/invertebrates/beetle-scarab-green.webp",
+			"src": "icons/creatures/invertebrates/beetle-stag-yellow-green.webp",
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"offsetX": 0,

--- a/packs/legendaryMonsters/core/scorpion-queen.json
+++ b/packs/legendaryMonsters/core/scorpion-queen.json
@@ -2,7 +2,7 @@
 	"name": "Scorpion Queen",
 	"type": "soloMonster",
 	"folder": null,
-	"img": "icons/creatures/invertebrates/scorpion-brown.webp",
+	"img": "icons/creatures/invertebrates/scorpion-yellow.webp",
 	"system": {
 		"attributes": {
 			"armor": "heavy",
@@ -47,7 +47,7 @@
 		"width": 2,
 		"height": 2,
 		"texture": {
-			"src": "icons/creatures/invertebrates/scorpion-brown.webp",
+			"src": "icons/creatures/invertebrates/scorpion-yellow.webp",
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"offsetX": 0,

--- a/packs/magicItems/core/gmGuide/endless-cask.json
+++ b/packs/magicItems/core/gmGuide/endless-cask.json
@@ -2,7 +2,7 @@
 	"folder": null,
 	"name": "Endless Cask",
 	"type": "object",
-	"img": "icons/containers/barrels/barrel-iron-tied-brown.webp",
+	"img": "icons/containers/barrels/barrel-hogshead-cask-oak-brown.webp",
 	"system": {
 		"macro": "",
 		"identifier": "",

--- a/packs/monsters/core/hill-and-field/bulette.json
+++ b/packs/monsters/core/hill-and-field/bulette.json
@@ -2,7 +2,7 @@
 	"name": "Bulette",
 	"type": "npc",
 	"folder": "ed190d32f397df62",
-	"img": "icons/creatures/reptiles/beast-armored-grey.webp",
+	"img": "icons/creatures/fish/fish-shark-swimming.webp",
 	"system": {
 		"attributes": {
 			"armor": "heavy",
@@ -48,7 +48,7 @@
 		"width": 2,
 		"height": 2,
 		"texture": {
-			"src": "icons/creatures/reptiles/beast-armored-grey.webp",
+			"src": "icons/creatures/fish/fish-shark-swimming.webp",
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"offsetX": 0,

--- a/packs/monsters/core/underground/giant-slug-minion.json
+++ b/packs/monsters/core/underground/giant-slug-minion.json
@@ -2,7 +2,7 @@
 	"name": "Giant Slug Minion",
 	"type": "minion",
 	"folder": "1e695c5c5b1b3293",
-	"img": "icons/environment/creatures/bug-centipede-brown.webp",
+	"img": "icons/creatures/invertebrates/snail-movement-green.webp",
 	"system": {
 		"attributes": {
 			"armor": "none",
@@ -42,7 +42,7 @@
 		"width": 1,
 		"height": 1,
 		"texture": {
-			"src": "icons/environment/creatures/bug-centipede-brown.webp",
+			"src": "icons/creatures/invertebrates/snail-movement-green.webp",
 			"anchorX": 0.5,
 			"anchorY": 0.5,
 			"offsetX": 0,


### PR DESCRIPTION
## Summary
- Replace invalid Foundry icon paths on Endless Cask, Kelebek, Poppy, Scorpion Queen, and Bulette (verified against Foundry core's `icons/` library).
- Swap Giant Slug Minion's centipede icon for `icons/creatures/invertebrates/snail-movement-green.webp` — a gastropod is a reasonable stand-in for a slug.
- Updated both `img` and the prototype token `texture.src` where applicable.

### Icon choices
| Entity | Icon |
| --- | --- |
| Endless Cask | `icons/containers/barrels/barrel-hogshead-cask-oak-brown.webp` |
| Kelebek, Entomancer | `icons/creatures/invertebrates/wasp-swarm-tan.webp` |
| Poppy, Giant Stinkbug | `icons/creatures/invertebrates/beetle-stag-yellow-green.webp` |
| Scorpion Queen | `icons/creatures/invertebrates/scorpion-yellow.webp` |
| Bulette | `icons/creatures/fish/fish-shark-swimming.webp` (bulette = land shark) |
| Giant Slug Minion | `icons/creatures/invertebrates/snail-movement-green.webp` |

## Test plan
- [ ] Open the Magic Items compendium and confirm Endless Cask shows an image.
- [ ] Open the Legendary Monsters compendium and confirm Kelebek, Poppy, and Scorpion Queen render.
- [ ] Open Hill and Field Creatures and confirm Bulette renders.
- [ ] Drop each actor onto a scene and confirm the prototype token uses the correct art.
- [ ] Confirm Giant Slug Minion no longer uses a centipede.