### PR TITLE
feat(combat): wire flunky tag to suppress critical hits

### DIFF
--- a/src/managers/ItemActivationManager.test.ts
+++ b/src/managers/ItemActivationManager.test.ts
@@ -366,6 +366,90 @@ describe('ItemActivationManager.getData (rolls)', () => {
 	});
 
 	describe('Damage effects', () => {
+		it('should prevent flunky NPC damage rolls from critting', async () => {
+			mockActor.type = 'npc';
+			(mockActor.system as Record<string, unknown>).details = { isFlunky: true };
+			mockItem.actor = mockActor;
+
+			manager = new ItemActivationManager(
+				mockItem as unknown as ConstructorParameters<typeof ItemActivationManager>[0],
+				{ fastForward: true },
+			);
+
+			const damageNode: EffectNode = {
+				id: 'damage-1',
+				type: 'damage',
+				damageType: 'slashing',
+				formula: '1d8',
+				canCrit: true,
+				canMiss: true,
+				parentContext: null,
+				parentNode: null,
+			} as EffectNode;
+
+			manager.activationData = { effects: [damageNode] };
+			mockReconstructEffectsTree.mockReturnValue([damageNode]);
+
+			const mockRoll = {
+				evaluate: vi.fn().mockResolvedValue(undefined),
+				toJSON: vi.fn().mockReturnValue({ total: 6 }),
+			};
+			vi.mocked(DamageRoll).mockImplementation(createMockConstructorImplementation(mockRoll));
+
+			await manager.getData();
+
+			expect(DamageRoll).toHaveBeenCalledWith(
+				'1d8',
+				{ level: 1, strength: 10 },
+				expect.objectContaining({
+					canCrit: false,
+					canMiss: true,
+				}),
+			);
+		});
+
+		it('should allow non-flunky NPC damage rolls to crit normally', async () => {
+			mockActor.type = 'npc';
+			(mockActor.system as Record<string, unknown>).details = { isFlunky: false };
+			mockItem.actor = mockActor;
+
+			manager = new ItemActivationManager(
+				mockItem as unknown as ConstructorParameters<typeof ItemActivationManager>[0],
+				{ fastForward: true },
+			);
+
+			const damageNode: EffectNode = {
+				id: 'damage-1',
+				type: 'damage',
+				damageType: 'slashing',
+				formula: '1d8',
+				canCrit: true,
+				canMiss: true,
+				parentContext: null,
+				parentNode: null,
+			} as EffectNode;
+
+			manager.activationData = { effects: [damageNode] };
+			mockReconstructEffectsTree.mockReturnValue([damageNode]);
+
+			const mockRoll = {
+				evaluate: vi.fn().mockResolvedValue(undefined),
+				toJSON: vi.fn().mockReturnValue({ total: 6 }),
+			};
+			vi.mocked(DamageRoll).mockImplementation(createMockConstructorImplementation(mockRoll));
+
+			await manager.getData();
+
+			expect(DamageRoll).toHaveBeenCalledWith(
+				'1d8',
+				{ level: 1, strength: 10 },
+				expect.objectContaining({
+					canCrit: true,
+					canMiss: true,
+				}),
+			);
+		});
+
 		it('should force minion damage rolls to miss on 1 and never crit', async () => {
 			manager = new ItemActivationManager(
 				mockItem as unknown as ConstructorParameters<typeof ItemActivationManager>[0],

--- a/src/managers/ItemActivationManager.ts
+++ b/src/managers/ItemActivationManager.ts
@@ -252,6 +252,11 @@ class ItemActivationManager {
 					const isMinion =
 						actorTags?.has('minion') ?? (this.actor?.type as string | undefined) === 'minion';
 
+					// Flunkies cannot crit but can still miss, same as minions.
+					const actorDetails = (this.actor?.system as { details?: { isFlunky?: boolean } } | null)
+						?.details;
+					const isFlunky = actorDetails?.isFlunky ?? false;
+
 					// AoE attacks share a single roll applied to all targets,
 					// so they cannot crit and cannot miss. Detect AoE from a
 					// defined activation template shape.
@@ -265,7 +270,8 @@ class ItemActivationManager {
 					// A wielder lacking proficiency in this weapon's type cannot crit.
 					const lacksProficiency = !hasWeaponProficiency(this.actor as any, this.#item as any);
 
-					const resolvedCanCrit = isAoE || isMinion || lacksProficiency ? false : (canCrit ?? true);
+					const resolvedCanCrit =
+						isAoE || isMinion || isFlunky || lacksProficiency ? false : (canCrit ?? true);
 					// Minions cannot crit but can still miss — the asymmetry with
 					// resolvedCanCrit above is intentional.
 					const resolvedCanMiss = isAoE ? false : isMinion || (canMiss ?? true);


### PR DESCRIPTION
## Summary

Wire the existing `isFlunky` NPC flag into the attack pipeline so flunky-tagged monsters cannot score critical hits. Flunkies can still miss normally (same asymmetry as minions). The data model field, UI checkbox, NPC sheet display, and localization already existed — this PR connects the flag to the combat logic.

## Changes

- Check `isFlunky` alongside `isMinion` when resolving `canCrit` in `ItemActivationManager`
- Add tests for flunky crit suppression and non-flunky crit passthrough

## Test Plan

- [x] `pnpm check` passes
- [x] Mark an NPC as Flunky, attack — no crits occur
- [x] Flunky attacks can still miss normally
- [x] Verify non-flunky NPCs can still crit

## Checklist

- [x] Added or updated unit tests
- [x] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [x] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** yes
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues

Closes #722