### PR TITLE
feat(dice): forced outcomes, thresholds, and reroll protocol

### DIFF
--- a/docs/system/dice-engine.md
+++ b/docs/system/dice-engine.md
@@ -77,11 +77,11 @@ When a player clicks "Attack" on a weapon, here's what happens (all in `src/dice
 
 5. **Foundry rolls the dice.** The custom `khn`/`kln` modifier handlers sort results and mark dice as discarded (leftmost dropped on ties). In modifier-mode, the `c`, `cv`, `v`, and `n` handlers also run — they attach Symbol-keyed metadata to each Die instance describing its crit/miss/explosion behavior. These handlers don't roll extra dice; they only tag metadata.
 
-6. **`DamageRoll._evaluate` interprets the results.** In modifier-mode, the engine iterates all Die terms, reads their modifier metadata, and dispatches per-die: `cv`-tagged dice that rolled max get a vicious explosion chain, `c`-tagged dice use Foundry's native `x` explosion, `n`-tagged dice are skipped for crit/miss. In legacy mode, the engine reads the single primary die and dispatches based on the `explosionStyle` option (`'none'` / `'standard'` / `'vicious'`). Crit detection in both modes uses the same value-based check: did a kept (active, non-discarded) die roll its max face value?
+6. **`DamageRoll._evaluate` interprets the results.** In modifier-mode, the engine iterates all Die terms, reads their modifier metadata, and dispatches per-die: `cv`-tagged dice that rolled max get a vicious explosion chain, `c`-tagged dice use Foundry's native `x` explosion, `n`-tagged dice are skipped for crit/miss. In legacy mode, the engine reads the single primary die and dispatches based on the `explosionStyle` option (`'none'` / `'standard'` / `'vicious'`). Crit detection in both modes uses a threshold check: did a kept (active, non-discarded) die meet `criticalThreshold` (defaults to the die's max face). Miss detection uses `fumbleThreshold` symmetrically (defaults to `1`).
 
-7. **Post-roll mutations.** `_applyPostRollMutations` processes an optional `mutations: MutationStep[]` array from the roll options. Each step targets specific dice, applies an operation (set, bump, max, floor, ceiling, etc.), and tags the result with metadata recording the original rolled value and whether the mutation counts as a crit or triggers explosion. See "Post-roll mutation pipeline" below.
+7. **Post-roll mutations.** `_applyPostRollMutations` processes an optional `mutations: MutationStep[]` array from the roll options. Each step targets specific dice, applies an operation (set, bump, max, floor, ceiling, etc.), and tags the result with metadata recording the original rolled value and whether the mutation counts as a crit or triggers explosion. See "Post-roll mutation pipeline" below. Forced crits (`forcedOutcome.crit = true`) are prepended to this pipeline as a `{ target: primary, operation: max, countsAsCrit: true, triggersExplosion: true }` step — the mutation pipeline then handles crit counting and vicious explosion dispatch.
 
-8. **Finalize the total.** `_finalizeOutcome` sets `isCritical` / `isMiss` / `critCount` flags and adjusts the total for vicious recalculation and the `primaryDieAsDamage: false` case (where the primary die's value is excluded from damage but its explosions still count). `critCount` tracks how many crit-capable dice independently rolled max — for a standard weapon this is 0 or 1, but for multi-die pools like Dravok's `4d4cv` it can be 2, 3, or even 4. `isCritical` is `critCount > 0`. If the `brutalPrimary` option is set, the primary die is reassigned to whichever die rolled highest (instead of leftmost).
+8. **Finalize the total.** `_finalizeOutcome` sets `isCritical` / `isMiss` / `critCount` flags and adjusts the total for vicious recalculation and the `primaryDieAsDamage: false` case (where the primary die's value is excluded from damage but its explosions still count). `critCount` tracks how many crit-capable dice independently rolled max — for a standard weapon this is 0 or 1, but for multi-die pools like Dravok's `4d4cv` it can be 2, 3, or even 4. `isCritical` is `critCount > 0`. If the `brutalPrimary` option is set, the primary die is reassigned to whichever die rolled highest (instead of leftmost). Finally, `forcedOutcome.miss = true` sets `isMiss = true` post-finalization unless a natural or forced crit has already fired (crit wins).
 
 9. **The chat card renders** (handled in `src/view/chat/components/`, outside the engine). The card shows the kept and dropped dice, the primary die, bonus dice, and the total.
 
@@ -119,6 +119,55 @@ Each mutated result is tagged with metadata preserving the original rolled value
 | BOUNDLESS RAGE ("Fury Die can't be less than 6") | no | no |
 
 Individual class features don't live in the engine — they emit `MutationStep` objects from the rules layer, and the engine processes them generically. The engine's only job is to apply the operation, tag the metadata, and honor the flags during crit detection and explosion dispatch.
+
+### Forced outcomes — `forcedOutcome`
+
+Some features override the roll's outcome regardless of what the dice actually rolled:
+
+- **Final Takedown** — "your next attack is a crit"
+- **Bubble of Light** — "the attack misses"
+- **Heads I Win, Tails You Lose** — forces crit
+- **Tuned Thrusters**, **Hexbinder no-valid-target** — force miss
+
+These are expressed declaratively via the `forcedOutcome` option:
+
+```typescript
+forcedOutcome?: {
+    crit?: boolean;   // force crit (prepended mutation, triggers explosion)
+    miss?: boolean;   // force miss (flag-only, post-finalization)
+    source?: string;  // label for chat card / logs
+}
+```
+
+**Forced crit** reuses the mutation pipeline: it injects a prepended `MutationStep` that sets the primary die to max with `countsAsCrit: true, triggersExplosion: true`. The existing pipeline then handles crit counting and vicious explosion dispatch — no duplicated logic.
+
+**Forced miss** is flag-only: it sets `isMiss = true` after finalization, leaving die values unchanged. Natural or forced crits override a forced miss (crit always wins).
+
+### Thresholds — `criticalThreshold` / `fumbleThreshold`
+
+Two roll-level options widen or narrow what counts as a crit or fumble:
+
+- **`criticalThreshold`** (default: `faces`) — a kept die crits if `result >= criticalThreshold`. Used by features like "Heads I Win, Tails You Lose" that let a die crit below max.
+- **`fumbleThreshold`** (default: `1`) — a kept die misses if `result <= fumbleThreshold`. Parry (monster trait) sets this to `2` on a d8, so both 1 and 2 miss.
+
+Thresholds apply in both modifier-mode and legacy mode. They affect crit/miss detection only — they do **not** alter explosion dispatch (a threshold-triggered crit below max will set `isCritical` but won't fire an explosion chain). Forced crit, not threshold, is the path for "crit with explosion regardless of value."
+
+### Reroll protocol — `DamageRoll.reroll(request)`
+
+Several features re-evaluate an already-rolled attack: Inerrant Strike, Mountain's Endurance, Songweaver's Inspiration, FAST, Pocket Sand, etc. The engine exposes a single entry point:
+
+```typescript
+await roll.reroll({ kind: 'whole', source: 'Inerrant Strike' });
+await roll.reroll({ kind: 'whole', rollModeAdjust: -1, source: 'FAST' });
+await roll.reroll({ kind: 'single', dieIndex: 2, source: 'Songweaver' });
+```
+
+Two variants:
+
+- **Whole-roll reroll** (`kind: 'whole'`) re-evaluates the roll from `originalFormula` with a fresh copy of the options. Callers can append `rollModeAdjust` (signed integer, added to `rollModeSources` or `rollMode` scalar) and/or `mutations` (appended to the options). Used for "reroll an attack with disadvantage" or "reroll and bump the primary +1."
+- **Single-die reroll** (`kind: 'single'`) clones the current roll, rerolls the die at the specified flattened active index, and re-runs finalization. NIMBLE_MODS metadata is preserved on the cloned die term. Used for "reroll one die, keep either" effects.
+
+The engine always returns a **new** `DamageRoll` — the original is never mutated. The caller (rules layer) decides what to do with the two rolls via a `KeepPolicy` (`'higher'` / `'lower'` / `'either'` / `'new'`). That decision is **not** engine logic — the engine produces rolls; the rules layer picks.
 
 ### Custom Die modifiers — `nimbleDieModifiers.ts`
 
@@ -180,6 +229,9 @@ Content authors can leave `weaponType` blank (nothing breaks) or set it for weap
 | Roll construction from an item | `src/managers/ItemActivationManager.ts` |
 | Weapon proficiency check | `src/view/sheets/components/attackUtils.ts` (`hasWeaponProficiency`) |
 | Post-roll mutation pipeline | `DamageRoll._applyPostRollMutations` + `src/dice/mutations.ts` |
+| Forced crit / forced miss | `DamageRoll.Options.forcedOutcome` |
+| Threshold wiring | `DamageRoll.Options.criticalThreshold` / `fumbleThreshold` |
+| Reroll protocol | `DamageRoll.reroll()` + `src/dice/reroll.ts` |
 | Multi-crit count | `DamageRoll.critCount` |
 | Brutal primary remapping | `DamageRoll.Options.brutalPrimary` |
 | Primary die value getter | `DamageRoll.primaryDieValue` |

--- a/src/dice/DamageRoll.test.ts
+++ b/src/dice/DamageRoll.test.ts
@@ -3076,3 +3076,572 @@ describe('mutations pipeline', () => {
 		expect(dieTerm.results[0].result).toBe(9);
 	});
 });
+
+describe('forcedOutcome', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		stubBaseRollEvaluate();
+	});
+
+	it('forced crit: primary rolled non-max → isCritical true, critCount 1, primary mutated to max', async () => {
+		const roll = new DamageRoll(
+			'1d8',
+			{},
+			{
+				canCrit: true,
+				canMiss: true,
+				rollMode: 0,
+				primaryDieValue: 0,
+				primaryDieModifier: 0,
+				forcedOutcome: { crit: true, source: 'Final Takedown' },
+			},
+		);
+		stagePrimaryDieResults(roll, [{ result: 3, active: true }], 3);
+		await (roll as any)._evaluate();
+
+		expect(roll.isCritical).toBe(true);
+		expect(roll.critCount).toBe(1);
+		expect(roll.isMiss).toBe(false);
+
+		const primary = roll.primaryDie!;
+		expect(primary.results[0].result).toBe(8);
+		const m = (primary.results[0] as MutatedResult).mutation;
+		expect(m).toBeDefined();
+		expect(m!.rolledValue).toBe(3);
+		expect(m!.source).toBe('Final Takedown');
+		expect(m!.countsAsCrit).toBe(true);
+		expect(m!.triggersExplosion).toBe(true);
+	});
+
+	it('forced miss: primary rolled non-1 → isMiss true, die value unchanged', async () => {
+		const roll = new DamageRoll(
+			'1d8',
+			{},
+			{
+				canCrit: true,
+				canMiss: true,
+				rollMode: 0,
+				primaryDieValue: 0,
+				primaryDieModifier: 0,
+				forcedOutcome: { miss: true, source: 'Bubble of Light' },
+			},
+		);
+		stagePrimaryDieResults(roll, [{ result: 5, active: true }], 5);
+		await (roll as any)._evaluate();
+
+		expect(roll.isMiss).toBe(true);
+		expect(roll.isCritical).toBe(false);
+		// Die value unchanged (no mutation applied for forced miss)
+		expect(roll.primaryDie!.results[0].result).toBe(5);
+		expect((roll.primaryDie!.results[0] as MutatedResult).mutation).toBeUndefined();
+	});
+
+	it('forced crit + miss → crit wins', async () => {
+		const roll = new DamageRoll(
+			'1d8',
+			{},
+			{
+				canCrit: true,
+				canMiss: true,
+				rollMode: 0,
+				primaryDieValue: 0,
+				primaryDieModifier: 0,
+				forcedOutcome: { crit: true, miss: true, source: 'Conflicting' },
+			},
+		);
+		stagePrimaryDieResults(roll, [{ result: 4, active: true }], 4);
+		await (roll as any)._evaluate();
+
+		expect(roll.isCritical).toBe(true);
+		expect(roll.isMiss).toBe(false);
+	});
+
+	it('forced miss does not override natural crit (high natural roll)', async () => {
+		const roll = new DamageRoll(
+			'1d8',
+			{},
+			{
+				canCrit: true,
+				canMiss: true,
+				rollMode: 0,
+				primaryDieValue: 0,
+				primaryDieModifier: 0,
+				forcedOutcome: { miss: true },
+			},
+		);
+		stagePrimaryDieResults(roll, [{ result: 8, active: true, exploded: true }], 8);
+		await (roll as any)._evaluate();
+
+		expect(roll.isCritical).toBe(true);
+		expect(roll.isMiss).toBe(false);
+	});
+
+	it('forced miss is ignored when canMiss is false (AoE / engine-disallowed miss)', async () => {
+		const roll = new DamageRoll(
+			'1d8',
+			{},
+			{
+				canCrit: true,
+				canMiss: false,
+				rollMode: 0,
+				primaryDieValue: 0,
+				primaryDieModifier: 0,
+				forcedOutcome: { miss: true, source: 'FireballAoE' },
+			},
+		);
+		stagePrimaryDieResults(roll, [{ result: 5, active: true }], 5);
+		await (roll as any)._evaluate();
+		expect(roll.isMiss).toBe(false);
+	});
+
+	it('forced crit implicitly enables canCrit (so the mutation can flip isCritical)', async () => {
+		const roll = new DamageRoll(
+			'1d8',
+			{},
+			{
+				// canCrit: false would normally lock isCritical to false. The
+				// constructor promotes it when forcedOutcome.crit is set.
+				canCrit: false,
+				canMiss: false,
+				rollMode: 0,
+				primaryDieValue: 0,
+				primaryDieModifier: 0,
+				forcedOutcome: { crit: true, source: 'Auto-Crit' },
+			},
+		);
+		// canCrit was promoted to true, so a PrimaryDie was extracted.
+		expect(roll.options.canCrit).toBe(true);
+		expect(roll.primaryDie).toBeDefined();
+		stagePrimaryDieResults(roll, [{ result: 3, active: true }], 3);
+		await (roll as any)._evaluate();
+		expect(roll.isCritical).toBe(true);
+	});
+
+	it('modifier-mode 4d4cv: forced crit mutates primary to max and triggersExplosion fires', async () => {
+		const roll = new DamageRoll(
+			'4d4cv',
+			{},
+			{
+				canCrit: true,
+				canMiss: true,
+				rollMode: 0,
+				primaryDieValue: 0,
+				primaryDieModifier: 0,
+				forcedOutcome: { crit: true, source: 'Vulnerable Underbelly' },
+			},
+		);
+		stageModifierModeRoll(
+			roll,
+			[
+				[
+					{ result: 2, active: true },
+					{ result: 3, active: true },
+					{ result: 1, active: true },
+					{ result: 2, active: true },
+				],
+			],
+			8,
+		);
+		await (roll as any)._evaluate();
+
+		expect(roll.isCritical).toBe(true);
+		expect(roll.critCount).toBeGreaterThanOrEqual(1);
+
+		const dieTerm = roll.terms.filter((t) => t instanceof foundry.dice.terms.Die)[0];
+		// Forced crit targets the primary die — leftmost for cv tag, which in
+		// this test is the sole 4d4cv term. All its ACTIVE results get mutated
+		// to max since `target: primary` hits every active result of that die.
+		expect(dieTerm.results[0].result).toBe(4);
+		// First active result is exploded (triggersExplosion: true).
+		expect(dieTerm.results[0].exploded).toBe(true);
+	});
+});
+
+describe('fumbleThreshold', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		stubBaseRollEvaluate();
+	});
+
+	it('Parry: d8, fumbleThreshold 2, rolls 2 → miss', async () => {
+		const roll = new DamageRoll(
+			'1d8',
+			{},
+			{
+				canCrit: true,
+				canMiss: true,
+				rollMode: 0,
+				primaryDieValue: 0,
+				primaryDieModifier: 0,
+				fumbleThreshold: 2,
+			},
+		);
+		stagePrimaryDieResults(roll, [{ result: 2, active: true }], 2);
+		await (roll as any)._evaluate();
+		expect(roll.isMiss).toBe(true);
+		expect(roll.isCritical).toBe(false);
+	});
+
+	it('Parry: d8, fumbleThreshold 2, rolls 3 → not miss', async () => {
+		const roll = new DamageRoll(
+			'1d8',
+			{},
+			{
+				canCrit: true,
+				canMiss: true,
+				rollMode: 0,
+				primaryDieValue: 0,
+				primaryDieModifier: 0,
+				fumbleThreshold: 2,
+			},
+		);
+		stagePrimaryDieResults(roll, [{ result: 3, active: true }], 3);
+		await (roll as any)._evaluate();
+		expect(roll.isMiss).toBe(false);
+	});
+
+	it('default fumbleThreshold (1): rolls 1 → miss (regression)', async () => {
+		const roll = new DamageRoll(
+			'1d8',
+			{},
+			{ canCrit: true, canMiss: true, rollMode: 0, primaryDieValue: 0, primaryDieModifier: 0 },
+		);
+		stagePrimaryDieResults(roll, [{ result: 1, active: true }], 1);
+		await (roll as any)._evaluate();
+		expect(roll.isMiss).toBe(true);
+	});
+
+	it('modifier-mode 1d8c: fumbleThreshold 2, rolls 2 → miss', async () => {
+		const roll = new DamageRoll(
+			'1d8c',
+			{},
+			{
+				canCrit: true,
+				canMiss: true,
+				rollMode: 0,
+				primaryDieValue: 0,
+				primaryDieModifier: 0,
+				fumbleThreshold: 2,
+			},
+		);
+		stageModifierModeRoll(roll, [[{ result: 2, active: true }]], 2);
+		await (roll as any)._evaluate();
+		expect(roll.isMiss).toBe(true);
+	});
+});
+
+describe('criticalThreshold', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		stubBaseRollEvaluate();
+	});
+
+	it('d8 criticalThreshold 7, rolls 7 → crit', async () => {
+		const roll = new DamageRoll(
+			'1d8',
+			{},
+			{
+				canCrit: true,
+				canMiss: true,
+				rollMode: 0,
+				primaryDieValue: 0,
+				primaryDieModifier: 0,
+				criticalThreshold: 7,
+			},
+		);
+		stagePrimaryDieResults(roll, [{ result: 7, active: true }], 7);
+		await (roll as any)._evaluate();
+		expect(roll.isCritical).toBe(true);
+		expect(roll.critCount).toBe(1);
+	});
+
+	it('d8 criticalThreshold 7, rolls 6 → not crit', async () => {
+		const roll = new DamageRoll(
+			'1d8',
+			{},
+			{
+				canCrit: true,
+				canMiss: true,
+				rollMode: 0,
+				primaryDieValue: 0,
+				primaryDieModifier: 0,
+				criticalThreshold: 7,
+			},
+		);
+		stagePrimaryDieResults(roll, [{ result: 6, active: true }], 6);
+		await (roll as any)._evaluate();
+		expect(roll.isCritical).toBe(false);
+	});
+
+	it('default criticalThreshold (faces): rolls max → crit (regression)', async () => {
+		const roll = new DamageRoll(
+			'1d8',
+			{},
+			{ canCrit: true, canMiss: true, rollMode: 0, primaryDieValue: 0, primaryDieModifier: 0 },
+		);
+		stagePrimaryDieResults(roll, [{ result: 8, active: true, exploded: true }], 8);
+		await (roll as any)._evaluate();
+		expect(roll.isCritical).toBe(true);
+	});
+
+	it('modifier-mode 1d8c: criticalThreshold 7, rolls 7 → crit', async () => {
+		const roll = new DamageRoll(
+			'1d8c',
+			{},
+			{
+				canCrit: true,
+				canMiss: true,
+				rollMode: 0,
+				primaryDieValue: 0,
+				primaryDieModifier: 0,
+				criticalThreshold: 7,
+			},
+		);
+		stageModifierModeRoll(roll, [[{ result: 7, active: true }]], 7);
+		await (roll as any)._evaluate();
+		expect(roll.isCritical).toBe(true);
+		expect(roll.critCount).toBe(1);
+	});
+});
+
+describe('reroll — whole', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		stubBaseRollEvaluate();
+	});
+
+	it('returns a new DamageRoll; original unchanged', async () => {
+		const roll = new DamageRoll(
+			'1d8',
+			{},
+			{ canCrit: true, canMiss: true, rollMode: 0, primaryDieValue: 0, primaryDieModifier: 0 },
+		);
+		stagePrimaryDieResults(roll, [{ result: 3, active: true }], 3);
+		await (roll as any)._evaluate();
+
+		const originalTotal = roll.total;
+		const rerolled = await roll.reroll({ kind: 'whole', source: 'Inerrant Strike' });
+
+		expect(rerolled).not.toBe(roll);
+		expect(rerolled).toBeInstanceOf(DamageRoll);
+		// Original left intact
+		expect(roll.total).toBe(originalTotal);
+		expect(roll.primaryDie!.results[0].result).toBe(3);
+	});
+
+	it('rollModeAdjust appends to rollModeSources when present', async () => {
+		const roll = new DamageRoll(
+			'1d8',
+			{},
+			{
+				canCrit: true,
+				canMiss: true,
+				rollMode: 0,
+				rollModeSources: [1],
+				primaryDieValue: 0,
+				primaryDieModifier: 0,
+			},
+		);
+		stagePrimaryDieResults(roll, [{ result: 5, active: true }], 5);
+		await (roll as any)._evaluate();
+
+		const rerolled = await roll.reroll({
+			kind: 'whole',
+			rollModeAdjust: -1,
+			source: 'FAST',
+		});
+
+		// Net rollMode should be 1 + (-1) = 0
+		expect(rerolled.options.netRollMode).toBe(0);
+		expect(rerolled.options.rollModeSources).toEqual([1, -1]);
+	});
+
+	it('rollModeAdjust on a scalar rollMode adds to it directly', async () => {
+		const roll = new DamageRoll(
+			'1d8',
+			{},
+			{ canCrit: true, canMiss: true, rollMode: 0, primaryDieValue: 0, primaryDieModifier: 0 },
+		);
+		stagePrimaryDieResults(roll, [{ result: 5, active: true }], 5);
+		await (roll as any)._evaluate();
+
+		const rerolled = await roll.reroll({
+			kind: 'whole',
+			rollModeAdjust: -1,
+			source: 'Pocket Sand',
+		});
+
+		expect(rerolled.options.rollMode).toBe(-1);
+	});
+
+	it('mutations passed via reroll are applied on the new roll (Inerrant Strike: bump +1)', async () => {
+		const roll = new DamageRoll(
+			'1d8',
+			{},
+			{ canCrit: true, canMiss: true, rollMode: 0, primaryDieValue: 0, primaryDieModifier: 0 },
+		);
+		stagePrimaryDieResults(roll, [{ result: 2, active: true }], 2);
+		await (roll as any)._evaluate();
+
+		const rerolled = await roll.reroll({
+			kind: 'whole',
+			mutations: [
+				{
+					target: { kind: 'primary' },
+					operation: { type: 'bump', delta: 1 },
+					source: 'Inerrant Strike',
+				},
+			],
+			source: 'Inerrant Strike',
+		});
+
+		// The new roll will re-preprocess and its options.mutations includes
+		// our step. Since the mock base _evaluate doesn't actually roll,
+		// primaryDie results are whatever the constructor primed. Just verify
+		// mutations survived onto options.
+		expect(rerolled.options.mutations).toBeDefined();
+		expect(rerolled.options.mutations!.some((m) => m.source === 'Inerrant Strike')).toBe(true);
+	});
+});
+
+describe('reroll — single die', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		stubBaseRollEvaluate();
+	});
+
+	it('rerolls one die result; other results unchanged; original unchanged', async () => {
+		const roll = new DamageRoll(
+			'1d8c',
+			{},
+			{
+				canCrit: true,
+				canMiss: true,
+				rollMode: 0,
+				primaryDieValue: 0,
+				primaryDieModifier: 0,
+			},
+		);
+		stageModifierModeRoll(roll, [[{ result: 3, active: true }]], 3);
+		await (roll as any)._evaluate();
+
+		const rerolled = await roll.reroll({
+			kind: 'single',
+			dieIndex: 0,
+			source: 'Songweaver',
+		});
+
+		expect(rerolled).not.toBe(roll);
+		// Original unchanged
+		const origDie = roll.terms.filter((t) => t instanceof foundry.dice.terms.Die)[0];
+		expect(origDie.results[0].result).toBe(3);
+
+		// Rerolled die has some new value (1..8). Value is random, just
+		// assert it's a legal d8 value.
+		const newDie = rerolled.terms.filter((t) => t instanceof foundry.dice.terms.Die)[0];
+		const newValue = newDie.results[0].result;
+		expect(newValue).toBeGreaterThanOrEqual(1);
+		expect(newValue).toBeLessThanOrEqual(8);
+	});
+
+	it('preserves NIMBLE_MODS metadata (c tag) on the rerolled die term', async () => {
+		const { NIMBLE_MODS: NIMBLE_MODS_sym } = await import('./nimbleDieModifiers.js');
+		const roll = new DamageRoll(
+			'1d8c',
+			{},
+			{
+				canCrit: true,
+				canMiss: true,
+				rollMode: 0,
+				primaryDieValue: 0,
+				primaryDieModifier: 0,
+			},
+		);
+		stageModifierModeRoll(roll, [[{ result: 4, active: true }]], 4);
+		await (roll as any)._evaluate();
+
+		const rerolled = await roll.reroll({
+			kind: 'single',
+			dieIndex: 0,
+			source: 'Songweaver',
+		});
+
+		const newDie = rerolled.terms.filter((t) => t instanceof foundry.dice.terms.Die)[0];
+		const meta = (newDie as any)[NIMBLE_MODS_sym];
+		expect(meta).toBeDefined();
+		expect(meta.canCrit).toBe(true);
+		expect(meta.explosionStyle).toBe('standard');
+	});
+
+	it('re-finalization updates isCritical / isMiss based on new die value (mocked value)', async () => {
+		const roll = new DamageRoll(
+			'1d8c',
+			{},
+			{
+				canCrit: true,
+				canMiss: true,
+				rollMode: 0,
+				primaryDieValue: 0,
+				primaryDieModifier: 0,
+			},
+		);
+		stageModifierModeRoll(roll, [[{ result: 3, active: true }]], 3);
+		await (roll as any)._evaluate();
+		expect(roll.isCritical).toBe(false);
+
+		// Monkey-patch Math.random to force an 8 (max for d8)
+		const origRandom = Math.random;
+		Math.random = () => 0.99;
+		try {
+			const rerolled = await roll.reroll({
+				kind: 'single',
+				dieIndex: 0,
+				source: 'Songweaver',
+			});
+			expect(rerolled.isCritical).toBe(true);
+		} finally {
+			Math.random = origRandom;
+		}
+	});
+
+	it('legacy mode: primaryDie on the reroll copy points into the copy\u2019s terms, not the original\u2019s', async () => {
+		const roll = new DamageRoll(
+			'1d8',
+			{},
+			{ canCrit: true, canMiss: true, rollMode: 0, primaryDieValue: 0, primaryDieModifier: 0 },
+		);
+		stagePrimaryDieResults(roll, [{ result: 3, active: true }], 3);
+		await (roll as any)._evaluate();
+
+		const rerolled = await roll.reroll({ kind: 'single', dieIndex: 0, source: 'x' });
+
+		// The copy's primaryDie must be one of the copy's own terms, not the
+		// original's. This guards against the constructor's throwaway extraction
+		// leaking out when legacy-mode finalization doesn't reassign primaryDie.
+		expect(rerolled.primaryDie).toBeDefined();
+		expect(rerolled.terms).toContain(rerolled.primaryDie);
+		expect(rerolled.primaryDie).not.toBe(roll.primaryDie);
+		// primaryDieValue must read the rerolled value, not a stale preset.
+		expect(rerolled.primaryDieValue).toBe(rerolled.primaryDie!.results[0].result);
+	});
+
+	it('throws if dieIndex is out of range', async () => {
+		const roll = new DamageRoll(
+			'1d8c',
+			{},
+			{
+				canCrit: true,
+				canMiss: true,
+				rollMode: 0,
+				primaryDieValue: 0,
+				primaryDieModifier: 0,
+			},
+		);
+		stageModifierModeRoll(roll, [[{ result: 5, active: true }]], 5);
+		await (roll as any)._evaluate();
+
+		await expect(roll.reroll({ kind: 'single', dieIndex: 99, source: 'x' })).rejects.toThrow(
+			/no active die result at index 99/,
+		);
+	});
+});

--- a/src/dice/DamageRoll.ts
+++ b/src/dice/DamageRoll.ts
@@ -3,7 +3,9 @@ import type { InexactPartial } from '#types/utils.js';
 
 import type { MutatedResult, MutationStep } from './mutations.js';
 import { applyMutationStep } from './mutations.js';
-import { getNimbleMods } from './nimbleDieModifiers.js';
+import type { NimbleDieMetadata } from './nimbleDieModifiers.js';
+import { getNimbleMods, NIMBLE_MODS } from './nimbleDieModifiers.js';
+import type { RerollRequest, SingleDieRerollRequest, WholeRerollRequest } from './reroll.js';
 import { PrimaryDie } from './terms/PrimaryDie.js';
 
 const Terms = foundry.dice.terms;
@@ -63,6 +65,22 @@ declare namespace DamageRoll {
 		brutalPrimary?: boolean;
 		/** Ordered list of post-roll value mutations to apply. */
 		mutations?: MutationStep[];
+		/**
+		 * Forced-outcome overrides applied after natural resolution. Used for
+		 * features that set the outcome regardless of die values (Final Takedown,
+		 * Bubble of Light, etc.).
+		 *
+		 * - `crit: true` — injects a prepended mutation that sets the primary
+		 *   die to max with `countsAsCrit: true, triggersExplosion: true`, so
+		 *   the existing mutation + explosion pipelines fire normally.
+		 * - `miss: true` — sets `isMiss = true` after finalization. Die values
+		 *   are not changed. Natural or forced crit overrides a forced miss.
+		 */
+		forcedOutcome?: {
+			crit?: boolean;
+			miss?: boolean;
+			source?: string;
+		};
 		/**
 		 * @deprecated Use `explosionStyle: 'vicious'` instead. Translated to
 		 *   `explosionStyle` by the constructor shim for back-compat.
@@ -203,6 +221,14 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 		this.options.canCrit ??= true;
 		this.options.canMiss ??= true;
 		this.options.rollMode ??= 0;
+
+		// Forced crit implies the roll can crit — otherwise the crit-detection
+		// branch in `_finalizeOutcome` wouldn't run and the forced-crit mutation
+		// would be invisible. `canMiss: false` (AoE) is deliberately NOT
+		// promoted: AoE rolls cannot miss regardless of `forcedOutcome.miss`.
+		if (this.options.forcedOutcome?.crit) {
+			this.options.canCrit = true;
+		}
 
 		// Aggregate multiple adv/dis sources into a single net rollMode.
 		// Per Nimble rules, advantage and disadvantage cancel 1-for-1.
@@ -517,6 +543,14 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 			}
 		}
 
+		// Forced miss: flag-only override applied after natural finalization.
+		// Natural or forced crit wins. Engine-level `canMiss: false` (e.g. AoE
+		// rolls) also wins — forced miss cannot turn an "can't miss" roll into
+		// a miss.
+		if (this.options.forcedOutcome?.miss && !this.isCritical && this.options.canMiss !== false) {
+			this.isMiss = true;
+		}
+
 		return this as DamageRoll.Evaluated<this>;
 	}
 
@@ -528,19 +562,29 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 		const isVicious = this.options.explosionStyle === 'vicious';
 
 		// Crit = a kept (active, non-discarded) result from the primary die
-		// rolled max face value. Value-based (not flag-based) so that
-		// explosionStyle: 'none' — which never sets the exploded flag —
-		// still detects crit correctly.
+		// that meets the crit threshold (default: faces). Value-based (not
+		// flag-based) so that explosionStyle: 'none' — which never sets the
+		// exploded flag — still detects crit correctly.
+		const critThreshold = this.options.criticalThreshold ?? primaryTerm.faces ?? Infinity;
 		if (this.options.canCrit) {
 			this.isCritical = primaryTerm.results.some((r) => {
-				if (!r.active || r.discarded || r.result !== primaryTerm.faces) return false;
+				if (!r.active || r.discarded || r.result < critThreshold) return false;
 				const m = (r as MutatedResult).mutation;
 				return !m || m.countsAsCrit;
 			});
 		}
 		this.critCount = this.isCritical ? 1 : 0;
 
-		if (this.options.canMiss) this.isMiss = primaryTerm.isMiss;
+		if (this.options.canMiss) {
+			if (this.isCritical) {
+				this.isMiss = false;
+			} else {
+				const fumbleThreshold = this.options.fumbleThreshold ?? 1;
+				this.isMiss = primaryTerm.results.some(
+					(r) => r.active && !r.discarded && r.result <= fumbleThreshold,
+				);
+			}
+		}
 
 		this._applyBrutalRemapping(
 			this.terms.filter((t): t is foundry.dice.terms.Die => t instanceof Terms.Die),
@@ -580,10 +624,24 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 	 * logic can decide per-result crit/explosion behavior.
 	 */
 	private _applyPostRollMutations(): void {
-		const mutations = this.options.mutations;
-		if (!mutations?.length) return;
+		const configured = this.options.mutations ?? [];
+		const steps: MutationStep[] = [];
+		// Forced crit is implemented as a prepended mutation so it reuses the
+		// existing mutation + explosion pipelines (Stage 4) without duplicating
+		// crit/explosion logic.
+		if (this.options.forcedOutcome?.crit) {
+			steps.push({
+				target: { kind: 'primary' },
+				operation: { type: 'max' },
+				countsAsCrit: true,
+				triggersExplosion: true,
+				source: this.options.forcedOutcome.source ?? 'Forced Crit',
+			});
+		}
+		if (configured.length) steps.push(...configured);
+		if (!steps.length) return;
 		const dieTerms = this.terms.filter((t): t is foundry.dice.terms.Die => t instanceof Terms.Die);
-		for (const step of mutations) {
+		for (const step of steps) {
 			applyMutationStep(step, dieTerms, this.primaryDie);
 		}
 	}
@@ -748,8 +806,9 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 			if (!(term instanceof Terms.Die)) continue;
 			const meta = getNimbleMods(term);
 			if (!meta?.canCrit) continue;
+			const critThreshold = this.options.criticalThreshold ?? term.faces ?? Infinity;
 			for (const r of term.results) {
-				if (!r.active || r.discarded || r.result !== term.faces) continue;
+				if (!r.active || r.discarded || r.result < critThreshold) continue;
 				const m = (r as MutatedResult).mutation;
 				if (!m || m.countsAsCrit) count++;
 			}
@@ -771,17 +830,27 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 
 		// ── Miss detection: leftmost non-neutral Die ──
 		if (this.options.canMiss) {
-			const missDie = dieTerms.find((term) => {
-				const meta = getNimbleMods(term);
-				// A die is "neutral" if tagged `n` (canCrit:false, explosionStyle:'none')
-				return !(meta && !meta.canCrit && meta.explosionStyle === 'none');
-			});
-			if (missDie) {
-				const firstActive = missDie.results.find((r) => r.active && !r.discarded);
-				this.isMiss = firstActive?.result === 1;
-			} else {
-				// All dice are neutral — no die qualifies for miss detection
+			if (this.isCritical) {
 				this.isMiss = false;
+			} else {
+				const missDie = dieTerms.find((term) => {
+					const meta = getNimbleMods(term);
+					// Miss detection runs on crit-capable dice only. Neutral
+					// (`n`) and vicious-without-crit (`v`) dice are not
+					// hit/miss arbiters. Untagged dice (no metadata — only
+					// reachable in edge-case constructions) fall through to
+					// the miss-detection path.
+					if (!meta) return true;
+					return meta.canCrit === true;
+				});
+				if (missDie) {
+					const firstActive = missDie.results.find((r) => r.active && !r.discarded);
+					const fumbleThreshold = this.options.fumbleThreshold ?? 1;
+					this.isMiss = firstActive !== undefined && firstActive.result <= fumbleThreshold;
+				} else {
+					// All dice are neutral — no die qualifies for miss detection
+					this.isMiss = false;
+				}
 			}
 		}
 
@@ -838,6 +907,224 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 
 		const internals = this as object as { _total: number };
 		internals._total = total;
+	}
+
+	/** ------------------------------------------------------ */
+	/**                     Reroll API                         */
+	/** ------------------------------------------------------ */
+
+	/**
+	 * Re-evaluate this roll under a Nimble reroll request. Always returns a
+	 * NEW DamageRoll — the original is never mutated. The caller (rules layer)
+	 * decides what to do with the two rolls (keep higher, keep lower, keep
+	 * either, keep new) via a `KeepPolicy`.
+	 *
+	 * - `kind: 'whole'` produces a fresh evaluated roll from `originalFormula`,
+	 *   optionally adjusting rollMode and/or adding mutations.
+	 * - `kind: 'single'` returns a deep copy of the current roll with one die
+	 *   re-rolled in place, finalization re-run, and NIMBLE_MODS preserved.
+	 *
+	 * Overloads the Foundry `Roll.reroll(options?)` signature so existing
+	 * callers that pass `Roll.Options` (or no argument) still work.
+	 */
+	override async reroll(options?: foundry.dice.Roll.Options): Promise<DamageRoll.Evaluated<this>>;
+	override async reroll(request: RerollRequest): Promise<DamageRoll>;
+	override async reroll(
+		arg?: RerollRequest | foundry.dice.Roll.Options,
+	): Promise<DamageRoll | DamageRoll.Evaluated<this>> {
+		if (arg && typeof arg === 'object' && 'kind' in arg) {
+			if (arg.kind === 'whole') return this._rerollWhole(arg);
+			if (arg.kind === 'single') return this._rerollSingleDie(arg);
+		}
+		// Delegate to the Foundry implementation for the legacy signature.
+		return super.reroll(arg as foundry.dice.Roll.Options | undefined) as Promise<
+			DamageRoll.Evaluated<this>
+		>;
+	}
+
+	/**
+	 * Implements the whole-roll reroll variant (AC#8).
+	 *
+	 * The new roll is constructed from `originalFormula` and a shallow copy of
+	 * `this.options` — the constructor re-runs preprocessing to re-extract a
+	 * PrimaryDie, so rollMode and mutation changes take effect naturally.
+	 */
+	private async _rerollWhole(request: WholeRerollRequest): Promise<DamageRoll> {
+		const newOptions: DamageRoll.Options = { ...this.options };
+		// Always force constructor to recompute netRollMode rather than reusing
+		// a stale cached value from the source options.
+		delete newOptions.netRollMode;
+
+		if (request.rollModeAdjust) {
+			if (Array.isArray(newOptions.rollModeSources)) {
+				newOptions.rollModeSources = [...newOptions.rollModeSources, request.rollModeAdjust];
+			} else {
+				newOptions.rollMode = (newOptions.rollMode ?? 0) + request.rollModeAdjust;
+			}
+		}
+
+		if (request.mutations?.length) {
+			newOptions.mutations = [...(newOptions.mutations ?? []), ...request.mutations];
+		}
+
+		// Shallow-copy `data` so feature-driven mutations on the reroll don't
+		// bleed back into the original roll's data.
+		const newData = { ...this.data };
+		const newRoll = new DamageRoll(this.originalFormula, newData, newOptions);
+		await newRoll.evaluate();
+		return newRoll;
+	}
+
+	/**
+	 * Implements the single-die reroll variant (AC#9, AC#10).
+	 *
+	 * Constructs a fresh DamageRoll shell from `originalFormula`/data/options,
+	 * then replaces its terms with structural clones of `this.terms` so the
+	 * prior evaluated state (rolled values, modifiers, discarded/active flags)
+	 * carries forward. NIMBLE_MODS metadata is re-attached from the cloned
+	 * modifiers. The targeted die is then re-rolled using a throwaway
+	 * `Roll(`1d{faces}`)` (so Foundry's RNG and DSN visualisation still apply),
+	 * outcome state is reset, and finalisation re-runs.
+	 */
+	private async _rerollSingleDie(request: SingleDieRerollRequest): Promise<DamageRoll> {
+		const copy = new DamageRoll(this.originalFormula, this.data, { ...this.options });
+		copy.terms = this.terms.map((t) => DamageRoll._cloneTerm(t));
+		copy.modifierMode = this.modifierMode;
+		// Constructor set `copy.primaryDie` to a throwaway PrimaryDie in the
+		// throwaway term array that we just replaced. Re-point it at the
+		// cloned PrimaryDie in `copy.terms` now so the stale reference can't
+		// leak out to callers (e.g. via `primaryDieValue`) if finalization
+		// doesn't explicitly reassign it.
+		copy.primaryDie = copy.terms.find(
+			(t): t is PrimaryDie | foundry.dice.terms.Die => t instanceof Terms.Die,
+		);
+		DamageRoll._reattachNimbleMods(copy.terms);
+
+		const dieTerms = copy.terms.filter((t): t is foundry.dice.terms.Die => t instanceof Terms.Die);
+		let flatIdx = 0;
+		let target: { term: foundry.dice.terms.Die; resultIdx: number } | undefined;
+		outer: for (const term of dieTerms) {
+			for (let i = 0; i < term.results.length; i++) {
+				const r = term.results[i];
+				if (r.active && !r.discarded) {
+					if (flatIdx === request.dieIndex) {
+						target = { term, resultIdx: i };
+						break outer;
+					}
+					flatIdx++;
+				}
+			}
+		}
+
+		if (!target) {
+			throw new Error(`DamageRoll.reroll: no active die result at index ${request.dieIndex}`);
+		}
+
+		const faces = target.term.faces ?? 6;
+		const newValue = Math.floor(Math.random() * faces) + 1;
+
+		const prev = target.term.results[target.resultIdx];
+		target.term.results[target.resultIdx] = {
+			...prev,
+			result: newValue,
+			// Drop stale flags/metadata from the prior evaluation. The mutation
+			// metadata and exploded flag described the pre-reroll value; they
+			// should not carry to the new value.
+			exploded: false,
+		};
+		delete (target.term.results[target.resultIdx] as MutatedResult).mutation;
+
+		// Reset outcome state before re-running finalization. excludedPrimaryDieValue
+		// gets recomputed by finalization when primaryDieAsDamage is false.
+		copy.isCritical = copy.options.canCrit ? undefined : false;
+		copy.isMiss = copy.options.canMiss ? undefined : false;
+		copy.critCount = 0;
+		copy.excludedPrimaryDieValue = 0;
+		copy._recalculateTotal();
+
+		if (copy.modifierMode) {
+			copy.critCount = copy._countModifierModeCrits();
+			copy._finalizeOutcomeModifierMode();
+		} else {
+			const primaryTerm = copy.terms.find((t) => t instanceof PrimaryDie);
+			if (primaryTerm) copy._finalizeOutcome(primaryTerm);
+		}
+
+		if (copy.options.forcedOutcome?.miss && !copy.isCritical && copy.options.canMiss !== false) {
+			copy.isMiss = true;
+		}
+
+		copy.resetFormula();
+		return copy;
+	}
+
+	/**
+	 * Structural clone of a RollTerm used by `_rerollSingleDie`. Preserves
+	 * values, modifiers, active/discarded flags, and evaluated state so the
+	 * cloned term is interchangeable with the source.
+	 */
+	private static _cloneTerm(term: foundry.dice.terms.RollTerm): foundry.dice.terms.RollTerm {
+		if (term instanceof PrimaryDie) {
+			const cloned = new PrimaryDie({
+				number: term.number ?? 1,
+				faces: term.faces ?? 6,
+				modifiers: (Array.isArray(term.modifiers)
+					? [...term.modifiers]
+					: []) as PrimaryDie.TermData['modifiers'],
+				options: { ...term.options },
+			});
+			cloned.results = term.results.map((r) => ({ ...r }));
+			(cloned as unknown as { _evaluated: boolean })._evaluated = (
+				term as unknown as { _evaluated: boolean }
+			)._evaluated;
+			return cloned;
+		}
+		if (term instanceof Terms.Die) {
+			const cloned = new Terms.Die({
+				number: term.number ?? 1,
+				faces: term.faces ?? 6,
+				modifiers: Array.isArray(term.modifiers) ? [...term.modifiers] : [],
+			} as unknown as foundry.dice.terms.Die.TermData);
+			cloned.results = term.results.map((r) => ({ ...r }));
+			(cloned as unknown as { _evaluated: boolean })._evaluated = (
+				term as unknown as { _evaluated: boolean }
+			)._evaluated;
+			return cloned;
+		}
+		// For non-dice terms (operators, numerics, parentheticals), shallow
+		// clone via the prototype — they carry no mutable roll state.
+		const proto = Object.getPrototypeOf(term) as object;
+		const cloned = Object.create(proto) as foundry.dice.terms.RollTerm;
+		Object.assign(cloned, term);
+		return cloned;
+	}
+
+	/**
+	 * Re-attach NIMBLE_MODS metadata to Die terms after a clone.
+	 * The symbol-keyed metadata is not copied by structural clone, but the
+	 * modifier strings (`c`, `cv`, `v`, `n`) survive and can be used to
+	 * rebuild it.
+	 */
+	private static _reattachNimbleMods(terms: foundry.dice.terms.RollTerm[]): void {
+		for (const term of terms) {
+			if (!(term instanceof Terms.Die)) continue;
+			if (!Array.isArray(term.modifiers)) continue;
+			const has = (m: string) => term.modifiers.includes(m);
+			let meta: NimbleDieMetadata | undefined;
+			// Treat a combined `c` + `v` (a hand-built array, unusual — formula
+			// parsing normalizes to `cv`) as crit-vicious. `cv` alone wins
+			// likewise.
+			if (has('cv') || (has('c') && has('v'))) {
+				meta = { canCrit: true, explosionStyle: 'vicious' };
+			} else if (has('c')) {
+				meta = { canCrit: true, explosionStyle: 'standard' };
+			} else if (has('v')) {
+				meta = { canCrit: false, explosionStyle: 'vicious' };
+			} else if (has('n')) {
+				meta = { canCrit: false, explosionStyle: 'none' };
+			}
+			if (meta) (term as unknown as Record<symbol, unknown>)[NIMBLE_MODS] = meta;
+		}
 	}
 
 	/**

--- a/src/dice/reroll.ts
+++ b/src/dice/reroll.ts
@@ -1,0 +1,48 @@
+/**
+ * Reroll protocol types for the Nimble dice engine.
+ *
+ * Two variants are supported:
+ *   - Whole-roll reroll: re-evaluates the whole `DamageRoll` from its
+ *     `originalFormula`, optionally adjusting rollMode (advantage/disadvantage)
+ *     or prepending mutations. Used by Inerrant Strike, Mountain's Endurance,
+ *     FAST, Pocket Sand, etc.
+ *   - Single-die reroll: re-rolls one die in-place on a copy of the existing
+ *     roll and re-runs finalization. Used by Songweaver's Inspiration,
+ *     Optimistic (Gnome), Elemental Destruction, etc.
+ *
+ * `KeepPolicy` is a hint for the CALLER (rules layer) — the engine always
+ * produces the rerolled roll; comparing and picking the winner is a rules-layer
+ * decision, not engine logic.
+ */
+
+import type { MutationStep } from './mutations.js';
+
+/** Reroll the entire evaluated roll from `originalFormula`, with adjustments. */
+interface WholeRerollRequest {
+	kind: 'whole';
+	/** Signed integer added to rollMode / appended to rollModeSources. */
+	rollModeAdjust?: number;
+	/** Mutations to apply on the reroll (e.g. Inerrant Strike: bump +1). */
+	mutations?: MutationStep[];
+	/** Source label (used in logs / chat card). */
+	source: string;
+}
+
+/** Reroll a single active die result in-place on a copy of the evaluated roll. */
+interface SingleDieRerollRequest {
+	kind: 'single';
+	/** Index into flattened active (non-discarded) die results. */
+	dieIndex: number;
+	/** Source label (used in logs / chat card). */
+	source: string;
+}
+
+type RerollRequest = WholeRerollRequest | SingleDieRerollRequest;
+
+/**
+ * Policy hint for the caller when comparing original vs. rerolled results.
+ * Not consumed by the engine.
+ */
+type KeepPolicy = 'higher' | 'lower' | 'either' | 'new';
+
+export type { KeepPolicy, RerollRequest, SingleDieRerollRequest, WholeRerollRequest };


### PR DESCRIPTION
## Summary

Stage 5 of the dice engine update. Adds three primitives so rules-layer features (Final Takedown, Parry, Songweaver's Inspiration, Mountain's Endurance, etc.) can be expressed declaratively without engine special-casing.

## Changes

- **`forcedOutcome` option** — `{ crit?, miss?, source? }` on `DamageRoll.Options`. Forced crit routes through the Stage 4 mutation pipeline (prepended `{ target: primary, operation: max, countsAsCrit: true, triggersExplosion: true }`); vicious explosion fires naturally. Forced miss is a post-finalization flag override. Forced crit implicitly promotes `canCrit: true`; forced miss respects `canMiss: false` (AoE wins).
- **`criticalThreshold` / `fumbleThreshold` wired** — previously scaffolded options are now active in both legacy and modifier-mode finalization paths. Parry (`fumbleThreshold: 2`) and "Heads I Win, Tails You Lose" (`criticalThreshold: faces-1`) work end-to-end.
- **Reroll protocol — `roll.reroll(request)`** — single method with two variants:
  - `kind: 'whole'`: re-evaluates from `originalFormula` with optional `rollModeAdjust` and/or appended mutations. Used for Inerrant Strike, Mountain's Endurance, FAST, Pocket Sand, etc.
  - `kind: 'single'`: clones the roll, rerolls one die in place (by flattened active index), re-runs finalization. `NIMBLE_MODS` metadata is preserved on the cloned die term. Used for Songweaver's Inspiration, Optimistic (Gnome), etc.
  - Always returns a new `DamageRoll`. The rules layer picks via a `KeepPolicy` (`'higher'`/`'lower'`/`'either'`/`'new'`) — not engine logic.
- **Modifier-mode miss detection tightened** — now requires `meta.canCrit === true`, so vicious-without-crit (`v`) dice are no longer treated as hit/miss arbiters.
- **Finalization crit-wins guard** — both finalization paths explicitly set `isMiss = false` when `isCritical`, so threshold overlap can't produce both flags true.
- New `src/dice/reroll.ts` with `RerollRequest` / `WholeRerollRequest` / `SingleDieRerollRequest` / `KeepPolicy` types.
- `docs/system/dice-engine.md` updated with Forced outcomes, Thresholds, and Reroll protocol subsections.

## Test Plan

- `pnpm test` — 1036/1036 passing (23 new tests on top of the existing 184 `DamageRoll.test.ts` suite).
- `pnpm check` — green (format, lint, circular deps, type-check, vitest).
- Reviewer can exercise the three primitives via the Dice Testbench (Debug Mode) by constructing rolls with `forcedOutcome`, thresholds, or calling `.reroll(...)` on an evaluated roll — but the full behaviour is covered by the unit suite.

Concrete test coverage added:
- `describe('forcedOutcome')` — forced crit sets flag + mutates primary; forced miss is flag-only; crit wins over miss; natural crit beats forced miss; forced miss ignored when `canMiss: false`; forced crit implicitly promotes `canCrit`; 4d4cv forced crit triggers vicious explosion.
- `describe('fumbleThreshold')` — Parry on d8 in legacy + modifier-mode; default behaviour regression.
- `describe('criticalThreshold')` — d8 threshold=7 in legacy + modifier-mode; default behaviour regression.
- `describe('reroll — whole')` — independent new roll, `rollModeAdjust` on `rollModeSources` + scalar, mutations on reroll.
- `describe('reroll — single die')` — rerolls one result, preserves `NIMBLE_MODS`, re-finalization flips `isCritical`, range check, throws on out-of-range index, legacy-mode `primaryDie` points into the copy's own terms (regression guard).

## Checklist

- [x] Added or updated unit tests
- [ ] PR targets the `dev` branch — **targets `dice/stage-4`** (stacked on the prior stage PRs, same pattern as #714–#717)
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`) — no user-facing strings added in this PR
- [ ] Tested in Foundry with no console errors — **deferred; engine-level work, Dice Testbench exercises the primitives**
- [x] **Have you used AI to assist with this PR?** yes
- [x] **If yes:** I have reviewed all AI-generated code against the repo's STYLE_GUIDE.md and AGENTS.md

## Related Issues

Part of Epic 1 (Nimble Dice Engine Update). Builds on #714 (stage-1), #715 (stage-2), #716 (stage-3), #717 (stage-4).
