### PR TITLE
feat(dice): die modifier vocabulary (c/cv/v/n)

### DIFF
--- a/docs/system/dice-engine.md
+++ b/docs/system/dice-engine.md
@@ -24,6 +24,33 @@ On top of that:
 - **AoE / multi-target attacks** can't miss and can't crit. One roll applies to everyone hit.
 - **Minions and no-proficiency weapons** can't crit.
 
+The "one primary die" model covers most weapons, but some abilities break it. Dravok's Terrible Maw rolls `4d4` where **every** die can independently crit with vicious explosion. d66/d88 lookup rolls use `2d6` where **neither** die can crit or miss. Mixed pools like a vicious weapon plus sneak attack (`1d8 + 2d6`) have one die that crits viciously while the rest are plain damage. The engine handles all of these through **die modifiers** — short tokens appended to individual dice in the formula that control their crit/miss/explosion behavior.
+
+## Die modifier vocabulary
+
+Each die in a formula can carry a modifier that tells the engine how to treat it:
+
+| Modifier | Meaning | Example |
+|----------|---------|---------|
+| `c` | Can crit. Max value → standard explosion chain (reroll, add to damage, repeat while max). | `1d8c` — standard weapon |
+| `cv` | Can crit with vicious explosion. Max value → roll 2 dice, left can chain, right cannot. | `1d8cv` — vicious weapon, `4d4cv` — Dravok |
+| `v` | Vicious metadata only. No crit detection. Warns if used without `c`. | — (rarely used alone) |
+| `n` | Neutral. No crit, no miss. Value contributes to damage normally. | `2d6n` — d66 roll, `2d8n` — AoE damage |
+
+**Formula examples:**
+
+| Formula | Meaning |
+|---------|---------|
+| `1d8c` | Standard single-die weapon. Primary die crits with standard explosion. |
+| `1d8cv` | Vicious weapon. Primary die crits with vicious explosion (2 dice per chain). |
+| `4d4cv` | Dravok's Terrible Maw. Each d4 independently checks crit, each with vicious explosion. |
+| `2d6n` | d66 tens-and-ones lookup. Neither die can crit or miss. |
+| `1d8cv + 2d6` | Vicious weapon plus sneak attack. The d8 crits viciously; the 2d6 are plain damage. |
+
+When a formula contains any Nimble modifier, the roll enters **modifier-mode** — the engine reads each die's modifier metadata instead of extracting a single primary die. This is transparent to callers: existing roll-level options (`canCrit`, `canMiss`, `isVicious`) are still accepted and translated to modifiers via a constructor shim.
+
+You can also type `/r 4d4cv` in Foundry chat to roll modifier-mode formulas directly. `DamageRoll.matches()` claims any formula containing Nimble modifiers, so the engine handles them instead of Foundry's base Roll class.
+
 ### The subtlety that breaks naive implementations
 
 Suppose you have `2d6` with advantage. That's a 3-dice pool: roll three, drop the lowest, keep two.
@@ -44,13 +71,13 @@ When a player clicks "Attack" on a weapon, here's what happens (all in `src/dice
 
 2. **Advantage and disadvantage sources are netted.** If two features give `+1 adv` and one gives `+1 dis`, the net is `+1 adv`. A single integer is passed to the next step.
 
-3. **`DamageRoll` constructs the formula.** The constructor separates the **primary pool** (the base weapon dice that can become primary) from the **bonus dice** (sneak attack, bonus elemental damage, etc.). It also applies the AoE / proficiency / minion flags that suppress crits or misses.
+3. **`DamageRoll` constructs the formula.** The constructor checks whether the formula contains Nimble die modifiers (`c`, `cv`, `n`). If so, the roll enters **modifier-mode** — each die's behavior comes from its modifier metadata, and no PrimaryDie extraction happens. If no Nimble modifiers are present, the **legacy path** runs: the constructor separates the primary pool from bonus dice and applies AoE / proficiency / minion flags.
 
-4. **Extra dice are added to the primary pool for advantage/disadvantage.** `|net|` extra dice get added, and a custom modifier (`khn` for advantage, `kln` for disadvantage) is emitted. `khn` = "keep highest Nimble." `kln` = "keep lowest Nimble." These are the Nimble-tie-aware versions of Foundry's built-in `kh`/`kl`.
+4. **Extra dice are added for advantage/disadvantage.** `|net|` extra dice get added, and a custom modifier (`khn` for advantage, `kln` for disadvantage) is emitted. This works in both modes. `khn` = "keep highest Nimble." `kln` = "keep lowest Nimble." These are the Nimble-tie-aware versions of Foundry's built-in `kh`/`kl`.
 
-5. **Foundry rolls the dice.** The custom `khn`/`kln` modifier handlers (in `src/dice/nimbleDieModifiers.ts`) sort the results and mark dice as discarded — crucially, they prefer dropping the **leftmost** tied die, which is the rule Foundry's native `kh`/`kl` does not guarantee.
+5. **Foundry rolls the dice.** The custom `khn`/`kln` modifier handlers sort results and mark dice as discarded (leftmost dropped on ties). In modifier-mode, the `c`, `cv`, `v`, and `n` handlers also run — they attach Symbol-keyed metadata to each Die instance describing its crit/miss/explosion behavior. These handlers don't roll extra dice; they only tag metadata.
 
-6. **`DamageRoll._evaluate` interprets the results.** It finds the primary die (leftmost non-discarded die of the primary pool), reads whether it rolled max (crit) or 1 (miss), and handles any crit explosion chain. Explosion behavior is controlled by the `explosionStyle` option: `'none'` (no explosions), `'standard'` (reroll on max, add to damage), or `'vicious'` (standard explosion plus the Vicious extra die). The legacy `isVicious` boolean is still accepted — a constructor shim maps it to the appropriate `explosionStyle`.
+6. **`DamageRoll._evaluate` interprets the results.** In modifier-mode, the engine iterates all Die terms, reads their modifier metadata, and dispatches per-die: `cv`-tagged dice that rolled max get a vicious explosion chain, `c`-tagged dice use Foundry's native `x` explosion, `n`-tagged dice are skipped for crit/miss. In legacy mode, the engine reads the single primary die and dispatches based on the `explosionStyle` option (`'none'` / `'standard'` / `'vicious'`). Crit detection in both modes uses the same value-based check: did a kept (active, non-discarded) die roll its max face value?
 
 7. **Post-roll mutation hook.** A no-op method `_applyPostRollMutations` is called between the dice rolling and the outcome being finalized. Today it does nothing. It's there as an extension point (see below).
 
@@ -75,12 +102,11 @@ When one of these lands, the feature's logic lives in its own rule file and gets
 
 ### Custom Die modifiers — `nimbleDieModifiers.ts`
 
-If you're adding a rule that changes how dice **resolve** (not just what their values are), register a new Foundry Die modifier here. Current examples: `khn` and `kln` for tie-aware drops. Future examples:
+Die modifiers control per-die behavior: crit capability, explosion style, and neutrality. The engine ships with `c`, `cv`, `v`, `n` (plus `khn`/`kln` for tie-aware advantage/disadvantage). Each modifier is a handler function registered on `Die.MODIFIERS` via `registerNimbleDieModifiers()` at system init.
 
-- **Dravok "Terrible Maw"** — "Every die in the pool independently checks crit, and each crit triggers Vicious." This is a custom modifier that marks individual dice with a crit flag, which `_finalizeOutcome` then reads.
-- **"Heads I Win, Tails You Lose"** — "Crit on 1 less than max." A modifier that shifts the crit threshold.
+Modifiers attach Symbol-keyed metadata to the Die instance during evaluation. The engine reads this metadata via `getNimbleMods(die)` during finalization. Modifiers never roll extra dice or mutate results — they're pure metadata. The explosion and crit logic lives in `DamageRoll._evaluate`.
 
-The pattern: write a handler function that mutates `this.results[]`, register it on `Die.MODIFIERS` via `registerNimbleDieModifiers()`, and emit the modifier token from wherever you build the roll.
+To add a new modifier: write a handler that attaches metadata via the `NIMBLE_MODS` symbol, register it in `registerNimbleDieModifiers()`, and emit the modifier token in the formula from wherever you build the roll. See the existing `c`/`cv`/`n` handlers in `nimbleDieModifiers.ts` for the pattern.
 
 ### AoE auto-flagging — `ItemActivationManager`
 
@@ -112,6 +138,7 @@ Content authors can leave `weaponType` blank (nothing breaks) or set it for weap
 | The roll formula preprocessing | `src/dice/DamageRoll.ts` (`_preProcessFormula`, `_applyRollMode`) |
 | The primary die logic | `src/dice/terms/PrimaryDie.ts` |
 | Tie-aware adv/dis handlers | `src/dice/nimbleDieModifiers.ts` |
+| Die modifier metadata (`c`, `cv`, `v`, `n`) | `src/dice/nimbleDieModifiers.ts` (`getNimbleMods()`, `NIMBLE_MODS`) |
 | Where custom modifiers get registered | `src/hooks/init.ts` (calls `registerNimbleDieModifiers()`) |
 | Roll construction from an item | `src/managers/ItemActivationManager.ts` |
 | Weapon proficiency check | `src/view/sheets/components/attackUtils.ts` (`hasWeaponProficiency`) |
@@ -132,6 +159,18 @@ A rogue attacks a Distracted goblin with a shortsword (`1d6`), with advantage fr
 7. **Crit explosion:** reroll the primary die, roll a `4`, add it. Not max, so stop.
 8. **`_applyPostRollMutations`:** no-op today. When Vicious Opportunist lands, this is where "set primary die to any value on hit against Distracted target" would run — potentially turning a hit into a crit.
 9. **`_finalizeOutcome`:** sets `isCritical = true`, `isMiss = false`. Total: primary `6 + 4` (explosion) + sneak attack `4 + 5` = `19` damage, crit flag set. Chat card renders it all.
+
+### Modifier-mode example: Dravok's Terrible Maw (`4d4cv`)
+
+A Dravok attacks with its Terrible Maw — `4d4cv`, every die can crit independently with vicious explosion.
+
+1. **Formula enters modifier-mode** because `cv` is a Nimble modifier. No PrimaryDie extraction.
+2. **Foundry rolls 4d4:** `[4, 2, 4, 1]`. The `cv` handler attaches crit-vicious metadata to the Die term.
+3. **Per-die crit check:** dice #1 and #3 rolled max (4 on a d4) → both are crits.
+4. **Vicious explosion for die #1:** roll 2d4 → `[3, 2]`. Left die (3) is not max, chain stops. +5 added.
+5. **Vicious explosion for die #3:** roll 2d4 → `[4, 1]`. Left die (4) is max → chain continues. Roll 2d4 again → `[2, 3]`. Chain stops. +10 added.
+6. **`isCritical = true`** (at least one die critted). Miss detection skipped (no non-neutral die rolled 1 — die #4 rolled 1 but miss reads leftmost die, which rolled 4).
+7. **Total:** `4 + 2 + 4 + 1` (base) + `3 + 2` (die #1 explosion) + `4 + 1 + 2 + 3` (die #3 explosion) = `26`.
 
 ## Developer testbench
 

--- a/src/dice/DamageRoll.test.ts
+++ b/src/dice/DamageRoll.test.ts
@@ -3,7 +3,16 @@ import type { EffectNode } from '#types/effectTree.js';
 import { ItemActivationManager, testDependencies } from '../managers/ItemActivationManager.js';
 import { hasWeaponProficiency } from '../utils/attackUtils.js';
 import { DamageRoll } from './DamageRoll.js';
-import { khn as nimbleKhn, kln as nimbleKln } from './nimbleDieModifiers.js';
+import {
+	getNimbleMods,
+	nimbleCrit,
+	nimbleCritVicious,
+	khn as nimbleKhn,
+	kln as nimbleKln,
+	nimbleNeutral,
+	nimbleVicious,
+} from './nimbleDieModifiers.js';
+import type { PrimaryDie } from './terms/PrimaryDie.js';
 
 type DieResult = {
 	result: number;
@@ -35,6 +44,10 @@ function stubBaseRollEvaluate() {
 				for (const m of term.modifiers as string[]) {
 					if (/^khn\d*$/.test(m)) nimbleKhn.call(term, m);
 					else if (/^kln\d*$/.test(m)) nimbleKln.call(term, m);
+					else if (m === 'cv') nimbleCritVicious.call(term, m);
+					else if (m === 'c') nimbleCrit.call(term, m);
+					else if (m === 'v') nimbleVicious.call(term, m);
+					else if (m === 'n') nimbleNeutral.call(term, m);
 				}
 			}
 			return this;
@@ -427,7 +440,8 @@ describe('DamageRoll vicious weapon preprocessing', () => {
 		);
 
 		expect(roll.primaryDie).toBeDefined();
-		expect(roll.primaryDie?.options.isVicious).toBe(true);
+		const primary = roll.primaryDie as PrimaryDie;
+		expect(primary.options.isVicious).toBe(true);
 	});
 
 	it('should not add isVicious to primary die when isVicious is false', () => {
@@ -446,7 +460,8 @@ describe('DamageRoll vicious weapon preprocessing', () => {
 
 		expect(roll.primaryDie).toBeDefined();
 		// isVicious should be undefined or false (not explicitly true)
-		expect(roll.primaryDie?.options.isVicious).toBeFalsy();
+		const primary = roll.primaryDie as PrimaryDie;
+		expect(primary.options.isVicious).toBeFalsy();
 	});
 });
 
@@ -1827,5 +1842,504 @@ describe('explosionStyle option', () => {
 		expect(legacyRoll.options.explosionStyle).toBe('vicious');
 		expect(newRoll.options.explosionStyle).toBe('vicious');
 		expect(legacyRoll.primaryDie?.modifiers).toEqual(newRoll.primaryDie?.modifiers);
+	});
+});
+
+// ─── Die Modifier Vocabulary (modifier-mode) ────────────────────────
+
+/**
+ * Stage results on the Nth Die term (0-indexed among Die terms only) in a
+ * DamageRoll. Used for modifier-mode tests where there is no PrimaryDie.
+ */
+function stageDieTermResults(roll: DamageRoll, dieTermIndex: number, results: DieResult[]): void {
+	const Terms = foundry.dice.terms;
+	const dieTerms = roll.terms.filter((t) => t instanceof Terms.Die);
+	const term = dieTerms[dieTermIndex];
+	if (!term) throw new Error(`No die term at index ${dieTermIndex}`);
+	(term as any).results = results;
+	(term as any)._evaluated = true;
+}
+
+function stageModifierModeRoll(roll: DamageRoll, dieResults: DieResult[][], total: number): void {
+	for (let i = 0; i < dieResults.length; i++) {
+		stageDieTermResults(roll, i, dieResults[i]);
+	}
+	(roll as any)._evaluated = true;
+	(roll as any)._total = total;
+}
+
+describe('die modifier vocabulary — modifier-mode', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		stubBaseRollEvaluate();
+	});
+
+	describe('modifier-mode detection and parsing', () => {
+		it('1d8c enters modifier-mode', () => {
+			const roll = new DamageRoll(
+				'1d8c',
+				{},
+				{
+					canCrit: true,
+					canMiss: true,
+					rollMode: 0,
+					primaryDieValue: 0,
+					primaryDieModifier: 0,
+				},
+			);
+			expect(roll.modifierMode).toBe(true);
+			expect(roll.primaryDie).toBeUndefined(); // no PrimaryDie term
+		});
+
+		it('1d8cv enters modifier-mode', () => {
+			const roll = new DamageRoll(
+				'1d8cv',
+				{},
+				{
+					canCrit: true,
+					canMiss: true,
+					rollMode: 0,
+					primaryDieValue: 0,
+					primaryDieModifier: 0,
+				},
+			);
+			expect(roll.modifierMode).toBe(true);
+		});
+
+		it('1d8n enters modifier-mode', () => {
+			const roll = new DamageRoll(
+				'1d8n',
+				{},
+				{
+					canCrit: false,
+					canMiss: false,
+					rollMode: 0,
+					primaryDieValue: 0,
+					primaryDieModifier: 0,
+				},
+			);
+			expect(roll.modifierMode).toBe(true);
+		});
+
+		it('1d8v enters modifier-mode', () => {
+			const roll = new DamageRoll(
+				'1d8v',
+				{},
+				{
+					canCrit: false,
+					canMiss: false,
+					rollMode: 0,
+					primaryDieValue: 0,
+					primaryDieModifier: 0,
+				},
+			);
+			expect(roll.modifierMode).toBe(true);
+		});
+
+		it('formula without Nimble modifiers does NOT enter modifier-mode', () => {
+			const roll = new DamageRoll(
+				'1d8',
+				{},
+				{
+					canCrit: true,
+					canMiss: true,
+					rollMode: 0,
+					primaryDieValue: 0,
+					primaryDieModifier: 0,
+				},
+			);
+			expect(roll.modifierMode).toBe(false);
+			expect(roll.primaryDie).toBeDefined(); // legacy PrimaryDie
+		});
+	});
+
+	describe('per-die crit detection', () => {
+		it('1d8c: rolling max sets isCritical', async () => {
+			const roll = new DamageRoll(
+				'1d8c',
+				{},
+				{
+					canCrit: true,
+					canMiss: true,
+					rollMode: 0,
+					primaryDieValue: 0,
+					primaryDieModifier: 0,
+				},
+			);
+			stageModifierModeRoll(roll, [[{ result: 8, active: true }]], 8);
+			await (roll as any)._evaluate();
+			expect(roll.isCritical).toBe(true);
+		});
+
+		it('1d8c: rolling non-max does not crit', async () => {
+			const roll = new DamageRoll(
+				'1d8c',
+				{},
+				{
+					canCrit: true,
+					canMiss: true,
+					rollMode: 0,
+					primaryDieValue: 0,
+					primaryDieModifier: 0,
+				},
+			);
+			stageModifierModeRoll(roll, [[{ result: 5, active: true }]], 5);
+			await (roll as any)._evaluate();
+			expect(roll.isCritical).toBe(false);
+		});
+
+		it('4d4cv: 2 of 4 dice at max → isCritical true', async () => {
+			const roll = new DamageRoll(
+				'4d4cv',
+				{},
+				{
+					canCrit: true,
+					canMiss: true,
+					rollMode: 0,
+					primaryDieValue: 0,
+					primaryDieModifier: 0,
+				},
+			);
+			stageModifierModeRoll(
+				roll,
+				[
+					[
+						{ result: 4, active: true },
+						{ result: 2, active: true },
+						{ result: 4, active: true },
+						{ result: 3, active: true },
+					],
+				],
+				13,
+			);
+			await (roll as any)._evaluate();
+			expect(roll.isCritical).toBe(true);
+		});
+
+		it('4d4cv: no dice at max → isCritical false', async () => {
+			const roll = new DamageRoll(
+				'4d4cv',
+				{},
+				{
+					canCrit: true,
+					canMiss: true,
+					rollMode: 0,
+					primaryDieValue: 0,
+					primaryDieModifier: 0,
+				},
+			);
+			stageModifierModeRoll(
+				roll,
+				[
+					[
+						{ result: 2, active: true },
+						{ result: 1, active: true },
+						{ result: 3, active: true },
+						{ result: 2, active: true },
+					],
+				],
+				8,
+			);
+			await (roll as any)._evaluate();
+			expect(roll.isCritical).toBe(false);
+		});
+	});
+
+	describe('neutral dice (n modifier)', () => {
+		it('2d6n: max roll does NOT set isCritical even with canCrit: true', async () => {
+			// canCrit: true so the constructor does NOT pre-lock isCritical to false.
+			// The n modifier metadata is what must prevent crit detection.
+			const roll = new DamageRoll(
+				'2d6n',
+				{},
+				{
+					canCrit: true,
+					canMiss: true,
+					rollMode: 0,
+					primaryDieValue: 0,
+					primaryDieModifier: 0,
+				},
+			);
+			stageModifierModeRoll(
+				roll,
+				[
+					[
+						{ result: 6, active: true },
+						{ result: 6, active: true },
+					],
+				],
+				12,
+			);
+			await (roll as any)._evaluate();
+			expect(roll.isCritical).toBe(false);
+		});
+
+		it('2d6n: rolling 1 does NOT set isMiss even with canMiss: true', async () => {
+			// canMiss: true so the constructor does NOT pre-lock isMiss to false.
+			// The n modifier makes all dice neutral, so no die qualifies for miss detection.
+			const roll = new DamageRoll(
+				'2d6n',
+				{},
+				{
+					canCrit: true,
+					canMiss: true,
+					rollMode: 0,
+					primaryDieValue: 0,
+					primaryDieModifier: 0,
+				},
+			);
+			stageModifierModeRoll(
+				roll,
+				[
+					[
+						{ result: 1, active: true },
+						{ result: 3, active: true },
+					],
+				],
+				4,
+			);
+			await (roll as any)._evaluate();
+			expect(roll.isMiss).toBe(false);
+		});
+	});
+
+	describe('mixed pools', () => {
+		it('1d8c + 2d6n: d8 crits, d6s are neutral', async () => {
+			const roll = new DamageRoll(
+				'1d8c + 2d6n',
+				{},
+				{
+					canCrit: true,
+					canMiss: true,
+					rollMode: 0,
+					primaryDieValue: 0,
+					primaryDieModifier: 0,
+				},
+			);
+			expect(roll.modifierMode).toBe(true);
+			// d8 rolls max (8), d6s roll max (6, 6) — only d8 should trigger crit
+			stageModifierModeRoll(
+				roll,
+				[
+					[{ result: 8, active: true }],
+					[
+						{ result: 6, active: true },
+						{ result: 6, active: true },
+					],
+				],
+				20,
+			);
+			await (roll as any)._evaluate();
+			expect(roll.isCritical).toBe(true);
+			// Verify the d6 max rolls did NOT influence the crit — check metadata
+			const Terms = foundry.dice.terms;
+			const d6Term = roll.terms.filter((t) => t instanceof Terms.Die)[1];
+			const d6Meta = getNimbleMods(d6Term);
+			expect(d6Meta?.canCrit).toBe(false);
+		});
+
+		it('1d8c + 2d6n: d8 rolls 1 → isMiss, neutral d6s ignored', async () => {
+			const roll = new DamageRoll(
+				'1d8c + 2d6n',
+				{},
+				{
+					canCrit: true,
+					canMiss: true,
+					rollMode: 0,
+					primaryDieValue: 0,
+					primaryDieModifier: 0,
+				},
+			);
+			stageModifierModeRoll(
+				roll,
+				[
+					[{ result: 1, active: true }],
+					[
+						{ result: 5, active: true },
+						{ result: 3, active: true },
+					],
+				],
+				9,
+			);
+			await (roll as any)._evaluate();
+			expect(roll.isMiss).toBe(true);
+			expect(roll.isCritical).toBe(false);
+		});
+
+		it('1d8cv + 2d6: unmodified d6s do not crit even if they roll max', async () => {
+			const roll = new DamageRoll(
+				'1d8cv + 2d6',
+				{},
+				{
+					canCrit: true,
+					canMiss: true,
+					rollMode: 0,
+					primaryDieValue: 0,
+					primaryDieModifier: 0,
+				},
+			);
+			// Any Nimble modifier triggers modifier-mode for the whole roll
+			expect(roll.modifierMode).toBe(true);
+			// d8 rolls 3 (not max), d6s roll 6+6 (max but no Nimble metadata)
+			stageModifierModeRoll(
+				roll,
+				[
+					[{ result: 3, active: true }],
+					[
+						{ result: 6, active: true },
+						{ result: 6, active: true },
+					],
+				],
+				15,
+			);
+			await (roll as any)._evaluate();
+			// d6s have no canCrit metadata → no crit from them
+			expect(roll.isCritical).toBe(false);
+		});
+	});
+
+	describe('miss detection in modifier-mode', () => {
+		it('leftmost non-neutral die rolling 1 → isMiss', async () => {
+			const roll = new DamageRoll(
+				'1d8c',
+				{},
+				{
+					canCrit: true,
+					canMiss: true,
+					rollMode: 0,
+					primaryDieValue: 0,
+					primaryDieModifier: 0,
+				},
+			);
+			stageModifierModeRoll(roll, [[{ result: 1, active: true }]], 1);
+			await (roll as any)._evaluate();
+			expect(roll.isMiss).toBe(true);
+			expect(roll.isCritical).toBe(false);
+		});
+
+		it('canMiss: false suppresses miss even in modifier-mode', async () => {
+			const roll = new DamageRoll(
+				'1d8c',
+				{},
+				{
+					canCrit: true,
+					canMiss: false,
+					rollMode: 0,
+					primaryDieValue: 0,
+					primaryDieModifier: 0,
+				},
+			);
+			stageModifierModeRoll(roll, [[{ result: 1, active: true }]], 1);
+			await (roll as any)._evaluate();
+			expect(roll.isMiss).toBe(false);
+		});
+	});
+
+	describe('primaryDie assignment in modifier-mode', () => {
+		it('assigns leftmost c-tagged die as primaryDie', async () => {
+			const roll = new DamageRoll(
+				'1d8c + 2d6',
+				{},
+				{
+					canCrit: true,
+					canMiss: true,
+					rollMode: 0,
+					primaryDieValue: 0,
+					primaryDieModifier: 0,
+				},
+			);
+			stageModifierModeRoll(
+				roll,
+				[
+					[{ result: 5, active: true }],
+					[
+						{ result: 3, active: true },
+						{ result: 2, active: true },
+					],
+				],
+				10,
+			);
+			await (roll as any)._evaluate();
+			// primaryDie should be the d8 (first Die term, tagged 'c')
+			expect(roll.primaryDie).toBeDefined();
+			expect(roll.primaryDie?.faces).toBe(8);
+		});
+	});
+
+	describe('primaryDieAsDamage: false in modifier-mode', () => {
+		it('excludes leftmost die base value from total', async () => {
+			const roll = new DamageRoll(
+				'1d8c + 2d6',
+				{},
+				{
+					canCrit: true,
+					canMiss: true,
+					rollMode: 0,
+					primaryDieValue: 0,
+					primaryDieModifier: 0,
+					primaryDieAsDamage: false,
+				},
+			);
+			stageModifierModeRoll(
+				roll,
+				[
+					[{ result: 5, active: true }],
+					[
+						{ result: 3, active: true },
+						{ result: 4, active: true },
+					],
+				],
+				12,
+			);
+			await (roll as any)._evaluate();
+			expect(roll.excludedPrimaryDieValue).toBe(5);
+			expect(roll.total).toBe(7); // 12 - 5
+		});
+	});
+
+	describe('c modifier adds x for standard explosion', () => {
+		it('1d8c die term gets x added by handler during evaluation', async () => {
+			const roll = new DamageRoll(
+				'1d8c',
+				{},
+				{
+					canCrit: true,
+					canMiss: true,
+					rollMode: 0,
+					primaryDieValue: 0,
+					primaryDieModifier: 0,
+				},
+			);
+			const Terms = foundry.dice.terms;
+			const dieTerm = roll.terms.find((t) => t instanceof Terms.Die);
+			// Before evaluation, the formula has 'c' but not yet 'x' (added by handler)
+			expect(dieTerm?.modifiers).toContain('c');
+			stageModifierModeRoll(roll, [[{ result: 5, active: true }]], 5);
+			await (roll as any)._evaluate();
+			// After evaluation, handler should have added 'x'
+			expect(dieTerm?.modifiers).toContain('x');
+		});
+	});
+
+	describe('cv modifier does NOT add x', () => {
+		it('1d8cv die term has cv but no x after evaluation', async () => {
+			const roll = new DamageRoll(
+				'1d8cv',
+				{},
+				{
+					canCrit: true,
+					canMiss: true,
+					rollMode: 0,
+					primaryDieValue: 0,
+					primaryDieModifier: 0,
+				},
+			);
+			const Terms = foundry.dice.terms;
+			const dieTerm = roll.terms.find((t) => t instanceof Terms.Die);
+			expect(dieTerm?.modifiers).toContain('cv');
+			stageModifierModeRoll(roll, [[{ result: 5, active: true }]], 5);
+			await (roll as any)._evaluate();
+			expect(dieTerm?.modifiers).not.toContain('x');
+		});
 	});
 });

--- a/src/dice/DamageRoll.ts
+++ b/src/dice/DamageRoll.ts
@@ -1,6 +1,7 @@
 import type { AnyObject, FixedInstanceType } from 'fvtt-types/utils';
 import type { InexactPartial } from '#types/utils.js';
 
+import { getNimbleMods } from './nimbleDieModifiers.js';
 import { PrimaryDie } from './terms/PrimaryDie.js';
 
 const Terms = foundry.dice.terms;
@@ -125,8 +126,20 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 	/** The original formula before preprocessing (e.g., before primary die extraction). */
 	originalFormula: string;
 
-	/** The primary die term used for critical/miss detection. */
-	primaryDie: PrimaryDie | undefined = undefined;
+	/**
+	 * The primary die term used for critical/miss detection.
+	 * In legacy mode this is a PrimaryDie instance; in modifier-mode it is the
+	 * leftmost Die tagged `c`/`cv` (or leftmost Die overall as fallback).
+	 */
+	primaryDie: PrimaryDie | foundry.dice.terms.Die | undefined = undefined;
+
+	/**
+	 * Whether this roll uses per-die modifier dispatch (modifier-mode).
+	 * True when the formula contains Nimble die modifiers (`c`, `cv`, `v`, `n`).
+	 * When true, `_extractPrimaryDie` is skipped and crit/miss detection uses
+	 * per-die metadata instead of PrimaryDie.
+	 */
+	modifierMode: boolean = false;
 
 	override _formula: string = '';
 
@@ -183,6 +196,28 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 			this.data ?? ({} as DamageRoll.Data),
 			(this.options ?? {}) as DamageRoll.Options,
 		);
+	}
+
+	/** ------------------------------------------------------ */
+	/**                Modifier-Mode Detection                */
+	/** ------------------------------------------------------ */
+
+	/** Nimble modifier tokens that trigger modifier-mode when present on any Die term. */
+	private static readonly NIMBLE_MODIFIER_TOKENS = new Set(['c', 'cv', 'v', 'n']);
+
+	/**
+	 * Check whether any Die term in `this.terms` carries a Nimble modifier.
+	 * If so, the roll enters modifier-mode and skips PrimaryDie extraction.
+	 */
+	private _hasNimbleModifiers(): boolean {
+		for (const term of this.terms) {
+			if (!(term instanceof Terms.Die)) continue;
+			if (!Array.isArray(term.modifiers)) continue;
+			for (const m of term.modifiers) {
+				if (DamageRoll.NIMBLE_MODIFIER_TOKENS.has(m)) return true;
+			}
+		}
+		return false;
 	}
 
 	/** ------------------------------------------------------ */
@@ -322,11 +357,32 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 	 * term) plus bonus dice when crit/miss detection is needed, or applying
 	 * adv/dis directly to the first die term in the AoE fallback case.
 	 *
+	 * If the formula already contains Nimble die modifiers (`c`, `cv`, `v`, `n`),
+	 * the roll enters modifier-mode: PrimaryDie extraction is skipped, and
+	 * crit/miss detection is deferred to per-die dispatch in `_evaluate`.
+	 *
 	 * @param _formula - The original dice formula (unused, kept for signature compatibility).
 	 * @param _data - Roll data (unused, kept for signature compatibility).
 	 * @param options - Roll options containing canCrit, canMiss, and rollMode settings.
 	 */
 	_preProcessFormula(_formula: string, _data: DamageRoll.Data, options: DamageRoll.Options) {
+		// ── Modifier-mode: formula already carries Nimble modifiers ──
+		if (this._hasNimbleModifiers()) {
+			this.modifierMode = true;
+			// Apply rollMode (advantage/disadvantage) to the first die term
+			// even in modifier-mode — it's orthogonal to crit/miss detection.
+			const { rollMode = 0 } = options;
+			if (rollMode) {
+				const firstDieTerm = this.terms.find((t) => t instanceof Terms.Die);
+				if (firstDieTerm) {
+					this._applyRollMode(firstDieTerm, rollMode);
+				}
+			}
+			this.resetFormula();
+			return;
+		}
+
+		// ── Legacy path: no Nimble modifiers in formula ──
 		const { rollMode = 0 } = options;
 		const needsPrimaryDie = options.canCrit || options.canMiss;
 
@@ -397,16 +453,25 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 
 		this._applyPostRollMutations();
 
-		const primaryTerm = this.terms.find((t) => t instanceof PrimaryDie);
-
-		if (primaryTerm) {
-			// For vicious weapons, handle explosion manually after initial roll
-			// (avoids Dice So Nice preempting the chain).
-			if (this.options.canCrit && this.options.explosionStyle === 'vicious') {
-				await this._evaluateViciousExplosion(primaryTerm);
+		if (this.modifierMode) {
+			// ── Modifier-mode: per-die vicious explosion ──
+			for (const term of this.terms) {
+				if (!(term instanceof Terms.Die)) continue;
+				const meta = getNimbleMods(term);
+				if (meta?.canCrit && meta.explosionStyle === 'vicious') {
+					await this._evaluateViciousExplosions(term);
+				}
 			}
-
-			this._finalizeOutcome(primaryTerm);
+			this._finalizeOutcomeModifierMode();
+		} else {
+			// ── Legacy path ──
+			const primaryTerm = this.terms.find((t) => t instanceof PrimaryDie);
+			if (primaryTerm) {
+				if (this.options.canCrit && this.options.explosionStyle === 'vicious') {
+					await this._evaluateViciousExplosion(primaryTerm);
+				}
+				this._finalizeOutcome(primaryTerm);
+			}
 		}
 
 		return this as DamageRoll.Evaluated<this>;
@@ -541,22 +606,136 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 	}
 
 	/**
-	 * Recalculates the roll total after vicious explosion added dice.
+	 * Per-die vicious explosion for modifier-mode. Unlike `_evaluateViciousExplosion`
+	 * which handles a single initial result, this method iterates ALL active,
+	 * non-discarded results that rolled max in a multi-die term (e.g. 4d4cv where
+	 * 2 of 4 dice crit) and fires a vicious explosion chain for each.
+	 */
+	private async _evaluateViciousExplosions(dieTerm: foundry.dice.terms.Die): Promise<void> {
+		const faces = dieTerm.faces ?? 6;
+		// Snapshot base results to avoid iterating over explosion dice we add
+		const baseResults = [...dieTerm.results];
+
+		for (const result of baseResults) {
+			if (!result.active || result.discarded || result.result !== faces) continue;
+
+			// Mark as exploded and chain
+			result.exploded = true;
+			let lastLeftResult = result.result;
+			let iterations = 0;
+			const maxIterations = 100;
+
+			while (lastLeftResult === faces && iterations < maxIterations) {
+				iterations++;
+				const explosionRoll = new Roll(`2d${faces}`);
+				await explosionRoll.evaluate();
+
+				const explosionDieTerm = explosionRoll.terms.find((t) => t instanceof Terms.Die) as
+					| foundry.dice.terms.Die
+					| undefined;
+				if (!explosionDieTerm || explosionDieTerm.results.length < 2) break;
+
+				const leftDie = explosionDieTerm.results[0] as foundry.dice.terms.DiceTerm.Result & {
+					provenance?: string;
+				};
+				const rightDie = explosionDieTerm.results[1] as foundry.dice.terms.DiceTerm.Result & {
+					provenance?: string;
+				};
+
+				leftDie.provenance = 'viciousChain';
+				rightDie.provenance = 'viciousBonus';
+				dieTerm.results.push(leftDie);
+				dieTerm.results.push(rightDie);
+
+				lastLeftResult = leftDie.result;
+				if (lastLeftResult === faces) leftDie.exploded = true;
+			}
+		}
+
+		this.resetFormula();
+	}
+
+	/**
+	 * Modifier-mode outcome finalization. Replaces `_finalizeOutcome` when the
+	 * roll uses per-die modifiers instead of a PrimaryDie term.
+	 */
+	private _finalizeOutcomeModifierMode(): void {
+		const dieTerms = this.terms.filter((t): t is foundry.dice.terms.Die => t instanceof Terms.Die);
+
+		// ── Crit detection: any crit-capable die that rolled max ──
+		let anyCritted = false;
+		for (const term of dieTerms) {
+			const meta = getNimbleMods(term);
+			if (!meta?.canCrit) continue;
+			if (term.results.some((r) => r.active && !r.discarded && r.result === term.faces)) {
+				anyCritted = true;
+				break;
+			}
+		}
+		if (this.options.canCrit) {
+			this.isCritical = anyCritted;
+		}
+
+		// ── Miss detection: leftmost non-neutral Die ──
+		if (this.options.canMiss) {
+			const missDie = dieTerms.find((term) => {
+				const meta = getNimbleMods(term);
+				// A die is "neutral" if tagged `n` (canCrit:false, explosionStyle:'none')
+				return !(meta && !meta.canCrit && meta.explosionStyle === 'none');
+			});
+			if (missDie) {
+				const firstActive = missDie.results.find((r) => r.active && !r.discarded);
+				this.isMiss = firstActive?.result === 1;
+			} else {
+				// All dice are neutral — no die qualifies for miss detection
+				this.isMiss = false;
+			}
+		}
+
+		// ── primaryDie assignment: leftmost c/cv tagged, or leftmost Die ──
+		const taggedPrimary = dieTerms.find((term) => {
+			const meta = getNimbleMods(term);
+			return meta?.canCrit === true;
+		});
+		this.primaryDie = taggedPrimary ?? dieTerms[0];
+
+		// ── Recalculate total if any vicious die critted ──
+		if (anyCritted) {
+			const hasVicious = dieTerms.some((term) => {
+				const meta = getNimbleMods(term);
+				return meta?.canCrit && meta.explosionStyle === 'vicious';
+			});
+			if (hasVicious) {
+				this._recalculateTotal();
+			}
+		}
+
+		// ── primaryDieAsDamage: false → exclude leftmost die's base value ──
+		if (!this.options.primaryDieAsDamage) {
+			const leftmostDie = dieTerms[0];
+			if (leftmostDie) {
+				const baseResult = leftmostDie.results.find((r) => r.active && !r.discarded);
+				if (baseResult) {
+					this.excludedPrimaryDieValue = baseResult.result;
+					const internals = this as object as { _total: number };
+					internals._total = (this._total ?? 0) - this.excludedPrimaryDieValue;
+				}
+			}
+		}
+	}
+
+	/**
+	 * Recalculates the roll total from all terms. Works in both legacy and
+	 * modifier-mode by summing active results from all Die/PrimaryDie terms
+	 * and totals from other terms.
 	 */
 	private _recalculateTotal(): void {
-		const primaryTerm = this.terms.find((t) => t instanceof PrimaryDie);
-		if (!primaryTerm) return;
-
-		// Sum all active, non-discarded results from primary die
-		const primaryTotal = primaryTerm.results
-			.filter((r) => r.active && !r.discarded)
-			.reduce((sum, r) => sum + r.result, 0);
-
-		// Recalculate total from all terms
 		let total = 0;
 		for (const term of this.terms) {
-			if (term instanceof PrimaryDie) {
-				total += primaryTotal;
+			if (term instanceof Terms.Die) {
+				total += term.results
+					.filter((r) => r.active && !r.discarded)
+					.reduce((sum, r) => sum + r.result, 0);
 			} else if ('total' in term && typeof term.total === 'number') {
 				total += term.total;
 			}
@@ -704,10 +883,23 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 		}
 
 		if (roll.terms) {
-			// Restore primaryDie if it exists in terms
-			const primaryTerm = roll.terms.find((t) => t instanceof PrimaryDie);
-			if (primaryTerm) {
-				roll.primaryDie = primaryTerm;
+			if (roll.modifierMode) {
+				// Modifier-mode: primary is leftmost Die with c/cv modifier
+				const taggedPrimary = roll.terms.find(
+					(t) =>
+						t instanceof Terms.Die &&
+						Array.isArray(t.modifiers) &&
+						(t.modifiers.includes('c') || t.modifiers.includes('cv')),
+				);
+				roll.primaryDie =
+					(taggedPrimary as foundry.dice.terms.Die | undefined) ??
+					(roll.terms.find((t) => t instanceof Terms.Die) as foundry.dice.terms.Die | undefined);
+			} else {
+				// Legacy: restore PrimaryDie if it exists in terms
+				const primaryTerm = roll.terms.find((t) => t instanceof PrimaryDie);
+				if (primaryTerm) {
+					roll.primaryDie = primaryTerm;
+				}
 			}
 		}
 

--- a/src/dice/nimbleDieModifiers.test.ts
+++ b/src/dice/nimbleDieModifiers.test.ts
@@ -1,0 +1,240 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	_resetVWarned,
+	getNimbleMods,
+	NIMBLE_MODS,
+	nimbleCrit,
+	nimbleCritVicious,
+	nimbleNeutral,
+	nimbleVicious,
+} from './nimbleDieModifiers.js';
+
+type DieResult = {
+	result: number;
+	active?: boolean;
+	discarded?: boolean;
+	exploded?: boolean;
+};
+
+interface MockDie {
+	results: DieResult[];
+	modifiers: string[];
+}
+
+function createMockDie(overrides?: Partial<MockDie>): MockDie {
+	return {
+		results: [],
+		modifiers: [],
+		...overrides,
+	};
+}
+
+// ─── nimbleCrit (c modifier) ────────────────────────────────────────
+
+describe('nimbleCrit', () => {
+	it('should attach canCrit: true and explosionStyle: standard', () => {
+		const die = createMockDie();
+
+		nimbleCrit.call(die, 'c');
+
+		const mods = getNimbleMods(die as unknown as Record<symbol, unknown>);
+		expect(mods).toEqual({ canCrit: true, explosionStyle: 'standard' });
+	});
+
+	it('should return true', () => {
+		const die = createMockDie();
+
+		const result = nimbleCrit.call(die, 'c');
+
+		expect(result).toBe(true);
+	});
+
+	it('should add x to modifiers when not already present', () => {
+		const die = createMockDie({ modifiers: [] });
+
+		nimbleCrit.call(die, 'c');
+
+		expect(die.modifiers).toContain('x');
+	});
+
+	it('should not duplicate x when already present in modifiers', () => {
+		const die = createMockDie({ modifiers: ['x'] });
+
+		nimbleCrit.call(die, 'c');
+
+		expect(die.modifiers).toEqual(['x']);
+	});
+
+	it('should preserve existing modifiers when adding x', () => {
+		const die = createMockDie({ modifiers: ['khn'] });
+
+		nimbleCrit.call(die, 'c');
+
+		expect(die.modifiers).toEqual(['khn', 'x']);
+	});
+});
+
+// ─── nimbleCritVicious (cv modifier) ────────────────────────────────
+
+describe('nimbleCritVicious', () => {
+	it('should attach canCrit: true and explosionStyle: vicious', () => {
+		const die = createMockDie();
+
+		nimbleCritVicious.call(die, 'cv');
+
+		const mods = getNimbleMods(die as unknown as Record<symbol, unknown>);
+		expect(mods).toEqual({ canCrit: true, explosionStyle: 'vicious' });
+	});
+
+	it('should return true', () => {
+		const die = createMockDie();
+
+		const result = nimbleCritVicious.call(die, 'cv');
+
+		expect(result).toBe(true);
+	});
+
+	it('should NOT add x to modifiers', () => {
+		const die = createMockDie({ modifiers: [] });
+
+		nimbleCritVicious.call(die, 'cv');
+
+		expect(die.modifiers).not.toContain('x');
+		expect(die.modifiers).toEqual([]);
+	});
+});
+
+// ─── nimbleVicious (v modifier) ─────────────────────────────────────
+
+describe('nimbleVicious', () => {
+	let warnSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		_resetVWarned();
+		vi.restoreAllMocks();
+		warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+	});
+
+	it('should attach canCrit: false and explosionStyle: vicious', () => {
+		const die = createMockDie();
+
+		nimbleVicious.call(die, 'v');
+
+		const mods = getNimbleMods(die as unknown as Record<symbol, unknown>);
+		expect(mods).toEqual({ canCrit: false, explosionStyle: 'vicious' });
+	});
+
+	it('should return true', () => {
+		const die = createMockDie();
+
+		const result = nimbleVicious.call(die, 'v');
+
+		expect(result).toBe(true);
+	});
+
+	it('should emit console.warn on first call', () => {
+		const die = createMockDie();
+
+		nimbleVicious.call(die, 'v');
+
+		expect(warnSpy).toHaveBeenCalledOnce();
+		expect(warnSpy).toHaveBeenCalledWith("Die modifier 'v' without 'c' has no effect");
+	});
+
+	it('should not emit console.warn on second call', () => {
+		const die1 = createMockDie();
+		const die2 = createMockDie();
+
+		nimbleVicious.call(die1, 'v');
+		nimbleVicious.call(die2, 'v');
+
+		expect(warnSpy).toHaveBeenCalledOnce();
+	});
+
+	it('should warn again after _resetVWarned is called', () => {
+		const die1 = createMockDie();
+		const die2 = createMockDie();
+
+		nimbleVicious.call(die1, 'v');
+		expect(warnSpy).toHaveBeenCalledOnce();
+
+		_resetVWarned();
+		nimbleVicious.call(die2, 'v');
+
+		expect(warnSpy).toHaveBeenCalledTimes(2);
+	});
+});
+
+// ─── nimbleNeutral (n modifier) ─────────────────────────────────────
+
+describe('nimbleNeutral', () => {
+	it('should attach canCrit: false and explosionStyle: none', () => {
+		const die = createMockDie();
+
+		nimbleNeutral.call(die, 'n');
+
+		const mods = getNimbleMods(die as unknown as Record<symbol, unknown>);
+		expect(mods).toEqual({ canCrit: false, explosionStyle: 'none' });
+	});
+
+	it('should return true', () => {
+		const die = createMockDie();
+
+		const result = nimbleNeutral.call(die, 'n');
+
+		expect(result).toBe(true);
+	});
+});
+
+// ─── getNimbleMods ──────────────────────────────────────────────────
+
+describe('getNimbleMods', () => {
+	it('should return undefined for a die without metadata', () => {
+		const die = createMockDie();
+
+		const mods = getNimbleMods(die as unknown as Record<symbol, unknown>);
+
+		expect(mods).toBeUndefined();
+	});
+
+	it('should return metadata after a modifier handler has run', () => {
+		const die = createMockDie();
+		nimbleCrit.call(die, 'c');
+
+		const mods = getNimbleMods(die as unknown as Record<symbol, unknown>);
+
+		expect(mods).toBeDefined();
+		expect(mods!.canCrit).toBe(true);
+		expect(mods!.explosionStyle).toBe('standard');
+	});
+
+	it('should return the most recently applied metadata when overwritten', () => {
+		const die = createMockDie();
+
+		nimbleCrit.call(die, 'c');
+		nimbleNeutral.call(die, 'n');
+
+		const mods = getNimbleMods(die as unknown as Record<symbol, unknown>);
+		expect(mods).toEqual({ canCrit: false, explosionStyle: 'none' });
+	});
+});
+
+// ─── NIMBLE_MODS symbol ─────────────────────────────────────────────
+
+describe('NIMBLE_MODS', () => {
+	it('should be a symbol', () => {
+		expect(typeof NIMBLE_MODS).toBe('symbol');
+	});
+
+	it('should have a descriptive name', () => {
+		expect(NIMBLE_MODS.description).toBe('nimbleMods');
+	});
+
+	it('should be directly readable on the die object after handler runs', () => {
+		const die = createMockDie();
+		nimbleCrit.call(die, 'c');
+
+		const raw = (die as unknown as Record<symbol, unknown>)[NIMBLE_MODS];
+		expect(raw).toEqual({ canCrit: true, explosionStyle: 'standard' });
+	});
+});

--- a/src/dice/nimbleDieModifiers.ts
+++ b/src/dice/nimbleDieModifiers.ts
@@ -7,6 +7,17 @@
  * modifiers — `khn` (keep highest, Nimble) and `kln` (keep lowest, Nimble) —
  * that enforce this rule.
  *
+ * Additionally, Nimble defines four die-level modifiers that express crit
+ * capability and explosion style per-die:
+ *   - `c`  — crit-capable, standard explosion (adds Foundry's `x` modifier)
+ *   - `cv` — crit-capable, vicious explosion (manual post-roll)
+ *   - `v`  — vicious explosion without crit capability (no effect, warning)
+ *   - `n`  — neutral die (no crit, no miss detection)
+ *
+ * These modifiers attach metadata to the Die instance via a Symbol-keyed
+ * property (`NIMBLE_MODS`), which DamageRoll reads during outcome finalization
+ * to perform per-die crit/miss dispatch.
+ *
  * Registration uses Foundry v13's `Die.MODIFIERS` static map plus a method
  * attached to `Die.prototype`. The handler signature matches Foundry's other
  * keep/drop handlers: `(modifier: string) => boolean | void`, called with
@@ -20,6 +31,37 @@
  *   - `kln3`   → keep 3 lowest
  */
 
+// ─── Die Modifier Metadata ──────────────────────────────────────────
+
+/**
+ * Symbol key for per-die Nimble metadata. Prevents collision with Foundry
+ * properties on Die instances.
+ */
+export const NIMBLE_MODS = Symbol('nimbleMods');
+
+/**
+ * Per-die metadata attached by Nimble modifier handlers (c, cv, v, n).
+ * Read by DamageRoll during outcome finalization to determine crit/miss
+ * behavior for each die independently.
+ */
+export interface NimbleDieMetadata {
+	canCrit: boolean;
+	explosionStyle: 'none' | 'standard' | 'vicious';
+}
+
+/**
+ * Read the Nimble modifier metadata from a Die instance.
+ * Returns `undefined` if no Nimble modifier handler has run on this die.
+ *
+ * Accepts any object — the Symbol key lookup is safe on objects without it.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function getNimbleMods(die: any): NimbleDieMetadata | undefined {
+	return die[NIMBLE_MODS] as NimbleDieMetadata | undefined;
+}
+
+// ─── Internal Types ─────────────────────────────────────────────────
+
 type DieResult = {
 	result: number;
 	active?: boolean;
@@ -29,6 +71,7 @@ type DieResult = {
 
 interface DieLike {
 	results: DieResult[];
+	modifiers?: string[];
 }
 
 function parseCount(modifier: string, prefix: 'khn' | 'kln'): number {
@@ -99,8 +142,103 @@ export function kln(this: DieLike, modifier: string): boolean {
 	return true;
 }
 
+// ─── Nimble Die Modifier Handlers (c, cv, v, n) ────────────────────
+
 /**
- * Register `khn` and `kln` as custom Die modifiers on Foundry's Die class.
+ * Foundry Die modifier handler: `c` — crit-capable with standard explosion.
+ *
+ * Attaches metadata `{ canCrit: true, explosionStyle: 'standard' }` and
+ * ensures Foundry's native `x` modifier is present for explosion chaining.
+ *
+ * @example `1d8c` — primary die can crit with standard explosion.
+ */
+export function nimbleCrit(this: DieLike, _modifier: string): boolean {
+	(this as unknown as Record<symbol, unknown>)[NIMBLE_MODS] = {
+		canCrit: true,
+		explosionStyle: 'standard',
+	} satisfies NimbleDieMetadata;
+	if (this.modifiers && !this.modifiers.includes('x')) {
+		this.modifiers.push('x');
+	}
+	return true;
+}
+
+/**
+ * Foundry Die modifier handler: `cv` — crit-capable with vicious explosion.
+ *
+ * Attaches metadata `{ canCrit: true, explosionStyle: 'vicious' }`. Does NOT
+ * add Foundry's `x` modifier — vicious explosion is handled manually by
+ * DamageRoll after evaluation to avoid Dice So Nice preempting the chain.
+ *
+ * @example `4d4cv` — Dravok crossbow, each d4 can crit independently.
+ */
+export function nimbleCritVicious(this: DieLike, _modifier: string): boolean {
+	(this as unknown as Record<symbol, unknown>)[NIMBLE_MODS] = {
+		canCrit: true,
+		explosionStyle: 'vicious',
+	} satisfies NimbleDieMetadata;
+	return true;
+}
+
+let _vWarned = false;
+
+/**
+ * Foundry Die modifier handler: `v` — vicious explosion without crit.
+ *
+ * Attaches metadata `{ canCrit: false, explosionStyle: 'vicious' }`. This
+ * modifier has no runtime effect without `c`; a one-time console warning is
+ * emitted to aid debugging.
+ *
+ * @example `1d8v` — legal to parse, but no effect at evaluation time.
+ */
+export function nimbleVicious(this: DieLike, _modifier: string): boolean {
+	(this as unknown as Record<symbol, unknown>)[NIMBLE_MODS] = {
+		canCrit: false,
+		explosionStyle: 'vicious',
+	} satisfies NimbleDieMetadata;
+	if (!_vWarned) {
+		console.warn("Die modifier 'v' without 'c' has no effect");
+		_vWarned = true;
+	}
+	return true;
+}
+
+/** Reset the `v` warning flag (for tests). */
+export function _resetVWarned(): void {
+	_vWarned = false;
+}
+
+/**
+ * Foundry Die modifier handler: `n` — neutral die.
+ *
+ * Attaches metadata `{ canCrit: false, explosionStyle: 'none' }`. This die is
+ * skipped for both crit and miss detection in DamageRoll's modifier-mode.
+ *
+ * @example `2d6n` — d66 roll, dice are neutral.
+ */
+export function nimbleNeutral(this: DieLike, _modifier: string): boolean {
+	(this as unknown as Record<symbol, unknown>)[NIMBLE_MODS] = {
+		canCrit: false,
+		explosionStyle: 'none',
+	} satisfies NimbleDieMetadata;
+	return true;
+}
+
+// ─── Registration ───────────────────────────────────────────────────
+
+/**
+ * Register all Nimble custom Die modifiers on Foundry's Die class.
+ *
+ * Registered modifiers:
+ *   - `khn` / `kln` — keep highest/lowest with leftmost-on-tie discard
+ *   - `cv` — crit-capable, vicious explosion
+ *   - `c`  — crit-capable, standard explosion
+ *   - `v`  — vicious (standalone, no crit)
+ *   - `n`  — neutral (skip crit/miss detection)
+ *
+ * **Ordering:** `cv` is registered BEFORE `c` so that Foundry's regex-based
+ * modifier matcher matches the longer prefix first, preventing `cv` from
+ * being split into `c` + `v`.
  *
  * Foundry v13 maps modifier-name keys to method-name strings on
  * `Die.MODIFIERS`. The actual handler function lives on `Die.prototype` under
@@ -123,6 +261,7 @@ export function registerNimbleDieModifiers(): void {
 		(Die as { MODIFIERS: Record<string, string> }).MODIFIERS = {} as Record<string, string>;
 	}
 
+	// Keep modifiers
 	if (!('khn' in Die.MODIFIERS)) {
 		Die.MODIFIERS.khn = 'keepNimbleHighest';
 	}
@@ -130,10 +269,39 @@ export function registerNimbleDieModifiers(): void {
 		Die.MODIFIERS.kln = 'keepNimbleLowest';
 	}
 
+	// Nimble die-level modifiers — cv before c for greedy prefix matching
+	if (!('cv' in Die.MODIFIERS)) {
+		Die.MODIFIERS.cv = 'nimbleCritVicious';
+	}
+	if (!('c' in Die.MODIFIERS)) {
+		Die.MODIFIERS.c = 'nimbleCrit';
+	}
+	if (!('v' in Die.MODIFIERS)) {
+		Die.MODIFIERS.v = 'nimbleVicious';
+	}
+	if (!('n' in Die.MODIFIERS)) {
+		Die.MODIFIERS.n = 'nimbleNeutral';
+	}
+
+	// Prototype method attachment — keep modifiers
 	if (typeof Die.prototype.keepNimbleHighest !== 'function') {
 		Die.prototype.keepNimbleHighest = khn;
 	}
 	if (typeof Die.prototype.keepNimbleLowest !== 'function') {
 		Die.prototype.keepNimbleLowest = kln;
+	}
+
+	// Prototype method attachment — die-level modifiers
+	if (typeof Die.prototype.nimbleCritVicious !== 'function') {
+		Die.prototype.nimbleCritVicious = nimbleCritVicious;
+	}
+	if (typeof Die.prototype.nimbleCrit !== 'function') {
+		Die.prototype.nimbleCrit = nimbleCrit;
+	}
+	if (typeof Die.prototype.nimbleVicious !== 'function') {
+		Die.prototype.nimbleVicious = nimbleVicious;
+	}
+	if (typeof Die.prototype.nimbleNeutral !== 'function') {
+		Die.prototype.nimbleNeutral = nimbleNeutral;
 	}
 }

--- a/src/view/debug/scenarios.ts
+++ b/src/view/debug/scenarios.ts
@@ -201,4 +201,34 @@ export const scenarios: Scenario[] = [
 		note: "Sneak Attack at level 15 becomes 2d20. Unusual bonus die size — verify the bonus dice render correctly and don't try to crit-explode (bonus dice never crit).",
 		formula: '1d6 + 2d20',
 	},
+
+	// --- Modifier-mode scenarios ---
+	{
+		id: 'dravok-4d4cv',
+		label: 'Dravok 4d4cv',
+		formula: '4d4cv',
+		note: 'Every d4 can crit independently, each with vicious explosion. Roll several times — any d4 that hits 4 should spawn a vicious chain.',
+	},
+	{
+		id: 'd66-2d6n',
+		label: 'd66 roll 2d6n',
+		formula: '2d6n',
+		canCrit: false,
+		canMiss: false,
+		note: 'Neutral dice — no crit, no miss. Rolling max should NOT trigger a critical hit.',
+	},
+	{
+		id: 'mixed-1d8cv-2d6',
+		label: 'Vicious + bonus 1d8cv + 2d6',
+		formula: '1d8cv + 2d6',
+		note: 'Primary d8 crits viciously, 2d6 is plain damage. Only the d8 should trigger crit detection.',
+	},
+	{
+		id: 'aoe-modifier-2d8n',
+		label: 'AoE via modifier 2d8n',
+		formula: '2d8n',
+		canCrit: false,
+		canMiss: false,
+		note: 'AoE-style damage via n modifier. No crit, no miss — outcome should always be HIT.',
+	},
 ];


### PR DESCRIPTION
## Summary

Registers `c`, `cv`, `v`, `n` as custom Foundry Die modifier handlers, enabling per-die crit/miss behavior via formula syntax. Formulas like `4d4cv` (Dravok — every die crits viciously) and `2d6n` (d66 — no crit/miss) now parse and evaluate correctly.

> **Stacked PR 3 of 5** — base: #714 (Stage 1 — explosionStyle)
> Next: `dice/stage-3` (critCount + brutalPrimary)

## Changes

- **Modifier handlers** in `nimbleDieModifiers.ts`: `c` (crit + standard explosion), `cv` (crit + vicious), `v` (metadata-only, warns without `c`), `n` (neutral — skip crit/miss). Each attaches Symbol-keyed metadata to the Die instance.
- **Modifier-mode** in `DamageRoll`: when formula contains Nimble modifiers, `_extractPrimaryDie` is skipped. `_evaluate` dispatches per-die vicious explosions. `_finalizeOutcomeModifierMode` handles per-die crit/miss detection, primaryDie assignment, and total recalculation.
- **4 testbench scenarios**: Dravok `4d4cv`, d66 `2d6n`, mixed `1d8cv + 2d6`, AoE `2d8n`.

## Tests

- 21 unit tests in new `nimbleDieModifiers.test.ts`.
- 20 integration tests in `DamageRoll.test.ts` for modifier-mode.
- All 791 tests pass (745 existing + 46 new).

## Checklist

- [x] `pnpm check` passes
- [x] Legacy rolls unchanged — shim handles translation
- [x] **AI-assisted:** reviewed against STYLE_GUIDE.md