### PR TITLE
feat(combat): add temporary bonus action slots to the action tracker

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -735,6 +735,7 @@
 			},
 			"heroicActions": {
 				"title": "Heroic Actions",
+				"addBonusAction": "Add bonus action",
 				"reactionsTitle": "Heroic Reactions",
 				"reactions": {
 					"actionCost": "This will use 1 action (reaction)",

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -735,7 +735,7 @@
 			},
 			"heroicActions": {
 				"title": "Heroic Actions",
-				"addBonusAction": "Add bonus action",
+				"addAdditionalAction": "Add 1 action",
 				"reactionsTitle": "Heroic Reactions",
 				"reactions": {
 					"actionCost": "This will use 1 action (reaction)",

--- a/src/documents/combat/combat.svelte.test.ts
+++ b/src/documents/combat/combat.svelte.test.ts
@@ -2714,7 +2714,7 @@ describe('NimbleCombat', () => {
 
 		expect(combatant.update).toHaveBeenCalledWith({
 			'system.actions.base.current': 3,
-			'system.actions.base.bonus': 0,
+			'system.actions.base.additional': 0,
 			'system.actions.heroic.defendAvailable': true,
 			'system.actions.heroic.interposeAvailable': true,
 			'system.actions.heroic.opportunityAttackAvailable': true,

--- a/src/documents/combat/combat.svelte.test.ts
+++ b/src/documents/combat/combat.svelte.test.ts
@@ -2714,6 +2714,7 @@ describe('NimbleCombat', () => {
 
 		expect(combatant.update).toHaveBeenCalledWith({
 			'system.actions.base.current': 3,
+			'system.actions.base.bonus': 0,
 			'system.actions.heroic.defendAvailable': true,
 			'system.actions.heroic.interposeAvailable': true,
 			'system.actions.heroic.opportunityAttackAvailable': true,

--- a/src/documents/combat/combat.svelte.ts
+++ b/src/documents/combat/combat.svelte.ts
@@ -693,7 +693,7 @@ class NimbleCombat extends Combat {
 		if (combatant.type === 'character') {
 			await combatant.update({
 				'system.actions.base.current': getCombatantBaseActionMax(combatant),
-				'system.actions.base.bonus': 0,
+				'system.actions.base.additional': 0,
 				...this.#buildHeroicReactionAvailabilityUpdate(true),
 			} as Record<string, unknown>);
 		}

--- a/src/documents/combat/combat.svelte.ts
+++ b/src/documents/combat/combat.svelte.ts
@@ -693,6 +693,7 @@ class NimbleCombat extends Combat {
 		if (combatant.type === 'character') {
 			await combatant.update({
 				'system.actions.base.current': getCombatantBaseActionMax(combatant),
+				'system.actions.base.bonus': 0,
 				...this.#buildHeroicReactionAvailabilityUpdate(true),
 			} as Record<string, unknown>);
 		}

--- a/src/documents/combat/combatantSystem.ts
+++ b/src/documents/combat/combatantSystem.ts
@@ -20,6 +20,15 @@ export function getCombatantBaseActions(combatant: Combatant.Implementation): Co
 	};
 }
 
+export function getCombatantBonusActions(combatant: Combatant.Implementation): number {
+	const actions = getCombatantSystem(combatant)?.actions?.base;
+	return normalizeNonNegativeInteger((actions as { bonus?: unknown } | undefined)?.bonus);
+}
+
+export function getCombatantEffectiveMax(combatant: Combatant.Implementation): number {
+	return getCombatantBaseActionMax(combatant) + getCombatantBonusActions(combatant);
+}
+
 export function getCombatantBaseActionCurrent(combatant: Combatant.Implementation): number {
 	return getCombatantBaseActions(combatant).current;
 }

--- a/src/documents/combat/combatantSystem.ts
+++ b/src/documents/combat/combatantSystem.ts
@@ -20,13 +20,13 @@ export function getCombatantBaseActions(combatant: Combatant.Implementation): Co
 	};
 }
 
-export function getCombatantBonusActions(combatant: Combatant.Implementation): number {
+export function getCombatantAdditionalActions(combatant: Combatant.Implementation): number {
 	const actions = getCombatantSystem(combatant)?.actions?.base;
-	return normalizeNonNegativeInteger((actions as { bonus?: unknown } | undefined)?.bonus);
+	return normalizeNonNegativeInteger((actions as { additional?: unknown } | undefined)?.additional);
 }
 
 export function getCombatantEffectiveMax(combatant: Combatant.Implementation): number {
-	return getCombatantBaseActionMax(combatant) + getCombatantBonusActions(combatant);
+	return getCombatantBaseActionMax(combatant) + getCombatantAdditionalActions(combatant);
 }
 
 export function getCombatantBaseActionCurrent(combatant: Combatant.Implementation): number {

--- a/src/models/combatant/CharacterCombatantDataModel.ts
+++ b/src/models/combatant/CharacterCombatantDataModel.ts
@@ -17,7 +17,7 @@ const nimbleCharacterCombatantSchema = () => ({
 				integer: true,
 				min: 0,
 			}),
-			bonus: new fields.NumberField({
+			additional: new fields.NumberField({
 				required: true,
 				initial: 0,
 				nullable: false,

--- a/src/models/combatant/CharacterCombatantDataModel.ts
+++ b/src/models/combatant/CharacterCombatantDataModel.ts
@@ -17,6 +17,13 @@ const nimbleCharacterCombatantSchema = () => ({
 				integer: true,
 				min: 0,
 			}),
+			bonus: new fields.NumberField({
+				required: true,
+				initial: 0,
+				nullable: false,
+				integer: true,
+				min: 0,
+			}),
 		}),
 		heroic: new fields.SchemaField({
 			interposeAvailable: new fields.BooleanField({

--- a/src/scss/base/_theme.scss
+++ b/src/scss/base/_theme.scss
@@ -91,6 +91,8 @@
 	--nimble-action-info-text-color: hsl(45, 60%, 65%);
 	--nimble-action-info-icon-color: hsl(45, 70%, 55%);
 	--nimble-action-button-icon-color: hsl(210, 70%, 65%);
+	--nimble-additional-action-color: hsl(210, 60%, 60%);
+	--nimble-additional-action-color-hover: hsl(210, 60%, 70%);
 
 	/** SPELL EFFECT COLORS **/
 	--nimble-spell-damage-color: hsl(0, 65%, 60%);

--- a/src/scss/base/_variables.scss
+++ b/src/scss/base/_variables.scss
@@ -142,6 +142,8 @@
 	--nimble-action-info-text-color: hsl(45, 70%, 28%);
 	--nimble-action-info-icon-color: hsl(45, 80%, 35%);
 	--nimble-action-button-icon-color: hsl(210, 65%, 45%);
+	--nimble-additional-action-color: hsl(210, 60%, 50%);
+	--nimble-additional-action-color-hover: hsl(210, 60%, 60%);
 
 	/** REACTION COLORS **/
 	// Defend (blue)

--- a/src/view/sheets/components/ActionTracker.svelte
+++ b/src/view/sheets/components/ActionTracker.svelte
@@ -35,8 +35,9 @@
 				</button>
 			{:else if state.hasInitiative}
 				<div class="action-tracker__pips">
-					{#each { length: state.actionsData.max }, i}
+					{#each { length: state.actionsData.effectiveMax }, i}
 						{@const isAvailable = i < state.actionsData.current}
+						{@const isBonus = i >= state.actionsData.max}
 						{@const isJustSpent = state.justSpentPips.has(i)}
 						{@const diceIcon = getDiceIcon(i)}
 
@@ -44,6 +45,7 @@
 							class="action-tracker__pip"
 							class:action-tracker__pip--available={isAvailable}
 							class:action-tracker__pip--spent={!isAvailable}
+							class:action-tracker__pip--bonus={isBonus}
 							class:action-tracker__pip--just-spent={isJustSpent}
 							type="button"
 							aria-label={state.getPipAriaLabel(i, isAvailable)}
@@ -51,9 +53,26 @@
 							data-tooltip-direction="RIGHT"
 							onclick={() => state.handlePipClick(i)}
 						>
-							<i class="fa-solid {diceIcon}"></i>
+							{#if diceIcon}
+								<i class="fa-solid {diceIcon}"></i>
+							{:else}
+								<span class="action-tracker__pip-number">{i + 1}</span>
+							{/if}
 						</button>
 					{/each}
+
+					{#if state.actionsData.effectiveMax < 10}
+						<button
+							class="action-tracker__add-bonus"
+							type="button"
+							aria-label="Add bonus action"
+							data-tooltip="Add bonus action"
+							data-tooltip-direction="RIGHT"
+							onclick={state.addBonusAction}
+						>
+							<i class="fa-solid fa-plus"></i>
+						</button>
+					{/if}
 				</div>
 
 				{#if state.isMyTurn}
@@ -183,11 +202,63 @@
 				}
 			}
 
+			&--bonus.action-tracker__pip--available {
+				i,
+				.action-tracker__pip-number {
+					color: hsl(45, 80%, 55%);
+				}
+
+				&:hover i,
+				&:hover .action-tracker__pip-number {
+					color: hsl(45, 80%, 65%);
+					filter: drop-shadow(0 0 4px hsl(45, 80%, 55%));
+				}
+			}
+
 			&--just-spent {
 				animation: pip-spent 0.6s ease-out;
 
 				i {
 					animation: pip-icon-spent 0.6s ease-out;
+				}
+			}
+		}
+
+		&__pip-number {
+			font-size: 0.75rem;
+			font-weight: 700;
+			line-height: 1;
+		}
+
+		&__add-bonus {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			width: 1.625rem;
+			height: 1.625rem;
+			padding: 0;
+			background: var(--nimble-box-background-color);
+			border: 1px solid var(--nimble-card-border-color);
+			border-radius: 4px;
+			cursor: pointer;
+			opacity: 0.5;
+			transition: all 0.15s ease;
+
+			:global(.theme-light) & {
+				border-color: hsl(220, 10%, 70%);
+			}
+
+			i {
+				font-size: 0.625rem;
+				color: var(--nimble-medium-text-color);
+			}
+
+			&:hover {
+				opacity: 1;
+				border-color: hsl(45, 80%, 55%);
+
+				i {
+					color: hsl(45, 80%, 55%);
 				}
 			}
 		}
@@ -278,6 +349,16 @@
 
 		&:hover {
 			border-color: hsl(220, 15%, 45%);
+			background: hsl(220, 15%, 22%);
+		}
+	}
+
+	:global(.theme-dark) .action-tracker__add-bonus {
+		background: hsl(220, 15%, 18%);
+		border-color: hsl(220, 10%, 30%);
+
+		&:hover {
+			border-color: hsl(45, 80%, 55%);
 			background: hsl(220, 15%, 22%);
 		}
 	}

--- a/src/view/sheets/components/ActionTracker.svelte
+++ b/src/view/sheets/components/ActionTracker.svelte
@@ -65,8 +65,8 @@
 						<button
 							class="action-tracker__add-bonus"
 							type="button"
-							aria-label="Add bonus action"
-							data-tooltip="Add bonus action"
+							aria-label={localize('NIMBLE.ui.heroicActions.addBonusAction')}
+							data-tooltip={localize('NIMBLE.ui.heroicActions.addBonusAction')}
 							data-tooltip-direction="RIGHT"
 							onclick={state.addBonusAction}
 						>

--- a/src/view/sheets/components/ActionTracker.svelte
+++ b/src/view/sheets/components/ActionTracker.svelte
@@ -37,7 +37,7 @@
 				<div class="action-tracker__pips">
 					{#each { length: state.actionsData.effectiveMax }, i}
 						{@const isAvailable = i < state.actionsData.current}
-						{@const isBonus = i >= state.actionsData.max}
+						{@const isAdditional = i >= state.actionsData.max}
 						{@const isJustSpent = state.justSpentPips.has(i)}
 						{@const diceIcon = getDiceIcon(i)}
 
@@ -45,7 +45,7 @@
 							class="action-tracker__pip"
 							class:action-tracker__pip--available={isAvailable}
 							class:action-tracker__pip--spent={!isAvailable}
-							class:action-tracker__pip--bonus={isBonus}
+							class:action-tracker__pip--additional={isAdditional}
 							class:action-tracker__pip--just-spent={isJustSpent}
 							type="button"
 							aria-label={state.getPipAriaLabel(i, isAvailable)}
@@ -63,12 +63,12 @@
 
 					{#if state.actionsData.effectiveMax < 10}
 						<button
-							class="action-tracker__add-bonus"
+							class="action-tracker__add-additional"
 							type="button"
-							aria-label={localize('NIMBLE.ui.heroicActions.addBonusAction')}
-							data-tooltip={localize('NIMBLE.ui.heroicActions.addBonusAction')}
+							aria-label={localize('NIMBLE.ui.heroicActions.addAdditionalAction')}
+							data-tooltip={localize('NIMBLE.ui.heroicActions.addAdditionalAction')}
 							data-tooltip-direction="RIGHT"
-							onclick={state.addBonusAction}
+							onclick={state.addAdditionalAction}
 						>
 							<i class="fa-solid fa-plus"></i>
 						</button>
@@ -202,7 +202,7 @@
 				}
 			}
 
-			&--bonus.action-tracker__pip--available {
+			&--additional.action-tracker__pip--available {
 				i,
 				.action-tracker__pip-number {
 					color: hsl(45, 80%, 55%);
@@ -230,7 +230,7 @@
 			line-height: 1;
 		}
 
-		&__add-bonus {
+		&__add-additional {
 			display: flex;
 			align-items: center;
 			justify-content: center;
@@ -353,7 +353,7 @@
 		}
 	}
 
-	:global(.theme-dark) .action-tracker__add-bonus {
+	:global(.theme-dark) .action-tracker__add-additional {
 		background: hsl(220, 15%, 18%);
 		border-color: hsl(220, 10%, 30%);
 

--- a/src/view/sheets/components/ActionTracker.svelte
+++ b/src/view/sheets/components/ActionTracker.svelte
@@ -205,13 +205,13 @@
 			&--additional.action-tracker__pip--available {
 				i,
 				.action-tracker__pip-number {
-					color: hsl(45, 80%, 55%);
+					color: var(--nimble-additional-action-color);
 				}
 
 				&:hover i,
 				&:hover .action-tracker__pip-number {
-					color: hsl(45, 80%, 65%);
-					filter: drop-shadow(0 0 4px hsl(45, 80%, 55%));
+					color: var(--nimble-additional-action-color-hover);
+					filter: drop-shadow(0 0 4px var(--nimble-additional-action-color));
 				}
 			}
 
@@ -255,10 +255,10 @@
 
 			&:hover {
 				opacity: 1;
-				border-color: hsl(45, 80%, 55%);
+				border-color: var(--nimble-additional-action-color);
 
 				i {
-					color: hsl(45, 80%, 55%);
+					color: var(--nimble-additional-action-color);
 				}
 			}
 		}
@@ -358,7 +358,7 @@
 		border-color: hsl(220, 10%, 30%);
 
 		&:hover {
-			border-color: hsl(45, 80%, 55%);
+			border-color: var(--nimble-additional-action-color);
 			background: hsl(220, 15%, 22%);
 		}
 	}

--- a/src/view/sheets/components/ActionTracker.svelte.ts
+++ b/src/view/sheets/components/ActionTracker.svelte.ts
@@ -2,8 +2,8 @@ import { untrack } from 'svelte';
 import { createSubscriber } from 'svelte/reactivity';
 import type { NimbleCharacter } from '#documents/actor/character.js';
 import {
+	getCombatantAdditionalActions,
 	getCombatantBaseActions,
-	getCombatantBonusActions,
 } from '#documents/combat/combatantSystem.js';
 import type { PromptedInitiativeOptions } from '#types/combat.js';
 import { getActiveCombatForCurrentScene, registerCombatStateHooks } from '#utils/combatState.js';
@@ -20,7 +20,7 @@ import { queueCombatantMutationWithFreshDocument } from '#utils/queueCombatantMu
 interface ActionsData {
 	current: number;
 	max: number;
-	bonus: number;
+	additional: number;
 	effectiveMax: number;
 }
 
@@ -86,16 +86,16 @@ export function createActionTrackerState(getActor: () => NimbleCharacter) {
 
 	function getActionsData(): ActionsData {
 		const combatant = getCombatantInCombat();
-		if (!combatant) return { current: 0, max: 3, bonus: 0, effectiveMax: 3 };
+		if (!combatant) return { current: 0, max: 3, additional: 0, effectiveMax: 3 };
 
 		const actions = getCombatantBaseActions(combatant);
-		const bonus = getCombatantBonusActions(combatant);
+		const additional = getCombatantAdditionalActions(combatant);
 		const max = actions.max || 3;
 		return {
 			current: actions.current,
 			max,
-			bonus,
-			effectiveMax: max + bonus,
+			additional,
+			effectiveMax: max + additional,
 		};
 	}
 
@@ -145,15 +145,15 @@ export function createActionTrackerState(getActor: () => NimbleCharacter) {
 		});
 	}
 
-	async function addBonusAction(): Promise<void> {
+	async function addAdditionalAction(): Promise<void> {
 		const combat = getActiveCombatForCurrentScene();
 		const combatantId = getCombatantInCombat()?.id ?? null;
 		if (!combat || !combatantId) return;
 
-		const maxBonusSlots = 10 - actionsData.max;
-		if (actionsData.bonus >= maxBonusSlots) return;
+		const maxAdditionalSlots = 10 - actionsData.max;
+		if (actionsData.additional >= maxAdditionalSlots) return;
 
-		const newBonus = actionsData.bonus + 1;
+		const newAdditional = actionsData.additional + 1;
 		const newCurrent = actionsData.current + 1;
 
 		await queueCombatantMutationWithFreshDocument({
@@ -161,7 +161,7 @@ export function createActionTrackerState(getActor: () => NimbleCharacter) {
 			combatantId,
 			mutation: async (currentCombatant) => {
 				await currentCombatant.update({
-					'system.actions.base.bonus': newBonus,
+					'system.actions.base.additional': newAdditional,
 					'system.actions.base.current': newCurrent,
 				} as Record<string, unknown>);
 			},
@@ -305,7 +305,7 @@ export function createActionTrackerState(getActor: () => NimbleCharacter) {
 		// Actions
 		rollInitiative,
 		endTurn,
-		addBonusAction,
+		addAdditionalAction,
 		handlePipClick,
 
 		// Helpers

--- a/src/view/sheets/components/ActionTracker.svelte.ts
+++ b/src/view/sheets/components/ActionTracker.svelte.ts
@@ -1,7 +1,10 @@
 import { untrack } from 'svelte';
 import { createSubscriber } from 'svelte/reactivity';
 import type { NimbleCharacter } from '#documents/actor/character.js';
-import { getCombatantBaseActions } from '#documents/combat/combatantSystem.js';
+import {
+	getCombatantBaseActions,
+	getCombatantBonusActions,
+} from '#documents/combat/combatantSystem.js';
 import type { PromptedInitiativeOptions } from '#types/combat.js';
 import { getActiveCombatForCurrentScene, registerCombatStateHooks } from '#utils/combatState.js';
 import { requestAdvanceCombatTurn } from '#utils/combatTurnActions.js';
@@ -17,6 +20,8 @@ import { queueCombatantMutationWithFreshDocument } from '#utils/queueCombatantMu
 interface ActionsData {
 	current: number;
 	max: number;
+	bonus: number;
+	effectiveMax: number;
 }
 
 // ============================================================================
@@ -32,11 +37,11 @@ const DICE_ICONS = [
 	'fa-dice-six',
 ];
 
-export function getDiceIcon(index: number): string {
+export function getDiceIcon(index: number): string | null {
 	if (index < DICE_ICONS.length) {
 		return DICE_ICONS[index];
 	}
-	return 'fa-dice-d6';
+	return null;
 }
 
 // ============================================================================
@@ -81,12 +86,16 @@ export function createActionTrackerState(getActor: () => NimbleCharacter) {
 
 	function getActionsData(): ActionsData {
 		const combatant = getCombatantInCombat();
-		if (!combatant) return { current: 0, max: 3 };
+		if (!combatant) return { current: 0, max: 3, bonus: 0, effectiveMax: 3 };
 
 		const actions = getCombatantBaseActions(combatant);
+		const bonus = getCombatantBonusActions(combatant);
+		const max = actions.max || 3;
 		return {
 			current: actions.current,
-			max: actions.max || 3,
+			max,
+			bonus,
+			effectiveMax: max + bonus,
 		};
 	}
 
@@ -131,6 +140,29 @@ export function createActionTrackerState(getActor: () => NimbleCharacter) {
 			mutation: async (currentCombatant) => {
 				await currentCombatant.update({
 					'system.actions.base.current': newValue,
+				} as Record<string, unknown>);
+			},
+		});
+	}
+
+	async function addBonusAction(): Promise<void> {
+		const combat = getActiveCombatForCurrentScene();
+		const combatantId = getCombatantInCombat()?.id ?? null;
+		if (!combat || !combatantId) return;
+
+		const maxBonusSlots = 10 - actionsData.max;
+		if (actionsData.bonus >= maxBonusSlots) return;
+
+		const newBonus = actionsData.bonus + 1;
+		const newCurrent = actionsData.current + 1;
+
+		await queueCombatantMutationWithFreshDocument({
+			combat,
+			combatantId,
+			mutation: async (currentCombatant) => {
+				await currentCombatant.update({
+					'system.actions.base.bonus': newBonus,
+					'system.actions.base.current': newCurrent,
 				} as Record<string, unknown>);
 			},
 		});
@@ -191,13 +223,11 @@ export function createActionTrackerState(getActor: () => NimbleCharacter) {
 		const isAvailable = index < actionsData.current;
 
 		if (isAvailable) {
-			// Spend one action
-			const newValue = Math.max(actionsData.current - 1, 0);
-			void updateActionPips(newValue);
+			const newCurrent = Math.max(actionsData.current - 1, 0);
+			void updateActionPips(newCurrent);
 		} else {
-			// Restore one action
-			const newValue = Math.min(actionsData.current + 1, actionsData.max);
-			void updateActionPips(newValue);
+			const newCurrent = Math.min(actionsData.current + 1, actionsData.effectiveMax);
+			void updateActionPips(newCurrent);
 		}
 	}
 
@@ -275,6 +305,7 @@ export function createActionTrackerState(getActor: () => NimbleCharacter) {
 		// Actions
 		rollInitiative,
 		endTurn,
+		addBonusAction,
 		handlePipClick,
 
 		// Helpers

--- a/src/view/ui/CtTopTracker.svelte
+++ b/src/view/ui/CtTopTracker.svelte
@@ -433,7 +433,7 @@
 									{#if canShowActions}
 										{@const displayCurrentActions = Math.max(0, Math.floor(actionState.current))}
 										{@const displayMaxActions = Math.max(0, Math.floor(actionState.effectiveMax))}
-										{@const hasBonus = actionState.bonus > 0}
+										{@const hasAdditional = actionState.additional > 0}
 										{@const canAdjustActions = canCurrentUserAdjustCombatantActions(
 											entry.combatant,
 										)}
@@ -459,12 +459,12 @@
 												{/if}
 												<span
 													class="nimble-ct__action-box"
-													class:nimble-ct__action-box--bonus={hasBonus}
+													class:nimble-ct__action-box--additional={hasAdditional}
 													data-tooltip={`Available actions: ${displayCurrentActions} / ${displayMaxActions}`}
 													data-tooltip-direction="UP"
 												>
-													{displayCurrentActions}/{#if hasBonus}<span
-															class="nimble-ct__action-max--bonus">{displayMaxActions}</span
+													{displayCurrentActions}/{#if hasAdditional}<span
+															class="nimble-ct__action-max--additional">{displayMaxActions}</span
 														>{:else}{displayMaxActions}{/if}
 												</span>
 												{#if canAdjustActions}
@@ -650,7 +650,7 @@
 									{#if canShowActions}
 										{@const displayCurrentActions = Math.max(0, Math.floor(actionState.current))}
 										{@const displayMaxActions = Math.max(0, Math.floor(actionState.effectiveMax))}
-										{@const hasBonus = actionState.bonus > 0}
+										{@const hasAdditional = actionState.additional > 0}
 										{@const canAdjustActions = canCurrentUserAdjustCombatantActions(combatant)}
 										<div class="nimble-ct__pips">
 											<div
@@ -674,12 +674,12 @@
 												{/if}
 												<span
 													class="nimble-ct__action-box"
-													class:nimble-ct__action-box--bonus={hasBonus}
+													class:nimble-ct__action-box--additional={hasAdditional}
 													data-tooltip={`Available actions: ${displayCurrentActions} / ${displayMaxActions}`}
 													data-tooltip-direction="UP"
 												>
-													{displayCurrentActions}/{#if hasBonus}<span
-															class="nimble-ct__action-max--bonus">{displayMaxActions}</span
+													{displayCurrentActions}/{#if hasAdditional}<span
+															class="nimble-ct__action-max--additional">{displayMaxActions}</span
 														>{:else}{displayMaxActions}{/if}
 												</span>
 												{#if canAdjustActions}
@@ -2115,11 +2115,11 @@
 		text-shadow: var(--nimble-ct-action-text-shadow);
 		box-shadow: 0 0 0.36rem var(--nimble-ct-action-box-glow);
 	}
-	.nimble-ct__action-box--bonus {
+	.nimble-ct__action-box--additional {
 		border-color: hsl(45, 60%, 40%);
 		box-shadow: 0 0 0.36rem hsla(45, 80%, 55%, 0.3);
 	}
-	.nimble-ct__action-max--bonus {
+	.nimble-ct__action-max--additional {
 		color: hsl(45, 80%, 55%);
 	}
 	.nimble-ct__action-adjust {

--- a/src/view/ui/CtTopTracker.svelte
+++ b/src/view/ui/CtTopTracker.svelte
@@ -432,7 +432,8 @@
 									{/if}
 									{#if canShowActions}
 										{@const displayCurrentActions = Math.max(0, Math.floor(actionState.current))}
-										{@const displayMaxActions = Math.max(0, Math.floor(actionState.max))}
+										{@const displayMaxActions = Math.max(0, Math.floor(actionState.effectiveMax))}
+										{@const hasBonus = actionState.bonus > 0}
 										{@const canAdjustActions = canCurrentUserAdjustCombatantActions(
 											entry.combatant,
 										)}
@@ -458,10 +459,13 @@
 												{/if}
 												<span
 													class="nimble-ct__action-box"
+													class:nimble-ct__action-box--bonus={hasBonus}
 													data-tooltip={`Available actions: ${displayCurrentActions} / ${displayMaxActions}`}
 													data-tooltip-direction="UP"
 												>
-													{displayCurrentActions}/{displayMaxActions}
+													{displayCurrentActions}/{#if hasBonus}<span
+															class="nimble-ct__action-max--bonus">{displayMaxActions}</span
+														>{:else}{displayMaxActions}{/if}
 												</span>
 												{#if canAdjustActions}
 													<button
@@ -645,7 +649,8 @@
 									{/if}
 									{#if canShowActions}
 										{@const displayCurrentActions = Math.max(0, Math.floor(actionState.current))}
-										{@const displayMaxActions = Math.max(0, Math.floor(actionState.max))}
+										{@const displayMaxActions = Math.max(0, Math.floor(actionState.effectiveMax))}
+										{@const hasBonus = actionState.bonus > 0}
 										{@const canAdjustActions = canCurrentUserAdjustCombatantActions(combatant)}
 										<div class="nimble-ct__pips">
 											<div
@@ -669,10 +674,13 @@
 												{/if}
 												<span
 													class="nimble-ct__action-box"
+													class:nimble-ct__action-box--bonus={hasBonus}
 													data-tooltip={`Available actions: ${displayCurrentActions} / ${displayMaxActions}`}
 													data-tooltip-direction="UP"
 												>
-													{displayCurrentActions}/{displayMaxActions}
+													{displayCurrentActions}/{#if hasBonus}<span
+															class="nimble-ct__action-max--bonus">{displayMaxActions}</span
+														>{:else}{displayMaxActions}{/if}
 												</span>
 												{#if canAdjustActions}
 													<button
@@ -2106,6 +2114,13 @@
 		font-variant-numeric: tabular-nums;
 		text-shadow: var(--nimble-ct-action-text-shadow);
 		box-shadow: 0 0 0.36rem var(--nimble-ct-action-box-glow);
+	}
+	.nimble-ct__action-box--bonus {
+		border-color: hsl(45, 60%, 40%);
+		box-shadow: 0 0 0.36rem hsla(45, 80%, 55%, 0.3);
+	}
+	.nimble-ct__action-max--bonus {
+		color: hsl(45, 80%, 55%);
 	}
 	.nimble-ct__action-adjust {
 		all: unset;

--- a/src/view/ui/ctTopTracker/resources.utils.ts
+++ b/src/view/ui/ctTopTracker/resources.utils.ts
@@ -1,3 +1,4 @@
+import { getCombatantBonusActions } from '../../../documents/combat/combatantSystem.js';
 import type {
 	CombatTrackerNonPlayerHpBarTextMode,
 	CombatTrackerPlayerHpBarTextMode,
@@ -444,12 +445,17 @@ export function getCombatantOutlineClass(combatant: Combatant.Implementation): s
 export function getActionState(combatant: Combatant.Implementation): {
 	current: number;
 	max: number;
+	bonus: number;
+	effectiveMax: number;
 } {
 	const normalizedCurrent = getCombatantCurrentActions(combatant);
 	const normalizedMax = getCombatantMaxActions(combatant);
+	const bonus = getCombatantBonusActions(combatant);
 	return {
 		current: normalizedCurrent,
 		max: normalizedMax,
+		bonus,
+		effectiveMax: normalizedMax + bonus,
 	};
 }
 

--- a/src/view/ui/ctTopTracker/resources.utils.ts
+++ b/src/view/ui/ctTopTracker/resources.utils.ts
@@ -1,4 +1,4 @@
-import { getCombatantBonusActions } from '../../../documents/combat/combatantSystem.js';
+import { getCombatantAdditionalActions } from '../../../documents/combat/combatantSystem.js';
 import type {
 	CombatTrackerNonPlayerHpBarTextMode,
 	CombatTrackerPlayerHpBarTextMode,
@@ -445,17 +445,17 @@ export function getCombatantOutlineClass(combatant: Combatant.Implementation): s
 export function getActionState(combatant: Combatant.Implementation): {
 	current: number;
 	max: number;
-	bonus: number;
+	additional: number;
 	effectiveMax: number;
 } {
 	const normalizedCurrent = getCombatantCurrentActions(combatant);
 	const normalizedMax = getCombatantMaxActions(combatant);
-	const bonus = getCombatantBonusActions(combatant);
+	const additional = getCombatantAdditionalActions(combatant);
 	return {
 		current: normalizedCurrent,
 		max: normalizedMax,
-		bonus,
-		effectiveMax: normalizedMax + bonus,
+		additional,
+		effectiveMax: normalizedMax + additional,
 	};
 }
 


### PR DESCRIPTION
## Summary

Add a "+" button to the action tracker that grants temporary bonus action slots, capped at 10 total. Bonus pips render in gold to distinguish from base actions, and reset to zero when the character's turn ends.

## Changes

- Add `system.actions.base.bonus` field to `CharacterCombatantDataModel`
- Add `getCombatantBonusActions` and `getCombatantEffectiveMax` helpers
- Reset bonus to 0 on turn end in `combat.svelte.ts`
- Render bonus pips with gold styling and "+" button in `ActionTracker.svelte`
- Show effective max with golden border in `CtTopTracker.svelte`
- Localize bonus action button strings via `en.json`

## Test Plan

- [x] `pnpm check` passes
- [x] "+" adds a gold bonus pip, current increments
- [x] Spending actions grays out pips but bonus slots remain visible
- [x] Combat tracker shows golden border and golden max number
- [x] Ending turn resets bonus to 0 and pips return to base 3
- [x] Bonus persists across round boundaries
- [x] "+" button hides at 10 total pips

## Checklist

- [x] Added or updated unit tests
- [x] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [x] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** yes
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues

Closes #724