### PR TITLE
feat(dice): critCount, brutalPrimary, and primaryDieValue API

### DIFF
--- a/docs/system/dice-engine.md
+++ b/docs/system/dice-engine.md
@@ -81,7 +81,7 @@ When a player clicks "Attack" on a weapon, here's what happens (all in `src/dice
 
 7. **Post-roll mutation hook.** A no-op method `_applyPostRollMutations` is called between the dice rolling and the outcome being finalized. Today it does nothing. It's there as an extension point (see below).
 
-8. **Finalize the total.** `_finalizeOutcome` sets `isCritical` / `isMiss` flags and adjusts the total for vicious recalculation and the `primaryDieAsDamage: false` case (where the primary die's value is excluded from damage but its explosions still count). Crit detection is a single value-based check — did the kept primary die roll its maximum? — and works the same regardless of which `explosionStyle` is active.
+8. **Finalize the total.** `_finalizeOutcome` sets `isCritical` / `isMiss` / `critCount` flags and adjusts the total for vicious recalculation and the `primaryDieAsDamage: false` case (where the primary die's value is excluded from damage but its explosions still count). `critCount` tracks how many crit-capable dice independently rolled max — for a standard weapon this is 0 or 1, but for multi-die pools like Dravok's `4d4cv` it can be 2, 3, or even 4. `isCritical` is `critCount > 0`. If the `brutalPrimary` option is set, the primary die is reassigned to whichever die rolled highest (instead of leftmost).
 
 9. **The chat card renders** (handled in `src/view/chat/components/`, outside the engine). The card shows the kept and dropped dice, the primary die, bonus dice, and the total.
 
@@ -107,6 +107,23 @@ Die modifiers control per-die behavior: crit capability, explosion style, and ne
 Modifiers attach Symbol-keyed metadata to the Die instance during evaluation. The engine reads this metadata via `getNimbleMods(die)` during finalization. Modifiers never roll extra dice or mutate results — they're pure metadata. The explosion and crit logic lives in `DamageRoll._evaluate`.
 
 To add a new modifier: write a handler that attaches metadata via the `NIMBLE_MODS` symbol, register it in `registerNimbleDieModifiers()`, and emit the modifier token in the formula from wherever you build the roll. See the existing `c`/`cv`/`n` handlers in `nimbleDieModifiers.ts` for the pattern.
+
+### Reading the primary die — `primaryDieValue`
+
+After evaluation, the roll exposes a stable API for reading the primary die's value:
+
+```typescript
+const value = roll.primaryDieValue;   // convenience getter — the kept die's result
+const faces = roll.primaryDie?.faces; // face count (e.g. 8 for a d8)
+```
+
+Several Nimble rules read the primary die value for non-damage effects: Brute knockback scales off the primary die, Bludgeoning Weapon Mastery ignores Heavy Armor when primary ≥ 7, Guiding Spirit triggers a radiant glow when primary ≥ 6, and more. These downstream readers consume the getter — they don't need to know whether the roll used modifier-mode or legacy PrimaryDie extraction.
+
+### Brutal monster trait — `brutalPrimary`
+
+The Brutal monster trait (GM:1894) changes primary die selection: "Treat the highest die rolled as the Primary Die." This is a roll-level option (`brutalPrimary: true`) set by `ItemActivationManager` from the actor's traits — not baked into the formula. The formula stays clean (e.g. `4d4cv`), and the trait flows from the actor.
+
+When `brutalPrimary` is true, the engine reassigns `primaryDie` to the die with the highest active non-discarded result after rolling. On ties, leftmost wins.
 
 ### AoE auto-flagging — `ItemActivationManager`
 
@@ -143,6 +160,9 @@ Content authors can leave `weaponType` blank (nothing breaks) or set it for weap
 | Roll construction from an item | `src/managers/ItemActivationManager.ts` |
 | Weapon proficiency check | `src/view/sheets/components/attackUtils.ts` (`hasWeaponProficiency`) |
 | The extension point for post-roll mutations | `DamageRoll._applyPostRollMutations` |
+| Multi-crit count | `DamageRoll.critCount` |
+| Brutal primary remapping | `DamageRoll.Options.brutalPrimary` |
+| Primary die value getter | `DamageRoll.primaryDieValue` |
 | Test coverage | `src/dice/DamageRoll.test.ts` |
 | Developer testbench | `src/view/debug/DiceTestbench.svelte` (gated behind the Debug Mode setting) |
 

--- a/src/dice/DamageRoll.test.ts
+++ b/src/dice/DamageRoll.test.ts
@@ -2762,3 +2762,75 @@ describe('primaryDieValue getter', () => {
 		expect(roll.primaryDieValue).toBe(6);
 	});
 });
+
+// ─── DamageRoll.matches ────────────────────────────────────────────────
+
+describe('DamageRoll.matches', () => {
+	// --- Single Nimble modifier ---
+	it('matches 4d4cv (crit-vicious)', () => expect(DamageRoll.matches('4d4cv')).toBe(true));
+	it('matches 1d8c (crit-standard)', () => expect(DamageRoll.matches('1d8c')).toBe(true));
+	it('matches 2d6n (neutral)', () => expect(DamageRoll.matches('2d6n')).toBe(true));
+	it('matches 1d8v (vicious standalone)', () => expect(DamageRoll.matches('1d8v')).toBe(true));
+	it('matches 2d8khn (keep-highest-nimble)', () => expect(DamageRoll.matches('2d8khn')).toBe(true));
+	it('matches 3d6kln2 (keep-lowest-nimble with count)', () =>
+		expect(DamageRoll.matches('3d6kln2')).toBe(true));
+
+	// --- Nimble modifier + plain terms ---
+	it('matches 1d8c + 2d6', () => expect(DamageRoll.matches('1d8c + 2d6')).toBe(true));
+	it('matches 1d12cv + 1d4', () => expect(DamageRoll.matches('1d12cv + 1d4')).toBe(true));
+	it('matches 3d8khn2 + 1d6', () => expect(DamageRoll.matches('3d8khn2 + 1d6')).toBe(true));
+	it('matches 1d8c + 2d6n + 3', () => expect(DamageRoll.matches('1d8c + 2d6n + 3')).toBe(true));
+
+	// --- Nimble modifier buried after plain dice ---
+	it('matches 2d6 + 1d8c + 4', () => expect(DamageRoll.matches('2d6 + 1d8c + 4')).toBe(true));
+	it('matches 1d4 + 2d6 + 1d8cv', () => expect(DamageRoll.matches('1d4 + 2d6 + 1d8cv')).toBe(true));
+
+	// --- Multiple Nimble modifiers across terms ---
+	it('matches 4d4cv + 2d6n (Dravok pool)', () =>
+		expect(DamageRoll.matches('4d4cv + 2d6n')).toBe(true));
+	it('matches 1d8c + 2d6n + 1d4v', () =>
+		expect(DamageRoll.matches('1d8c + 2d6n + 1d4v')).toBe(true));
+	it('matches 2d8c + 3d6n + 1d4v + 2d10khn + 5', () =>
+		expect(DamageRoll.matches('2d8c + 3d6n + 1d4v + 2d10khn + 5')).toBe(true));
+
+	// --- Nimble modifiers adjacent to operators (no spaces) ---
+	it('matches 1d8c+2d6', () => expect(DamageRoll.matches('1d8c+2d6')).toBe(true));
+	it('matches 2d4cv+1d6n+3', () => expect(DamageRoll.matches('2d4cv+1d6n+3')).toBe(true));
+
+	// --- Plain formulas (must NOT match) ---
+	it('does not match 2d6+3', () => expect(DamageRoll.matches('2d6+3')).toBe(false));
+	it('does not match 1d20', () => expect(DamageRoll.matches('1d20')).toBe(false));
+	it('does not match 5+3 (no dice)', () => expect(DamageRoll.matches('5+3')).toBe(false));
+	it('does not match 2d8 + 1d6 + 5', () => expect(DamageRoll.matches('2d8 + 1d6 + 5')).toBe(false));
+	it('does not match 4d6 + 2d8 + 1d4 + 10', () =>
+		expect(DamageRoll.matches('4d6 + 2d8 + 1d4 + 10')).toBe(false));
+
+	// --- Foundry built-in modifiers that share prefixes (must NOT match) ---
+	it('does not match 4d6kh3 (Foundry keep-highest)', () =>
+		expect(DamageRoll.matches('4d6kh3')).toBe(false));
+	it('does not match 2d20kh (Foundry keep-highest)', () =>
+		expect(DamageRoll.matches('2d20kh')).toBe(false));
+	it('does not match 4d6kl3 (Foundry keep-lowest)', () =>
+		expect(DamageRoll.matches('4d6kl3')).toBe(false));
+	it('does not match 8d6cs>3 (Foundry count-successes)', () =>
+		expect(DamageRoll.matches('8d6cs>3')).toBe(false));
+	it('does not match 8d6cf<2 (Foundry count-failures)', () =>
+		expect(DamageRoll.matches('8d6cf<2')).toBe(false));
+	it('does not match 1d6x (Foundry exploding)', () =>
+		expect(DamageRoll.matches('1d6x')).toBe(false));
+	it('does not match 1d6r1 (Foundry reroll)', () =>
+		expect(DamageRoll.matches('1d6r1')).toBe(false));
+	it('does not match 4d6dh (Foundry drop-highest)', () =>
+		expect(DamageRoll.matches('4d6dh')).toBe(false));
+	it('does not match 4d6dl (Foundry drop-lowest)', () =>
+		expect(DamageRoll.matches('4d6dl')).toBe(false));
+	it('does not match 2d6min2 (Foundry minimum)', () =>
+		expect(DamageRoll.matches('2d6min2')).toBe(false));
+	it('does not match 2d6max5 (Foundry maximum)', () =>
+		expect(DamageRoll.matches('2d6max5')).toBe(false));
+
+	// --- Mixed: Foundry modifiers + plain (no Nimble) ---
+	it('does not match 4d6kh3 + 2d8 + 5', () =>
+		expect(DamageRoll.matches('4d6kh3 + 2d8 + 5')).toBe(false));
+	it('does not match 2d20kh + 1d6', () => expect(DamageRoll.matches('2d20kh + 1d6')).toBe(false));
+});

--- a/src/dice/DamageRoll.test.ts
+++ b/src/dice/DamageRoll.test.ts
@@ -2343,3 +2343,422 @@ describe('die modifier vocabulary — modifier-mode', () => {
 		});
 	});
 });
+
+// ─── critCount ─────────────────────────────────────────────────────────
+
+describe('critCount', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		stubBaseRollEvaluate();
+	});
+
+	describe('modifier-mode', () => {
+		it('4d4cv with 0 of 4 at max → critCount === 0', async () => {
+			const roll = new DamageRoll(
+				'4d4cv',
+				{},
+				{
+					canCrit: true,
+					canMiss: true,
+					rollMode: 0,
+					primaryDieValue: 0,
+					primaryDieModifier: 0,
+				},
+			);
+			stageModifierModeRoll(
+				roll,
+				[
+					[
+						{ result: 2, active: true },
+						{ result: 1, active: true },
+						{ result: 3, active: true },
+						{ result: 2, active: true },
+					],
+				],
+				8,
+			);
+			await (roll as any)._evaluate();
+			expect(roll.critCount).toBe(0);
+			expect(roll.isCritical).toBe(false);
+		});
+
+		it('4d4cv with 1 of 4 at max → critCount === 1, isCritical === true', async () => {
+			const roll = new DamageRoll(
+				'4d4cv',
+				{},
+				{
+					canCrit: true,
+					canMiss: true,
+					rollMode: 0,
+					primaryDieValue: 0,
+					primaryDieModifier: 0,
+				},
+			);
+			stageModifierModeRoll(
+				roll,
+				[
+					[
+						{ result: 4, active: true },
+						{ result: 1, active: true },
+						{ result: 3, active: true },
+						{ result: 2, active: true },
+					],
+				],
+				10,
+			);
+			await (roll as any)._evaluate();
+			expect(roll.critCount).toBe(1);
+			expect(roll.isCritical).toBe(true);
+		});
+
+		it('4d4cv with 3 of 4 at max → critCount === 3, isCritical === true', async () => {
+			const roll = new DamageRoll(
+				'4d4cv',
+				{},
+				{
+					canCrit: true,
+					canMiss: true,
+					rollMode: 0,
+					primaryDieValue: 0,
+					primaryDieModifier: 0,
+				},
+			);
+			stageModifierModeRoll(
+				roll,
+				[
+					[
+						{ result: 4, active: true },
+						{ result: 4, active: true },
+						{ result: 4, active: true },
+						{ result: 2, active: true },
+					],
+				],
+				14,
+			);
+			await (roll as any)._evaluate();
+			expect(roll.critCount).toBe(3);
+			expect(roll.isCritical).toBe(true);
+		});
+	});
+
+	describe('legacy mode', () => {
+		it('standard crit → critCount === 1', async () => {
+			const roll = new DamageRoll(
+				'1d8',
+				{},
+				{
+					canCrit: true,
+					canMiss: true,
+					rollMode: 0,
+					primaryDieValue: 0,
+					primaryDieModifier: 0,
+				},
+			);
+			stagePrimaryDieResults(
+				roll,
+				[
+					{ result: 8, active: true, exploded: true },
+					{ result: 5, active: true },
+				],
+				13,
+			);
+			await (roll as any)._evaluate();
+			expect(roll.critCount).toBe(1);
+			expect(roll.isCritical).toBe(true);
+		});
+
+		it('no crit → critCount === 0', async () => {
+			const roll = new DamageRoll(
+				'1d8',
+				{},
+				{
+					canCrit: true,
+					canMiss: true,
+					rollMode: 0,
+					primaryDieValue: 0,
+					primaryDieModifier: 0,
+				},
+			);
+			stagePrimaryDieResults(roll, [{ result: 5, active: true }], 5);
+			await (roll as any)._evaluate();
+			expect(roll.critCount).toBe(0);
+			expect(roll.isCritical).toBe(false);
+		});
+	});
+
+	describe('serialization', () => {
+		it('critCount survives toJSON → fromData round-trip', () => {
+			const roll = new DamageRoll(
+				'4d4cv',
+				{},
+				{
+					canCrit: true,
+					canMiss: true,
+					rollMode: 0,
+					primaryDieValue: 0,
+					primaryDieModifier: 0,
+				},
+			);
+			// Manually set critCount as if the roll was evaluated
+			roll.critCount = 3;
+			roll.isCritical = true;
+
+			const json = roll.toJSON();
+			expect(json.critCount).toBe(3);
+
+			const restored = DamageRoll.fromData(json as any);
+			expect(restored.critCount).toBe(3);
+		});
+
+		it('critCount defaults to 0 when missing from serialized data', () => {
+			const data = {
+				formula: '1d6',
+				data: {},
+				options: {},
+				terms: [],
+				originalFormula: '1d6',
+				evaluated: true,
+				isCritical: false,
+			};
+			const roll = DamageRoll.fromData(data);
+			expect(roll.critCount).toBe(0);
+		});
+	});
+});
+
+// ─── brutalPrimary option ──────────────────────────────────────────────
+
+describe('brutalPrimary option', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		stubBaseRollEvaluate();
+	});
+
+	describe('modifier-mode', () => {
+		it('3d8c with brutalPrimary: highest-value die becomes primary', async () => {
+			const roll = new DamageRoll(
+				'3d8c',
+				{},
+				{
+					canCrit: true,
+					canMiss: true,
+					rollMode: 0,
+					primaryDieValue: 0,
+					primaryDieModifier: 0,
+					brutalPrimary: true,
+				},
+			);
+			// Stage 3 results on the single 3d8c term: [2, 7, 4]
+			stageModifierModeRoll(
+				roll,
+				[
+					[
+						{ result: 2, active: true },
+						{ result: 7, active: true },
+						{ result: 4, active: true },
+					],
+				],
+				13,
+			);
+			await (roll as any)._evaluate();
+			// The single term contains the result 7; primaryDie should be that term
+			expect(roll.primaryDie).toBeDefined();
+			expect(roll.primaryDieValue).toBe(7);
+		});
+
+		it('3d8c with brutalPrimary: ties go to leftmost', async () => {
+			const roll = new DamageRoll(
+				'3d8c',
+				{},
+				{
+					canCrit: true,
+					canMiss: true,
+					rollMode: 0,
+					primaryDieValue: 0,
+					primaryDieModifier: 0,
+					brutalPrimary: true,
+				},
+			);
+			// Stage: [5, 5, 3] — tie at 5, leftmost (first encountered) wins
+			stageModifierModeRoll(
+				roll,
+				[
+					[
+						{ result: 5, active: true },
+						{ result: 5, active: true },
+						{ result: 3, active: true },
+					],
+				],
+				13,
+			);
+			await (roll as any)._evaluate();
+			expect(roll.primaryDie).toBeDefined();
+			// The term is the same (single 3d8c term), primary value should be 5
+			expect(roll.primaryDieValue).toBe(5);
+		});
+
+		it('4d4cv with brutalPrimary: Dravok + Brutal → highest d4 is primary', async () => {
+			const roll = new DamageRoll(
+				'4d4cv',
+				{},
+				{
+					canCrit: true,
+					canMiss: true,
+					rollMode: 0,
+					primaryDieValue: 0,
+					primaryDieModifier: 0,
+					brutalPrimary: true,
+				},
+			);
+			stageModifierModeRoll(
+				roll,
+				[
+					[
+						{ result: 2, active: true },
+						{ result: 4, active: true },
+						{ result: 1, active: true },
+						{ result: 3, active: true },
+					],
+				],
+				10,
+			);
+			await (roll as any)._evaluate();
+			expect(roll.primaryDie).toBeDefined();
+			expect(roll.primaryDieValue).toBe(4);
+		});
+
+		it('multi-term pool with brutalPrimary: picks term with highest result', async () => {
+			const roll = new DamageRoll(
+				'1d8c + 2d6n',
+				{},
+				{
+					canCrit: true,
+					canMiss: true,
+					rollMode: 0,
+					primaryDieValue: 0,
+					primaryDieModifier: 0,
+					brutalPrimary: true,
+				},
+			);
+			// d8 rolls 3, d6s roll [5, 6] — d6 term has higher value
+			stageModifierModeRoll(
+				roll,
+				[
+					[{ result: 3, active: true }],
+					[
+						{ result: 5, active: true },
+						{ result: 6, active: true },
+					],
+				],
+				14,
+			);
+			await (roll as any)._evaluate();
+			// Brutal should pick the d6 term (which has the 6)
+			expect(roll.primaryDie?.faces).toBe(6);
+		});
+	});
+
+	describe('legacy mode', () => {
+		it('brutalPrimary on single-die roll is a no-op', async () => {
+			const roll = new DamageRoll(
+				'1d8',
+				{},
+				{
+					canCrit: true,
+					canMiss: true,
+					rollMode: 0,
+					primaryDieValue: 0,
+					primaryDieModifier: 0,
+					brutalPrimary: true,
+				},
+			);
+			stagePrimaryDieResults(roll, [{ result: 5, active: true }], 5);
+			await (roll as any)._evaluate();
+			// Only one die term — primaryDie stays the same
+			expect(roll.primaryDie).toBeDefined();
+			expect(roll.primaryDieValue).toBe(5);
+		});
+	});
+});
+
+// ─── primaryDieValue getter ────────────────────────────────────────────
+
+describe('primaryDieValue getter', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		stubBaseRollEvaluate();
+	});
+
+	it('returns the kept value of the primary die after evaluation', async () => {
+		const roll = new DamageRoll(
+			'1d8',
+			{},
+			{
+				canCrit: true,
+				canMiss: true,
+				rollMode: 0,
+				primaryDieValue: 0,
+				primaryDieModifier: 0,
+			},
+		);
+		stagePrimaryDieResults(roll, [{ result: 5, active: true }], 5);
+		await (roll as any)._evaluate();
+		expect(roll.primaryDieValue).toBe(5);
+	});
+
+	it('returns the active non-discarded result when advantage drops a die', async () => {
+		const roll = new DamageRoll(
+			'1d8',
+			{},
+			{
+				canCrit: true,
+				canMiss: true,
+				rollMode: 1,
+				primaryDieValue: 0,
+				primaryDieModifier: 0,
+			},
+		);
+		stagePrimaryDieResults(
+			roll,
+			[
+				{ result: 3, active: false, discarded: true },
+				{ result: 7, active: true },
+			],
+			7,
+		);
+		await (roll as any)._evaluate();
+		expect(roll.primaryDieValue).toBe(7);
+	});
+
+	it('returns undefined when no primaryDie exists', () => {
+		const roll = new DamageRoll(
+			'5',
+			{},
+			{
+				canCrit: false,
+				canMiss: false,
+				rollMode: 0,
+				primaryDieValue: 0,
+				primaryDieModifier: 0,
+			},
+		);
+		expect(roll.primaryDieValue).toBeUndefined();
+	});
+
+	it('works in modifier-mode', async () => {
+		const roll = new DamageRoll(
+			'1d8c',
+			{},
+			{
+				canCrit: true,
+				canMiss: true,
+				rollMode: 0,
+				primaryDieValue: 0,
+				primaryDieModifier: 0,
+			},
+		);
+		stageModifierModeRoll(roll, [[{ result: 6, active: true }]], 6);
+		await (roll as any)._evaluate();
+		expect(roll.primaryDieValue).toBe(6);
+	});
+});

--- a/src/dice/DamageRoll.ts
+++ b/src/dice/DamageRoll.ts
@@ -53,6 +53,13 @@ declare namespace DamageRoll {
 		 */
 		explosionStyle?: 'none' | 'standard' | 'vicious';
 		/**
+		 * When true, the primary die is the highest-value result in the pool,
+		 * not the leftmost. Driven by the Brutal monster trait (GM:1894).
+		 * Set by ItemActivationManager from actor traits — not baked into formulas.
+		 * Default: false
+		 */
+		brutalPrimary?: boolean;
+		/**
 		 * @deprecated Use `explosionStyle: 'vicious'` instead. Translated to
 		 *   `explosionStyle` by the constructor shim for back-compat.
 		 */
@@ -75,6 +82,7 @@ declare namespace DamageRoll {
 		evaluated?: boolean;
 		isCritical?: boolean;
 		isMiss?: boolean;
+		critCount?: number;
 		_total?: number;
 		_formula?: string;
 		excludedPrimaryDieValue?: number;
@@ -123,15 +131,43 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 	/** Whether this roll resulted in a miss. Undefined until evaluated. */
 	isMiss: undefined | boolean = undefined;
 
+	/** Number of crit-capable dice that rolled max. 0 until evaluated. */
+	critCount: number = 0;
+
 	/** The original formula before preprocessing (e.g., before primary die extraction). */
 	originalFormula: string;
 
 	/**
-	 * The primary die term used for critical/miss detection.
-	 * In legacy mode this is a PrimaryDie instance; in modifier-mode it is the
-	 * leftmost Die tagged `c`/`cv` (or leftmost Die overall as fallback).
+	 * The primary die term used for crit/miss detection and rules-level value reads.
+	 *
+	 * **Reading the primary die value (stable API):**
+	 * ```typescript
+	 * const value = roll.primaryDieValue;          // convenience getter
+	 * const faces = roll.primaryDie?.faces;
+	 * ```
+	 *
+	 * In legacy mode: a PrimaryDie instance (leftmost, extracted from formula).
+	 * In modifier-mode: the leftmost Die tagged `c`/`cv`, or the highest-value
+	 * die if `brutalPrimary` is active, falling back to leftmost Die overall.
 	 */
 	primaryDie: PrimaryDie | foundry.dice.terms.Die | undefined = undefined;
+
+	/** The kept value of the primary die after evaluation. Undefined if unevaluated. */
+	get primaryDieValue(): number | undefined {
+		const die = this.primaryDie;
+		if (!die) return undefined;
+		if (this.options.brutalPrimary) {
+			// Brutal: the "primary" value is the highest active non-discarded result
+			let max = -1;
+			for (const r of die.results) {
+				if (r.active && !r.discarded && r.result > max) {
+					max = r.result;
+				}
+			}
+			return max >= 0 ? max : undefined;
+		}
+		return die.results.find((r) => r.active && !r.discarded)?.result;
+	}
 
 	/**
 	 * Whether this roll uses per-die modifier dispatch (modifier-mode).
@@ -454,6 +490,9 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 		this._applyPostRollMutations();
 
 		if (this.modifierMode) {
+			// ── Count crits BEFORE vicious explosions to avoid counting chain dice ──
+			this.critCount = this._countModifierModeCrits();
+
 			// ── Modifier-mode: per-die vicious explosion ──
 			for (const term of this.terms) {
 				if (!(term instanceof Terms.Die)) continue;
@@ -493,8 +532,13 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 				(r) => r.active && !r.discarded && r.result === primaryTerm.faces,
 			);
 		}
+		this.critCount = this.isCritical ? 1 : 0;
 
 		if (this.options.canMiss) this.isMiss = primaryTerm.isMiss;
+
+		this._applyBrutalRemapping(
+			this.terms.filter((t): t is foundry.dice.terms.Die => t instanceof Terms.Die),
+		);
 
 		// Recalculate total if vicious explosion added dice
 		// This must happen BEFORE primaryDieAsDamage exclusion to avoid double-counting
@@ -656,24 +700,55 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 	}
 
 	/**
+	 * When `brutalPrimary` is active, scan all Die terms and reassign
+	 * `primaryDie` to the term containing the highest active non-discarded
+	 * result. Ties: leftmost wins (strict `>`, not `>=`).
+	 */
+	private _applyBrutalRemapping(dieTerms: foundry.dice.terms.Die[]): void {
+		if (!this.options.brutalPrimary) return;
+		let highestValue = -1;
+		let highestDie: foundry.dice.terms.Die | undefined;
+		for (const term of dieTerms) {
+			for (const r of term.results) {
+				if (r.active && !r.discarded && r.result > highestValue) {
+					highestValue = r.result;
+					highestDie = term;
+				}
+			}
+		}
+		if (highestDie) this.primaryDie = highestDie;
+	}
+
+	/**
+	 * Count crit-capable dice that rolled max BEFORE vicious explosions append
+	 * chain dice to the results array. Called from `_evaluate` so that
+	 * `critCount` reflects base crits only, not continuation dice.
+	 */
+	private _countModifierModeCrits(): number {
+		let count = 0;
+		for (const term of this.terms) {
+			if (!(term instanceof Terms.Die)) continue;
+			const meta = getNimbleMods(term);
+			if (!meta?.canCrit) continue;
+			for (const r of term.results) {
+				if (r.active && !r.discarded && r.result === term.faces) {
+					count++;
+				}
+			}
+		}
+		return count;
+	}
+
+	/**
 	 * Modifier-mode outcome finalization. Replaces `_finalizeOutcome` when the
 	 * roll uses per-die modifiers instead of a PrimaryDie term.
 	 */
 	private _finalizeOutcomeModifierMode(): void {
 		const dieTerms = this.terms.filter((t): t is foundry.dice.terms.Die => t instanceof Terms.Die);
 
-		// ── Crit detection: any crit-capable die that rolled max ──
-		let anyCritted = false;
-		for (const term of dieTerms) {
-			const meta = getNimbleMods(term);
-			if (!meta?.canCrit) continue;
-			if (term.results.some((r) => r.active && !r.discarded && r.result === term.faces)) {
-				anyCritted = true;
-				break;
-			}
-		}
+		// ── Crit detection: critCount was computed before vicious explosions in _evaluate ──
 		if (this.options.canCrit) {
-			this.isCritical = anyCritted;
+			this.isCritical = this.critCount > 0;
 		}
 
 		// ── Miss detection: leftmost non-neutral Die ──
@@ -699,8 +774,10 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 		});
 		this.primaryDie = taggedPrimary ?? dieTerms[0];
 
+		this._applyBrutalRemapping(dieTerms);
+
 		// ── Recalculate total if any vicious die critted ──
-		if (anyCritted) {
+		if (this.critCount > 0) {
 			const hasVicious = dieTerms.some((term) => {
 				const meta = getNimbleMods(term);
 				return meta?.canCrit && meta.explosionStyle === 'vicious';
@@ -759,6 +836,7 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 			originalFormula: this.originalFormula,
 			isMiss: this.isMiss,
 			isCritical: this.isCritical,
+			critCount: this.critCount,
 			excludedPrimaryDieValue: this.excludedPrimaryDieValue,
 		};
 	}
@@ -901,9 +979,14 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 					roll.primaryDie = primaryTerm;
 				}
 			}
+
+			roll._applyBrutalRemapping(
+				roll.terms.filter((t): t is foundry.dice.terms.Die => t instanceof Terms.Die),
+			);
 		}
 
-		// Restore excludedPrimaryDieValue if it was serialized
+		// Restore critCount and excludedPrimaryDieValue if serialized
+		roll.critCount = data.critCount ?? 0;
 		roll.excludedPrimaryDieValue = data.excludedPrimaryDieValue ?? 0;
 
 		return roll as FixedInstanceType<T>;

--- a/src/dice/DamageRoll.ts
+++ b/src/dice/DamageRoll.ts
@@ -846,6 +846,19 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 	/** ------------------------------------------------------ */
 
 	/**
+	 * Claim formulas containing Nimble die modifiers for DamageRoll processing.
+	 * Called by Foundry's `Roll.create()` when iterating `CONFIG.Dice.rolls`.
+	 *
+	 * Alternation order matters: longer tokens first (`cv` before `c`,
+	 * `khn`/`kln` before `n`). The trailing `(?![a-z])` prevents false
+	 * positives against Foundry modifiers that share a prefix (e.g. `cs`
+	 * count-successes, `cf` count-failures must not match Nimble `c`).
+	 */
+	static matches(formula: string): boolean {
+		return /\d+d\d+(?:cv|c|v|khn|kln|n)(?![a-z])/.test(formula);
+	}
+
+	/**
 	 * Type guard to check if terms array contains RollTerm instances.
 	 *
 	 * @param terms - The terms array to check.

--- a/src/hooks/init.ts
+++ b/src/hooks/init.ts
@@ -54,6 +54,28 @@ export default function init() {
 	CONFIG.Dice.rolls.push(NimbleRoll as (typeof CONFIG.Dice.rolls)[number]);
 	CONFIG.Dice.types.push(PrimaryDie);
 
+	// Override Roll.create so /r formulas with Nimble modifiers route to DamageRoll.
+	// Foundry v13's default Roll.create just instantiates CONFIG.Dice.rolls[0] (the
+	// base Roll), so Nimble-modifier formulas would never reach DamageRoll without this.
+	if (typeof foundry.dice.Roll.create === 'function') {
+		const originalRollCreate = foundry.dice.Roll.create.bind(foundry.dice.Roll);
+		// @ts-expect-error — override is type-compatible at runtime; static generic signature is not re-expressible
+		foundry.dice.Roll.create = (
+			formula: string,
+			data?: Record<string, unknown>,
+			options?: Record<string, unknown>,
+		) => {
+			if (DamageRoll.matches(formula)) {
+				return new DamageRoll(
+					formula,
+					(data ?? {}) as DamageRoll.Data,
+					options as unknown as DamageRoll.Options,
+				);
+			}
+			return originalRollCreate(formula, data, options);
+		};
+	}
+
 	// Register Nimble custom Die modifiers (khn / kln — leftmost-on-tie keep).
 	registerNimbleDieModifiers();
 

--- a/src/view/debug/DiceTestbench.state.svelte.ts
+++ b/src/view/debug/DiceTestbench.state.svelte.ts
@@ -34,6 +34,7 @@ export function createDiceTestbenchState() {
 	let disCount = $state(0);
 	let forceCrit = $state(false);
 	let forceMiss = $state(false);
+	let brutalPrimary = $state(false);
 	let specificValues = $state<Array<number | null>>([]);
 	let showSpecific = $state(false);
 
@@ -183,6 +184,7 @@ export function createDiceTestbenchState() {
 		disCount = scenario.disCount ?? 0;
 		forceCrit = scenario.forceCrit ?? false;
 		forceMiss = scenario.forceMiss ?? false;
+		brutalPrimary = scenario.brutalPrimary ?? false;
 		specificValues = [];
 		showSpecific = false;
 		lastResult = null;
@@ -213,6 +215,7 @@ export function createDiceTestbenchState() {
 					primaryDieModifier: 0,
 					rollMode: 0,
 					rollModeSources: rollModeSourcesArray,
+					brutalPrimary,
 				},
 				stagedValues,
 				actorData as never,
@@ -372,6 +375,12 @@ export function createDiceTestbenchState() {
 		},
 		get forceMiss() {
 			return forceMiss;
+		},
+		get brutalPrimary() {
+			return brutalPrimary;
+		},
+		set brutalPrimary(v) {
+			brutalPrimary = v;
 		},
 		get specificValues() {
 			return specificValues;

--- a/src/view/debug/DiceTestbench.svelte
+++ b/src/view/debug/DiceTestbench.svelte
@@ -82,6 +82,10 @@
 				<input type="checkbox" bind:checked={state.primaryDieAsDamage} />
 				{localize('NIMBLE.diceTestbench.rollBuilder.flags.primaryDieAsDamage')}
 			</label>
+			<label>
+				<input type="checkbox" bind:checked={state.brutalPrimary} />
+				{localize('NIMBLE.diceTestbench.rollBuilder.flags.brutalPrimary')}
+			</label>
 		</div>
 
 		<label class="nimble-testbench__field">
@@ -408,6 +412,7 @@
 						state: String(state.lastResult.trace.isMiss),
 					})}
 				</span>
+				<span>critCount: {state.lastResult.trace.critCount}</span>
 				{#if state.lastResult.trace.stagedValuesRemaining > 0}
 					<span class="nimble-testbench__trace-warning">
 						{localize('NIMBLE.diceTestbench.results.stagedRemaining', {

--- a/src/view/debug/DiceTestbench.types.ts
+++ b/src/view/debug/DiceTestbench.types.ts
@@ -25,6 +25,7 @@ export type TermDump = {
 export type TraceDump = {
 	isCritical: boolean;
 	isMiss: boolean;
+	critCount: number;
 	total: number;
 	stagedValuesRemaining: number;
 };

--- a/src/view/debug/scenarios.ts
+++ b/src/view/debug/scenarios.ts
@@ -47,6 +47,7 @@ export type Scenario = {
 	disCount?: number;
 	forceCrit?: boolean;
 	forceMiss?: boolean;
+	brutalPrimary?: boolean;
 };
 
 export const scenarios: Scenario[] = [
@@ -207,7 +208,7 @@ export const scenarios: Scenario[] = [
 		id: 'dravok-4d4cv',
 		label: 'Dravok 4d4cv',
 		formula: '4d4cv',
-		note: 'Every d4 can crit independently, each with vicious explosion. Roll several times — any d4 that hits 4 should spawn a vicious chain.',
+		note: 'Every d4 can crit independently, each with vicious explosion. Roll several times — any d4 that hits 4 should spawn a vicious chain. Check critCount reflects how many base dice critted (not chain dice).',
 	},
 	{
 		id: 'd66-2d6n',
@@ -230,5 +231,21 @@ export const scenarios: Scenario[] = [
 		canCrit: false,
 		canMiss: false,
 		note: 'AoE-style damage via n modifier. No crit, no miss — outcome should always be HIT.',
+	},
+
+	// --- Brutal trait scenarios ---
+	{
+		id: 'brutal-3d8c',
+		label: 'Brutal 3d8c',
+		formula: '3d8c',
+		brutalPrimary: true,
+		note: 'Brutal trait: highest-value die becomes primary (set via roll option, not formula). Roll a few times — primary should shift to whichever d8 rolled highest.',
+	},
+	{
+		id: 'brutal-dravok-4d4cv',
+		label: 'Brutal Dravok 4d4cv',
+		formula: '4d4cv',
+		brutalPrimary: true,
+		note: 'Dravok + Brutal: highest-value d4 is primary. Vicious explosions still fire on any d4 that crits. Check that primary shifts to the highest roller.',
 	},
 ];

--- a/src/view/debug/stageAndRoll.ts
+++ b/src/view/debug/stageAndRoll.ts
@@ -18,6 +18,7 @@ export type StagedValue = { value: number; faces: number };
 export type StageAndRollTrace = {
 	isCritical: boolean;
 	isMiss: boolean;
+	critCount: number;
 	total: number;
 	stagedValuesRemaining: number;
 };
@@ -66,6 +67,7 @@ export async function stageAndRoll(
 			trace: {
 				isCritical: roll.isCritical ?? false,
 				isMiss: roll.isMiss ?? false,
+				critCount: roll.critCount,
 				total: roll.total ?? 0,
 				stagedValuesRemaining: queue.length,
 			},


### PR DESCRIPTION
## Summary

Adds multi-crit tracking (`critCount`), the Brutal monster trait roll option (`brutalPrimary`), a convenience `primaryDieValue` getter, and routes `/r` formulas with Nimble modifiers to `DamageRoll`.

> **Stacked PR 4 of 5** — base: #715 (Stage 2 — modifier vocabulary)
> Next: `dice/stage-4` (value mutation framework)

## Changes

- **`critCount: number`** on `DamageRoll` — counts how many crit-capable dice independently rolled max. `isCritical` now derived as `critCount > 0`. Counted BEFORE vicious explosions to avoid counting chain dice. Serialized in `toJSON()`/`fromData()`.
- **`brutalPrimary: boolean`** roll option — when true, primaryDie is reassigned to the highest-value die after rolling (Brutal monster trait, GM:1894). Implemented as a roll-level option (not a modifier) because traits are actor-level, not formula-level.
- **`primaryDieValue` getter** — convenience accessor: `roll.primaryDieValue` returns the kept value of the primary die. Documented API contract for downstream rules readers (knockback, Weapon Mastery, Guiding Spirit, etc.).
- **`DamageRoll.matches()`** — routes `/r` chat formulas containing Nimble modifiers (`c`, `cv`, `v`, `n`) to `DamageRoll` so vicious explosions fire from chat.
- **Testbench scenario** for Brutal primary.

## Tests

- 51 new tests covering critCount (modifier-mode + legacy), brutalPrimary remapping, primaryDieValue, `/r` routing via `matches()`.
- All 842 tests pass.

## Checklist

- [x] `pnpm check` passes
- [x] Zero regression on existing tests
- [x] **AI-assisted:** reviewed against STYLE_GUIDE.md