### PR TITLE
feat(sheets): search features, inventory, and spells by description text

### DIFF
--- a/src/utils/stripHtml.ts
+++ b/src/utils/stripHtml.ts
@@ -1,0 +1,5 @@
+const HTML_TAG_PATTERN = /<[^>]*>/g;
+
+export function stripHtml(html: string): string {
+	return html.replace(HTML_TAG_PATTERN, '');
+}

--- a/src/view/dataPreparationHelpers/filterItems.test.ts
+++ b/src/view/dataPreparationHelpers/filterItems.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest';
+import filterItems from './filterItems.js';
+
+function makeActor(items: { name: string; type: string; system?: Record<string, unknown> }[]) {
+	return {
+		items: items.map((item) => ({
+			...item,
+			system: item.system ?? {},
+		})),
+	} as unknown as Parameters<typeof filterItems>[0];
+}
+
+describe('filterItems', () => {
+	it('returns items matching the required types', () => {
+		const actor = makeActor([
+			{ name: 'Fireball', type: 'spell' },
+			{ name: 'Shield', type: 'feature' },
+		]);
+
+		const result = filterItems(actor, ['feature'], '');
+		expect(result).toHaveLength(1);
+		expect(result[0].name).toBe('Shield');
+	});
+
+	it('accepts a single type string', () => {
+		const actor = makeActor([
+			{ name: 'Shield', type: 'feature' },
+			{ name: 'Sword', type: 'object' },
+		]);
+
+		const result = filterItems(actor, 'feature', '');
+		expect(result).toHaveLength(1);
+		expect(result[0].name).toBe('Shield');
+	});
+
+	it('matches against item name (case-insensitive)', () => {
+		const actor = makeActor([
+			{ name: 'Second Wind', type: 'feature' },
+			{ name: 'Steady Aim', type: 'feature' },
+		]);
+
+		const result = filterItems(actor, ['feature'], 'wind');
+		expect(result).toHaveLength(1);
+		expect(result[0].name).toBe('Second Wind');
+	});
+
+	it('matches against string description (feature/boon)', () => {
+		const actor = makeActor([
+			{
+				name: 'Second Wind',
+				type: 'feature',
+				system: { description: '<p>Recover hit points during a <strong>field rest</strong>.</p>' },
+			},
+			{
+				name: 'Steady Aim',
+				type: 'feature',
+				system: { description: '<p>Gain advantage on your next attack roll.</p>' },
+			},
+		]);
+
+		const result = filterItems(actor, ['feature'], 'field rest');
+		expect(result).toHaveLength(1);
+		expect(result[0].name).toBe('Second Wind');
+	});
+
+	it('matches against object description fields (inventory)', () => {
+		const actor = makeActor([
+			{
+				name: 'Healing Potion',
+				type: 'object',
+				system: {
+					description: {
+						public: '<p>Restores 2d4+2 hit points when consumed.</p>',
+						unidentified: '<p>A bubbling red liquid.</p>',
+						secret: '',
+					},
+				},
+			},
+			{
+				name: 'Rope',
+				type: 'object',
+				system: {
+					description: {
+						public: '<p>50 feet of hempen rope.</p>',
+						unidentified: '',
+						secret: '',
+					},
+				},
+			},
+		]);
+
+		const result = filterItems(actor, ['object'], 'hit points');
+		expect(result).toHaveLength(1);
+		expect(result[0].name).toBe('Healing Potion');
+	});
+
+	it('matches against spell description fields', () => {
+		const actor = makeActor([
+			{
+				name: 'Arcane Bolt',
+				type: 'spell',
+				system: {
+					description: {
+						baseEffect: '<p>Deal 1d10 force damage to a target.</p>',
+						higherLevelEffect: '',
+						upcastEffect: '',
+					},
+				},
+			},
+		]);
+
+		const result = filterItems(actor, ['spell'], 'force damage');
+		expect(result).toHaveLength(1);
+		expect(result[0].name).toBe('Arcane Bolt');
+	});
+
+	it('does not match against HTML tags', () => {
+		const actor = makeActor([
+			{
+				name: 'Shield',
+				type: 'feature',
+				system: { description: '<p class="rest-block">Gain +2 AC.</p>' },
+			},
+		]);
+
+		const result = filterItems(actor, ['feature'], 'rest-block');
+		expect(result).toHaveLength(0);
+	});
+
+	it('prefers name match (returns item when name matches even if description does not)', () => {
+		const actor = makeActor([
+			{
+				name: 'Field Rest Recovery',
+				type: 'feature',
+				system: { description: '<p>Some unrelated text.</p>' },
+			},
+		]);
+
+		const result = filterItems(actor, ['feature'], 'field rest');
+		expect(result).toHaveLength(1);
+	});
+
+	it('handles items with no description gracefully', () => {
+		const actor = makeActor([{ name: 'Mystery', type: 'feature', system: {} }]);
+
+		const result = filterItems(actor, ['feature'], 'anything');
+		expect(result).toHaveLength(0);
+	});
+
+	it('handles null description gracefully', () => {
+		const actor = makeActor([{ name: 'Mystery', type: 'feature', system: { description: null } }]);
+
+		const result = filterItems(actor, ['feature'], 'anything');
+		expect(result).toHaveLength(0);
+	});
+
+	it('returns all items of type when search term is empty', () => {
+		const actor = makeActor([
+			{ name: 'A', type: 'feature' },
+			{ name: 'B', type: 'feature' },
+			{ name: 'C', type: 'spell' },
+		]);
+
+		const result = filterItems(actor, ['feature'], '');
+		expect(result).toHaveLength(2);
+	});
+});

--- a/src/view/dataPreparationHelpers/filterItems.ts
+++ b/src/view/dataPreparationHelpers/filterItems.ts
@@ -1,15 +1,41 @@
 import type { NimbleCharacter } from '../../documents/actor/character.js';
 import type { NimbleBaseItem } from '../../documents/item/base.svelte.js';
 
+const HTML_TAG_PATTERN = /<[^>]*>/g;
+
+function stripHtml(html: string): string {
+	return html.replace(HTML_TAG_PATTERN, '');
+}
+
+/** Description can be a plain HTML string, an object with string fields, or absent. */
+type ItemDescription = string | Record<string, string> | null | undefined;
+
+function getDescriptionText(description: ItemDescription): string {
+	if (typeof description === 'string') return stripHtml(description);
+	if (typeof description === 'object' && description !== null) {
+		return Object.values(description)
+			.filter((v): v is string => typeof v === 'string')
+			.map(stripHtml)
+			.join(' ');
+	}
+	return '';
+}
+
 export default function filterItems(
 	actor: NimbleCharacter,
-	requiredItemTypes: string[],
+	requiredItemTypes: string[] | string,
 	searchTerm: string,
 ): NimbleBaseItem[] {
+	const types = Array.isArray(requiredItemTypes) ? requiredItemTypes : [requiredItemTypes];
 	return actor.items.filter((item) => {
-		if (!requiredItemTypes.includes(item.type)) return false;
+		if (!types.includes(item.type)) return false;
 		if (!searchTerm) return true;
 
-		return item.name.toLocaleLowerCase().includes(searchTerm.toLocaleLowerCase());
+		const term = searchTerm.toLocaleLowerCase();
+		if (item.name.toLocaleLowerCase().includes(term)) return true;
+
+		const system = item.system as { description?: ItemDescription };
+		const descriptionText = getDescriptionText(system.description);
+		return descriptionText.toLocaleLowerCase().includes(term);
 	}) as NimbleBaseItem[];
 }

--- a/src/view/dataPreparationHelpers/filterItems.ts
+++ b/src/view/dataPreparationHelpers/filterItems.ts
@@ -1,11 +1,6 @@
 import type { NimbleCharacter } from '../../documents/actor/character.js';
 import type { NimbleBaseItem } from '../../documents/item/base.svelte.js';
-
-const HTML_TAG_PATTERN = /<[^>]*>/g;
-
-function stripHtml(html: string): string {
-	return html.replace(HTML_TAG_PATTERN, '');
-}
+import { stripHtml } from '../../utils/stripHtml.js';
 
 /** Description can be a plain HTML string, an object with string fields, or absent. */
 type ItemDescription = string | Record<string, string> | null | undefined;

--- a/src/view/sheets/components/AttackActionPanel.svelte.ts
+++ b/src/view/sheets/components/AttackActionPanel.svelte.ts
@@ -7,6 +7,11 @@ import { evaluateFormula as evalFormula } from '../../../utils/evaluateFormula.j
 import localize from '../../../utils/localize.js';
 import sortItems from '../../../utils/sortItems.js';
 
+const HTML_TAG_PATTERN = /<[^>]*>/g;
+function stripHtml(html: string): string {
+	return html.replace(HTML_TAG_PATTERN, '');
+}
+
 /** System data for weapon items */
 interface WeaponSystemData {
 	objectType: string;
@@ -61,7 +66,12 @@ export function createAttackPanelState(
 		if (!searchTerm) return weaponItems;
 
 		const search = searchTerm.toLocaleLowerCase();
-		return weaponItems.filter((item) => item.name.toLocaleLowerCase().includes(search));
+		return weaponItems.filter((item) => {
+			if (item.name.toLocaleLowerCase().includes(search)) return true;
+			const desc = getSystemData(item).description;
+			const text = typeof desc === 'object' ? desc?.public : desc;
+			return typeof text === 'string' && stripHtml(text).toLocaleLowerCase().includes(search);
+		});
 	});
 
 	const showUnarmedStrike = $derived(
@@ -82,7 +92,12 @@ export function createAttackPanelState(
 		if (!searchTerm) return features;
 
 		const search = searchTerm.toLocaleLowerCase();
-		return features.filter((item) => item.name.toLocaleLowerCase().includes(search));
+		return features.filter((item) => {
+			if (item.name.toLocaleLowerCase().includes(search)) return true;
+			const desc = getSystemData(item).description;
+			const text = typeof desc === 'object' ? desc?.public : desc;
+			return typeof text === 'string' && stripHtml(text).toLocaleLowerCase().includes(search);
+		});
 	});
 
 	function getWeaponDamage(item: Item): string {

--- a/src/view/sheets/components/AttackActionPanel.svelte.ts
+++ b/src/view/sheets/components/AttackActionPanel.svelte.ts
@@ -6,11 +6,7 @@ import { getUnarmedDamageFormula, hasUnarmedProficiency } from '../../../utils/a
 import { evaluateFormula as evalFormula } from '../../../utils/evaluateFormula.js';
 import localize from '../../../utils/localize.js';
 import sortItems from '../../../utils/sortItems.js';
-
-const HTML_TAG_PATTERN = /<[^>]*>/g;
-function stripHtml(html: string): string {
-	return html.replace(HTML_TAG_PATTERN, '');
-}
+import { stripHtml } from '../../../utils/stripHtml.js';
 
 /** System data for weapon items */
 interface WeaponSystemData {
@@ -141,7 +137,7 @@ export function createAttackPanelState(
 
 		if (!desc || typeof desc !== 'string') return '';
 
-		const stripped = desc.replace(/<[^>]*>/g, '').trim();
+		const stripped = stripHtml(desc).trim();
 		return stripped ? desc : '';
 	}
 


### PR DESCRIPTION
## Summary

Expand item search filters to match against item descriptions in addition to names, with HTML tag stripping so searches match rendered text.

## Changes

- Add description matching to `filterItems` for features, boons, inventory items, and spells
- Extend `AttackActionPanel` inline search to also match weapon/attack feature descriptions
- Extract shared `stripHtml` utility to `src/utils/stripHtml.ts`
- Add 11 unit tests covering name matching, description matching for all item types, HTML stripping, and edge cases

## Test Plan

- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] Search Features tab for keyword in description (e.g. "field rest")
- [x] Search Inventory tab for keyword in item description
- [x] Search Spells tab for keyword in spell effect text
- [x] Search Actions tab for keyword in weapon/attack description

## Checklist

- [x] Added or updated unit tests
- [x] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [x] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** yes
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues

Closes #725