### PR TITLE
fix(compendium): Songweaver spell school level 1 and fire in my bones

### DIFF
--- a/packs/classFeatures/core/songweaver/songweaver-progression/wind-spellcasting-and.json
+++ b/packs/classFeatures/core/songweaver/songweaver-progression/wind-spellcasting-and.json
@@ -33,7 +33,12 @@
 				],
 				"mode": "selectSchool",
 				"count": 1,
-				"label": "Choose One Additional School"
+				"label": "Choose One Additional School",
+				"predicate": {
+					"level": {
+						"min": 1
+					}
+				}
 			}
 		],
 		"activation": {

--- a/packs/classFeatures/core/songweaver/songweaver-subclasses/herald-of-courage/fire-in-my-bones.json
+++ b/packs/classFeatures/core/songweaver/songweaver-subclasses/herald-of-courage/fire-in-my-bones.json
@@ -33,7 +33,7 @@
 				"width": 1
 			}
 		},
-		"description": "<p>Whenever you use Songweaver's Inspiration, your allies within 12 spaces who can hear you gain WIL temp HP.</p>",
+		"description": "<p>Your Songweaver's Inspiration also grants your target 1 additional action.</p>",
 		"featureType": "class",
 		"class": "songweaver",
 		"group": "herald-of-courage",


### PR DESCRIPTION
## Summary

<!-- One or two sentences: what does this PR do and why? -->
Fixes Songweavers spell selection to level 1 and fix Fire in My Bones description.

## Changes

<!-- Bullet list of the key changes. Keep it high-level. -->

- Correct Fire in my Bones
- Correct min spell school level on Songweaver spells

## Test Plan

<!-- How will the person reviewing this test it actually works? Include steps the reviewer needs to take to avoid too much guessing -->



## Checklist

- [ ] Added or updated unit tests
- [ ] PR targets the `dev` branch
- [ ] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [ ] No hardcoded user-facing strings (used `localize()`)
- [ ] Tested in Foundry with no console errors
- [ ] **Have you used AI to assist with this PR?** yes / no
- [ ] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->
