### PR TITLE
feat(dice): post-roll value mutation framework

### DIFF
--- a/docs/system/dice-engine.md
+++ b/docs/system/dice-engine.md
@@ -79,7 +79,7 @@ When a player clicks "Attack" on a weapon, here's what happens (all in `src/dice
 
 6. **`DamageRoll._evaluate` interprets the results.** In modifier-mode, the engine iterates all Die terms, reads their modifier metadata, and dispatches per-die: `cv`-tagged dice that rolled max get a vicious explosion chain, `c`-tagged dice use Foundry's native `x` explosion, `n`-tagged dice are skipped for crit/miss. In legacy mode, the engine reads the single primary die and dispatches based on the `explosionStyle` option (`'none'` / `'standard'` / `'vicious'`). Crit detection in both modes uses the same value-based check: did a kept (active, non-discarded) die roll its max face value?
 
-7. **Post-roll mutation hook.** A no-op method `_applyPostRollMutations` is called between the dice rolling and the outcome being finalized. Today it does nothing. It's there as an extension point (see below).
+7. **Post-roll mutations.** `_applyPostRollMutations` processes an optional `mutations: MutationStep[]` array from the roll options. Each step targets specific dice, applies an operation (set, bump, max, floor, ceiling, etc.), and tags the result with metadata recording the original rolled value and whether the mutation counts as a crit or triggers explosion. See "Post-roll mutation pipeline" below.
 
 8. **Finalize the total.** `_finalizeOutcome` sets `isCritical` / `isMiss` / `critCount` flags and adjusts the total for vicious recalculation and the `primaryDieAsDamage: false` case (where the primary die's value is excluded from damage but its explosions still count). `critCount` tracks how many crit-capable dice independently rolled max — for a standard weapon this is 0 or 1, but for multi-die pools like Dravok's `4d4cv` it can be 2, 3, or even 4. `isCritical` is `critCount > 0`. If the `brutalPrimary` option is set, the primary die is reassigned to whichever die rolled highest (instead of leftmost).
 
@@ -89,16 +89,36 @@ When a player clicks "Attack" on a weapon, here's what happens (all in `src/dice
 
 If you're adding a class feature, monster trait, or spell that does something unusual with dice, here's where it plugs in. **You should almost never have to modify `DamageRoll.ts` itself** — that's the whole point of the structure below.
 
-### Post-roll mutation hook — `_applyPostRollMutations`
+### Post-roll mutation pipeline — `_applyPostRollMutations`
 
-Today this is an empty method called from `_evaluate` after Foundry rolls the dice but before the outcome is finalized. It's reserved for features that need to **change a die's value after it's rolled**, then have hit/miss/crit re-evaluated against the new value. Examples of features that will land here:
+The mutation pipeline lets features **change die values after rolling** with explicit control over whether the change counts as a crit and whether it triggers explosion. This is the engine's answer to a class of Nimble rules that modify dice outcomes post-roll.
 
-- **Hexbinder "Doomed"** — "Next roll against target has every die treated as max." That's a post-roll value override on a subset of the pool.
-- **Cheat class "Vicious Opportunist"** — "On hitting a Distracted target, set the Primary Die to any value you choose. Setting it to max counts as a crit."
-- **Berserker "Blood Frenzy"** — "On crit, set a Fury Die to its maximum value."
-- **Hexbinder "Soothsayer"** — "Expend a Futuresight Die to add or subtract 1 from any die rolled, clamped to its natural range."
+Callers pass a `mutations: MutationStep[]` array in the roll options. Each step declares:
 
-When one of these lands, the feature's logic lives in its own rule file and gets invoked from `_applyPostRollMutations`. The rule mutates `primaryDie.results[].result` and returns. `_finalizeOutcome` then re-reads the primary die state and the outcome updates automatically.
+- **Target** — which dice to mutate: `'primary'` (primary die only), `'all'` (every die), `'tagged'` (dice with a specific modifier), or `'index'` (a specific result).
+- **Operation** — what to do:
+  - `set` — set to an exact value (Vicious Opportunist: "set Primary Die to any value")
+  - `bump` — add or subtract N, clamped to [1, faces] (Juggernaut: "+1 to primary die")
+  - `max` — set to face maximum (Doomed: "all dice treated as max")
+  - `min` — set to 1
+  - `floor` — if below minimum, raise to minimum (BOUNDLESS RAGE: "Fury Die can't be less than 6")
+  - `ceiling` — if above maximum, lower to maximum
+- **`countsAsCrit`** — does a mutated-to-max result count as a crit? (default: false)
+- **`triggersExplosion`** — does a mutated-to-max result trigger the explosion chain? (default: false)
+
+Each mutated result is tagged with metadata preserving the original rolled value and the mutation source. This lets the chat card show "rolled 3 → mutated to 8 (Doomed)" without the engine losing track of what actually happened.
+
+**The critical design insight** is the carveout table — different features that both "set to max" have different crit/explosion rules:
+
+| Feature | countsAsCrit | triggersExplosion |
+|---------|:---:|:---:|
+| Vicious Opportunist ("setting to max counts as a crit") | yes | yes |
+| Doomed ("counts as crit but subsequent crit damage is not included") | yes | **no** |
+| Cunning Strike ("Sneak Attack dice deal max") | no | no |
+| Juggernaut ("+1 to primary die") | no | no |
+| BOUNDLESS RAGE ("Fury Die can't be less than 6") | no | no |
+
+Individual class features don't live in the engine — they emit `MutationStep` objects from the rules layer, and the engine processes them generically. The engine's only job is to apply the operation, tag the metadata, and honor the flags during crit detection and explosion dispatch.
 
 ### Custom Die modifiers — `nimbleDieModifiers.ts`
 
@@ -159,7 +179,7 @@ Content authors can leave `weaponType` blank (nothing breaks) or set it for weap
 | Where custom modifiers get registered | `src/hooks/init.ts` (calls `registerNimbleDieModifiers()`) |
 | Roll construction from an item | `src/managers/ItemActivationManager.ts` |
 | Weapon proficiency check | `src/view/sheets/components/attackUtils.ts` (`hasWeaponProficiency`) |
-| The extension point for post-roll mutations | `DamageRoll._applyPostRollMutations` |
+| Post-roll mutation pipeline | `DamageRoll._applyPostRollMutations` + `src/dice/mutations.ts` |
 | Multi-crit count | `DamageRoll.critCount` |
 | Brutal primary remapping | `DamageRoll.Options.brutalPrimary` |
 | Primary die value getter | `DamageRoll.primaryDieValue` |
@@ -177,7 +197,7 @@ A rogue attacks a Distracted goblin with a shortsword (`1d6`), with advantage fr
 5. **`khn` handler runs:** the `1` is marked discarded (leftmost lowest), the `6` is active.
 6. **`_evaluate` reads the primary die:** it's the `6`, which is max → crit.
 7. **Crit explosion:** reroll the primary die, roll a `4`, add it. Not max, so stop.
-8. **`_applyPostRollMutations`:** no-op today. When Vicious Opportunist lands, this is where "set primary die to any value on hit against Distracted target" would run — potentially turning a hit into a crit.
+8. **`_applyPostRollMutations`:** if the target were Doomed, a mutation step `{ target: 'all', operation: 'max', countsAsCrit: true, triggersExplosion: false }` would set every die to max. The roll would count as a crit (for knockback, conditions, etc.) but no explosion chain would fire — matching the Doomed rule exactly. If instead the rogue used Vicious Opportunist to set the primary to max, the step would use `triggersExplosion: true` and the explosion chain would fire normally.
 9. **`_finalizeOutcome`:** sets `isCritical = true`, `isMiss = false`. Total: primary `6 + 4` (explosion) + sneak attack `4 + 5` = `19` damage, crit flag set. Chat card renders it all.
 
 ### Modifier-mode example: Dravok's Terrible Maw (`4d4cv`)

--- a/docs/system/dice-engine.md
+++ b/docs/system/dice-engine.md
@@ -77,11 +77,11 @@ When a player clicks "Attack" on a weapon, here's what happens (all in `src/dice
 
 5. **Foundry rolls the dice.** The custom `khn`/`kln` modifier handlers sort results and mark dice as discarded (leftmost dropped on ties). In modifier-mode, the `c`, `cv`, `v`, and `n` handlers also run — they attach Symbol-keyed metadata to each Die instance describing its crit/miss/explosion behavior. These handlers don't roll extra dice; they only tag metadata.
 
-6. **`DamageRoll._evaluate` interprets the results.** In modifier-mode, the engine iterates all Die terms, reads their modifier metadata, and dispatches per-die: `cv`-tagged dice that rolled max get a vicious explosion chain, `c`-tagged dice use Foundry's native `x` explosion, `n`-tagged dice are skipped for crit/miss. In legacy mode, the engine reads the single primary die and dispatches based on the `explosionStyle` option (`'none'` / `'standard'` / `'vicious'`). Crit detection in both modes uses the same value-based check: did a kept (active, non-discarded) die roll its max face value?
+6. **`DamageRoll._evaluate` interprets the results.** In modifier-mode, the engine iterates all Die terms, reads their modifier metadata, and dispatches per-die: `cv`-tagged dice that rolled max get a vicious explosion chain, `c`-tagged dice use Foundry's native `x` explosion, `n`-tagged dice are skipped for crit/miss. In legacy mode, the engine reads the single primary die and dispatches based on the `explosionStyle` option (`'none'` / `'standard'` / `'vicious'`). Crit detection in both modes uses a threshold check: did a kept (active, non-discarded) die meet `criticalThreshold` (defaults to the die's max face). Miss detection uses `fumbleThreshold` symmetrically (defaults to `1`).
 
-7. **Post-roll mutations.** `_applyPostRollMutations` processes an optional `mutations: MutationStep[]` array from the roll options. Each step targets specific dice, applies an operation (set, bump, max, floor, ceiling, etc.), and tags the result with metadata recording the original rolled value and whether the mutation counts as a crit or triggers explosion. See "Post-roll mutation pipeline" below.
+7. **Post-roll mutations.** `_applyPostRollMutations` processes an optional `mutations: MutationStep[]` array from the roll options. Each step targets specific dice, applies an operation (set, bump, max, floor, ceiling, etc.), and tags the result with metadata recording the original rolled value and whether the mutation counts as a crit or triggers explosion. See "Post-roll mutation pipeline" below. Forced crits (`forcedOutcome.crit = true`) are prepended to this pipeline as a `{ target: primary, operation: max, countsAsCrit: true, triggersExplosion: true }` step — the mutation pipeline then handles crit counting and vicious explosion dispatch.
 
-8. **Finalize the total.** `_finalizeOutcome` sets `isCritical` / `isMiss` / `critCount` flags and adjusts the total for vicious recalculation and the `primaryDieAsDamage: false` case (where the primary die's value is excluded from damage but its explosions still count). `critCount` tracks how many crit-capable dice independently rolled max — for a standard weapon this is 0 or 1, but for multi-die pools like Dravok's `4d4cv` it can be 2, 3, or even 4. `isCritical` is `critCount > 0`. If the `brutalPrimary` option is set, the primary die is reassigned to whichever die rolled highest (instead of leftmost).
+8. **Finalize the total.** `_finalizeOutcome` sets `isCritical` / `isMiss` / `critCount` flags and adjusts the total for vicious recalculation and the `primaryDieAsDamage: false` case (where the primary die's value is excluded from damage but its explosions still count). `critCount` tracks how many crit-capable dice independently rolled max — for a standard weapon this is 0 or 1, but for multi-die pools like Dravok's `4d4cv` it can be 2, 3, or even 4. `isCritical` is `critCount > 0`. If the `brutalPrimary` option is set, the primary die is reassigned to whichever die rolled highest (instead of leftmost). Finally, `forcedOutcome.miss = true` sets `isMiss = true` post-finalization unless a natural or forced crit has already fired (crit wins).
 
 9. **The chat card renders** (handled in `src/view/chat/components/`, outside the engine). The card shows the kept and dropped dice, the primary die, bonus dice, and the total.
 
@@ -119,6 +119,55 @@ Each mutated result is tagged with metadata preserving the original rolled value
 | BOUNDLESS RAGE ("Fury Die can't be less than 6") | no | no |
 
 Individual class features don't live in the engine — they emit `MutationStep` objects from the rules layer, and the engine processes them generically. The engine's only job is to apply the operation, tag the metadata, and honor the flags during crit detection and explosion dispatch.
+
+### Forced outcomes — `forcedOutcome`
+
+Some features override the roll's outcome regardless of what the dice actually rolled:
+
+- **Final Takedown** — "your next attack is a crit"
+- **Bubble of Light** — "the attack misses"
+- **Heads I Win, Tails You Lose** — forces crit
+- **Tuned Thrusters**, **Hexbinder no-valid-target** — force miss
+
+These are expressed declaratively via the `forcedOutcome` option:
+
+```typescript
+forcedOutcome?: {
+    crit?: boolean;   // force crit (prepended mutation, triggers explosion)
+    miss?: boolean;   // force miss (flag-only, post-finalization)
+    source?: string;  // label for chat card / logs
+}
+```
+
+**Forced crit** reuses the mutation pipeline: it injects a prepended `MutationStep` that sets the primary die to max with `countsAsCrit: true, triggersExplosion: true`. The existing pipeline then handles crit counting and vicious explosion dispatch — no duplicated logic.
+
+**Forced miss** is flag-only: it sets `isMiss = true` after finalization, leaving die values unchanged. Natural or forced crits override a forced miss (crit always wins).
+
+### Thresholds — `criticalThreshold` / `fumbleThreshold`
+
+Two roll-level options widen or narrow what counts as a crit or fumble:
+
+- **`criticalThreshold`** (default: `faces`) — a kept die crits if `result >= criticalThreshold`. Used by features like "Heads I Win, Tails You Lose" that let a die crit below max.
+- **`fumbleThreshold`** (default: `1`) — a kept die misses if `result <= fumbleThreshold`. Parry (monster trait) sets this to `2` on a d8, so both 1 and 2 miss.
+
+Thresholds apply in both modifier-mode and legacy mode. They affect crit/miss detection only — they do **not** alter explosion dispatch (a threshold-triggered crit below max will set `isCritical` but won't fire an explosion chain). Forced crit, not threshold, is the path for "crit with explosion regardless of value."
+
+### Reroll protocol — `DamageRoll.reroll(request)`
+
+Several features re-evaluate an already-rolled attack: Inerrant Strike, Mountain's Endurance, Songweaver's Inspiration, FAST, Pocket Sand, etc. The engine exposes a single entry point:
+
+```typescript
+await roll.reroll({ kind: 'whole', source: 'Inerrant Strike' });
+await roll.reroll({ kind: 'whole', rollModeAdjust: -1, source: 'FAST' });
+await roll.reroll({ kind: 'single', dieIndex: 2, source: 'Songweaver' });
+```
+
+Two variants:
+
+- **Whole-roll reroll** (`kind: 'whole'`) re-evaluates the roll from `originalFormula` with a fresh copy of the options. Callers can append `rollModeAdjust` (signed integer, added to `rollModeSources` or `rollMode` scalar) and/or `mutations` (appended to the options). Used for "reroll an attack with disadvantage" or "reroll and bump the primary +1."
+- **Single-die reroll** (`kind: 'single'`) clones the current roll, rerolls the die at the specified flattened active index, and re-runs finalization. NIMBLE_MODS metadata is preserved on the cloned die term. Used for "reroll one die, keep either" effects.
+
+The engine always returns a **new** `DamageRoll` — the original is never mutated. The caller (rules layer) decides what to do with the two rolls via a `KeepPolicy` (`'higher'` / `'lower'` / `'either'` / `'new'`). That decision is **not** engine logic — the engine produces rolls; the rules layer picks.
 
 ### Custom Die modifiers — `nimbleDieModifiers.ts`
 
@@ -180,6 +229,9 @@ Content authors can leave `weaponType` blank (nothing breaks) or set it for weap
 | Roll construction from an item | `src/managers/ItemActivationManager.ts` |
 | Weapon proficiency check | `src/view/sheets/components/attackUtils.ts` (`hasWeaponProficiency`) |
 | Post-roll mutation pipeline | `DamageRoll._applyPostRollMutations` + `src/dice/mutations.ts` |
+| Forced crit / forced miss | `DamageRoll.Options.forcedOutcome` |
+| Threshold wiring | `DamageRoll.Options.criticalThreshold` / `fumbleThreshold` |
+| Reroll protocol | `DamageRoll.reroll()` + `src/dice/reroll.ts` |
 | Multi-crit count | `DamageRoll.critCount` |
 | Brutal primary remapping | `DamageRoll.Options.brutalPrimary` |
 | Primary die value getter | `DamageRoll.primaryDieValue` |

--- a/src/dice/DamageRoll.test.ts
+++ b/src/dice/DamageRoll.test.ts
@@ -3,6 +3,7 @@ import type { EffectNode } from '#types/effectTree.js';
 import { ItemActivationManager, testDependencies } from '../managers/ItemActivationManager.js';
 import { hasWeaponProficiency } from '../utils/attackUtils.js';
 import { DamageRoll } from './DamageRoll.js';
+import type { MutatedResult, MutationStep } from './mutations.js';
 import {
 	getNimbleMods,
 	nimbleCrit,
@@ -2833,4 +2834,245 @@ describe('DamageRoll.matches', () => {
 	it('does not match 4d6kh3 + 2d8 + 5', () =>
 		expect(DamageRoll.matches('4d6kh3 + 2d8 + 5')).toBe(false));
 	it('does not match 2d20kh + 1d6', () => expect(DamageRoll.matches('2d20kh + 1d6')).toBe(false));
+});
+
+describe('mutations pipeline', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		stubBaseRollEvaluate();
+	});
+
+	it('empty mutations array → no change (baseline)', async () => {
+		const roll = new DamageRoll(
+			'1d8c',
+			{},
+			{
+				canCrit: true,
+				canMiss: true,
+				rollMode: 0,
+				primaryDieValue: 0,
+				primaryDieModifier: 0,
+				mutations: [],
+			},
+		);
+		stageModifierModeRoll(roll, [[{ result: 5, active: true }]], 5);
+		await (roll as any)._evaluate();
+		expect(roll.isCritical).toBe(false);
+		expect(roll.critCount).toBe(0);
+		// No mutation metadata on the result
+		const r = roll.terms.filter((t) => t instanceof foundry.dice.terms.Die)[0].results[0];
+		expect((r as MutatedResult).mutation).toBeUndefined();
+	});
+
+	it('Doomed: max all dice, countsAsCrit true, no explosion', async () => {
+		const mutations: MutationStep[] = [
+			{
+				target: { kind: 'all' },
+				operation: { type: 'max' },
+				countsAsCrit: true,
+				triggersExplosion: false,
+				source: 'Doomed',
+			},
+		];
+		const roll = new DamageRoll(
+			'1d8c',
+			{},
+			{
+				canCrit: true,
+				canMiss: true,
+				rollMode: 0,
+				primaryDieValue: 0,
+				primaryDieModifier: 0,
+				mutations,
+			},
+		);
+		// Seed die to non-max value — mutation will set it to max
+		stageModifierModeRoll(roll, [[{ result: 3, active: true }]], 3);
+		await (roll as any)._evaluate();
+
+		// Value is now max
+		const dieTerm = roll.terms.filter((t) => t instanceof foundry.dice.terms.Die)[0];
+		expect(dieTerm.results[0].result).toBe(8);
+
+		// Crit detected (countsAsCrit: true)
+		expect(roll.isCritical).toBe(true);
+		expect(roll.critCount).toBe(1);
+
+		// Mutation metadata preserved
+		const m = (dieTerm.results[0] as MutatedResult).mutation;
+		expect(m).toBeDefined();
+		expect(m!.rolledValue).toBe(3);
+		expect(m!.source).toBe('Doomed');
+		expect(m!.triggersExplosion).toBe(false);
+
+		// No explosion dice — the c modifier has standard explosion via `x`,
+		// which runs during super._evaluate() BEFORE mutations. Since the die
+		// rolled 3 originally, no explosion fired. The mutation sets it to 8
+		// after, but standard explosion already resolved as a no-op.
+		// Verify no extra results were appended.
+		expect(dieTerm.results).toHaveLength(1);
+	});
+
+	it('Vicious Opportunist: set primary to max, crit detected and explosion not suppressed', async () => {
+		const mutations: MutationStep[] = [
+			{
+				target: { kind: 'primary' },
+				operation: { type: 'set', value: 8 },
+				countsAsCrit: true,
+				triggersExplosion: true,
+				source: 'Vicious Opportunist',
+			},
+		];
+		const roll = new DamageRoll(
+			'1d8cv',
+			{},
+			{
+				canCrit: true,
+				canMiss: true,
+				rollMode: 0,
+				primaryDieValue: 0,
+				primaryDieModifier: 0,
+				mutations,
+			},
+		);
+		// Seed die to non-max — mutation will set to max
+		stageModifierModeRoll(roll, [[{ result: 2, active: true }]], 2);
+		await (roll as any)._evaluate();
+
+		const dieTerm = roll.terms.filter((t) => t instanceof foundry.dice.terms.Die)[0];
+		expect(dieTerm.results[0].result).toBe(8);
+
+		// Crit detected (countsAsCrit: true on mutated max)
+		expect(roll.isCritical).toBe(true);
+		expect(roll.critCount).toBe(1);
+
+		// Mutation metadata
+		const m = (dieTerm.results[0] as MutatedResult).mutation;
+		expect(m).toBeDefined();
+		expect(m!.source).toBe('Vicious Opportunist');
+		expect(m!.triggersExplosion).toBe(true);
+
+		// Vicious explosion should fire (triggersExplosion: true) — verify
+		// the initial result was marked exploded to start the chain.
+		// (The mock Roll environment doesn't produce real explosion results,
+		// but the exploded flag proves the guard didn't suppress it.)
+		expect(dieTerm.results[0].exploded).toBe(true);
+	});
+
+	it('Juggernaut: bump +1, does not crit (countsAsCrit defaults false)', async () => {
+		const mutations: MutationStep[] = [
+			{
+				target: { kind: 'primary' },
+				operation: { type: 'bump', delta: 1 },
+				source: 'Juggernaut',
+			},
+		];
+		const roll = new DamageRoll(
+			'1d8c',
+			{},
+			{
+				canCrit: true,
+				canMiss: true,
+				rollMode: 0,
+				primaryDieValue: 0,
+				primaryDieModifier: 0,
+				mutations,
+			},
+		);
+		// Seed to 5 → becomes 6 after bump
+		stageModifierModeRoll(roll, [[{ result: 5, active: true }]], 5);
+		await (roll as any)._evaluate();
+
+		const dieTerm = roll.terms.filter((t) => t instanceof foundry.dice.terms.Die)[0];
+		expect(dieTerm.results[0].result).toBe(6);
+		expect(roll.isCritical).toBe(false);
+
+		const m = (dieTerm.results[0] as MutatedResult).mutation;
+		expect(m!.rolledValue).toBe(5);
+	});
+
+	it('Juggernaut: bump to max does NOT crit (countsAsCrit: false)', async () => {
+		const mutations: MutationStep[] = [
+			{
+				target: { kind: 'primary' },
+				operation: { type: 'bump', delta: 1 },
+				source: 'Juggernaut',
+			},
+		];
+		const roll = new DamageRoll(
+			'1d8c',
+			{},
+			{
+				canCrit: true,
+				canMiss: true,
+				rollMode: 0,
+				primaryDieValue: 0,
+				primaryDieModifier: 0,
+				mutations,
+			},
+		);
+		// Seed to 7 → becomes 8 (max) after bump, but countsAsCrit defaults false
+		stageModifierModeRoll(roll, [[{ result: 7, active: true }]], 7);
+		await (roll as any)._evaluate();
+
+		const dieTerm = roll.terms.filter((t) => t instanceof foundry.dice.terms.Die)[0];
+		expect(dieTerm.results[0].result).toBe(8);
+		expect(roll.isCritical).toBe(false);
+		expect(roll.critCount).toBe(0);
+	});
+
+	it('BOUNDLESS RAGE: floor 6 on d12, below minimum raised', async () => {
+		const mutations: MutationStep[] = [
+			{
+				target: { kind: 'all' },
+				operation: { type: 'floor', minimum: 6 },
+				source: 'BOUNDLESS RAGE',
+			},
+		];
+		const roll = new DamageRoll(
+			'1d12c',
+			{},
+			{
+				canCrit: true,
+				canMiss: true,
+				rollMode: 0,
+				primaryDieValue: 0,
+				primaryDieModifier: 0,
+				mutations,
+			},
+		);
+		stageModifierModeRoll(roll, [[{ result: 3, active: true }]], 3);
+		await (roll as any)._evaluate();
+
+		const dieTerm = roll.terms.filter((t) => t instanceof foundry.dice.terms.Die)[0];
+		expect(dieTerm.results[0].result).toBe(6);
+		expect((dieTerm.results[0] as MutatedResult).mutation!.rolledValue).toBe(3);
+	});
+
+	it('BOUNDLESS RAGE: floor 6 on d12, above minimum unchanged', async () => {
+		const mutations: MutationStep[] = [
+			{
+				target: { kind: 'all' },
+				operation: { type: 'floor', minimum: 6 },
+				source: 'BOUNDLESS RAGE',
+			},
+		];
+		const roll = new DamageRoll(
+			'1d12c',
+			{},
+			{
+				canCrit: true,
+				canMiss: true,
+				rollMode: 0,
+				primaryDieValue: 0,
+				primaryDieModifier: 0,
+				mutations,
+			},
+		);
+		stageModifierModeRoll(roll, [[{ result: 9, active: true }]], 9);
+		await (roll as any)._evaluate();
+
+		const dieTerm = roll.terms.filter((t) => t instanceof foundry.dice.terms.Die)[0];
+		expect(dieTerm.results[0].result).toBe(9);
+	});
 });

--- a/src/dice/DamageRoll.test.ts
+++ b/src/dice/DamageRoll.test.ts
@@ -3076,3 +3076,572 @@ describe('mutations pipeline', () => {
 		expect(dieTerm.results[0].result).toBe(9);
 	});
 });
+
+describe('forcedOutcome', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		stubBaseRollEvaluate();
+	});
+
+	it('forced crit: primary rolled non-max → isCritical true, critCount 1, primary mutated to max', async () => {
+		const roll = new DamageRoll(
+			'1d8',
+			{},
+			{
+				canCrit: true,
+				canMiss: true,
+				rollMode: 0,
+				primaryDieValue: 0,
+				primaryDieModifier: 0,
+				forcedOutcome: { crit: true, source: 'Final Takedown' },
+			},
+		);
+		stagePrimaryDieResults(roll, [{ result: 3, active: true }], 3);
+		await (roll as any)._evaluate();
+
+		expect(roll.isCritical).toBe(true);
+		expect(roll.critCount).toBe(1);
+		expect(roll.isMiss).toBe(false);
+
+		const primary = roll.primaryDie!;
+		expect(primary.results[0].result).toBe(8);
+		const m = (primary.results[0] as MutatedResult).mutation;
+		expect(m).toBeDefined();
+		expect(m!.rolledValue).toBe(3);
+		expect(m!.source).toBe('Final Takedown');
+		expect(m!.countsAsCrit).toBe(true);
+		expect(m!.triggersExplosion).toBe(true);
+	});
+
+	it('forced miss: primary rolled non-1 → isMiss true, die value unchanged', async () => {
+		const roll = new DamageRoll(
+			'1d8',
+			{},
+			{
+				canCrit: true,
+				canMiss: true,
+				rollMode: 0,
+				primaryDieValue: 0,
+				primaryDieModifier: 0,
+				forcedOutcome: { miss: true, source: 'Bubble of Light' },
+			},
+		);
+		stagePrimaryDieResults(roll, [{ result: 5, active: true }], 5);
+		await (roll as any)._evaluate();
+
+		expect(roll.isMiss).toBe(true);
+		expect(roll.isCritical).toBe(false);
+		// Die value unchanged (no mutation applied for forced miss)
+		expect(roll.primaryDie!.results[0].result).toBe(5);
+		expect((roll.primaryDie!.results[0] as MutatedResult).mutation).toBeUndefined();
+	});
+
+	it('forced crit + miss → crit wins', async () => {
+		const roll = new DamageRoll(
+			'1d8',
+			{},
+			{
+				canCrit: true,
+				canMiss: true,
+				rollMode: 0,
+				primaryDieValue: 0,
+				primaryDieModifier: 0,
+				forcedOutcome: { crit: true, miss: true, source: 'Conflicting' },
+			},
+		);
+		stagePrimaryDieResults(roll, [{ result: 4, active: true }], 4);
+		await (roll as any)._evaluate();
+
+		expect(roll.isCritical).toBe(true);
+		expect(roll.isMiss).toBe(false);
+	});
+
+	it('forced miss does not override natural crit (high natural roll)', async () => {
+		const roll = new DamageRoll(
+			'1d8',
+			{},
+			{
+				canCrit: true,
+				canMiss: true,
+				rollMode: 0,
+				primaryDieValue: 0,
+				primaryDieModifier: 0,
+				forcedOutcome: { miss: true },
+			},
+		);
+		stagePrimaryDieResults(roll, [{ result: 8, active: true, exploded: true }], 8);
+		await (roll as any)._evaluate();
+
+		expect(roll.isCritical).toBe(true);
+		expect(roll.isMiss).toBe(false);
+	});
+
+	it('forced miss is ignored when canMiss is false (AoE / engine-disallowed miss)', async () => {
+		const roll = new DamageRoll(
+			'1d8',
+			{},
+			{
+				canCrit: true,
+				canMiss: false,
+				rollMode: 0,
+				primaryDieValue: 0,
+				primaryDieModifier: 0,
+				forcedOutcome: { miss: true, source: 'FireballAoE' },
+			},
+		);
+		stagePrimaryDieResults(roll, [{ result: 5, active: true }], 5);
+		await (roll as any)._evaluate();
+		expect(roll.isMiss).toBe(false);
+	});
+
+	it('forced crit implicitly enables canCrit (so the mutation can flip isCritical)', async () => {
+		const roll = new DamageRoll(
+			'1d8',
+			{},
+			{
+				// canCrit: false would normally lock isCritical to false. The
+				// constructor promotes it when forcedOutcome.crit is set.
+				canCrit: false,
+				canMiss: false,
+				rollMode: 0,
+				primaryDieValue: 0,
+				primaryDieModifier: 0,
+				forcedOutcome: { crit: true, source: 'Auto-Crit' },
+			},
+		);
+		// canCrit was promoted to true, so a PrimaryDie was extracted.
+		expect(roll.options.canCrit).toBe(true);
+		expect(roll.primaryDie).toBeDefined();
+		stagePrimaryDieResults(roll, [{ result: 3, active: true }], 3);
+		await (roll as any)._evaluate();
+		expect(roll.isCritical).toBe(true);
+	});
+
+	it('modifier-mode 4d4cv: forced crit mutates primary to max and triggersExplosion fires', async () => {
+		const roll = new DamageRoll(
+			'4d4cv',
+			{},
+			{
+				canCrit: true,
+				canMiss: true,
+				rollMode: 0,
+				primaryDieValue: 0,
+				primaryDieModifier: 0,
+				forcedOutcome: { crit: true, source: 'Vulnerable Underbelly' },
+			},
+		);
+		stageModifierModeRoll(
+			roll,
+			[
+				[
+					{ result: 2, active: true },
+					{ result: 3, active: true },
+					{ result: 1, active: true },
+					{ result: 2, active: true },
+				],
+			],
+			8,
+		);
+		await (roll as any)._evaluate();
+
+		expect(roll.isCritical).toBe(true);
+		expect(roll.critCount).toBeGreaterThanOrEqual(1);
+
+		const dieTerm = roll.terms.filter((t) => t instanceof foundry.dice.terms.Die)[0];
+		// Forced crit targets the primary die — leftmost for cv tag, which in
+		// this test is the sole 4d4cv term. All its ACTIVE results get mutated
+		// to max since `target: primary` hits every active result of that die.
+		expect(dieTerm.results[0].result).toBe(4);
+		// First active result is exploded (triggersExplosion: true).
+		expect(dieTerm.results[0].exploded).toBe(true);
+	});
+});
+
+describe('fumbleThreshold', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		stubBaseRollEvaluate();
+	});
+
+	it('Parry: d8, fumbleThreshold 2, rolls 2 → miss', async () => {
+		const roll = new DamageRoll(
+			'1d8',
+			{},
+			{
+				canCrit: true,
+				canMiss: true,
+				rollMode: 0,
+				primaryDieValue: 0,
+				primaryDieModifier: 0,
+				fumbleThreshold: 2,
+			},
+		);
+		stagePrimaryDieResults(roll, [{ result: 2, active: true }], 2);
+		await (roll as any)._evaluate();
+		expect(roll.isMiss).toBe(true);
+		expect(roll.isCritical).toBe(false);
+	});
+
+	it('Parry: d8, fumbleThreshold 2, rolls 3 → not miss', async () => {
+		const roll = new DamageRoll(
+			'1d8',
+			{},
+			{
+				canCrit: true,
+				canMiss: true,
+				rollMode: 0,
+				primaryDieValue: 0,
+				primaryDieModifier: 0,
+				fumbleThreshold: 2,
+			},
+		);
+		stagePrimaryDieResults(roll, [{ result: 3, active: true }], 3);
+		await (roll as any)._evaluate();
+		expect(roll.isMiss).toBe(false);
+	});
+
+	it('default fumbleThreshold (1): rolls 1 → miss (regression)', async () => {
+		const roll = new DamageRoll(
+			'1d8',
+			{},
+			{ canCrit: true, canMiss: true, rollMode: 0, primaryDieValue: 0, primaryDieModifier: 0 },
+		);
+		stagePrimaryDieResults(roll, [{ result: 1, active: true }], 1);
+		await (roll as any)._evaluate();
+		expect(roll.isMiss).toBe(true);
+	});
+
+	it('modifier-mode 1d8c: fumbleThreshold 2, rolls 2 → miss', async () => {
+		const roll = new DamageRoll(
+			'1d8c',
+			{},
+			{
+				canCrit: true,
+				canMiss: true,
+				rollMode: 0,
+				primaryDieValue: 0,
+				primaryDieModifier: 0,
+				fumbleThreshold: 2,
+			},
+		);
+		stageModifierModeRoll(roll, [[{ result: 2, active: true }]], 2);
+		await (roll as any)._evaluate();
+		expect(roll.isMiss).toBe(true);
+	});
+});
+
+describe('criticalThreshold', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		stubBaseRollEvaluate();
+	});
+
+	it('d8 criticalThreshold 7, rolls 7 → crit', async () => {
+		const roll = new DamageRoll(
+			'1d8',
+			{},
+			{
+				canCrit: true,
+				canMiss: true,
+				rollMode: 0,
+				primaryDieValue: 0,
+				primaryDieModifier: 0,
+				criticalThreshold: 7,
+			},
+		);
+		stagePrimaryDieResults(roll, [{ result: 7, active: true }], 7);
+		await (roll as any)._evaluate();
+		expect(roll.isCritical).toBe(true);
+		expect(roll.critCount).toBe(1);
+	});
+
+	it('d8 criticalThreshold 7, rolls 6 → not crit', async () => {
+		const roll = new DamageRoll(
+			'1d8',
+			{},
+			{
+				canCrit: true,
+				canMiss: true,
+				rollMode: 0,
+				primaryDieValue: 0,
+				primaryDieModifier: 0,
+				criticalThreshold: 7,
+			},
+		);
+		stagePrimaryDieResults(roll, [{ result: 6, active: true }], 6);
+		await (roll as any)._evaluate();
+		expect(roll.isCritical).toBe(false);
+	});
+
+	it('default criticalThreshold (faces): rolls max → crit (regression)', async () => {
+		const roll = new DamageRoll(
+			'1d8',
+			{},
+			{ canCrit: true, canMiss: true, rollMode: 0, primaryDieValue: 0, primaryDieModifier: 0 },
+		);
+		stagePrimaryDieResults(roll, [{ result: 8, active: true, exploded: true }], 8);
+		await (roll as any)._evaluate();
+		expect(roll.isCritical).toBe(true);
+	});
+
+	it('modifier-mode 1d8c: criticalThreshold 7, rolls 7 → crit', async () => {
+		const roll = new DamageRoll(
+			'1d8c',
+			{},
+			{
+				canCrit: true,
+				canMiss: true,
+				rollMode: 0,
+				primaryDieValue: 0,
+				primaryDieModifier: 0,
+				criticalThreshold: 7,
+			},
+		);
+		stageModifierModeRoll(roll, [[{ result: 7, active: true }]], 7);
+		await (roll as any)._evaluate();
+		expect(roll.isCritical).toBe(true);
+		expect(roll.critCount).toBe(1);
+	});
+});
+
+describe('reroll — whole', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		stubBaseRollEvaluate();
+	});
+
+	it('returns a new DamageRoll; original unchanged', async () => {
+		const roll = new DamageRoll(
+			'1d8',
+			{},
+			{ canCrit: true, canMiss: true, rollMode: 0, primaryDieValue: 0, primaryDieModifier: 0 },
+		);
+		stagePrimaryDieResults(roll, [{ result: 3, active: true }], 3);
+		await (roll as any)._evaluate();
+
+		const originalTotal = roll.total;
+		const rerolled = await roll.reroll({ kind: 'whole', source: 'Inerrant Strike' });
+
+		expect(rerolled).not.toBe(roll);
+		expect(rerolled).toBeInstanceOf(DamageRoll);
+		// Original left intact
+		expect(roll.total).toBe(originalTotal);
+		expect(roll.primaryDie!.results[0].result).toBe(3);
+	});
+
+	it('rollModeAdjust appends to rollModeSources when present', async () => {
+		const roll = new DamageRoll(
+			'1d8',
+			{},
+			{
+				canCrit: true,
+				canMiss: true,
+				rollMode: 0,
+				rollModeSources: [1],
+				primaryDieValue: 0,
+				primaryDieModifier: 0,
+			},
+		);
+		stagePrimaryDieResults(roll, [{ result: 5, active: true }], 5);
+		await (roll as any)._evaluate();
+
+		const rerolled = await roll.reroll({
+			kind: 'whole',
+			rollModeAdjust: -1,
+			source: 'FAST',
+		});
+
+		// Net rollMode should be 1 + (-1) = 0
+		expect(rerolled.options.netRollMode).toBe(0);
+		expect(rerolled.options.rollModeSources).toEqual([1, -1]);
+	});
+
+	it('rollModeAdjust on a scalar rollMode adds to it directly', async () => {
+		const roll = new DamageRoll(
+			'1d8',
+			{},
+			{ canCrit: true, canMiss: true, rollMode: 0, primaryDieValue: 0, primaryDieModifier: 0 },
+		);
+		stagePrimaryDieResults(roll, [{ result: 5, active: true }], 5);
+		await (roll as any)._evaluate();
+
+		const rerolled = await roll.reroll({
+			kind: 'whole',
+			rollModeAdjust: -1,
+			source: 'Pocket Sand',
+		});
+
+		expect(rerolled.options.rollMode).toBe(-1);
+	});
+
+	it('mutations passed via reroll are applied on the new roll (Inerrant Strike: bump +1)', async () => {
+		const roll = new DamageRoll(
+			'1d8',
+			{},
+			{ canCrit: true, canMiss: true, rollMode: 0, primaryDieValue: 0, primaryDieModifier: 0 },
+		);
+		stagePrimaryDieResults(roll, [{ result: 2, active: true }], 2);
+		await (roll as any)._evaluate();
+
+		const rerolled = await roll.reroll({
+			kind: 'whole',
+			mutations: [
+				{
+					target: { kind: 'primary' },
+					operation: { type: 'bump', delta: 1 },
+					source: 'Inerrant Strike',
+				},
+			],
+			source: 'Inerrant Strike',
+		});
+
+		// The new roll will re-preprocess and its options.mutations includes
+		// our step. Since the mock base _evaluate doesn't actually roll,
+		// primaryDie results are whatever the constructor primed. Just verify
+		// mutations survived onto options.
+		expect(rerolled.options.mutations).toBeDefined();
+		expect(rerolled.options.mutations!.some((m) => m.source === 'Inerrant Strike')).toBe(true);
+	});
+});
+
+describe('reroll — single die', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		stubBaseRollEvaluate();
+	});
+
+	it('rerolls one die result; other results unchanged; original unchanged', async () => {
+		const roll = new DamageRoll(
+			'1d8c',
+			{},
+			{
+				canCrit: true,
+				canMiss: true,
+				rollMode: 0,
+				primaryDieValue: 0,
+				primaryDieModifier: 0,
+			},
+		);
+		stageModifierModeRoll(roll, [[{ result: 3, active: true }]], 3);
+		await (roll as any)._evaluate();
+
+		const rerolled = await roll.reroll({
+			kind: 'single',
+			dieIndex: 0,
+			source: 'Songweaver',
+		});
+
+		expect(rerolled).not.toBe(roll);
+		// Original unchanged
+		const origDie = roll.terms.filter((t) => t instanceof foundry.dice.terms.Die)[0];
+		expect(origDie.results[0].result).toBe(3);
+
+		// Rerolled die has some new value (1..8). Value is random, just
+		// assert it's a legal d8 value.
+		const newDie = rerolled.terms.filter((t) => t instanceof foundry.dice.terms.Die)[0];
+		const newValue = newDie.results[0].result;
+		expect(newValue).toBeGreaterThanOrEqual(1);
+		expect(newValue).toBeLessThanOrEqual(8);
+	});
+
+	it('preserves NIMBLE_MODS metadata (c tag) on the rerolled die term', async () => {
+		const { NIMBLE_MODS: NIMBLE_MODS_sym } = await import('./nimbleDieModifiers.js');
+		const roll = new DamageRoll(
+			'1d8c',
+			{},
+			{
+				canCrit: true,
+				canMiss: true,
+				rollMode: 0,
+				primaryDieValue: 0,
+				primaryDieModifier: 0,
+			},
+		);
+		stageModifierModeRoll(roll, [[{ result: 4, active: true }]], 4);
+		await (roll as any)._evaluate();
+
+		const rerolled = await roll.reroll({
+			kind: 'single',
+			dieIndex: 0,
+			source: 'Songweaver',
+		});
+
+		const newDie = rerolled.terms.filter((t) => t instanceof foundry.dice.terms.Die)[0];
+		const meta = (newDie as any)[NIMBLE_MODS_sym];
+		expect(meta).toBeDefined();
+		expect(meta.canCrit).toBe(true);
+		expect(meta.explosionStyle).toBe('standard');
+	});
+
+	it('re-finalization updates isCritical / isMiss based on new die value (mocked value)', async () => {
+		const roll = new DamageRoll(
+			'1d8c',
+			{},
+			{
+				canCrit: true,
+				canMiss: true,
+				rollMode: 0,
+				primaryDieValue: 0,
+				primaryDieModifier: 0,
+			},
+		);
+		stageModifierModeRoll(roll, [[{ result: 3, active: true }]], 3);
+		await (roll as any)._evaluate();
+		expect(roll.isCritical).toBe(false);
+
+		// Monkey-patch Math.random to force an 8 (max for d8)
+		const origRandom = Math.random;
+		Math.random = () => 0.99;
+		try {
+			const rerolled = await roll.reroll({
+				kind: 'single',
+				dieIndex: 0,
+				source: 'Songweaver',
+			});
+			expect(rerolled.isCritical).toBe(true);
+		} finally {
+			Math.random = origRandom;
+		}
+	});
+
+	it('legacy mode: primaryDie on the reroll copy points into the copy\u2019s terms, not the original\u2019s', async () => {
+		const roll = new DamageRoll(
+			'1d8',
+			{},
+			{ canCrit: true, canMiss: true, rollMode: 0, primaryDieValue: 0, primaryDieModifier: 0 },
+		);
+		stagePrimaryDieResults(roll, [{ result: 3, active: true }], 3);
+		await (roll as any)._evaluate();
+
+		const rerolled = await roll.reroll({ kind: 'single', dieIndex: 0, source: 'x' });
+
+		// The copy's primaryDie must be one of the copy's own terms, not the
+		// original's. This guards against the constructor's throwaway extraction
+		// leaking out when legacy-mode finalization doesn't reassign primaryDie.
+		expect(rerolled.primaryDie).toBeDefined();
+		expect(rerolled.terms).toContain(rerolled.primaryDie);
+		expect(rerolled.primaryDie).not.toBe(roll.primaryDie);
+		// primaryDieValue must read the rerolled value, not a stale preset.
+		expect(rerolled.primaryDieValue).toBe(rerolled.primaryDie!.results[0].result);
+	});
+
+	it('throws if dieIndex is out of range', async () => {
+		const roll = new DamageRoll(
+			'1d8c',
+			{},
+			{
+				canCrit: true,
+				canMiss: true,
+				rollMode: 0,
+				primaryDieValue: 0,
+				primaryDieModifier: 0,
+			},
+		);
+		stageModifierModeRoll(roll, [[{ result: 5, active: true }]], 5);
+		await (roll as any)._evaluate();
+
+		await expect(roll.reroll({ kind: 'single', dieIndex: 99, source: 'x' })).rejects.toThrow(
+			/no active die result at index 99/,
+		);
+	});
+});

--- a/src/dice/DamageRoll.ts
+++ b/src/dice/DamageRoll.ts
@@ -3,7 +3,9 @@ import type { InexactPartial } from '#types/utils.js';
 
 import type { MutatedResult, MutationStep } from './mutations.js';
 import { applyMutationStep } from './mutations.js';
-import { getNimbleMods } from './nimbleDieModifiers.js';
+import type { NimbleDieMetadata } from './nimbleDieModifiers.js';
+import { getNimbleMods, NIMBLE_MODS } from './nimbleDieModifiers.js';
+import type { RerollRequest, SingleDieRerollRequest, WholeRerollRequest } from './reroll.js';
 import { PrimaryDie } from './terms/PrimaryDie.js';
 
 const Terms = foundry.dice.terms;
@@ -63,6 +65,22 @@ declare namespace DamageRoll {
 		brutalPrimary?: boolean;
 		/** Ordered list of post-roll value mutations to apply. */
 		mutations?: MutationStep[];
+		/**
+		 * Forced-outcome overrides applied after natural resolution. Used for
+		 * features that set the outcome regardless of die values (Final Takedown,
+		 * Bubble of Light, etc.).
+		 *
+		 * - `crit: true` — injects a prepended mutation that sets the primary
+		 *   die to max with `countsAsCrit: true, triggersExplosion: true`, so
+		 *   the existing mutation + explosion pipelines fire normally.
+		 * - `miss: true` — sets `isMiss = true` after finalization. Die values
+		 *   are not changed. Natural or forced crit overrides a forced miss.
+		 */
+		forcedOutcome?: {
+			crit?: boolean;
+			miss?: boolean;
+			source?: string;
+		};
 		/**
 		 * @deprecated Use `explosionStyle: 'vicious'` instead. Translated to
 		 *   `explosionStyle` by the constructor shim for back-compat.
@@ -203,6 +221,14 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 		this.options.canCrit ??= true;
 		this.options.canMiss ??= true;
 		this.options.rollMode ??= 0;
+
+		// Forced crit implies the roll can crit — otherwise the crit-detection
+		// branch in `_finalizeOutcome` wouldn't run and the forced-crit mutation
+		// would be invisible. `canMiss: false` (AoE) is deliberately NOT
+		// promoted: AoE rolls cannot miss regardless of `forcedOutcome.miss`.
+		if (this.options.forcedOutcome?.crit) {
+			this.options.canCrit = true;
+		}
 
 		// Aggregate multiple adv/dis sources into a single net rollMode.
 		// Per Nimble rules, advantage and disadvantage cancel 1-for-1.
@@ -517,6 +543,14 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 			}
 		}
 
+		// Forced miss: flag-only override applied after natural finalization.
+		// Natural or forced crit wins. Engine-level `canMiss: false` (e.g. AoE
+		// rolls) also wins — forced miss cannot turn an "can't miss" roll into
+		// a miss.
+		if (this.options.forcedOutcome?.miss && !this.isCritical && this.options.canMiss !== false) {
+			this.isMiss = true;
+		}
+
 		return this as DamageRoll.Evaluated<this>;
 	}
 
@@ -528,19 +562,29 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 		const isVicious = this.options.explosionStyle === 'vicious';
 
 		// Crit = a kept (active, non-discarded) result from the primary die
-		// rolled max face value. Value-based (not flag-based) so that
-		// explosionStyle: 'none' — which never sets the exploded flag —
-		// still detects crit correctly.
+		// that meets the crit threshold (default: faces). Value-based (not
+		// flag-based) so that explosionStyle: 'none' — which never sets the
+		// exploded flag — still detects crit correctly.
+		const critThreshold = this.options.criticalThreshold ?? primaryTerm.faces ?? Infinity;
 		if (this.options.canCrit) {
 			this.isCritical = primaryTerm.results.some((r) => {
-				if (!r.active || r.discarded || r.result !== primaryTerm.faces) return false;
+				if (!r.active || r.discarded || r.result < critThreshold) return false;
 				const m = (r as MutatedResult).mutation;
 				return !m || m.countsAsCrit;
 			});
 		}
 		this.critCount = this.isCritical ? 1 : 0;
 
-		if (this.options.canMiss) this.isMiss = primaryTerm.isMiss;
+		if (this.options.canMiss) {
+			if (this.isCritical) {
+				this.isMiss = false;
+			} else {
+				const fumbleThreshold = this.options.fumbleThreshold ?? 1;
+				this.isMiss = primaryTerm.results.some(
+					(r) => r.active && !r.discarded && r.result <= fumbleThreshold,
+				);
+			}
+		}
 
 		this._applyBrutalRemapping(
 			this.terms.filter((t): t is foundry.dice.terms.Die => t instanceof Terms.Die),
@@ -580,10 +624,24 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 	 * logic can decide per-result crit/explosion behavior.
 	 */
 	private _applyPostRollMutations(): void {
-		const mutations = this.options.mutations;
-		if (!mutations?.length) return;
+		const configured = this.options.mutations ?? [];
+		const steps: MutationStep[] = [];
+		// Forced crit is implemented as a prepended mutation so it reuses the
+		// existing mutation + explosion pipelines (Stage 4) without duplicating
+		// crit/explosion logic.
+		if (this.options.forcedOutcome?.crit) {
+			steps.push({
+				target: { kind: 'primary' },
+				operation: { type: 'max' },
+				countsAsCrit: true,
+				triggersExplosion: true,
+				source: this.options.forcedOutcome.source ?? 'Forced Crit',
+			});
+		}
+		if (configured.length) steps.push(...configured);
+		if (!steps.length) return;
 		const dieTerms = this.terms.filter((t): t is foundry.dice.terms.Die => t instanceof Terms.Die);
-		for (const step of mutations) {
+		for (const step of steps) {
 			applyMutationStep(step, dieTerms, this.primaryDie);
 		}
 	}
@@ -748,8 +806,9 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 			if (!(term instanceof Terms.Die)) continue;
 			const meta = getNimbleMods(term);
 			if (!meta?.canCrit) continue;
+			const critThreshold = this.options.criticalThreshold ?? term.faces ?? Infinity;
 			for (const r of term.results) {
-				if (!r.active || r.discarded || r.result !== term.faces) continue;
+				if (!r.active || r.discarded || r.result < critThreshold) continue;
 				const m = (r as MutatedResult).mutation;
 				if (!m || m.countsAsCrit) count++;
 			}
@@ -771,17 +830,27 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 
 		// ── Miss detection: leftmost non-neutral Die ──
 		if (this.options.canMiss) {
-			const missDie = dieTerms.find((term) => {
-				const meta = getNimbleMods(term);
-				// A die is "neutral" if tagged `n` (canCrit:false, explosionStyle:'none')
-				return !(meta && !meta.canCrit && meta.explosionStyle === 'none');
-			});
-			if (missDie) {
-				const firstActive = missDie.results.find((r) => r.active && !r.discarded);
-				this.isMiss = firstActive?.result === 1;
-			} else {
-				// All dice are neutral — no die qualifies for miss detection
+			if (this.isCritical) {
 				this.isMiss = false;
+			} else {
+				const missDie = dieTerms.find((term) => {
+					const meta = getNimbleMods(term);
+					// Miss detection runs on crit-capable dice only. Neutral
+					// (`n`) and vicious-without-crit (`v`) dice are not
+					// hit/miss arbiters. Untagged dice (no metadata — only
+					// reachable in edge-case constructions) fall through to
+					// the miss-detection path.
+					if (!meta) return true;
+					return meta.canCrit === true;
+				});
+				if (missDie) {
+					const firstActive = missDie.results.find((r) => r.active && !r.discarded);
+					const fumbleThreshold = this.options.fumbleThreshold ?? 1;
+					this.isMiss = firstActive !== undefined && firstActive.result <= fumbleThreshold;
+				} else {
+					// All dice are neutral — no die qualifies for miss detection
+					this.isMiss = false;
+				}
 			}
 		}
 
@@ -838,6 +907,224 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 
 		const internals = this as object as { _total: number };
 		internals._total = total;
+	}
+
+	/** ------------------------------------------------------ */
+	/**                     Reroll API                         */
+	/** ------------------------------------------------------ */
+
+	/**
+	 * Re-evaluate this roll under a Nimble reroll request. Always returns a
+	 * NEW DamageRoll — the original is never mutated. The caller (rules layer)
+	 * decides what to do with the two rolls (keep higher, keep lower, keep
+	 * either, keep new) via a `KeepPolicy`.
+	 *
+	 * - `kind: 'whole'` produces a fresh evaluated roll from `originalFormula`,
+	 *   optionally adjusting rollMode and/or adding mutations.
+	 * - `kind: 'single'` returns a deep copy of the current roll with one die
+	 *   re-rolled in place, finalization re-run, and NIMBLE_MODS preserved.
+	 *
+	 * Overloads the Foundry `Roll.reroll(options?)` signature so existing
+	 * callers that pass `Roll.Options` (or no argument) still work.
+	 */
+	override async reroll(options?: foundry.dice.Roll.Options): Promise<DamageRoll.Evaluated<this>>;
+	override async reroll(request: RerollRequest): Promise<DamageRoll>;
+	override async reroll(
+		arg?: RerollRequest | foundry.dice.Roll.Options,
+	): Promise<DamageRoll | DamageRoll.Evaluated<this>> {
+		if (arg && typeof arg === 'object' && 'kind' in arg) {
+			if (arg.kind === 'whole') return this._rerollWhole(arg);
+			if (arg.kind === 'single') return this._rerollSingleDie(arg);
+		}
+		// Delegate to the Foundry implementation for the legacy signature.
+		return super.reroll(arg as foundry.dice.Roll.Options | undefined) as Promise<
+			DamageRoll.Evaluated<this>
+		>;
+	}
+
+	/**
+	 * Implements the whole-roll reroll variant (AC#8).
+	 *
+	 * The new roll is constructed from `originalFormula` and a shallow copy of
+	 * `this.options` — the constructor re-runs preprocessing to re-extract a
+	 * PrimaryDie, so rollMode and mutation changes take effect naturally.
+	 */
+	private async _rerollWhole(request: WholeRerollRequest): Promise<DamageRoll> {
+		const newOptions: DamageRoll.Options = { ...this.options };
+		// Always force constructor to recompute netRollMode rather than reusing
+		// a stale cached value from the source options.
+		delete newOptions.netRollMode;
+
+		if (request.rollModeAdjust) {
+			if (Array.isArray(newOptions.rollModeSources)) {
+				newOptions.rollModeSources = [...newOptions.rollModeSources, request.rollModeAdjust];
+			} else {
+				newOptions.rollMode = (newOptions.rollMode ?? 0) + request.rollModeAdjust;
+			}
+		}
+
+		if (request.mutations?.length) {
+			newOptions.mutations = [...(newOptions.mutations ?? []), ...request.mutations];
+		}
+
+		// Shallow-copy `data` so feature-driven mutations on the reroll don't
+		// bleed back into the original roll's data.
+		const newData = { ...this.data };
+		const newRoll = new DamageRoll(this.originalFormula, newData, newOptions);
+		await newRoll.evaluate();
+		return newRoll;
+	}
+
+	/**
+	 * Implements the single-die reroll variant (AC#9, AC#10).
+	 *
+	 * Constructs a fresh DamageRoll shell from `originalFormula`/data/options,
+	 * then replaces its terms with structural clones of `this.terms` so the
+	 * prior evaluated state (rolled values, modifiers, discarded/active flags)
+	 * carries forward. NIMBLE_MODS metadata is re-attached from the cloned
+	 * modifiers. The targeted die is then re-rolled using a throwaway
+	 * `Roll(`1d{faces}`)` (so Foundry's RNG and DSN visualisation still apply),
+	 * outcome state is reset, and finalisation re-runs.
+	 */
+	private async _rerollSingleDie(request: SingleDieRerollRequest): Promise<DamageRoll> {
+		const copy = new DamageRoll(this.originalFormula, this.data, { ...this.options });
+		copy.terms = this.terms.map((t) => DamageRoll._cloneTerm(t));
+		copy.modifierMode = this.modifierMode;
+		// Constructor set `copy.primaryDie` to a throwaway PrimaryDie in the
+		// throwaway term array that we just replaced. Re-point it at the
+		// cloned PrimaryDie in `copy.terms` now so the stale reference can't
+		// leak out to callers (e.g. via `primaryDieValue`) if finalization
+		// doesn't explicitly reassign it.
+		copy.primaryDie = copy.terms.find(
+			(t): t is PrimaryDie | foundry.dice.terms.Die => t instanceof Terms.Die,
+		);
+		DamageRoll._reattachNimbleMods(copy.terms);
+
+		const dieTerms = copy.terms.filter((t): t is foundry.dice.terms.Die => t instanceof Terms.Die);
+		let flatIdx = 0;
+		let target: { term: foundry.dice.terms.Die; resultIdx: number } | undefined;
+		outer: for (const term of dieTerms) {
+			for (let i = 0; i < term.results.length; i++) {
+				const r = term.results[i];
+				if (r.active && !r.discarded) {
+					if (flatIdx === request.dieIndex) {
+						target = { term, resultIdx: i };
+						break outer;
+					}
+					flatIdx++;
+				}
+			}
+		}
+
+		if (!target) {
+			throw new Error(`DamageRoll.reroll: no active die result at index ${request.dieIndex}`);
+		}
+
+		const faces = target.term.faces ?? 6;
+		const newValue = Math.floor(Math.random() * faces) + 1;
+
+		const prev = target.term.results[target.resultIdx];
+		target.term.results[target.resultIdx] = {
+			...prev,
+			result: newValue,
+			// Drop stale flags/metadata from the prior evaluation. The mutation
+			// metadata and exploded flag described the pre-reroll value; they
+			// should not carry to the new value.
+			exploded: false,
+		};
+		delete (target.term.results[target.resultIdx] as MutatedResult).mutation;
+
+		// Reset outcome state before re-running finalization. excludedPrimaryDieValue
+		// gets recomputed by finalization when primaryDieAsDamage is false.
+		copy.isCritical = copy.options.canCrit ? undefined : false;
+		copy.isMiss = copy.options.canMiss ? undefined : false;
+		copy.critCount = 0;
+		copy.excludedPrimaryDieValue = 0;
+		copy._recalculateTotal();
+
+		if (copy.modifierMode) {
+			copy.critCount = copy._countModifierModeCrits();
+			copy._finalizeOutcomeModifierMode();
+		} else {
+			const primaryTerm = copy.terms.find((t) => t instanceof PrimaryDie);
+			if (primaryTerm) copy._finalizeOutcome(primaryTerm);
+		}
+
+		if (copy.options.forcedOutcome?.miss && !copy.isCritical && copy.options.canMiss !== false) {
+			copy.isMiss = true;
+		}
+
+		copy.resetFormula();
+		return copy;
+	}
+
+	/**
+	 * Structural clone of a RollTerm used by `_rerollSingleDie`. Preserves
+	 * values, modifiers, active/discarded flags, and evaluated state so the
+	 * cloned term is interchangeable with the source.
+	 */
+	private static _cloneTerm(term: foundry.dice.terms.RollTerm): foundry.dice.terms.RollTerm {
+		if (term instanceof PrimaryDie) {
+			const cloned = new PrimaryDie({
+				number: term.number ?? 1,
+				faces: term.faces ?? 6,
+				modifiers: (Array.isArray(term.modifiers)
+					? [...term.modifiers]
+					: []) as PrimaryDie.TermData['modifiers'],
+				options: { ...term.options },
+			});
+			cloned.results = term.results.map((r) => ({ ...r }));
+			(cloned as unknown as { _evaluated: boolean })._evaluated = (
+				term as unknown as { _evaluated: boolean }
+			)._evaluated;
+			return cloned;
+		}
+		if (term instanceof Terms.Die) {
+			const cloned = new Terms.Die({
+				number: term.number ?? 1,
+				faces: term.faces ?? 6,
+				modifiers: Array.isArray(term.modifiers) ? [...term.modifiers] : [],
+			} as unknown as foundry.dice.terms.Die.TermData);
+			cloned.results = term.results.map((r) => ({ ...r }));
+			(cloned as unknown as { _evaluated: boolean })._evaluated = (
+				term as unknown as { _evaluated: boolean }
+			)._evaluated;
+			return cloned;
+		}
+		// For non-dice terms (operators, numerics, parentheticals), shallow
+		// clone via the prototype — they carry no mutable roll state.
+		const proto = Object.getPrototypeOf(term) as object;
+		const cloned = Object.create(proto) as foundry.dice.terms.RollTerm;
+		Object.assign(cloned, term);
+		return cloned;
+	}
+
+	/**
+	 * Re-attach NIMBLE_MODS metadata to Die terms after a clone.
+	 * The symbol-keyed metadata is not copied by structural clone, but the
+	 * modifier strings (`c`, `cv`, `v`, `n`) survive and can be used to
+	 * rebuild it.
+	 */
+	private static _reattachNimbleMods(terms: foundry.dice.terms.RollTerm[]): void {
+		for (const term of terms) {
+			if (!(term instanceof Terms.Die)) continue;
+			if (!Array.isArray(term.modifiers)) continue;
+			const has = (m: string) => term.modifiers.includes(m);
+			let meta: NimbleDieMetadata | undefined;
+			// Treat a combined `c` + `v` (a hand-built array, unusual — formula
+			// parsing normalizes to `cv`) as crit-vicious. `cv` alone wins
+			// likewise.
+			if (has('cv') || (has('c') && has('v'))) {
+				meta = { canCrit: true, explosionStyle: 'vicious' };
+			} else if (has('c')) {
+				meta = { canCrit: true, explosionStyle: 'standard' };
+			} else if (has('v')) {
+				meta = { canCrit: false, explosionStyle: 'vicious' };
+			} else if (has('n')) {
+				meta = { canCrit: false, explosionStyle: 'none' };
+			}
+			if (meta) (term as unknown as Record<symbol, unknown>)[NIMBLE_MODS] = meta;
+		}
 	}
 
 	/**

--- a/src/dice/DamageRoll.ts
+++ b/src/dice/DamageRoll.ts
@@ -1,6 +1,8 @@
 import type { AnyObject, FixedInstanceType } from 'fvtt-types/utils';
 import type { InexactPartial } from '#types/utils.js';
 
+import type { MutatedResult, MutationStep } from './mutations.js';
+import { applyMutationStep } from './mutations.js';
 import { getNimbleMods } from './nimbleDieModifiers.js';
 import { PrimaryDie } from './terms/PrimaryDie.js';
 
@@ -59,6 +61,8 @@ declare namespace DamageRoll {
 		 * Default: false
 		 */
 		brutalPrimary?: boolean;
+		/** Ordered list of post-roll value mutations to apply. */
+		mutations?: MutationStep[];
 		/**
 		 * @deprecated Use `explosionStyle: 'vicious'` instead. Translated to
 		 *   `explosionStyle` by the constructor shim for back-compat.
@@ -528,9 +532,11 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 		// explosionStyle: 'none' — which never sets the exploded flag —
 		// still detects crit correctly.
 		if (this.options.canCrit) {
-			this.isCritical = primaryTerm.results.some(
-				(r) => r.active && !r.discarded && r.result === primaryTerm.faces,
-			);
+			this.isCritical = primaryTerm.results.some((r) => {
+				if (!r.active || r.discarded || r.result !== primaryTerm.faces) return false;
+				const m = (r as MutatedResult).mutation;
+				return !m || m.countsAsCrit;
+			});
 		}
 		this.critCount = this.isCritical ? 1 : 0;
 
@@ -568,12 +574,18 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 	}
 
 	/**
-	 * Extension point for features that mutate primary die values after
-	 * rolling but before outcome resolution (e.g. Hexbinder Doomed,
-	 * Vicious Opportunist). Intentionally empty today.
+	 * Process declarative mutation steps that modify die results after rolling
+	 * but before crit detection and explosion dispatch (e.g. Hexbinder Doomed,
+	 * Vicious Opportunist). Each step tags results with metadata so downstream
+	 * logic can decide per-result crit/explosion behavior.
 	 */
 	private _applyPostRollMutations(): void {
-		// No-op. Reserved for future mutation features.
+		const mutations = this.options.mutations;
+		if (!mutations?.length) return;
+		const dieTerms = this.terms.filter((t): t is foundry.dice.terms.Die => t instanceof Terms.Die);
+		for (const step of mutations) {
+			applyMutationStep(step, dieTerms, this.primaryDie);
+		}
 	}
 
 	/**
@@ -599,6 +611,9 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 
 		// Check if initial roll is a crit (max value)
 		if (initialResult.result !== faces) return;
+		// Skip explosion for mutated results unless triggersExplosion is true
+		const mut = (initialResult as MutatedResult).mutation;
+		if (mut && !mut.triggersExplosion) return;
 
 		// Mark initial result as exploded
 		initialResult.exploded = true;
@@ -662,6 +677,9 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 
 		for (const result of baseResults) {
 			if (!result.active || result.discarded || result.result !== faces) continue;
+			// Skip explosion for mutated results unless triggersExplosion is true
+			const m = (result as MutatedResult).mutation;
+			if (m && !m.triggersExplosion) continue;
 
 			// Mark as exploded and chain
 			result.exploded = true;
@@ -731,9 +749,9 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 			const meta = getNimbleMods(term);
 			if (!meta?.canCrit) continue;
 			for (const r of term.results) {
-				if (r.active && !r.discarded && r.result === term.faces) {
-					count++;
-				}
+				if (!r.active || r.discarded || r.result !== term.faces) continue;
+				const m = (r as MutatedResult).mutation;
+				if (!m || m.countsAsCrit) count++;
 			}
 		}
 		return count;

--- a/src/dice/mutations.test.ts
+++ b/src/dice/mutations.test.ts
@@ -1,0 +1,304 @@
+import { describe, expect, it } from 'vitest';
+import type { MutatedResult, MutationStep } from './mutations.js';
+import { applyMutationStep } from './mutations.js';
+import { NIMBLE_MODS } from './nimbleDieModifiers.js';
+
+const Terms = foundry.dice.terms;
+
+/** Create a mock Die term with pre-set results. */
+function makeDie(
+	faces: number,
+	results: Array<{ result: number; active?: boolean; discarded?: boolean }>,
+	modifiers: string[] = [],
+): foundry.dice.terms.Die {
+	// Cast modifiers to satisfy Foundry's stricter TermData typing in tests
+	const die = new Terms.Die({ faces, number: results.length, modifiers } as any);
+	(die as any).results = results.map((r) => ({
+		result: r.result,
+		active: r.active ?? true,
+		discarded: r.discarded ?? false,
+	}));
+	return die;
+}
+
+describe('applyMutationStep', () => {
+	describe('set operation', () => {
+		it('sets result to exact value and tags metadata', () => {
+			const die = makeDie(8, [{ result: 3 }]);
+			const step: MutationStep = {
+				target: { kind: 'all' },
+				operation: { type: 'set', value: 7 },
+				source: 'Test',
+			};
+			applyMutationStep(step, [die], undefined);
+
+			expect(die.results[0].result).toBe(7);
+			const m = (die.results[0] as MutatedResult).mutation;
+			expect(m).toBeDefined();
+			expect(m!.rolledValue).toBe(3);
+			expect(m!.source).toBe('Test');
+			expect(m!.countsAsCrit).toBe(false);
+			expect(m!.triggersExplosion).toBe(false);
+		});
+
+		it('clamps set value to [1, faces]', () => {
+			const die = makeDie(6, [{ result: 4 }]);
+			applyMutationStep(
+				{ target: { kind: 'all' }, operation: { type: 'set', value: 10 } },
+				[die],
+				undefined,
+			);
+			expect(die.results[0].result).toBe(6);
+
+			const die2 = makeDie(6, [{ result: 4 }]);
+			applyMutationStep(
+				{ target: { kind: 'all' }, operation: { type: 'set', value: 0 } },
+				[die2],
+				undefined,
+			);
+			expect(die2.results[0].result).toBe(1);
+		});
+	});
+
+	describe('bump operation', () => {
+		it('increments result by delta', () => {
+			const die = makeDie(8, [{ result: 5 }]);
+			applyMutationStep(
+				{
+					target: { kind: 'all' },
+					operation: { type: 'bump', delta: 1 },
+					source: 'Juggernaut',
+				},
+				[die],
+				undefined,
+			);
+			expect(die.results[0].result).toBe(6);
+			expect((die.results[0] as MutatedResult).mutation!.rolledValue).toBe(5);
+		});
+
+		it('clamps bump at faces (max)', () => {
+			const die = makeDie(8, [{ result: 8 }]);
+			applyMutationStep(
+				{ target: { kind: 'all' }, operation: { type: 'bump', delta: 1 } },
+				[die],
+				undefined,
+			);
+			expect(die.results[0].result).toBe(8);
+		});
+
+		it('decrements and clamps at 1 (min)', () => {
+			const die = makeDie(8, [{ result: 2 }]);
+			applyMutationStep(
+				{ target: { kind: 'all' }, operation: { type: 'bump', delta: -5 } },
+				[die],
+				undefined,
+			);
+			expect(die.results[0].result).toBe(1);
+			expect((die.results[0] as MutatedResult).mutation!.rolledValue).toBe(2);
+		});
+	});
+
+	describe('max operation', () => {
+		it('sets result to faces', () => {
+			const die = makeDie(12, [{ result: 7 }]);
+			applyMutationStep(
+				{ target: { kind: 'all' }, operation: { type: 'max' }, source: 'Doomed' },
+				[die],
+				undefined,
+			);
+			expect(die.results[0].result).toBe(12);
+			expect((die.results[0] as MutatedResult).mutation!.rolledValue).toBe(7);
+		});
+	});
+
+	describe('min operation', () => {
+		it('sets result to 1', () => {
+			const die = makeDie(8, [{ result: 5 }]);
+			applyMutationStep({ target: { kind: 'all' }, operation: { type: 'min' } }, [die], undefined);
+			expect(die.results[0].result).toBe(1);
+		});
+	});
+
+	describe('floor operation', () => {
+		it('raises result below minimum', () => {
+			const die = makeDie(12, [{ result: 3 }]);
+			applyMutationStep(
+				{
+					target: { kind: 'all' },
+					operation: { type: 'floor', minimum: 6 },
+					source: 'BOUNDLESS RAGE',
+				},
+				[die],
+				undefined,
+			);
+			expect(die.results[0].result).toBe(6);
+			expect((die.results[0] as MutatedResult).mutation!.rolledValue).toBe(3);
+		});
+
+		it('does not lower result above minimum', () => {
+			const die = makeDie(12, [{ result: 9 }]);
+			applyMutationStep(
+				{
+					target: { kind: 'all' },
+					operation: { type: 'floor', minimum: 6 },
+					source: 'BOUNDLESS RAGE',
+				},
+				[die],
+				undefined,
+			);
+			expect(die.results[0].result).toBe(9);
+			// Still tagged even though value didn't change
+			expect((die.results[0] as MutatedResult).mutation!.rolledValue).toBe(9);
+		});
+
+		it('clamps floor minimum to faces', () => {
+			const die = makeDie(4, [{ result: 2 }]);
+			applyMutationStep(
+				{ target: { kind: 'all' }, operation: { type: 'floor', minimum: 6 } },
+				[die],
+				undefined,
+			);
+			// floor 6 on d4 clamps to faces=4
+			expect(die.results[0].result).toBe(4);
+		});
+	});
+
+	describe('ceiling operation', () => {
+		it('lowers result above maximum', () => {
+			const die = makeDie(8, [{ result: 7 }]);
+			applyMutationStep(
+				{ target: { kind: 'all' }, operation: { type: 'ceiling', maximum: 4 } },
+				[die],
+				undefined,
+			);
+			expect(die.results[0].result).toBe(4);
+			expect((die.results[0] as MutatedResult).mutation!.rolledValue).toBe(7);
+		});
+
+		it('does not raise result below maximum', () => {
+			const die = makeDie(8, [{ result: 3 }]);
+			applyMutationStep(
+				{ target: { kind: 'all' }, operation: { type: 'ceiling', maximum: 4 } },
+				[die],
+				undefined,
+			);
+			expect(die.results[0].result).toBe(3);
+		});
+	});
+
+	describe('target: primary', () => {
+		it('mutates only primary die results', () => {
+			const primary = makeDie(8, [{ result: 3 }]);
+			const bonus = makeDie(6, [{ result: 4 }]);
+			applyMutationStep(
+				{ target: { kind: 'primary' }, operation: { type: 'max' } },
+				[primary, bonus],
+				primary,
+			);
+			expect(primary.results[0].result).toBe(8);
+			expect(bonus.results[0].result).toBe(4); // untouched
+		});
+
+		it('falls back to leftmost c/cv-tagged die when primaryDie is undefined', () => {
+			const tagged = makeDie(8, [{ result: 3 }], ['c']);
+			(tagged as any)[NIMBLE_MODS] = { canCrit: true, explosionStyle: 'standard' };
+
+			const untagged = makeDie(6, [{ result: 5 }]);
+			applyMutationStep(
+				{ target: { kind: 'primary' }, operation: { type: 'max' } },
+				[tagged, untagged],
+				undefined,
+			);
+			expect(tagged.results[0].result).toBe(8);
+			expect(untagged.results[0].result).toBe(5);
+		});
+	});
+
+	describe('target: all', () => {
+		it('mutates all active results across all die terms', () => {
+			const d1 = makeDie(8, [{ result: 3 }, { result: 6 }]);
+			const d2 = makeDie(6, [{ result: 2 }]);
+			applyMutationStep(
+				{ target: { kind: 'all' }, operation: { type: 'max' } },
+				[d1, d2],
+				undefined,
+			);
+			expect(d1.results[0].result).toBe(8);
+			expect(d1.results[1].result).toBe(8);
+			expect(d2.results[0].result).toBe(6);
+		});
+
+		it('skips discarded results', () => {
+			const die = makeDie(8, [
+				{ result: 3, active: true },
+				{ result: 5, active: false, discarded: true },
+			]);
+			applyMutationStep({ target: { kind: 'all' }, operation: { type: 'max' } }, [die], undefined);
+			expect(die.results[0].result).toBe(8);
+			expect(die.results[1].result).toBe(5); // untouched
+		});
+	});
+
+	describe('target: tagged', () => {
+		it('mutates only dice with matching modifier', () => {
+			const cDie = makeDie(8, [{ result: 3 }], ['c']);
+			const nDie = makeDie(6, [{ result: 4 }], ['n']);
+			applyMutationStep(
+				{ target: { kind: 'tagged', modifier: 'c' }, operation: { type: 'max' } },
+				[cDie, nDie],
+				undefined,
+			);
+			expect(cDie.results[0].result).toBe(8);
+			expect(nDie.results[0].result).toBe(4);
+		});
+	});
+
+	describe('target: index', () => {
+		it('mutates only the result at the given flattened index', () => {
+			const d1 = makeDie(8, [{ result: 3 }, { result: 6 }]);
+			const d2 = makeDie(6, [{ result: 2 }]);
+			applyMutationStep(
+				{ target: { kind: 'index', index: 1 }, operation: { type: 'min' } },
+				[d1, d2],
+				undefined,
+			);
+			expect(d1.results[0].result).toBe(3); // index 0, untouched
+			expect(d1.results[1].result).toBe(1); // index 1, mutated
+			expect(d2.results[0].result).toBe(2); // index 2, untouched
+		});
+	});
+
+	describe('mutation metadata flags', () => {
+		it('propagates countsAsCrit and triggersExplosion from step', () => {
+			const die = makeDie(8, [{ result: 3 }]);
+			applyMutationStep(
+				{
+					target: { kind: 'all' },
+					operation: { type: 'set', value: 8 },
+					countsAsCrit: true,
+					triggersExplosion: true,
+					source: 'Vicious Opportunist',
+				},
+				[die],
+				undefined,
+			);
+			const m = (die.results[0] as MutatedResult).mutation!;
+			expect(m.countsAsCrit).toBe(true);
+			expect(m.triggersExplosion).toBe(true);
+			expect(m.source).toBe('Vicious Opportunist');
+		});
+
+		it('defaults countsAsCrit and triggersExplosion to false', () => {
+			const die = makeDie(8, [{ result: 5 }]);
+			applyMutationStep(
+				{ target: { kind: 'all' }, operation: { type: 'bump', delta: 1 } },
+				[die],
+				undefined,
+			);
+			const m = (die.results[0] as MutatedResult).mutation!;
+			expect(m.countsAsCrit).toBe(false);
+			expect(m.triggersExplosion).toBe(false);
+			expect(m.source).toBe('unknown');
+		});
+	});
+});

--- a/src/dice/mutations.ts
+++ b/src/dice/mutations.ts
@@ -1,0 +1,218 @@
+/**
+ * Post-roll value mutation framework for the Nimble dice engine.
+ *
+ * Mutations are declarative instructions that modify die results after rolling
+ * but before crit detection and explosion dispatch. Each mutation step targets
+ * specific results and applies an operation, tagging the result with metadata
+ * so downstream logic (crit counting, explosion) can make per-result decisions.
+ *
+ * @example Doomed: maximize all dice, counts as crit, no explosion
+ * ```typescript
+ * const step: MutationStep = {
+ *     target: { kind: 'all' },
+ *     operation: { type: 'max' },
+ *     countsAsCrit: true,
+ *     triggersExplosion: false,
+ *     source: 'Doomed',
+ * };
+ * ```
+ */
+
+import { getNimbleMods } from './nimbleDieModifiers.js';
+import type { PrimaryDie } from './terms/PrimaryDie.js';
+
+// ─── Types ──────────────────────────────────────────────────────────
+
+/** Which die results to target. */
+type MutationTarget =
+	| { kind: 'primary' }
+	| { kind: 'all' }
+	| { kind: 'tagged'; modifier: 'c' | 'cv' | 'n' }
+	| { kind: 'index'; index: number };
+
+/** What to do to the targeted results. */
+type MutationOperation =
+	| { type: 'set'; value: number }
+	| { type: 'bump'; delta: number }
+	| { type: 'max' }
+	| { type: 'min' }
+	| { type: 'floor'; minimum: number }
+	| { type: 'ceiling'; maximum: number };
+
+/** Metadata attached to a mutated die result. */
+interface MutationMetadata {
+	/** What the die actually rolled before mutation. */
+	rolledValue: number;
+	/** Source label for display (e.g. "Doomed", "Vicious Opportunist"). */
+	source: string;
+	/** Does the mutated value count as a crit if it equals max? */
+	countsAsCrit: boolean;
+	/** If countsAsCrit, does it also trigger explosion? */
+	triggersExplosion: boolean;
+}
+
+/** A die result that may carry mutation metadata. */
+interface MutatedResult extends foundry.dice.terms.DiceTerm.Result {
+	mutation?: MutationMetadata;
+}
+
+/** A declarative instruction processed by the engine during _applyPostRollMutations. */
+interface MutationStep {
+	/** Which die results to target. */
+	target: MutationTarget;
+	/** What to do to the targeted results. */
+	operation: MutationOperation;
+	/** Does the mutated value count as a crit if it equals max? Default: false. */
+	countsAsCrit?: boolean;
+	/** If countsAsCrit, does it also trigger explosion? Default: false. */
+	triggersExplosion?: boolean;
+	/** Source label for chat card display (e.g. "Doomed", "Vicious Opportunist"). */
+	source?: string;
+}
+
+// ─── Target Resolution ──────────────────────────────────────────────
+
+/**
+ * Resolve a MutationTarget to a list of `{ term, result }` pairs to mutate.
+ *
+ * For `primary` targets in modifier-mode (where primaryDie may not yet be
+ * assigned), falls back to the leftmost Die with a `c` or `cv` modifier.
+ */
+function resolveTargets(
+	target: MutationTarget,
+	dieTerms: foundry.dice.terms.Die[],
+	primaryDie: foundry.dice.terms.Die | PrimaryDie | undefined,
+): Array<{ term: foundry.dice.terms.Die; result: MutatedResult }> {
+	const hits: Array<{ term: foundry.dice.terms.Die; result: MutatedResult }> = [];
+
+	switch (target.kind) {
+		case 'primary': {
+			// Use provided primaryDie; fall back to leftmost c/cv-tagged die
+			let die = primaryDie;
+			if (!die) {
+				die = dieTerms.find((t) => {
+					const meta = getNimbleMods(t);
+					return meta?.canCrit === true;
+				});
+			}
+			if (die) {
+				for (const r of die.results) {
+					if (r.active && !r.discarded) {
+						hits.push({ term: die, result: r as MutatedResult });
+					}
+				}
+			}
+			break;
+		}
+		case 'all': {
+			for (const term of dieTerms) {
+				for (const r of term.results) {
+					if (r.active && !r.discarded) {
+						hits.push({ term, result: r as MutatedResult });
+					}
+				}
+			}
+			break;
+		}
+		case 'tagged': {
+			const modifierToMatch = target.modifier;
+			for (const term of dieTerms) {
+				if (!Array.isArray(term.modifiers)) continue;
+				// Match on the Nimble modifier token
+				const hasModifier = term.modifiers.includes(modifierToMatch);
+				if (!hasModifier) continue;
+				for (const r of term.results) {
+					if (r.active && !r.discarded) {
+						hits.push({ term, result: r as MutatedResult });
+					}
+				}
+			}
+			break;
+		}
+		case 'index': {
+			// Flatten all active results across all die terms, pick by index
+			let idx = 0;
+			for (const term of dieTerms) {
+				for (const r of term.results) {
+					if (r.active && !r.discarded) {
+						if (idx === target.index) {
+							hits.push({ term, result: r as MutatedResult });
+							return hits;
+						}
+						idx++;
+					}
+				}
+			}
+			break;
+		}
+	}
+
+	return hits;
+}
+
+// ─── Operation Application ──────────────────────────────────────────
+
+/** Clamp a value to [1, faces]. */
+function clamp(value: number, faces: number): number {
+	return Math.max(1, Math.min(faces, value));
+}
+
+/**
+ * Apply a single MutationStep to the given die terms.
+ *
+ * Resolves targets, applies the operation to each targeted result, and tags
+ * each with mutation metadata preserving the original rolled value.
+ *
+ * @param step - The mutation step to apply.
+ * @param dieTerms - All Die terms in the roll.
+ * @param primaryDie - The current primary die reference (may be undefined in modifier-mode).
+ */
+function applyMutationStep(
+	step: MutationStep,
+	dieTerms: foundry.dice.terms.Die[],
+	primaryDie: foundry.dice.terms.Die | PrimaryDie | undefined,
+): void {
+	const hits = resolveTargets(step.target, dieTerms, primaryDie);
+
+	for (const { term, result } of hits) {
+		const faces = term.faces ?? 6;
+		const originalValue = result.result;
+		const op = step.operation;
+
+		switch (op.type) {
+			case 'set':
+				result.result = clamp(op.value, faces);
+				break;
+			case 'bump':
+				result.result = clamp(result.result + op.delta, faces);
+				break;
+			case 'max':
+				result.result = faces;
+				break;
+			case 'min':
+				result.result = 1;
+				break;
+			case 'floor':
+				if (result.result < op.minimum) {
+					result.result = clamp(op.minimum, faces);
+				}
+				break;
+			case 'ceiling':
+				if (result.result > op.maximum) {
+					result.result = clamp(op.maximum, faces);
+				}
+				break;
+		}
+
+		// Always tag mutation metadata, even if value didn't change
+		(result as MutatedResult).mutation = {
+			rolledValue: originalValue,
+			source: step.source ?? 'unknown',
+			countsAsCrit: step.countsAsCrit ?? false,
+			triggersExplosion: step.triggersExplosion ?? false,
+		};
+	}
+}
+
+export { applyMutationStep };
+export type { MutatedResult, MutationMetadata, MutationOperation, MutationStep, MutationTarget };

--- a/src/dice/reroll.ts
+++ b/src/dice/reroll.ts
@@ -1,0 +1,48 @@
+/**
+ * Reroll protocol types for the Nimble dice engine.
+ *
+ * Two variants are supported:
+ *   - Whole-roll reroll: re-evaluates the whole `DamageRoll` from its
+ *     `originalFormula`, optionally adjusting rollMode (advantage/disadvantage)
+ *     or prepending mutations. Used by Inerrant Strike, Mountain's Endurance,
+ *     FAST, Pocket Sand, etc.
+ *   - Single-die reroll: re-rolls one die in-place on a copy of the existing
+ *     roll and re-runs finalization. Used by Songweaver's Inspiration,
+ *     Optimistic (Gnome), Elemental Destruction, etc.
+ *
+ * `KeepPolicy` is a hint for the CALLER (rules layer) — the engine always
+ * produces the rerolled roll; comparing and picking the winner is a rules-layer
+ * decision, not engine logic.
+ */
+
+import type { MutationStep } from './mutations.js';
+
+/** Reroll the entire evaluated roll from `originalFormula`, with adjustments. */
+interface WholeRerollRequest {
+	kind: 'whole';
+	/** Signed integer added to rollMode / appended to rollModeSources. */
+	rollModeAdjust?: number;
+	/** Mutations to apply on the reroll (e.g. Inerrant Strike: bump +1). */
+	mutations?: MutationStep[];
+	/** Source label (used in logs / chat card). */
+	source: string;
+}
+
+/** Reroll a single active die result in-place on a copy of the evaluated roll. */
+interface SingleDieRerollRequest {
+	kind: 'single';
+	/** Index into flattened active (non-discarded) die results. */
+	dieIndex: number;
+	/** Source label (used in logs / chat card). */
+	source: string;
+}
+
+type RerollRequest = WholeRerollRequest | SingleDieRerollRequest;
+
+/**
+ * Policy hint for the caller when comparing original vs. rerolled results.
+ * Not consumed by the engine.
+ */
+type KeepPolicy = 'higher' | 'lower' | 'either' | 'new';
+
+export type { KeepPolicy, RerollRequest, SingleDieRerollRequest, WholeRerollRequest };


### PR DESCRIPTION
## Summary

Wires `_applyPostRollMutations` into a declarative pipeline for post-roll value modification, with per-result mutation flags that distinguish natural rolls from mutated values. Solves the Doomed carveout: "max-ify all dice, counts as crit, but does NOT trigger explosion."

> **Stacked PR 5 of 5** — base: #716 (Stage 3 — critCount + brutalPrimary)

## Changes

- **New `src/dice/mutations.ts`** — exports `MutationStep`, `MutationTarget`, `MutationOperation`, `MutatedResult` types and `applyMutationStep()` function.
- **`mutations?: MutationStep[]`** on `DamageRoll.Options` — ordered list of post-roll mutations.
- **`_applyPostRollMutations`** processes the pipeline: resolves targets, applies operations (set, bump, max, min, floor, ceiling), tags each mutated result with `mutation` metadata preserving `rolledValue`, `source`, `countsAsCrit`, and `triggersExplosion`.
- **Crit detection updated** — respects `mutation.countsAsCrit` flag. Natural max always counts; mutated max counts only when flagged.
- **Explosion dispatch updated** — respects `mutation.triggersExplosion` flag. Doomed (`triggersExplosion: false`) skips vicious explosion; Vicious Opportunist (`triggersExplosion: true`) fires it.

## Design

The carveout table that drives the framework:

| Feature | Operation | countsAsCrit | triggersExplosion |
|---------|-----------|:---:|:---:|
| Vicious Opportunist | set to max | yes | yes |
| Doomed | max all dice | yes | **no** |
| Cunning Strike | max Sneak Attack dice | no | no |
| Juggernaut | bump +1 | no | no |
| BOUNDLESS RAGE | floor 6 on Fury Die | no | no |

## Tests

- Unit tests in new `mutations.test.ts` for each operation + target type.
- Integration tests in `DamageRoll.test.ts` proving Doomed, Vicious Opportunist, Juggernaut, and BOUNDLESS RAGE scenarios.
- All 869 tests pass.

## Checklist

- [x] `pnpm check` passes
- [x] Framework only — individual class features wire into this API separately
- [x] **AI-assisted:** reviewed against STYLE_GUIDE.md