### PR TITLE
feat(level-up): grant and remove spells during subclass selection

### DIFF
--- a/packs/classFeatures/core/mage/mage-subclasses/invoker-of-flame/fiery-dedication.json
+++ b/packs/classFeatures/core/mage/mage-subclasses/invoker-of-flame/fiery-dedication.json
@@ -1,0 +1,70 @@
+{
+	"folder": "59db813ebedd1bfc",
+	"name": "Fiery Dedication",
+	"type": "feature",
+	"img": "icons/magic/fire/flame-burning-fist-strike.webp",
+	"system": {
+		"macro": "",
+		"identifier": "",
+		"rules": [
+			{
+				"id": "zrDZ3F9lsca00DYU",
+				"type": "restrictSpellSchools",
+				"allowedSchools": [
+					"fire"
+				],
+				"exceptionFromSchools": [
+					"ice",
+					"lightning"
+				],
+				"exceptionCount": 1
+			}
+		],
+		"activation": {
+			"acquireTargetsFromTemplate": false,
+			"cost": {
+				"details": "",
+				"quantity": 1,
+				"type": "none",
+				"isReaction": false
+			},
+			"duration": {
+				"details": "",
+				"quantity": 1,
+				"type": "none"
+			},
+			"effects": [],
+			"showDescription": true,
+			"targets": {
+				"count": 1,
+				"restrictions": ""
+			},
+			"template": {
+				"length": 1,
+				"radius": 1,
+				"shape": "",
+				"width": 1
+			}
+		},
+		"description": "<p>You can only cast fire spells from now on. Choose an Ice or Lightning spell and treat it as a fire spell.</p><p><strong>Embers.</strong> Whenever you cast a fire spell, gain a number of Embers equal to the Mana spent on it. Embers can be spent to power up your spells (and expire when an encounter ends):</p><ul><li><strong>Kindle Blaze.</strong> (2 Embers) Heart's Fire on an ally with fewer than 3 actions for free.</li><li><strong>Consuming Fire.</strong> (4 Embers) When you target a single Smoldering creature, damage creatures adjacent to them as well.</li><li><strong>Overheat.</strong> (6 Embers) Creatures damaged by this spell are considered Vulnerable to it.</li></ul>",
+		"featureType": "class",
+		"class": "mage",
+		"group": "invoker-of-flame",
+		"gainedAtLevel": 3,
+		"subclass": true,
+		"gainedAtLevels": [
+			3
+		]
+	},
+	"effects": [],
+	"flags": {},
+	"_stats": {
+		"coreVersion": "13.347",
+		"systemId": "nimble",
+		"systemVersion": "0.8.8",
+		"createdTime": 1761540819964,
+		"modifiedTime": 1761540819964,
+		"lastModifiedBy": "zvcmZ9cAKxekqF5X"
+	},
+	"_id": "MLQWERLDATsHh8DE"
+}

--- a/packs/classFeatures/core/mage/mage-subclasses/invoker-of-frost/crown-of-ice.json
+++ b/packs/classFeatures/core/mage/mage-subclasses/invoker-of-frost/crown-of-ice.json
@@ -1,0 +1,70 @@
+{
+	"folder": "b16e22d84ef5f116",
+	"name": "Crown of Ice",
+	"type": "feature",
+	"img": "icons/magic/water/snowflake-ice-blue-white.webp",
+	"system": {
+		"macro": "",
+		"identifier": "",
+		"rules": [
+			{
+				"id": "RIrwGETV63SGveKU",
+				"type": "restrictSpellSchools",
+				"allowedSchools": [
+					"ice"
+				],
+				"exceptionFromSchools": [
+					"fire",
+					"lightning"
+				],
+				"exceptionCount": 1
+			}
+		],
+		"activation": {
+			"acquireTargetsFromTemplate": false,
+			"cost": {
+				"details": "",
+				"quantity": 1,
+				"type": "none",
+				"isReaction": false
+			},
+			"duration": {
+				"details": "",
+				"quantity": 1,
+				"type": "none"
+			},
+			"effects": [],
+			"showDescription": true,
+			"targets": {
+				"count": 1,
+				"restrictions": ""
+			},
+			"template": {
+				"length": 1,
+				"radius": 1,
+				"shape": "",
+				"width": 1
+			}
+		},
+		"description": "<p>You can only cast Ice spells from now on. Choose 1 Fire or Lightning spell and treat it as an Ice spell.</p><p><strong>Aura of Cold.</strong> Adjacent enemies are Slowed. Your unused Frost Shield Temp HP last until the end of the encounter and can accumulate.</p>",
+		"featureType": "class",
+		"class": "mage",
+		"group": "invoker-of-frost",
+		"gainedAtLevel": 3,
+		"subclass": true,
+		"gainedAtLevels": [
+			3
+		]
+	},
+	"effects": [],
+	"flags": {},
+	"_stats": {
+		"coreVersion": "13.347",
+		"systemId": "nimble",
+		"systemVersion": "0.8.8",
+		"createdTime": 1761540819964,
+		"modifiedTime": 1761540819964,
+		"lastModifiedBy": "zvcmZ9cAKxekqF5X"
+	},
+	"_id": "evQTlTP6JuIzKzt1"
+}

--- a/packs/classFeatures/core/mage/mage-subclasses/invoker-of-surges/electrical-dedication.json
+++ b/packs/classFeatures/core/mage/mage-subclasses/invoker-of-surges/electrical-dedication.json
@@ -1,0 +1,70 @@
+{
+	"folder": "00feffbeaf0d38b2",
+	"name": "Electrical Dedication",
+	"type": "feature",
+	"img": "icons/magic/lightning/bolt-strike-blue.webp",
+	"system": {
+		"macro": "",
+		"identifier": "",
+		"rules": [
+			{
+				"id": "AsZusTagR9ydyv6V",
+				"type": "restrictSpellSchools",
+				"allowedSchools": [
+					"lightning"
+				],
+				"exceptionFromSchools": [
+					"ice",
+					"fire"
+				],
+				"exceptionCount": 1
+			}
+		],
+		"activation": {
+			"acquireTargetsFromTemplate": false,
+			"cost": {
+				"details": "",
+				"quantity": 1,
+				"type": "none",
+				"isReaction": false
+			},
+			"duration": {
+				"details": "",
+				"quantity": 1,
+				"type": "none"
+			},
+			"effects": [],
+			"showDescription": true,
+			"targets": {
+				"count": 1,
+				"restrictions": ""
+			},
+			"template": {
+				"length": 1,
+				"radius": 1,
+				"shape": "",
+				"width": 1
+			}
+		},
+		"description": "<p>You give up Spellshaper abilities and you can only cast lightning spells from now on. Choose 1 Ice or Fire spell and treat it as a Lightning spell.</p><p><strong>Power Surge.</strong> After you cast a damaging spell, you may take 4 lightning damage to add 1d8 to the damage. While Charged, if you would become Charged again, gain <em>Supercharged</em>.</p><p><strong>Supercharged Abilities.</strong> When Supercharged you may end the condition to use one of these abilities for free at any time.</p><ul><li><strong>Blur.</strong> Reduce ALL non-lightning damage you take by KEY this round.</li><li><strong>Overload.</strong> When an enemy is damaged, add 1 maximized Power Surge Die.</li><li><strong>Warp.</strong> Teleport up to 8 spaces away; you may swap places with a willing ally.</li></ul>",
+		"featureType": "class",
+		"class": "mage",
+		"group": "invoker-of-surges",
+		"gainedAtLevel": 3,
+		"subclass": true,
+		"gainedAtLevels": [
+			3
+		]
+	},
+	"effects": [],
+	"flags": {},
+	"_stats": {
+		"coreVersion": "13.347",
+		"systemId": "nimble",
+		"systemVersion": "0.8.8",
+		"createdTime": 1761540819964,
+		"modifiedTime": 1761540819964,
+		"lastModifiedBy": "zvcmZ9cAKxekqF5X"
+	},
+	"_id": "Vij67KihB4IEf4E6"
+}

--- a/packs/ids.json
+++ b/packs/ids.json
@@ -316,6 +316,15 @@
 						"nullify": "alpqbmQnF94N1KFw",
 						"steel-will": "u7UhIHOiXrAv6DEY",
 						"supreme-control": "cCqrZ6XZBRiMhwdh"
+					},
+					"invoker-of-flame": {
+						"fiery-dedication": "MLQWERLDATsHh8DE"
+					},
+					"invoker-of-frost": {
+						"crown-of-ice": "evQTlTP6JuIzKzt1"
+					},
+					"invoker-of-surges": {
+						"electrical-dedication": "Vij67KihB4IEf4E6"
 					}
 				},
 				"spellshaper": {
@@ -1214,7 +1223,10 @@
 			},
 			"mage": {
 				"invoker-of-chaos": "58r5iO7h0lyo6DfE",
-				"invoker-of-control": "z9e6kfg68COw9TM3"
+				"invoker-of-control": "z9e6kfg68COw9TM3",
+				"invoker-of-flame": "eb0XDzWIbAKuA2Di",
+				"invoker-of-frost": "bEWmxrpD4wHsSzQ8",
+				"invoker-of-surges": "eKn9R6LmAOoKqNDK"
 			},
 			"oathsworn": {
 				"oath-of-refuge": "DN0a2Kd6zthckU1n",

--- a/packs/ids.json
+++ b/packs/ids.json
@@ -348,6 +348,15 @@
 						"nullify": "alpqbmQnF94N1KFw",
 						"steel-will": "u7UhIHOiXrAv6DEY",
 						"supreme-control": "cCqrZ6XZBRiMhwdh"
+					},
+					"invoker-of-flame": {
+						"fiery-dedication": "MLQWERLDATsHh8DE"
+					},
+					"invoker-of-frost": {
+						"crown-of-ice": "evQTlTP6JuIzKzt1"
+					},
+					"invoker-of-surges": {
+						"electrical-dedication": "Vij67KihB4IEf4E6"
 					}
 				},
 				"spellshaper": {
@@ -1246,7 +1255,10 @@
 			},
 			"mage": {
 				"invoker-of-chaos": "58r5iO7h0lyo6DfE",
-				"invoker-of-control": "z9e6kfg68COw9TM3"
+				"invoker-of-control": "z9e6kfg68COw9TM3",
+				"invoker-of-flame": "eb0XDzWIbAKuA2Di",
+				"invoker-of-frost": "bEWmxrpD4wHsSzQ8",
+				"invoker-of-surges": "eKn9R6LmAOoKqNDK"
 			},
 			"oathsworn": {
 				"oath-of-refuge": "DN0a2Kd6zthckU1n",

--- a/packs/subclasses/core/mage/invoker-of-flame.json
+++ b/packs/subclasses/core/mage/invoker-of-flame.json
@@ -1,0 +1,25 @@
+{
+	"folder": "5b9d52290963bc16",
+	"name": "Invoker of Flame",
+	"type": "subclass",
+	"img": "icons/magic/fire/flame-burning-fist-strike.webp",
+	"system": {
+		"macro": "",
+		"identifier": "flame",
+		"rules": [],
+		"description": "<p><em>You dedicate yourself to the art of Pyromancy; choosing to relinquish control over the other elements so that your flames may burn brighter and hotter than any who has come before you.</em></p><p>LEVEL 3</p><p><strong>Fiery Dedication.</strong> You can only cast fire spells from now on. Choose an Ice or Lightning spell and treat it as a fire spell.</p><p><strong>Embers.</strong> Whenever you cast a fire spell, gain a number of Embers equal to the Mana spent on it. Embers can be spent to power up your spells (and expire when an encounter ends):</p><ul><li><strong>Kindle Blaze.</strong> (2 Embers) Heart's Fire on an ally with fewer than 3 actions for free.</li><li><strong>Consuming Fire.</strong> (4 Embers) When you target a single Smoldering creature, damage creatures adjacent to them as well.</li><li><strong>Overheat.</strong> (6 Embers) Creatures damaged by this spell are considered Vulnerable to it.</li></ul><p>LEVEL 7</p><p><strong>Thy Embers' Keeper.</strong> When initiative is rolled, gain WIL Embers.</p><p><strong>Flame Weaver.</strong> You may use Embers in place of Mana for Spellshaper abilities.</p><p><strong>Fireshaper.</strong> Choose 1 additional Lightning or Ice spell and treat it as a fire spell.</p><p>LEVEL 11</p><p><strong>Flash Fire.</strong> When you roll initiative choose WIL enemies to gain Smoldering.</p><p><strong>Wildfire.</strong> Choose 1 additional Lightning or Ice spell and treat it as a fire spell.</p><p>LEVEL 15</p><p><strong>The Phoenix.</strong> (1/Safe Rest) Reaction, (when you drop to 0 hp) Gain the effects of the Dragonform spell; when it ends gain 1 wound.</p><p><strong>Wildfire.</strong> Choose 1 additional Lightning or Ice spell and treat it as a fire spell.</p>",
+		"parentClass": "mage",
+		"resources": []
+	},
+	"effects": [],
+	"flags": {},
+	"_stats": {
+		"coreVersion": "13.347",
+		"systemId": "nimble",
+		"systemVersion": "0.8.8",
+		"createdTime": 1761527184804,
+		"modifiedTime": 1761527184804,
+		"lastModifiedBy": "zvcmZ9cAKxekqF5X"
+	},
+	"_id": "eb0XDzWIbAKuA2Di"
+}

--- a/packs/subclasses/core/mage/invoker-of-frost.json
+++ b/packs/subclasses/core/mage/invoker-of-frost.json
@@ -1,0 +1,25 @@
+{
+	"folder": "5b9d52290963bc16",
+	"name": "Invoker of Frost",
+	"type": "subclass",
+	"img": "icons/magic/water/snowflake-ice-blue-white.webp",
+	"system": {
+		"macro": "",
+		"identifier": "frost",
+		"rules": [],
+		"description": "<p>LEVEL 3</p><p><strong>Crown of Ice.</strong> You can only cast Ice spells from now on. Choose 1 Fire or Lightning spell and treat it as an Ice spell.</p><p><strong>Aura of Cold.</strong> Adjacent enemies are Slowed. Your unused Frost Shield Temp HP last until the end of the encounter and can accumulate.</p><p>LEVEL 7</p><p><strong>Crystalline Aegis.</strong> When your Frost Shield Temp HP is lost, cast Shatter for free on an adjacent enemy. Choose 1 additional Lightning or Fire spell and treat it as an Ice spell.</p><p>LEVEL 11</p><p><strong>Bitter Cold.</strong> Your spells ignore the armor of creatures Hampered by you. Choose 1 additional Lightning or Fire spell and treat it as an Ice spell.</p><p>LEVEL 15</p><p><strong>Deep Freeze.</strong> Reduce the mana cost of all spells by 2 while you have any Temp HP from Frost Shield. Choose 1 additional Lightning or Fire spell and treat it as an Ice spell.</p>",
+		"parentClass": "mage",
+		"resources": []
+	},
+	"effects": [],
+	"flags": {},
+	"_stats": {
+		"coreVersion": "13.347",
+		"systemId": "nimble",
+		"systemVersion": "0.8.8",
+		"createdTime": 1761527184804,
+		"modifiedTime": 1761527184804,
+		"lastModifiedBy": "zvcmZ9cAKxekqF5X"
+	},
+	"_id": "bEWmxrpD4wHsSzQ8"
+}

--- a/packs/subclasses/core/mage/invoker-of-surges.json
+++ b/packs/subclasses/core/mage/invoker-of-surges.json
@@ -1,0 +1,25 @@
+{
+	"folder": "5b9d52290963bc16",
+	"name": "Invoker of Surges",
+	"type": "subclass",
+	"img": "icons/magic/lightning/bolt-strike-blue.webp",
+	"system": {
+		"macro": "",
+		"identifier": "surges",
+		"rules": [],
+		"description": "<p><em>Dangerous. Fast.</em></p><p>LEVEL 3</p><p><strong>Electrical Dedication.</strong> You give up Spellshaper abilities and you can only cast lightning spells from now on. Choose 1 Ice or Fire spell and treat it as a Lightning spell.</p><p><strong>Power Surge.</strong> After you cast a damaging spell, you may take 4 lightning damage to add 1d8 to the damage. While Charged, if you would become Charged again, gain <em>Supercharged</em>.</p><p><strong>Supercharged Abilities.</strong> When Supercharged you may end the condition to use one of these abilities for free at any time.</p><ul><li><strong>Blur.</strong> Reduce ALL non-lightning damage you take by KEY this round.</li><li><strong>Overload.</strong> When an enemy is damaged, add 1 maximized Power Surge Die.</li><li><strong>Warp.</strong> Teleport up to 8 spaces away; you may swap places with a willing ally.</li></ul><p>LEVEL 7</p><p><strong>Jumpstart.</strong> Gain +INT Initiative. When you roll initiative, become Charged; on a result of 20+, become Supercharged instead.</p><p><strong>Power Surge (2).</strong> Your Power Surge die becomes a d12.</p><p>LEVEL 11</p><p><strong>Lingering Charge.</strong> (1/encounter) Use a Supercharged ability even if you are not Supercharged, then become Supercharged.</p><p><strong>Conduit of Power.</strong> Whenever you would move while Charged, you may teleport instead.</p><p>LEVEL 15</p><p><strong>Power Surge (3).</strong> Your Power Surge die becomes a d20.</p><p><strong>Haywire.</strong> Whenever you use Power Surge, you may take 8 damage instead to become Supercharged.</p>",
+		"parentClass": "mage",
+		"resources": []
+	},
+	"effects": [],
+	"flags": {},
+	"_stats": {
+		"coreVersion": "13.347",
+		"systemId": "nimble",
+		"systemVersion": "0.8.8",
+		"createdTime": 1761527184804,
+		"modifiedTime": 1761527184804,
+		"lastModifiedBy": "zvcmZ9cAKxekqF5X"
+	},
+	"_id": "eKn9R6LmAOoKqNDK"
+}

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -497,6 +497,7 @@
 			"spell": "Spell",
 			"featuresRemoved": "Features Removed",
 			"spellsRemoved": "Spells Removed",
+			"spellsRestored": "Spells Restored",
 			"removed": "removed",
 			"warningMessage": "This action will permanently revert the last level up. This cannot be undone.",
 			"confirmLevelDown": "Confirm Level Down",
@@ -645,6 +646,7 @@
 			"grantItem": "Item",
 			"grantProficiency": "Proficiency",
 			"grantSpells": "Spells",
+			"removeSpells": "Remove Spells",
 			"healingPotionBonus": "Healing Potion Bonus",
 			"hitDiceAdvantage": "Hit Dice Advantage",
 			"incrementHitDice": "Increment Hit Dice",
@@ -2059,7 +2061,9 @@
 			"selectSpellAriaLabel": "Select {spellName}",
 			"deselectSpellAriaLabel": "Deselect {spellName}",
 			"levelUpHeader": "Granted Spells",
-			"levelUpHint": "You gain the following spells at this level."
+			"levelUpHint": "You gain the following spells at this level.",
+			"levelUpRemovalHeader": "Spells Removed by Subclass",
+			"levelUpRemovalHint": "Your subclass removes the following spells from your spell list."
 		},
 		"classSelection": {
 			"stepSelectClass": "Step 1: Select Class",

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -498,6 +498,7 @@
 			"featuresRemoved": "Features Removed",
 			"spellsRemoved": "Spells Removed",
 			"spellsRestored": "Spells Restored",
+			"spellsReverted": "Spells Reverted to Original School",
 			"removed": "removed",
 			"warningMessage": "This action will permanently revert the last level up. This cannot be undone.",
 			"confirmLevelDown": "Confirm Level Down",
@@ -647,6 +648,7 @@
 			"grantProficiency": "Proficiency",
 			"grantSpells": "Spells",
 			"removeSpells": "Remove Spells",
+			"restrictSpellSchools": "Restrict Spell Schools",
 			"healingPotionBonus": "Healing Potion Bonus",
 			"hitDiceAdvantage": "Hit Dice Advantage",
 			"incrementHitDice": "Increment Hit Dice",
@@ -853,6 +855,18 @@
 				},
 				"mode": { "label": "Selection mode" },
 				"count": { "label": "How many to choose" }
+			},
+			"restrictSpellSchools": {
+				"description": "Restrict which spell schools the actor may cast (‘you can only cast fire spells from now on’). Removes owned automation-granted spells from other schools and stops them being auto-granted at later levels. Optionally lets the player keep one spell from a removed school and retag it to an allowed school.",
+				"allowedSchools": {
+					"label": "Allowed schools",
+					"hint": "Schools the actor may still cast. Spells from every other school are removed and no longer auto-granted."
+				},
+				"exceptionFromSchools": {
+					"label": "Keep-one from schools",
+					"hint": "Schools the player may pick one spell from to keep and retag to the first allowed school. Leave empty to allow no exception."
+				},
+				"exceptionCount": { "label": "How many to keep" }
 			},
 			"healingPotionBonus": {
 				"description": "Add a flat or formula-based bonus to healing received from potions.",
@@ -2063,7 +2077,10 @@
 			"levelUpHeader": "Granted Spells",
 			"levelUpHint": "You gain the following spells at this level.",
 			"levelUpRemovalHeader": "Spells Removed by Subclass",
-			"levelUpRemovalHint": "Your subclass removes the following spells from your spell list."
+			"levelUpRemovalHint": "Your subclass removes the following spells from your spell list.",
+			"levelUpExceptionHeader": "Keep and Convert a Spell",
+			"levelUpExceptionHint": "Your subclass lets you keep one spell from a removed school. It will be retagged to your new school.",
+			"convertedSpellLabel": "Converted to {school}"
 		},
 		"classSelection": {
 			"stepSelectClass": "Step 1: Select Class",

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -622,6 +622,7 @@
 			"spell": "Spell",
 			"featuresRemoved": "Features Removed",
 			"spellsRemoved": "Spells Removed",
+			"spellsRestored": "Spells Restored",
 			"removed": "removed",
 			"warningMessage": "This action will permanently revert the last level up. This cannot be undone.",
 			"confirmLevelDown": "Confirm Level Down",
@@ -795,6 +796,7 @@
 			"grantItem": "Item",
 			"grantProficiency": "Proficiency",
 			"grantSpells": "Spells",
+			"removeSpells": "Remove Spells",
 			"healingPotionBonus": "Healing Potion Bonus",
 			"hitDiceAdvantage": "Hit Dice Advantage",
 			"incrementHitDice": "Increment Hit Dice",
@@ -2623,7 +2625,9 @@
 			"selectSpellAriaLabel": "Select {spellName}",
 			"deselectSpellAriaLabel": "Deselect {spellName}",
 			"levelUpHeader": "Granted Spells",
-			"levelUpHint": "You gain the following spells at this level."
+			"levelUpHint": "You gain the following spells at this level.",
+			"levelUpRemovalHeader": "Spells Removed by Subclass",
+			"levelUpRemovalHint": "Your subclass removes the following spells from your spell list."
 		},
 		"classSelection": {
 			"stepSelectClass": "Step 1: Select Class",

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -623,6 +623,7 @@
 			"featuresRemoved": "Features Removed",
 			"spellsRemoved": "Spells Removed",
 			"spellsRestored": "Spells Restored",
+			"spellsReverted": "Spells Reverted to Original School",
 			"removed": "removed",
 			"warningMessage": "This action will permanently revert the last level up. This cannot be undone.",
 			"confirmLevelDown": "Confirm Level Down",
@@ -797,6 +798,7 @@
 			"grantProficiency": "Proficiency",
 			"grantSpells": "Spells",
 			"removeSpells": "Remove Spells",
+			"restrictSpellSchools": "Restrict Spell Schools",
 			"healingPotionBonus": "Healing Potion Bonus",
 			"hitDiceAdvantage": "Hit Dice Advantage",
 			"incrementHitDice": "Increment Hit Dice",
@@ -1151,6 +1153,18 @@
 				"count": {
 					"label": "How many to choose"
 				}
+			},
+			"restrictSpellSchools": {
+				"description": "Restrict which spell schools the actor may cast (‘you can only cast fire spells from now on’). Removes owned automation-granted spells from other schools and stops them being auto-granted at later levels. Optionally lets the player keep one spell from a removed school and retag it to an allowed school.",
+				"allowedSchools": {
+					"label": "Allowed schools",
+					"hint": "Schools the actor may still cast. Spells from every other school are removed and no longer auto-granted."
+				},
+				"exceptionFromSchools": {
+					"label": "Keep-one from schools",
+					"hint": "Schools the player may pick one spell from to keep and retag to the first allowed school. Leave empty to allow no exception."
+				},
+				"exceptionCount": { "label": "How many to keep" }
 			},
 			"healingPotionBonus": {
 				"description": "Add a flat or formula-based bonus to healing received from potions.",
@@ -2627,7 +2641,10 @@
 			"levelUpHeader": "Granted Spells",
 			"levelUpHint": "You gain the following spells at this level.",
 			"levelUpRemovalHeader": "Spells Removed by Subclass",
-			"levelUpRemovalHint": "Your subclass removes the following spells from your spell list."
+			"levelUpRemovalHint": "Your subclass removes the following spells from your spell list.",
+			"levelUpExceptionHeader": "Keep and Convert a Spell",
+			"levelUpExceptionHint": "Your subclass lets you keep one spell from a removed school. It will be retagged to your new school.",
+			"convertedSpellLabel": "Converted to {school}"
 		},
 		"classSelection": {
 			"stepSelectClass": "Step 1: Select Class",

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -1154,6 +1154,13 @@
 					"label": "How many to choose"
 				}
 			},
+			"removeSpells": {
+				"description": "Remove specific spells from the actor when this feature is granted. Only spells that were automation-granted (with a matching compendium source) are removed.",
+				"uuids": {
+					"label": "Specific spells",
+					"hint": "Drag spells from a compendium or sidebar onto each slot to remove them."
+				}
+			},
 			"restrictSpellSchools": {
 				"description": "Restrict which spell schools the actor may cast (‘you can only cast fire spells from now on’). Removes owned automation-granted spells from other schools and stops them being auto-granted at later levels. Optionally lets the player keep one spell from a removed school and retag it to an allowed school.",
 				"allowedSchools": {
@@ -2643,8 +2650,7 @@
 			"levelUpRemovalHeader": "Spells Removed by Subclass",
 			"levelUpRemovalHint": "Your subclass removes the following spells from your spell list.",
 			"levelUpExceptionHeader": "Keep and Convert a Spell",
-			"levelUpExceptionHint": "Your subclass lets you keep one spell from a removed school. It will be retagged to your new school.",
-			"convertedSpellLabel": "Converted to {school}"
+			"levelUpExceptionHint": "Your subclass lets you keep one spell from a removed school. It will be retagged to your new school."
 		},
 		"classSelection": {
 			"stepSelectClass": "Step 1: Select Class",

--- a/src/config/registerRulesConfig.ts
+++ b/src/config/registerRulesConfig.ts
@@ -26,6 +26,7 @@ import { MaxWoundsRule } from '../models/rules/maxWounds.js';
 import { ModifyPoolRule } from '../models/rules/modifyPool.js';
 import { ModifyToggleRule } from '../models/rules/modifyToggle.js';
 import { NoteRule } from '../models/rules/note.js';
+import { RemoveSpellsRule } from '../models/rules/removeSpells.js';
 import { SavingThrowBonusRule } from '../models/rules/savingThrowBonus.js';
 import { SavingThrowRollModeRule } from '../models/rules/savingThrowRollMode.js';
 import { SkillBonusRule } from '../models/rules/skillBonus.js';
@@ -50,6 +51,7 @@ export default function registerRulesConfig() {
 		grantItem: 'NIMBLE.ruleTypes.grantItem',
 		grantProficiency: 'NIMBLE.ruleTypes.grantProficiency',
 		grantSpells: 'NIMBLE.ruleTypes.grantSpells',
+		removeSpells: 'NIMBLE.ruleTypes.removeSpells',
 		healingPotionBonus: 'NIMBLE.ruleTypes.healingPotionBonus',
 		hitDiceAdvantage: 'NIMBLE.ruleTypes.hitDiceAdvantage',
 		incrementHitDice: 'NIMBLE.ruleTypes.incrementHitDice',
@@ -87,6 +89,7 @@ export default function registerRulesConfig() {
 		grantItem: ItemGrantRule,
 		grantProficiency: GrantProficiencyRule,
 		grantSpells: GrantSpellsRule,
+		removeSpells: RemoveSpellsRule,
 		healingPotionBonus: HealingPotionBonusRule,
 		hitDiceAdvantage: HitDiceAdvantageRule,
 		incrementHitDice: IncrementHitDiceRule,

--- a/src/config/registerRulesConfig.ts
+++ b/src/config/registerRulesConfig.ts
@@ -27,6 +27,7 @@ import { ModifyPoolRule } from '../models/rules/modifyPool.js';
 import { ModifyToggleRule } from '../models/rules/modifyToggle.js';
 import { NoteRule } from '../models/rules/note.js';
 import { RemoveSpellsRule } from '../models/rules/removeSpells.js';
+import { RestrictSpellSchoolsRule } from '../models/rules/restrictSpellSchools.js';
 import { SavingThrowBonusRule } from '../models/rules/savingThrowBonus.js';
 import { SavingThrowRollModeRule } from '../models/rules/savingThrowRollMode.js';
 import { SkillBonusRule } from '../models/rules/skillBonus.js';
@@ -52,6 +53,7 @@ export default function registerRulesConfig() {
 		grantProficiency: 'NIMBLE.ruleTypes.grantProficiency',
 		grantSpells: 'NIMBLE.ruleTypes.grantSpells',
 		removeSpells: 'NIMBLE.ruleTypes.removeSpells',
+		restrictSpellSchools: 'NIMBLE.ruleTypes.restrictSpellSchools',
 		healingPotionBonus: 'NIMBLE.ruleTypes.healingPotionBonus',
 		hitDiceAdvantage: 'NIMBLE.ruleTypes.hitDiceAdvantage',
 		incrementHitDice: 'NIMBLE.ruleTypes.incrementHitDice',
@@ -90,6 +92,7 @@ export default function registerRulesConfig() {
 		grantProficiency: GrantProficiencyRule,
 		grantSpells: GrantSpellsRule,
 		removeSpells: RemoveSpellsRule,
+		restrictSpellSchools: RestrictSpellSchoolsRule,
 		healingPotionBonus: HealingPotionBonusRule,
 		hitDiceAdvantage: HitDiceAdvantageRule,
 		incrementHitDice: IncrementHitDiceRule,

--- a/src/config/registerRulesConfig.ts
+++ b/src/config/registerRulesConfig.ts
@@ -36,6 +36,7 @@ import { ModifyToggleRule } from '../models/rules/modifyToggle.js';
 import { NoteRule } from '../models/rules/note.js';
 import { PoolGainMessageRule } from '../models/rules/poolGainMessage.js';
 import { RemoveSpellsRule } from '../models/rules/removeSpells.js';
+import { RestrictSpellSchoolsRule } from '../models/rules/restrictSpellSchools.js';
 import { SavingThrowBonusRule } from '../models/rules/savingThrowBonus.js';
 import { SavingThrowRollModeRule } from '../models/rules/savingThrowRollMode.js';
 import { SituationalRollModeRule } from '../models/rules/situationalRollMode.js';
@@ -68,6 +69,7 @@ export default function registerRulesConfig() {
 		grantProficiency: 'NIMBLE.ruleTypes.grantProficiency',
 		grantSpells: 'NIMBLE.ruleTypes.grantSpells',
 		removeSpells: 'NIMBLE.ruleTypes.removeSpells',
+		restrictSpellSchools: 'NIMBLE.ruleTypes.restrictSpellSchools',
 		healingPotionBonus: 'NIMBLE.ruleTypes.healingPotionBonus',
 		hitDiceAdvantage: 'NIMBLE.ruleTypes.hitDiceAdvantage',
 		incrementHitDice: 'NIMBLE.ruleTypes.incrementHitDice',
@@ -117,6 +119,7 @@ export default function registerRulesConfig() {
 		grantProficiency: GrantProficiencyRule,
 		grantSpells: GrantSpellsRule,
 		removeSpells: RemoveSpellsRule,
+		restrictSpellSchools: RestrictSpellSchoolsRule,
 		healingPotionBonus: HealingPotionBonusRule,
 		hitDiceAdvantage: HitDiceAdvantageRule,
 		incrementHitDice: IncrementHitDiceRule,

--- a/src/config/registerRulesConfig.ts
+++ b/src/config/registerRulesConfig.ts
@@ -35,6 +35,7 @@ import { ModifyPoolRule } from '../models/rules/modifyPool.js';
 import { ModifyToggleRule } from '../models/rules/modifyToggle.js';
 import { NoteRule } from '../models/rules/note.js';
 import { PoolGainMessageRule } from '../models/rules/poolGainMessage.js';
+import { RemoveSpellsRule } from '../models/rules/removeSpells.js';
 import { SavingThrowBonusRule } from '../models/rules/savingThrowBonus.js';
 import { SavingThrowRollModeRule } from '../models/rules/savingThrowRollMode.js';
 import { SituationalRollModeRule } from '../models/rules/situationalRollMode.js';
@@ -66,6 +67,7 @@ export default function registerRulesConfig() {
 		grantItem: 'NIMBLE.ruleTypes.grantItem',
 		grantProficiency: 'NIMBLE.ruleTypes.grantProficiency',
 		grantSpells: 'NIMBLE.ruleTypes.grantSpells',
+		removeSpells: 'NIMBLE.ruleTypes.removeSpells',
 		healingPotionBonus: 'NIMBLE.ruleTypes.healingPotionBonus',
 		hitDiceAdvantage: 'NIMBLE.ruleTypes.hitDiceAdvantage',
 		incrementHitDice: 'NIMBLE.ruleTypes.incrementHitDice',
@@ -114,6 +116,7 @@ export default function registerRulesConfig() {
 		grantItem: ItemGrantRule,
 		grantProficiency: GrantProficiencyRule,
 		grantSpells: GrantSpellsRule,
+		removeSpells: RemoveSpellsRule,
 		healingPotionBonus: HealingPotionBonusRule,
 		hitDiceAdvantage: HitDiceAdvantageRule,
 		incrementHitDice: IncrementHitDiceRule,

--- a/src/documents/actor/character.ts
+++ b/src/documents/actor/character.ts
@@ -86,6 +86,7 @@ interface LevelUpDialogData {
 		poolMaxBonuses?: Record<string, number>;
 	};
 	spellUuids: string[];
+	removedSpellUuids?: string[];
 }
 
 export class NimbleCharacter extends NimbleBaseActor<'character'> {
@@ -1366,6 +1367,39 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 		const classFeatureIds = await this.grantLevelUpFeatures(typedDialogData.classFeatures);
 
 		const grantedFeatureIds = [...epicBoonIds, ...classFeatureIds];
+		// Remove spells declared by removeSpells rules on granted features.
+		// Removal happens before grants so that a replacement scenario (remove X, grant X)
+		// does not accidentally delete the newly-granted copy.
+		const removedSpells: Array<{ uuid: string; name: string; img: string }> = [];
+		const removedSpellUuids = typedDialogData.removedSpellUuids ?? [];
+
+		if (removedSpellUuids.length > 0) {
+			const spellsToDelete = this.items.filter((item) => {
+				if (item.type !== 'spell') return false;
+				const source = (item as unknown as { _stats?: { compendiumSource?: string } })._stats
+					?.compendiumSource;
+				return !!source && removedSpellUuids.includes(source);
+			});
+
+			if (spellsToDelete.length > 0) {
+				for (const spell of spellsToDelete) {
+					removedSpells.push({
+						uuid: (spell as unknown as { _stats: { compendiumSource: string } })._stats
+							.compendiumSource,
+						name: spell.name ?? '',
+						img: spell.img ?? 'icons/svg/item-bag.svg',
+					});
+				}
+
+				const idsToDelete = spellsToDelete
+					.map((s) => s.id)
+					.filter((id): id is string => id !== null);
+
+				if (idsToDelete.length > 0) {
+					await this.deleteEmbeddedDocuments('Item', idsToDelete);
+				}
+			}
+		}
 
 		// Create spell documents
 		let grantedSpellIds: string[] = [];
@@ -1406,6 +1440,7 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 			grantedFeatureIds,
 			grantedSpellIds,
 			poolMaxBonuses: typedDialogData.classFeatures?.poolMaxBonuses ?? {},
+			removedSpells,
 		};
 
 		actorUpdates['system.levelUpHistory'] = [...this.system.levelUpHistory, historyEntry];
@@ -1673,6 +1708,27 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 			const validSpellIds = lastHistory.grantedSpellIds.filter((id) => this.items.get(id));
 			if (validSpellIds.length > 0) {
 				await this.deleteEmbeddedDocuments('Item', validSpellIds);
+			}
+		}
+
+		// Restore spells that were removed during subclass selection
+		const removedSpells = lastHistory.removedSpells;
+
+		if (removedSpells && removedSpells.length > 0) {
+			const spellDocumentSources: Item.CreateData[] = [];
+
+			for (const removedSpell of removedSpells) {
+				const spell = await fromUuid(removedSpell.uuid as `Item.${string}`);
+				if (spell) {
+					const source = (spell as Item).toObject();
+					(source as { _stats: { compendiumSource?: string } })._stats.compendiumSource =
+						removedSpell.uuid;
+					spellDocumentSources.push(source as object as Item.CreateData);
+				}
+			}
+
+			if (spellDocumentSources.length > 0) {
+				await this.createEmbeddedDocuments('Item', spellDocumentSources);
 			}
 		}
 

--- a/src/documents/actor/character.ts
+++ b/src/documents/actor/character.ts
@@ -8,6 +8,7 @@ import { SYSTEM_ID, systemHookName } from '#system';
 import type { SkillKeyType } from '#types/skillKey.js';
 import { getHighestSpellTier } from '#utils/spell/getHighestSpellTier.ts';
 import CharacterMetaConfigDialog from '#view/dialogs/CharacterMetaConfigDialog.svelte';
+import { retagEffectsDamageType, SCHOOL_TO_DAMAGE_TYPE } from '#view/dialogs/spellGrantUtils.ts';
 import getDeterministicBonus from '../../dice/getDeterministicBonus.ts';
 import { NimbleRoll } from '../../dice/NimbleRoll.js';
 import { HitDiceManager, incrementDieSize } from '../../managers/HitDiceManager.js';
@@ -87,6 +88,8 @@ interface LevelUpDialogData {
 	};
 	spellUuids: string[];
 	removedSpellUuids?: string[];
+	/** Owned spells to keep and retag to a new school (restrictSpellSchools exception). */
+	convertedSpells?: Array<{ uuid: string; toSchool: string; toDamageType: string | null }>;
 }
 
 export class NimbleCharacter extends NimbleBaseActor<'character'> {
@@ -1367,6 +1370,55 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 		const classFeatureIds = await this.grantLevelUpFeatures(typedDialogData.classFeatures);
 
 		const grantedFeatureIds = [...epicBoonIds, ...classFeatureIds];
+
+		// Retag "keep and convert" exception spells (restrictSpellSchools) to their
+		// new school before removal, so the survivor now reads as an allowed-school
+		// spell and won't be swept. The original school/effects are recorded for a
+		// clean level-down restore.
+		const convertedSpells: Array<{ uuid: string; fromSchool: string; toSchool: string }> = [];
+		const conversionInputs = typedDialogData.convertedSpells ?? [];
+
+		if (conversionInputs.length > 0) {
+			const spellUpdates: Array<Record<string, unknown>> = [];
+			for (const conversion of conversionInputs) {
+				const spell = this.items.find((item) => {
+					if (item.type !== 'spell') return false;
+					const source = (item as unknown as { _stats?: { compendiumSource?: string } })._stats
+						?.compendiumSource;
+					return source === conversion.uuid;
+				});
+				if (!spell) continue;
+
+				const system = (
+					spell as unknown as {
+						system?: { school?: string; activation?: { effects?: unknown[] } };
+					}
+				).system;
+				const fromSchool = system?.school ?? '';
+
+				const update: Record<string, unknown> = {
+					_id: spell.id,
+					'system.school': conversion.toSchool,
+				};
+				if (conversion.toDamageType) {
+					update['system.activation.effects'] = retagEffectsDamageType(
+						system?.activation?.effects,
+						conversion.toDamageType,
+					);
+				}
+				spellUpdates.push(update);
+				convertedSpells.push({
+					uuid: conversion.uuid,
+					fromSchool,
+					toSchool: conversion.toSchool,
+				});
+			}
+
+			if (spellUpdates.length > 0) {
+				await this.updateEmbeddedDocuments('Item', spellUpdates);
+			}
+		}
+
 		// Remove spells declared by removeSpells rules on granted features.
 		// Removal happens before grants so that a replacement scenario (remove X, grant X)
 		// does not accidentally delete the newly-granted copy.
@@ -1441,6 +1493,7 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 			grantedSpellIds,
 			poolMaxBonuses: typedDialogData.classFeatures?.poolMaxBonuses ?? {},
 			removedSpells,
+			convertedSpells,
 		};
 
 		actorUpdates['system.levelUpHistory'] = [...this.system.levelUpHistory, historyEntry];
@@ -1729,6 +1782,42 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 
 			if (spellDocumentSources.length > 0) {
 				await this.createEmbeddedDocuments('Item', spellDocumentSources);
+			}
+		}
+
+		// Revert spells retagged by a restrictSpellSchools exception this level,
+		// restoring their original school and elemental damage type.
+		const convertedSpells = lastHistory.convertedSpells;
+
+		if (convertedSpells && convertedSpells.length > 0) {
+			const spellUpdates: Array<Record<string, unknown>> = [];
+			for (const converted of convertedSpells) {
+				const spell = this.items.find((item) => {
+					if (item.type !== 'spell') return false;
+					const source = (item as unknown as { _stats?: { compendiumSource?: string } })._stats
+						?.compendiumSource;
+					return source === converted.uuid;
+				});
+				if (!spell) continue;
+
+				const system = (spell as unknown as { system?: { activation?: { effects?: unknown[] } } })
+					.system;
+				const update: Record<string, unknown> = {
+					_id: spell.id,
+					'system.school': converted.fromSchool,
+				};
+				const fromDamageType = SCHOOL_TO_DAMAGE_TYPE[converted.fromSchool];
+				if (fromDamageType) {
+					update['system.activation.effects'] = retagEffectsDamageType(
+						system?.activation?.effects,
+						fromDamageType,
+					);
+				}
+				spellUpdates.push(update);
+			}
+
+			if (spellUpdates.length > 0) {
+				await this.updateEmbeddedDocuments('Item', spellUpdates);
 			}
 		}
 

--- a/src/documents/actor/character.ts
+++ b/src/documents/actor/character.ts
@@ -107,6 +107,7 @@ interface LevelUpDialogData {
 		poolMaxBonuses?: Record<string, number>;
 	};
 	spellUuids: string[];
+	removedSpellUuids?: string[];
 }
 
 export class NimbleCharacter extends NimbleBaseActor<'character'> {
@@ -1562,6 +1563,39 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 		const classFeatureIds = await this.grantLevelUpFeatures(typedDialogData.classFeatures);
 
 		const grantedFeatureIds = [...epicBoonIds, ...classFeatureIds];
+		// Remove spells declared by removeSpells rules on granted features.
+		// Removal happens before grants so that a replacement scenario (remove X, grant X)
+		// does not accidentally delete the newly-granted copy.
+		const removedSpells: Array<{ uuid: string; name: string; img: string }> = [];
+		const removedSpellUuids = typedDialogData.removedSpellUuids ?? [];
+
+		if (removedSpellUuids.length > 0) {
+			const spellsToDelete = this.items.filter((item) => {
+				if (item.type !== 'spell') return false;
+				const source = (item as unknown as { _stats?: { compendiumSource?: string } })._stats
+					?.compendiumSource;
+				return !!source && removedSpellUuids.includes(source);
+			});
+
+			if (spellsToDelete.length > 0) {
+				for (const spell of spellsToDelete) {
+					removedSpells.push({
+						uuid: (spell as unknown as { _stats: { compendiumSource: string } })._stats
+							.compendiumSource,
+						name: spell.name ?? '',
+						img: spell.img ?? 'icons/svg/item-bag.svg',
+					});
+				}
+
+				const idsToDelete = spellsToDelete
+					.map((s) => s.id)
+					.filter((id): id is string => id !== null);
+
+				if (idsToDelete.length > 0) {
+					await this.deleteEmbeddedDocuments('Item', idsToDelete);
+				}
+			}
+		}
 
 		// Create spell documents
 		let grantedSpellIds: string[] = [];
@@ -1602,6 +1636,7 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 			grantedFeatureIds,
 			grantedSpellIds,
 			poolMaxBonuses: typedDialogData.classFeatures?.poolMaxBonuses ?? {},
+			removedSpells,
 		};
 
 		actorUpdates['system.levelUpHistory'] = [...this.system.levelUpHistory, historyEntry];
@@ -1869,6 +1904,27 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 			const validSpellIds = lastHistory.grantedSpellIds.filter((id) => this.items.get(id));
 			if (validSpellIds.length > 0) {
 				await this.deleteEmbeddedDocuments('Item', validSpellIds);
+			}
+		}
+
+		// Restore spells that were removed during subclass selection
+		const removedSpells = lastHistory.removedSpells;
+
+		if (removedSpells && removedSpells.length > 0) {
+			const spellDocumentSources: Item.CreateData[] = [];
+
+			for (const removedSpell of removedSpells) {
+				const spell = await fromUuid(removedSpell.uuid as `Item.${string}`);
+				if (spell) {
+					const source = (spell as Item).toObject();
+					(source as { _stats: { compendiumSource?: string } })._stats.compendiumSource =
+						removedSpell.uuid;
+					spellDocumentSources.push(source as object as Item.CreateData);
+				}
+			}
+
+			if (spellDocumentSources.length > 0) {
+				await this.createEmbeddedDocuments('Item', spellDocumentSources);
 			}
 		}
 

--- a/src/documents/actor/character.ts
+++ b/src/documents/actor/character.ts
@@ -17,8 +17,8 @@ import findMissingLevelSelections, {
 } from '#utils/findMissingLevelSelections.ts';
 import { buildClassFeatureIndex } from '#utils/getClassFeatures.ts';
 import { getHighestSpellTier } from '#utils/spell/getHighestSpellTier.ts';
+import { retagEffectsDamageType, SCHOOL_TO_DAMAGE_TYPE } from '#utils/spell/spellDamageType.ts';
 import CharacterMetaConfigDialog from '#view/dialogs/CharacterMetaConfigDialog.svelte';
-import { retagEffectsDamageType, SCHOOL_TO_DAMAGE_TYPE } from '#view/dialogs/spellGrantUtils.ts';
 import getDeterministicBonus from '../../dice/getDeterministicBonus.ts';
 import { NimbleRoll } from '../../dice/NimbleRoll.js';
 import { HitDiceManager, incrementDieSize } from '../../managers/HitDiceManager.js';

--- a/src/documents/actor/character.ts
+++ b/src/documents/actor/character.ts
@@ -18,6 +18,7 @@ import findMissingLevelSelections, {
 import { buildClassFeatureIndex } from '#utils/getClassFeatures.ts';
 import { getHighestSpellTier } from '#utils/spell/getHighestSpellTier.ts';
 import CharacterMetaConfigDialog from '#view/dialogs/CharacterMetaConfigDialog.svelte';
+import { retagEffectsDamageType, SCHOOL_TO_DAMAGE_TYPE } from '#view/dialogs/spellGrantUtils.ts';
 import getDeterministicBonus from '../../dice/getDeterministicBonus.ts';
 import { NimbleRoll } from '../../dice/NimbleRoll.js';
 import { HitDiceManager, incrementDieSize } from '../../managers/HitDiceManager.js';
@@ -108,6 +109,8 @@ interface LevelUpDialogData {
 	};
 	spellUuids: string[];
 	removedSpellUuids?: string[];
+	/** Owned spells to keep and retag to a new school (restrictSpellSchools exception). */
+	convertedSpells?: Array<{ uuid: string; toSchool: string; toDamageType: string | null }>;
 }
 
 export class NimbleCharacter extends NimbleBaseActor<'character'> {
@@ -1563,6 +1566,55 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 		const classFeatureIds = await this.grantLevelUpFeatures(typedDialogData.classFeatures);
 
 		const grantedFeatureIds = [...epicBoonIds, ...classFeatureIds];
+
+		// Retag "keep and convert" exception spells (restrictSpellSchools) to their
+		// new school before removal, so the survivor now reads as an allowed-school
+		// spell and won't be swept. The original school/effects are recorded for a
+		// clean level-down restore.
+		const convertedSpells: Array<{ uuid: string; fromSchool: string; toSchool: string }> = [];
+		const conversionInputs = typedDialogData.convertedSpells ?? [];
+
+		if (conversionInputs.length > 0) {
+			const spellUpdates: Array<Record<string, unknown>> = [];
+			for (const conversion of conversionInputs) {
+				const spell = this.items.find((item) => {
+					if (item.type !== 'spell') return false;
+					const source = (item as unknown as { _stats?: { compendiumSource?: string } })._stats
+						?.compendiumSource;
+					return source === conversion.uuid;
+				});
+				if (!spell) continue;
+
+				const system = (
+					spell as unknown as {
+						system?: { school?: string; activation?: { effects?: unknown[] } };
+					}
+				).system;
+				const fromSchool = system?.school ?? '';
+
+				const update: Record<string, unknown> = {
+					_id: spell.id,
+					'system.school': conversion.toSchool,
+				};
+				if (conversion.toDamageType) {
+					update['system.activation.effects'] = retagEffectsDamageType(
+						system?.activation?.effects,
+						conversion.toDamageType,
+					);
+				}
+				spellUpdates.push(update);
+				convertedSpells.push({
+					uuid: conversion.uuid,
+					fromSchool,
+					toSchool: conversion.toSchool,
+				});
+			}
+
+			if (spellUpdates.length > 0) {
+				await this.updateEmbeddedDocuments('Item', spellUpdates);
+			}
+		}
+
 		// Remove spells declared by removeSpells rules on granted features.
 		// Removal happens before grants so that a replacement scenario (remove X, grant X)
 		// does not accidentally delete the newly-granted copy.
@@ -1637,6 +1689,7 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 			grantedSpellIds,
 			poolMaxBonuses: typedDialogData.classFeatures?.poolMaxBonuses ?? {},
 			removedSpells,
+			convertedSpells,
 		};
 
 		actorUpdates['system.levelUpHistory'] = [...this.system.levelUpHistory, historyEntry];
@@ -1925,6 +1978,42 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 
 			if (spellDocumentSources.length > 0) {
 				await this.createEmbeddedDocuments('Item', spellDocumentSources);
+			}
+		}
+
+		// Revert spells retagged by a restrictSpellSchools exception this level,
+		// restoring their original school and elemental damage type.
+		const convertedSpells = lastHistory.convertedSpells;
+
+		if (convertedSpells && convertedSpells.length > 0) {
+			const spellUpdates: Array<Record<string, unknown>> = [];
+			for (const converted of convertedSpells) {
+				const spell = this.items.find((item) => {
+					if (item.type !== 'spell') return false;
+					const source = (item as unknown as { _stats?: { compendiumSource?: string } })._stats
+						?.compendiumSource;
+					return source === converted.uuid;
+				});
+				if (!spell) continue;
+
+				const system = (spell as unknown as { system?: { activation?: { effects?: unknown[] } } })
+					.system;
+				const update: Record<string, unknown> = {
+					_id: spell.id,
+					'system.school': converted.fromSchool,
+				};
+				const fromDamageType = SCHOOL_TO_DAMAGE_TYPE[converted.fromSchool];
+				if (fromDamageType) {
+					update['system.activation.effects'] = retagEffectsDamageType(
+						system?.activation?.effects,
+						fromDamageType,
+					);
+				}
+				spellUpdates.push(update);
+			}
+
+			if (spellUpdates.length > 0) {
+				await this.updateEmbeddedDocuments('Item', spellUpdates);
 			}
 		}
 

--- a/src/models/actor/CharacterDataModel.ts
+++ b/src/models/actor/CharacterDataModel.ts
@@ -416,6 +416,16 @@ const characterSchema = () => ({
 				}),
 				{ required: true, nullable: false, initial: () => [] },
 			),
+			// Spells retagged to a new school by a restrictSpellSchools exception, so a
+			// level-down can restore their original school and elemental damage type.
+			convertedSpells: new fields.ArrayField(
+				new fields.SchemaField({
+					uuid: new fields.StringField({ required: true, nullable: false, initial: '' }),
+					fromSchool: new fields.StringField({ required: true, nullable: false, initial: '' }),
+					toSchool: new fields.StringField({ required: true, nullable: false, initial: '' }),
+				}),
+				{ required: true, nullable: false, initial: () => [] },
+			),
 		}),
 		{ required: true, nullable: false, initial: () => [] },
 	),
@@ -518,6 +528,8 @@ interface LevelUpHistoryEntry {
 	/** Pool max bonuses chosen at this level (e.g. { 'combat-dice': 1 }). */
 	poolMaxBonuses: Record<string, number>;
 	removedSpells: Array<{ uuid: string; name: string; img: string }>;
+	/** Spells retagged to a new school this level (for restoring on level-down). */
+	convertedSpells: Array<{ uuid: string; fromSchool: string; toSchool: string }>;
 }
 
 declare namespace NimbleCharacterData {

--- a/src/models/actor/CharacterDataModel.ts
+++ b/src/models/actor/CharacterDataModel.ts
@@ -408,6 +408,14 @@ const characterSchema = () => ({
 				new fields.NumberField({ required: true, initial: 0, integer: true, nullable: false }),
 				{ required: true, nullable: false, initial: () => ({}) },
 			),
+			removedSpells: new fields.ArrayField(
+				new fields.SchemaField({
+					uuid: new fields.StringField({ required: true, nullable: false, initial: '' }),
+					name: new fields.StringField({ required: true, nullable: false, initial: '' }),
+					img: new fields.StringField({ required: true, nullable: false, initial: '' }),
+				}),
+				{ required: true, nullable: false, initial: () => [] },
+			),
 		}),
 		{ required: true, nullable: false, initial: () => [] },
 	),
@@ -509,6 +517,7 @@ interface LevelUpHistoryEntry {
 	grantedSpellIds: string[];
 	/** Pool max bonuses chosen at this level (e.g. { 'combat-dice': 1 }). */
 	poolMaxBonuses: Record<string, number>;
+	removedSpells: Array<{ uuid: string; name: string; img: string }>;
 }
 
 declare namespace NimbleCharacterData {

--- a/src/models/actor/CharacterDataModel.ts
+++ b/src/models/actor/CharacterDataModel.ts
@@ -422,6 +422,14 @@ const characterSchema = () => ({
 				new fields.NumberField({ required: true, initial: 0, integer: true, nullable: false }),
 				{ required: true, nullable: false, initial: () => ({}) },
 			),
+			removedSpells: new fields.ArrayField(
+				new fields.SchemaField({
+					uuid: new fields.StringField({ required: true, nullable: false, initial: '' }),
+					name: new fields.StringField({ required: true, nullable: false, initial: '' }),
+					img: new fields.StringField({ required: true, nullable: false, initial: '' }),
+				}),
+				{ required: true, nullable: false, initial: () => [] },
+			),
 		}),
 		{ required: true, nullable: false, initial: () => [] },
 	),
@@ -523,6 +531,7 @@ interface LevelUpHistoryEntry {
 	grantedSpellIds: string[];
 	/** Pool max bonuses chosen at this level (e.g. { 'combat-dice': 1 }). */
 	poolMaxBonuses: Record<string, number>;
+	removedSpells: Array<{ uuid: string; name: string; img: string }>;
 }
 
 declare namespace NimbleCharacterData {

--- a/src/models/actor/CharacterDataModel.ts
+++ b/src/models/actor/CharacterDataModel.ts
@@ -430,6 +430,16 @@ const characterSchema = () => ({
 				}),
 				{ required: true, nullable: false, initial: () => [] },
 			),
+			// Spells retagged to a new school by a restrictSpellSchools exception, so a
+			// level-down can restore their original school and elemental damage type.
+			convertedSpells: new fields.ArrayField(
+				new fields.SchemaField({
+					uuid: new fields.StringField({ required: true, nullable: false, initial: '' }),
+					fromSchool: new fields.StringField({ required: true, nullable: false, initial: '' }),
+					toSchool: new fields.StringField({ required: true, nullable: false, initial: '' }),
+				}),
+				{ required: true, nullable: false, initial: () => [] },
+			),
 		}),
 		{ required: true, nullable: false, initial: () => [] },
 	),
@@ -532,6 +542,8 @@ interface LevelUpHistoryEntry {
 	/** Pool max bonuses chosen at this level (e.g. { 'combat-dice': 1 }). */
 	poolMaxBonuses: Record<string, number>;
 	removedSpells: Array<{ uuid: string; name: string; img: string }>;
+	/** Spells retagged to a new school this level (for restoring on level-down). */
+	convertedSpells: Array<{ uuid: string; fromSchool: string; toSchool: string }>;
 }
 
 declare namespace NimbleCharacterData {

--- a/src/models/rules/removeSpells.test.ts
+++ b/src/models/rules/removeSpells.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { RemoveSpellsRule } from './removeSpells.js';
+
+describe('RemoveSpellsRule', () => {
+	describe('schema', () => {
+		it('defines the expected fields', () => {
+			const schema = RemoveSpellsRule.defineSchema();
+			expect(schema).toHaveProperty('type');
+			expect(schema).toHaveProperty('uuids');
+		});
+
+		it('defaults type to removeSpells', () => {
+			const schema = RemoveSpellsRule.defineSchema();
+			const type = schema.type as unknown as { initial: string };
+			expect(type.initial).toBe('removeSpells');
+		});
+
+		it('defaults uuids to an empty array', () => {
+			const schema = RemoveSpellsRule.defineSchema();
+			const uuids = schema.uuids as unknown as { initial: string[] };
+			expect(uuids.initial).toEqual([]);
+		});
+	});
+
+	describe('class metadata', () => {
+		it('exposes the picker group and i18n description key', () => {
+			expect(RemoveSpellsRule.group).toBe('grants');
+			expect(RemoveSpellsRule.description).toBe('NIMBLE.rules.removeSpells.description');
+		});
+	});
+});

--- a/src/models/rules/removeSpells.ts
+++ b/src/models/rules/removeSpells.ts
@@ -1,0 +1,40 @@
+import { NimbleBaseRule } from './base.js';
+
+function schema() {
+	const { fields } = foundry.data;
+
+	return {
+		type: new fields.StringField({ required: true, nullable: false, initial: 'removeSpells' }),
+		uuids: new fields.ArrayField(new fields.StringField(), {
+			required: false,
+			nullable: false,
+			initial: [],
+		}),
+	};
+}
+
+declare namespace RemoveSpellsRule {
+	type Schema = NimbleBaseRule.Schema & ReturnType<typeof schema>;
+}
+
+/**
+ * Rule that removes specific spells from the actor when the feature is granted.
+ * Only removes spells that were automation-granted (have a matching compendiumSource).
+ * Processed by the level-up flow, not during actor data preparation.
+ */
+class RemoveSpellsRule extends NimbleBaseRule<RemoveSpellsRule.Schema> {
+	declare uuids: string[];
+
+	static override defineSchema(): RemoveSpellsRule.Schema {
+		return {
+			...NimbleBaseRule.defineSchema(),
+			...schema(),
+		};
+	}
+
+	override tooltipInfo(): string {
+		return super.tooltipInfo(new Map([['uuids', 'string[]']]));
+	}
+}
+
+export { RemoveSpellsRule };

--- a/src/models/rules/removeSpells.ts
+++ b/src/models/rules/removeSpells.ts
@@ -1,3 +1,4 @@
+import { withWidget } from './_widgetOption.js';
 import { NimbleBaseRule } from './base.js';
 
 function schema() {
@@ -5,11 +6,24 @@ function schema() {
 
 	return {
 		type: new fields.StringField({ required: true, nullable: false, initial: 'removeSpells' }),
-		uuids: new fields.ArrayField(new fields.StringField(), {
-			required: false,
-			nullable: false,
-			initial: [],
-		}),
+		uuids: new fields.ArrayField(
+			new fields.StringField(
+				withWidget({
+					required: false,
+					nullable: false,
+					initial: '',
+					widget: 'documentUuid',
+					documentTypes: ['Item.spell'],
+				}),
+			),
+			{
+				required: false,
+				nullable: false,
+				initial: [],
+				label: 'NIMBLE.rules.removeSpells.uuids.label',
+				hint: 'NIMBLE.rules.removeSpells.uuids.hint',
+			},
+		),
 	};
 }
 
@@ -23,6 +37,10 @@ declare namespace RemoveSpellsRule {
  * Processed by the level-up flow, not during actor data preparation.
  */
 class RemoveSpellsRule extends NimbleBaseRule<RemoveSpellsRule.Schema> {
+	static override group = 'grants';
+
+	static override description = 'NIMBLE.rules.removeSpells.description';
+
 	declare uuids: string[];
 
 	static override defineSchema(): RemoveSpellsRule.Schema {

--- a/src/models/rules/restrictSpellSchools.test.ts
+++ b/src/models/rules/restrictSpellSchools.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { RestrictSpellSchoolsRule } from './restrictSpellSchools.js';
+
+describe('RestrictSpellSchoolsRule', () => {
+	describe('schema', () => {
+		it('defines the expected fields', () => {
+			const schema = RestrictSpellSchoolsRule.defineSchema();
+			expect(schema).toHaveProperty('type');
+			expect(schema).toHaveProperty('allowedSchools');
+			expect(schema).toHaveProperty('exceptionFromSchools');
+			expect(schema).toHaveProperty('exceptionCount');
+		});
+
+		it('defaults type to restrictSpellSchools', () => {
+			const schema = RestrictSpellSchoolsRule.defineSchema();
+			const type = schema.type as unknown as { initial: string };
+			expect(type.initial).toBe('restrictSpellSchools');
+		});
+
+		it('declares spell-school choices on the school arrays', () => {
+			const schema = RestrictSpellSchoolsRule.defineSchema();
+			const allowed = schema.allowedSchools as unknown as {
+				element: { choices: () => string[] };
+			};
+			const choices = allowed.element.choices();
+			expect(choices).toContain('fire');
+		});
+
+		it('defaults exceptionCount to 1', () => {
+			const schema = RestrictSpellSchoolsRule.defineSchema();
+			const count = schema.exceptionCount as unknown as { initial: number };
+			expect(count.initial).toBe(1);
+		});
+	});
+
+	describe('class metadata', () => {
+		it('exposes the picker group and i18n description key', () => {
+			expect(RestrictSpellSchoolsRule.group).toBe('grants');
+			expect(RestrictSpellSchoolsRule.description).toBe(
+				'NIMBLE.rules.restrictSpellSchools.description',
+			);
+		});
+	});
+});

--- a/src/models/rules/restrictSpellSchools.ts
+++ b/src/models/rules/restrictSpellSchools.ts
@@ -1,0 +1,96 @@
+import { NimbleBaseRule } from './base.js';
+
+function schema() {
+	const { fields } = foundry.data;
+
+	return {
+		type: new fields.StringField({
+			required: true,
+			nullable: false,
+			initial: 'restrictSpellSchools',
+		}),
+		// Schools the actor may still cast from once this rule applies. Spells from
+		// any other school are removed on application and never auto-granted again.
+		allowedSchools: new fields.ArrayField(
+			new fields.StringField({
+				choices: () => Object.keys(CONFIG.NIMBLE.spellSchools),
+			}),
+			{
+				required: false,
+				nullable: false,
+				initial: [],
+				label: 'NIMBLE.rules.restrictSpellSchools.allowedSchools.label',
+				hint: 'NIMBLE.rules.restrictSpellSchools.allowedSchools.hint',
+			},
+		),
+		// Schools the player may pick a "keep and convert" exception spell from
+		// (e.g. Ice or Lightning for the Invoker of Flame). The chosen spell is
+		// retained and retagged to the first allowed school. Empty = no exception.
+		exceptionFromSchools: new fields.ArrayField(
+			new fields.StringField({
+				choices: () => Object.keys(CONFIG.NIMBLE.spellSchools),
+			}),
+			{
+				required: false,
+				nullable: false,
+				initial: [],
+				label: 'NIMBLE.rules.restrictSpellSchools.exceptionFromSchools.label',
+				hint: 'NIMBLE.rules.restrictSpellSchools.exceptionFromSchools.hint',
+			},
+		),
+		// How many exception spells the player may keep and convert.
+		exceptionCount: new fields.NumberField({
+			required: false,
+			nullable: false,
+			initial: 1,
+			integer: true,
+			min: 0,
+			label: 'NIMBLE.rules.restrictSpellSchools.exceptionCount.label',
+		}),
+	};
+}
+
+declare namespace RestrictSpellSchoolsRule {
+	type Schema = NimbleBaseRule.Schema & ReturnType<typeof schema>;
+}
+
+/**
+ * Rule that restricts which spell schools an actor may cast from ("you can only
+ * cast fire spells from now on"). Processed by the level-up flow, not during
+ * actor data preparation.
+ *
+ * On application it removes owned automation-granted spells from disallowed
+ * schools (except a player-chosen exception, which is retained and retagged to
+ * an allowed school). Because the level-up flow re-reads active restrictions on
+ * every level, disallowed schools are also filtered out of future auto-grants.
+ */
+class RestrictSpellSchoolsRule extends NimbleBaseRule<RestrictSpellSchoolsRule.Schema> {
+	static override group = 'grants';
+
+	static override description = 'NIMBLE.rules.restrictSpellSchools.description';
+
+	declare allowedSchools: string[];
+
+	declare exceptionFromSchools: string[];
+
+	declare exceptionCount: number;
+
+	static override defineSchema(): RestrictSpellSchoolsRule.Schema {
+		return {
+			...NimbleBaseRule.defineSchema(),
+			...schema(),
+		};
+	}
+
+	override tooltipInfo(): string {
+		return super.tooltipInfo(
+			new Map([
+				['allowedSchools', 'string[]'],
+				['exceptionFromSchools', 'string[]'],
+				['exceptionCount', 'number'],
+			]),
+		);
+	}
+}
+
+export { RestrictSpellSchoolsRule };

--- a/src/utils/classProgression/mage.expect.ts
+++ b/src/utils/classProgression/mage.expect.ts
@@ -236,6 +236,12 @@ export const REPORT: Report = {
 			asi: 'capstone',
 		},
 	],
-	subclasses: ['Invoker Of Chaos', 'Invoker Of Control'],
+	subclasses: [
+		'Invoker Of Chaos',
+		'Invoker Of Control',
+		'Invoker Of Flame',
+		'Invoker Of Frost',
+		'Invoker Of Surges',
+	],
 	subclassSelectLevel: 3,
 };

--- a/src/utils/spell/spellDamageType.test.ts
+++ b/src/utils/spell/spellDamageType.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { retagEffectsDamageType, schoolToDamageType } from './spellDamageType.ts';
+
+describe('schoolToDamageType', () => {
+	it('maps elemental schools to their damage type (ice → cold)', () => {
+		expect(schoolToDamageType('fire')).toBe('fire');
+		expect(schoolToDamageType('ice')).toBe('cold');
+		expect(schoolToDamageType('lightning')).toBe('lightning');
+	});
+
+	it('returns null for a non-elemental school', () => {
+		expect(schoolToDamageType('radiant')).toBeNull();
+	});
+});
+
+describe('retagEffectsDamageType', () => {
+	it('remaps elemental damage types nested under saving-throw outcomes', () => {
+		const effects = [
+			{
+				type: 'savingThrow',
+				on: {
+					failedSave: [{ type: 'damage', damageType: 'cold', formula: '2d6' }],
+					passedSave: [{ type: 'note', text: 'half' }],
+				},
+			},
+		];
+		const result = retagEffectsDamageType(effects, 'fire') as typeof effects;
+		expect(result[0].on.failedSave[0].damageType).toBe('fire');
+		// Non-damage nodes are untouched.
+		expect((result[0].on.passedSave[0] as { text: string }).text).toBe('half');
+	});
+
+	it('remaps a top-level damage node', () => {
+		const effects = [{ type: 'damage', damageType: 'lightning', formula: '3d8' }];
+		const result = retagEffectsDamageType(effects, 'cold') as Array<{ damageType: string }>;
+		expect(result[0].damageType).toBe('cold');
+	});
+
+	it('leaves non-elemental damage types untouched', () => {
+		const effects = [{ type: 'damage', damageType: 'radiant', formula: '1d6' }];
+		const result = retagEffectsDamageType(effects, 'fire') as Array<{ damageType: string }>;
+		expect(result[0].damageType).toBe('radiant');
+	});
+
+	it('does not mutate the original effects array', () => {
+		const effects = [{ type: 'damage', damageType: 'fire' }];
+		retagEffectsDamageType(effects, 'cold');
+		expect(effects[0].damageType).toBe('fire');
+	});
+
+	it('returns an empty array for non-array input', () => {
+		expect(retagEffectsDamageType(undefined, 'fire')).toEqual([]);
+	});
+});

--- a/src/utils/spell/spellDamageType.ts
+++ b/src/utils/spell/spellDamageType.ts
@@ -1,0 +1,55 @@
+/**
+ * Maps a spell school to the damage type its spells deal. Used when retagging a
+ * "keep and convert" exception spell so its elemental damage matches the new
+ * school. Note the mapping is not identity: the Ice school deals `cold` damage.
+ */
+export const SCHOOL_TO_DAMAGE_TYPE: Record<string, string> = {
+	fire: 'fire',
+	ice: 'cold',
+	lightning: 'lightning',
+};
+
+/** The elemental damage types that a conversion may rewrite. */
+const ELEMENTAL_DAMAGE_TYPES = new Set(Object.values(SCHOOL_TO_DAMAGE_TYPE));
+
+/** Resolves the damage type for a school, or null when the school is non-elemental. */
+export function schoolToDamageType(school: string): string | null {
+	return SCHOOL_TO_DAMAGE_TYPE[school] ?? null;
+}
+
+/**
+ * Deep-clones a spell's `activation.effects` array, remapping any elemental
+ * damage type (fire/cold/lightning) to `toDamageType`. Non-elemental damage
+ * (radiant, necrotic, physical, …) is left untouched. Recurses into the nested
+ * `on.<outcome>` effect arrays produced by saving-throw and attack effects.
+ */
+export function retagEffectsDamageType(effects: unknown, toDamageType: string): unknown[] {
+	if (!Array.isArray(effects)) return [];
+
+	const remapNode = (node: unknown): unknown => {
+		if (!node || typeof node !== 'object') return node;
+		const clone: Record<string, unknown> = { ...(node as Record<string, unknown>) };
+
+		if (
+			typeof clone.damageType === 'string' &&
+			ELEMENTAL_DAMAGE_TYPES.has(clone.damageType as string)
+		) {
+			clone.damageType = toDamageType;
+		}
+
+		if (clone.on && typeof clone.on === 'object') {
+			const on = clone.on as Record<string, unknown>;
+			const newOn: Record<string, unknown> = { ...on };
+			for (const [outcome, children] of Object.entries(on)) {
+				if (Array.isArray(children)) {
+					newOn[outcome] = children.map(remapNode);
+				}
+			}
+			clone.on = newOn;
+		}
+
+		return clone;
+	};
+
+	return effects.map(remapNode);
+}

--- a/src/view/dialogs/CharacterLevelDownDialog.svelte
+++ b/src/view/dialogs/CharacterLevelDownDialog.svelte
@@ -26,6 +26,7 @@
 	const grantedSpells = $derived(state.grantedSpells);
 	const poolBonusChanges = $derived(state.poolBonusChanges);
 	const removedSpells = $derived(state.removedSpells);
+	const revertedSpells = $derived(state.revertedSpells);
 </script>
 
 <article class="nimble-sheet__body">
@@ -192,6 +193,29 @@
 			</div>
 			<ul class="nimble-level-down-group__list">
 				{#each removedSpells as spell}
+					<li class="nimble-level-down-group__card">
+						<img
+							class="nimble-level-down-group__card-img"
+							src={spell.img || 'icons/svg/item-bag.svg'}
+							alt={spell.name}
+						/>
+						<span class="nimble-level-down-group__card-name">{spell.name}</span>
+					</li>
+				{/each}
+			</ul>
+		</section>
+	{/if}
+
+	{#if revertedSpells.length > 0}
+		<section class="nimble-level-down-group">
+			<div class="nimble-level-down-group__header">
+				<i class="fa-solid fa-arrow-rotate-left"></i>
+				<h4 class="nimble-level-down-group__title">
+					{levelDownDialog.spellsReverted}
+				</h4>
+			</div>
+			<ul class="nimble-level-down-group__list">
+				{#each revertedSpells as spell}
 					<li class="nimble-level-down-group__card">
 						<img
 							class="nimble-level-down-group__card-img"

--- a/src/view/dialogs/CharacterLevelDownDialog.svelte
+++ b/src/view/dialogs/CharacterLevelDownDialog.svelte
@@ -25,6 +25,7 @@
 	const grantedFeatures = $derived(state.grantedFeatures);
 	const grantedSpells = $derived(state.grantedSpells);
 	const poolBonusChanges = $derived(state.poolBonusChanges);
+	const removedSpells = $derived(state.removedSpells);
 </script>
 
 <article class="nimble-sheet__body">
@@ -168,6 +169,29 @@
 			</div>
 			<ul class="nimble-level-down-group__list">
 				{#each grantedSpells as spell}
+					<li class="nimble-level-down-group__card">
+						<img
+							class="nimble-level-down-group__card-img"
+							src={spell.img || 'icons/svg/item-bag.svg'}
+							alt={spell.name}
+						/>
+						<span class="nimble-level-down-group__card-name">{spell.name}</span>
+					</li>
+				{/each}
+			</ul>
+		</section>
+	{/if}
+
+	{#if removedSpells.length > 0}
+		<section class="nimble-level-down-group">
+			<div class="nimble-level-down-group__header">
+				<i class="fa-solid fa-wand-sparkles"></i>
+				<h4 class="nimble-level-down-group__title">
+					{levelDownDialog.spellsRestored}
+				</h4>
+			</div>
+			<ul class="nimble-level-down-group__list">
+				{#each removedSpells as spell}
 					<li class="nimble-level-down-group__card">
 						<img
 							class="nimble-level-down-group__card-img"

--- a/src/view/dialogs/CharacterLevelDownDialogState.svelte.ts
+++ b/src/view/dialogs/CharacterLevelDownDialogState.svelte.ts
@@ -31,6 +31,7 @@ interface LevelDownActor {
 			grantedFeatureIds: string[];
 			grantedSpellIds?: string[];
 			poolMaxBonuses?: Record<string, number>;
+			removedSpells?: Array<{ uuid: string; name: string; img: string }>;
 		}>;
 	};
 	classes: Record<string, ClassItemShape | undefined>;
@@ -135,6 +136,9 @@ export function createLevelDownState(
 		}));
 	});
 
+	// Get spells that were removed during subclass selection and will be restored
+	const removedSpells = $derived(lastHistory?.removedSpells ?? []);
+
 	function submit() {
 		getDialog().submit({
 			confirmed: true,
@@ -177,6 +181,9 @@ export function createLevelDownState(
 		},
 		get poolBonusChanges() {
 			return poolBonusChanges;
+		},
+		get removedSpells() {
+			return removedSpells;
 		},
 		submit,
 	};

--- a/src/view/dialogs/CharacterLevelDownDialogState.svelte.ts
+++ b/src/view/dialogs/CharacterLevelDownDialogState.svelte.ts
@@ -32,11 +32,14 @@ interface LevelDownActor {
 			grantedSpellIds?: string[];
 			poolMaxBonuses?: Record<string, number>;
 			removedSpells?: Array<{ uuid: string; name: string; img: string }>;
+			convertedSpells?: Array<{ uuid: string; fromSchool: string; toSchool: string }>;
 		}>;
 	};
 	classes: Record<string, ClassItemShape | undefined>;
 	items: {
-		filter(fn: (i: { type: string }) => boolean): Array<{ name: string; img?: string }>;
+		filter(
+			fn: (i: { type: string }) => boolean,
+		): Array<{ name: string; img?: string; _stats?: { compendiumSource?: string } }>;
 		get(id: string): { name: string; img?: string } | undefined;
 	};
 }
@@ -139,6 +142,23 @@ export function createLevelDownState(
 	// Get spells that were removed during subclass selection and will be restored
 	const removedSpells = $derived(lastHistory?.removedSpells ?? []);
 
+	// Get spells retagged by a restrictSpellSchools exception that will be reverted
+	// to their original school. Names/images come from the owned spell items.
+	const revertedSpells = $derived.by(() => {
+		const converted = lastHistory?.convertedSpells ?? [];
+		if (converted.length === 0) return [];
+
+		const ownedSpells = getActor().items.filter((i) => i.type === 'spell');
+		return converted.map((entry) => {
+			const owned = ownedSpells.find((s) => s._stats?.compendiumSource === entry.uuid);
+			return {
+				uuid: entry.uuid,
+				name: owned?.name ?? '',
+				img: owned?.img ?? 'icons/svg/item-bag.svg',
+			};
+		});
+	});
+
 	function submit() {
 		getDialog().submit({
 			confirmed: true,
@@ -184,6 +204,9 @@ export function createLevelDownState(
 		},
 		get removedSpells() {
 			return removedSpells;
+		},
+		get revertedSpells() {
+			return revertedSpells;
 		},
 		submit,
 	};

--- a/src/view/dialogs/CharacterLevelUpDialog.svelte
+++ b/src/view/dialogs/CharacterLevelUpDialog.svelte
@@ -28,6 +28,7 @@
 	const classFeatures = $derived(state.classFeatures);
 	const featuresLoading = $derived(state.featuresLoading);
 	const autoGrantedSpells = $derived(state.autoGrantedSpells);
+	const spellsToRemove = $derived(state.spellsToRemove);
 	const isComplete = $derived(state.isComplete);
 </script>
 
@@ -82,6 +83,7 @@
 		selectedSchools={state.selectedSchools}
 		selectedSpells={state.selectedSpells}
 		confirmedSchools={state.confirmedSchools}
+		{spellsToRemove}
 		onSchoolsChange={(schools) => (state.selectedSchools = schools)}
 		onSpellsChange={(spells) => (state.selectedSpells = spells)}
 		onConfirmedChange={(confirmed) => (state.confirmedSchools = confirmed)}

--- a/src/view/dialogs/CharacterLevelUpDialog.svelte
+++ b/src/view/dialogs/CharacterLevelUpDialog.svelte
@@ -84,8 +84,11 @@
 		selectedSpells={state.selectedSpells}
 		confirmedSchools={state.confirmedSchools}
 		{spellsToRemove}
+		exceptionSelections={state.exceptionSelections}
+		selectedExceptions={state.selectedExceptions}
 		onSchoolsChange={(schools) => (state.selectedSchools = schools)}
 		onSpellsChange={(spells) => (state.selectedSpells = spells)}
+		onExceptionsChange={(spells) => (state.selectedExceptions = spells)}
 		onConfirmedChange={(confirmed) => (state.confirmedSchools = confirmed)}
 	/>
 </section>

--- a/src/view/dialogs/CharacterLevelUpDialogState.svelte.ts
+++ b/src/view/dialogs/CharacterLevelUpDialogState.svelte.ts
@@ -16,16 +16,28 @@ import { getSpellsFromIndex } from '#utils/getSpellsFromIndex.ts';
 import getSubclassChoices from '#utils/getSubclassChoices.ts';
 import getSubclassFeaturesFromIndex from '#utils/getSubclassFeatures.ts';
 import isLevelUpOptionApplicable from '#utils/isLevelUpOptionApplicable.ts';
+import localize from '#utils/localize.ts';
 
 import type { SchoolSelectionGroup, SpellSelectionGroup } from './characterCreation/types.js';
 import { EPIC_BOON_LEVEL, SUBCLASS_LEVEL } from './const/levelUpConstants.ts';
 import {
 	collectKnownSchools,
+	collectSchoolRemovals,
 	collectSpellGrants,
 	collectSpellRemovals,
+	collectSpellRestrictions,
 	type RulesArray,
 	type SpellRemovalEntry,
+	type SpellRestriction,
+	schoolToDamageType,
 } from './spellGrantUtils.ts';
+
+/** A player-chosen exception spell to keep and retag to a new school. */
+interface ConvertedSpell {
+	uuid: string;
+	toSchool: string;
+	toDamageType: string | null;
+}
 
 /** Structural type for what the factory accesses on a class item */
 interface ClassItemShape {
@@ -44,6 +56,7 @@ interface LevelUpDocument {
 		system?: {
 			rules?: Array<{ type: string; [key: string]: unknown }>;
 			school?: string;
+			tier?: number;
 			parentClass?: string;
 		};
 		_stats?: { compendiumSource?: string };
@@ -137,7 +150,11 @@ export function createLevelUpState(
 	let selectedSchools = $state<Map<string, string[]>>(new Map());
 	let selectedSpells = $state<Map<string, string[]>>(new Map());
 	let confirmedSchools = $state<Set<string>>(new Set());
-	let spellsToRemove = $state<SpellRemovalEntry[]>([]);
+
+	// The player's chosen "keep and convert a spell" exceptions, per picker group.
+	// The restriction, exception picker, and removal set are all pure computations
+	// derived below, so they never form an effect read/write cycle.
+	let selectedExceptions = $state<Map<string, string[]>>(new Map());
 
 	// Load spell index
 	buildSpellIndex()
@@ -231,24 +248,121 @@ export function createLevelUpState(
 			});
 	});
 
-	// Compute spells to remove from removeSpells rules on features being granted
-	$effect(() => {
-		if (featuresLoading || !classFeatures) {
-			spellsToRemove = [];
-			return;
-		}
-
-		const items = getDocument().items ?? [];
-		const ownedSpellItems = items.filter((i) => i.type === 'spell');
-
-		const removalRulesArrays: RulesArray[] = [];
+	// Helper: collect rule arrays from the features being granted this level.
+	function collectNewFeatureRules(): RulesArray[] {
+		const arrays: RulesArray[] = [];
+		if (!classFeatures) return arrays;
 		for (const feature of classFeatures.autoGrant) {
 			const featureItem = feature as unknown as { system?: { rules?: unknown[] } };
 			const rules = (featureItem.system?.rules ?? []) as unknown as RulesArray;
-			if (rules.length > 0) removalRulesArrays.push(rules);
+			if (rules.length > 0) arrays.push(rules);
+		}
+		return arrays;
+	}
+
+	// Helper: collect rule arrays from features already on the character.
+	function collectExistingFeatureRules(): RulesArray[] {
+		const arrays: RulesArray[] = [];
+		for (const item of getDocument().items ?? []) {
+			if (item.type !== 'feature') continue;
+			const rules = (item.system?.rules ?? []) as unknown as RulesArray;
+			if (rules.length > 0) arrays.push(rules);
+		}
+		return arrays;
+	}
+
+	// The persistent spell-school restriction, unioned from restrictSpellSchools
+	// rules on both new and existing features. Because it is derived (not written
+	// in an effect), it re-computes lazily and keeps filtering grants at every
+	// future level without any read/write cycle.
+	const spellRestriction = $derived.by<SpellRestriction>(() => {
+		if (featuresLoading || !classFeatures) {
+			return {
+				active: false,
+				allowedSchools: new Set(),
+				exceptionFromSchools: [],
+				exceptionCount: 0,
+			};
+		}
+		return collectSpellRestrictions([
+			...collectNewFeatureRules(),
+			...collectExistingFeatureRules(),
+		]);
+	});
+
+	// The one-time "keep and convert a spell" picker, offered only when a
+	// restriction is applied THIS level (a new feature), so the player isn't
+	// re-prompted on later level-ups. The pool is the owned spells from the
+	// removed schools — the player keeps one and it is retagged to the new school.
+	const exceptionSelections = $derived.by<SpellSelectionGroup[]>(() => {
+		if (featuresLoading || !classFeatures) return [];
+
+		const newRestriction = collectSpellRestrictions(collectNewFeatureRules());
+		const exceptionSchools = new Set(newRestriction.exceptionFromSchools);
+		if (newRestriction.exceptionCount <= 0 || exceptionSchools.size === 0) return [];
+
+		const ownedSpellItems = (getDocument().items ?? []).filter((i) => i.type === 'spell');
+		const availableSpells: SpellIndexEntry[] = [];
+		const seen = new Set<string>();
+		for (const item of ownedSpellItems) {
+			const source = item._stats?.compendiumSource;
+			const school = item.system?.school ?? '';
+			if (!source || seen.has(source) || !exceptionSchools.has(school)) continue;
+			seen.add(source);
+			availableSpells.push({
+				uuid: source,
+				name: item.name ?? '',
+				img: item.img ?? 'icons/svg/item-bag.svg',
+				school,
+				tier: item.system?.tier ?? 0,
+				isUtility: false,
+				classes: [],
+			});
 		}
 
-		spellsToRemove = collectSpellRemovals(removalRulesArrays, ownedSpellItems);
+		if (availableSpells.length === 0) return [];
+		return [
+			{
+				ruleId: 'restrict-spell-exception',
+				label: localize('NIMBLE.spellGrants.levelUpExceptionHeader'),
+				availableSpells,
+				count: newRestriction.exceptionCount,
+				utilityOnly: false,
+				forClass: characterClass?.identifier ?? '',
+				source: 'class',
+			},
+		];
+	});
+
+	// Spells to remove: UUID-based removeSpells rules on new features, plus
+	// school-based removal from an active restriction (excluding the player's
+	// chosen keep-and-convert exceptions). Derived so it stays in sync with the
+	// exception picks without an effect.
+	const spellsToRemove = $derived.by<SpellRemovalEntry[]>(() => {
+		if (featuresLoading || !classFeatures) return [];
+
+		const ownedSpellItems = (getDocument().items ?? []).filter((i) => i.type === 'spell');
+		const uuidRemovals = collectSpellRemovals(collectNewFeatureRules(), ownedSpellItems);
+
+		const keepUuids = new Set<string>();
+		for (const uuids of selectedExceptions.values()) {
+			for (const uuid of uuids) keepUuids.add(uuid);
+		}
+		const schoolRemovals = collectSchoolRemovals(
+			ownedSpellItems,
+			spellRestriction.allowedSchools,
+			keepUuids,
+		);
+
+		// Merge, de-duplicating by UUID.
+		const merged: SpellRemovalEntry[] = [];
+		const seen = new Set<string>();
+		for (const entry of [...uuidRemovals, ...schoolRemovals]) {
+			if (seen.has(entry.uuid)) continue;
+			seen.add(entry.uuid);
+			merged.push(entry);
+		}
+		return merged;
 	});
 
 	// Process spell grants when class features and spell index are ready
@@ -308,6 +422,7 @@ export function createLevelUpState(
 			levelingTo,
 			ownedSpellUuids,
 			knownSchools,
+			spellRestriction.allowedSchools,
 		);
 
 		autoGrantedSpells = result.autoGrant;
@@ -409,6 +524,10 @@ export function createLevelUpState(
 			const selected = selectedSpells.get(group.ruleId) ?? [];
 			if (selected.length < group.count) return false;
 		}
+		for (const group of exceptionSelections) {
+			const selected = selectedExceptions.get(group.ruleId) ?? [];
+			if (selected.length < group.count) return false;
+		}
 		return true;
 	});
 
@@ -505,9 +624,29 @@ export function createLevelUpState(
 		return bonuses;
 	}
 
+	// Build the list of chosen exception spells to retain and retag to the new
+	// school. Each converts to the restriction's first allowed school (e.g. fire).
+	function computeConvertedSpells(): ConvertedSpell[] {
+		const toSchool = [...spellRestriction.allowedSchools][0];
+		if (!toSchool) return [];
+
+		const converted: ConvertedSpell[] = [];
+		const seen = new Set<string>();
+		for (const uuids of selectedExceptions.values()) {
+			for (const uuid of uuids) {
+				if (seen.has(uuid)) continue;
+				seen.add(uuid);
+				converted.push({ uuid, toSchool, toDamageType: schoolToDamageType(toSchool) });
+			}
+		}
+		return converted;
+	}
+
 	// Actions
 	function submit() {
 		const poolMaxBonuses = computePoolMaxBonuses();
+		const convertedSpells = computeConvertedSpells();
+		const convertedUuids = new Set(convertedSpells.map((c) => c.uuid));
 		getDialog().submit({
 			selectedAbilityScore: selectedAbilityScores,
 			selectedSubclass,
@@ -523,7 +662,12 @@ export function createLevelUpState(
 					}
 				: undefined,
 			spellUuids: getGrantedSpellUuids(),
-			removedSpellUuids: spellsToRemove.map((s) => s.uuid),
+			// A converted spell is kept and retagged, never removed — guard against a
+			// stale removal entry deleting the spell we mean to retain.
+			removedSpellUuids: spellsToRemove
+				.map((s) => s.uuid)
+				.filter((uuid) => !convertedUuids.has(uuid)),
+			convertedSpells,
 		});
 	}
 
@@ -585,6 +729,15 @@ export function createLevelUpState(
 		},
 		get spellsToRemove() {
 			return spellsToRemove;
+		},
+		get exceptionSelections() {
+			return exceptionSelections;
+		},
+		get selectedExceptions() {
+			return selectedExceptions;
+		},
+		set selectedExceptions(v: Map<string, string[]>) {
+			selectedExceptions = v;
 		},
 		get schoolSelections() {
 			return schoolSelections;

--- a/src/view/dialogs/CharacterLevelUpDialogState.svelte.ts
+++ b/src/view/dialogs/CharacterLevelUpDialogState.svelte.ts
@@ -19,7 +19,13 @@ import isLevelUpOptionApplicable from '#utils/isLevelUpOptionApplicable.ts';
 
 import type { SchoolSelectionGroup, SpellSelectionGroup } from './characterCreation/types.js';
 import { EPIC_BOON_LEVEL, SUBCLASS_LEVEL } from './const/levelUpConstants.ts';
-import { collectKnownSchools, collectSpellGrants, type RulesArray } from './spellGrantUtils.ts';
+import {
+	collectKnownSchools,
+	collectSpellGrants,
+	collectSpellRemovals,
+	type RulesArray,
+	type SpellRemovalEntry,
+} from './spellGrantUtils.ts';
 
 /** Structural type for what the factory accesses on a class item */
 interface ClassItemShape {
@@ -34,6 +40,7 @@ interface LevelUpDocument {
 		type: string;
 		uuid?: string;
 		name?: string;
+		img?: string;
 		system?: {
 			rules?: Array<{ type: string; [key: string]: unknown }>;
 			school?: string;
@@ -130,6 +137,7 @@ export function createLevelUpState(
 	let selectedSchools = $state<Map<string, string[]>>(new Map());
 	let selectedSpells = $state<Map<string, string[]>>(new Map());
 	let confirmedSchools = $state<Set<string>>(new Set());
+	let spellsToRemove = $state<SpellRemovalEntry[]>([]);
 
 	// Load spell index
 	buildSpellIndex()
@@ -221,6 +229,26 @@ export function createLevelUpState(
 				console.warn('Nimble | Failed to load class features:', err);
 				featuresLoading = false;
 			});
+	});
+
+	// Compute spells to remove from removeSpells rules on features being granted
+	$effect(() => {
+		if (featuresLoading || !classFeatures) {
+			spellsToRemove = [];
+			return;
+		}
+
+		const items = getDocument().items ?? [];
+		const ownedSpellItems = items.filter((i) => i.type === 'spell');
+
+		const removalRulesArrays: RulesArray[] = [];
+		for (const feature of classFeatures.autoGrant) {
+			const featureItem = feature as unknown as { system?: { rules?: unknown[] } };
+			const rules = (featureItem.system?.rules ?? []) as unknown as RulesArray;
+			if (rules.length > 0) removalRulesArrays.push(rules);
+		}
+
+		spellsToRemove = collectSpellRemovals(removalRulesArrays, ownedSpellItems);
 	});
 
 	// Process spell grants when class features and spell index are ready
@@ -495,6 +523,7 @@ export function createLevelUpState(
 					}
 				: undefined,
 			spellUuids: getGrantedSpellUuids(),
+			removedSpellUuids: spellsToRemove.map((s) => s.uuid),
 		});
 	}
 
@@ -553,6 +582,9 @@ export function createLevelUpState(
 		},
 		get autoGrantedSpells() {
 			return autoGrantedSpells;
+		},
+		get spellsToRemove() {
+			return spellsToRemove;
 		},
 		get schoolSelections() {
 			return schoolSelections;

--- a/src/view/dialogs/CharacterLevelUpDialogState.svelte.ts
+++ b/src/view/dialogs/CharacterLevelUpDialogState.svelte.ts
@@ -17,6 +17,7 @@ import getSubclassChoices from '#utils/getSubclassChoices.ts';
 import getSubclassFeaturesFromIndex from '#utils/getSubclassFeatures.ts';
 import isLevelUpOptionApplicable from '#utils/isLevelUpOptionApplicable.ts';
 import localize from '#utils/localize.ts';
+import { schoolToDamageType } from '#utils/spell/spellDamageType.ts';
 
 import type { SchoolSelectionGroup, SpellSelectionGroup } from './characterCreation/types.js';
 import { EPIC_BOON_LEVEL, SUBCLASS_LEVEL } from './const/levelUpConstants.ts';
@@ -29,7 +30,6 @@ import {
 	type RulesArray,
 	type SpellRemovalEntry,
 	type SpellRestriction,
-	schoolToDamageType,
 } from './spellGrantUtils.ts';
 
 /** A player-chosen exception spell to keep and retag to a new school. */

--- a/src/view/dialogs/components/levelUpHelper/LevelUpSpellGrants.svelte
+++ b/src/view/dialogs/components/levelUpHelper/LevelUpSpellGrants.svelte
@@ -16,6 +16,7 @@
 		selectedSchools,
 		selectedSpells,
 		confirmedSchools,
+		spellsToRemove,
 		onSchoolsChange,
 		onSpellsChange,
 		onConfirmedChange,
@@ -29,6 +30,7 @@
 		selectedSchools,
 		selectedSpells,
 		confirmedSchools,
+		spellsToRemove,
 		onSchoolsChange,
 		onSpellsChange,
 		onConfirmedChange,
@@ -120,6 +122,25 @@
 				/>
 			{/each}
 		{/if}
+
+		{#if spellsToRemove.length > 0}
+			<div class="level-up-spell-grants__removal-group">
+				<h4
+					class="level-up-spell-grants__removal-label nimble-heading"
+					data-heading-variant="subsection"
+				>
+					{localize('NIMBLE.spellGrants.levelUpRemovalHeader')}
+				</h4>
+				<Hint hintText={localize('NIMBLE.spellGrants.levelUpRemovalHint')} />
+				<ul class="level-up-spell-grants__spell-list">
+					{#each spellsToRemove as spell (spell.uuid)}
+						<LevelUpSpellCard
+							spell={{ ...spell, school: '', tier: 0, isUtility: false, classes: [] }}
+						/>
+					{/each}
+				</ul>
+			</div>
+		{/if}
 	</section>
 {/if}
 
@@ -140,6 +161,18 @@
 		}
 
 		&__school-label {
+			margin: 0 0 0.5rem 0;
+		}
+
+		&__removal-group {
+			margin-bottom: 1rem;
+
+			&:last-child {
+				margin-bottom: 0;
+			}
+		}
+
+		&__removal-label {
 			margin: 0 0 0.5rem 0;
 		}
 

--- a/src/view/dialogs/components/levelUpHelper/LevelUpSpellGrants.svelte
+++ b/src/view/dialogs/components/levelUpHelper/LevelUpSpellGrants.svelte
@@ -17,8 +17,11 @@
 		selectedSpells,
 		confirmedSchools,
 		spellsToRemove,
+		exceptionSelections,
+		selectedExceptions,
 		onSchoolsChange,
 		onSpellsChange,
+		onExceptionsChange,
 		onConfirmedChange,
 	}: LevelUpSpellGrantsProps = $props();
 
@@ -31,11 +34,20 @@
 		selectedSpells,
 		confirmedSchools,
 		spellsToRemove,
+		exceptionSelections,
+		selectedExceptions,
 		onSchoolsChange,
 		onSpellsChange,
+		onExceptionsChange,
 		onConfirmedChange,
 	}));
-	const { handleSchoolSelect, handleSchoolConfirm, handleSchoolEdit, handleSpellSelect } = state;
+	const {
+		handleSchoolSelect,
+		handleSchoolConfirm,
+		handleSchoolEdit,
+		handleSpellSelect,
+		handleExceptionSelect,
+	} = state;
 	const hasAnyGrants = $derived(state.hasAnyGrants);
 	const spellsBySchool = $derived(state.spellsBySchool);
 </script>
@@ -123,6 +135,25 @@
 			{/each}
 		{/if}
 
+		{#if exceptionSelections.length > 0}
+			<div class="level-up-spell-grants__exception-group">
+				<h4
+					class="level-up-spell-grants__exception-label nimble-heading"
+					data-heading-variant="subsection"
+				>
+					{localize('NIMBLE.spellGrants.levelUpExceptionHeader')}
+				</h4>
+				<Hint hintText={localize('NIMBLE.spellGrants.levelUpExceptionHint')} />
+				{#each exceptionSelections as group (group.ruleId)}
+					<SpellSelection
+						{group}
+						selected={selectedExceptions.get(group.ruleId) ?? []}
+						onSelect={(spellUuids) => handleExceptionSelect(group.ruleId, spellUuids)}
+					/>
+				{/each}
+			</div>
+		{/if}
+
 		{#if spellsToRemove.length > 0}
 			<div class="level-up-spell-grants__removal-group">
 				<h4
@@ -173,6 +204,18 @@
 		}
 
 		&__removal-label {
+			margin: 0 0 0.5rem 0;
+		}
+
+		&__exception-group {
+			margin-bottom: 1rem;
+
+			&:last-child {
+				margin-bottom: 0;
+			}
+		}
+
+		&__exception-label {
 			margin: 0 0 0.5rem 0;
 		}
 

--- a/src/view/dialogs/components/levelUpHelper/LevelUpSpellGrants.svelte.ts
+++ b/src/view/dialogs/components/levelUpHelper/LevelUpSpellGrants.svelte.ts
@@ -11,7 +11,8 @@ export function createLevelUpSpellGrantsState(getProps: () => LevelUpSpellGrants
 	const hasAnyGrants = $derived(
 		getProps().spells.length > 0 ||
 			getProps().schoolSelections.length > 0 ||
-			getProps().spellSelections.length > 0,
+			getProps().spellSelections.length > 0 ||
+			getProps().spellsToRemove.length > 0,
 	);
 
 	const spellsBySchool = $derived.by(() => {

--- a/src/view/dialogs/components/levelUpHelper/LevelUpSpellGrants.svelte.ts
+++ b/src/view/dialogs/components/levelUpHelper/LevelUpSpellGrants.svelte.ts
@@ -12,7 +12,8 @@ export function createLevelUpSpellGrantsState(getProps: () => LevelUpSpellGrants
 		getProps().spells.length > 0 ||
 			getProps().schoolSelections.length > 0 ||
 			getProps().spellSelections.length > 0 ||
-			getProps().spellsToRemove.length > 0,
+			getProps().spellsToRemove.length > 0 ||
+			getProps().exceptionSelections.length > 0,
 	);
 
 	const spellsBySchool = $derived.by(() => {
@@ -51,6 +52,13 @@ export function createLevelUpSpellGrantsState(getProps: () => LevelUpSpellGrants
 		props.onSpellsChange(newMap);
 	}
 
+	function handleExceptionSelect(ruleId: string, spellUuids: string[]) {
+		const props = getProps();
+		const newMap = new Map(props.selectedExceptions);
+		newMap.set(ruleId, spellUuids);
+		props.onExceptionsChange(newMap);
+	}
+
 	return {
 		get hasAnyGrants() {
 			return hasAnyGrants;
@@ -62,5 +70,6 @@ export function createLevelUpSpellGrantsState(getProps: () => LevelUpSpellGrants
 		handleSchoolConfirm,
 		handleSchoolEdit,
 		handleSpellSelect,
+		handleExceptionSelect,
 	};
 }

--- a/src/view/dialogs/spellGrantUtils.test.ts
+++ b/src/view/dialogs/spellGrantUtils.test.ts
@@ -6,6 +6,7 @@ import type { RulesArray } from './spellGrantUtils.js';
 import {
 	collectKnownSchools,
 	collectSpellGrants,
+	collectSpellRemovals,
 	predicatePassesAtLevel,
 	resolveSchools,
 } from './spellGrantUtils.js';
@@ -628,5 +629,113 @@ describe('collectSpellGrants', () => {
 			expect(result.spellSelections).toHaveLength(1);
 			expect(result.spellSelections[0].ruleId).toBe('spell-choice-1-ice');
 		});
+	});
+});
+
+describe('collectSpellRemovals', () => {
+	function makeOwnedSpell(overrides: { compendiumSource?: string; name?: string; img?: string }) {
+		return {
+			name: overrides.name ?? 'A Spell',
+			img: overrides.img ?? 'icons/svg/item-bag.svg',
+			_stats: overrides.compendiumSource
+				? { compendiumSource: overrides.compendiumSource }
+				: undefined,
+		};
+	}
+
+	it('returns empty array when no removeSpells rules exist', () => {
+		const rules: RulesArray = [{ type: 'grantSpells', schools: ['fire'] }];
+		const owned = [makeOwnedSpell({ compendiumSource: 'uuid-fire-1', name: 'Ember' })];
+		expect(collectSpellRemovals([rules], owned)).toEqual([]);
+	});
+
+	it('returns empty array when owned spells list is empty', () => {
+		const rules: RulesArray = [{ type: 'removeSpells', uuids: ['uuid-fire-1'] }];
+		expect(collectSpellRemovals([rules], [])).toEqual([]);
+	});
+
+	it('returns empty array when no owned spell matches the removal UUIDs', () => {
+		const rules: RulesArray = [{ type: 'removeSpells', uuids: ['uuid-ice-1'] }];
+		const owned = [makeOwnedSpell({ compendiumSource: 'uuid-fire-1', name: 'Ember' })];
+		expect(collectSpellRemovals([rules], owned)).toEqual([]);
+	});
+
+	it('does not remove spells without a compendiumSource', () => {
+		const rules: RulesArray = [{ type: 'removeSpells', uuids: ['uuid-fire-1'] }];
+		const owned = [{ name: 'Manual Spell', img: 'icons/svg/item-bag.svg', _stats: undefined }];
+		expect(collectSpellRemovals([rules], owned)).toEqual([]);
+	});
+
+	it('matches and returns a spell whose compendiumSource is in the removal UUIDs', () => {
+		const rules: RulesArray = [{ type: 'removeSpells', uuids: ['uuid-fire-1'] }];
+		const owned = [
+			makeOwnedSpell({ compendiumSource: 'uuid-fire-1', name: 'Ember', img: 'fire.png' }),
+		];
+		const result = collectSpellRemovals([rules], owned);
+		expect(result).toHaveLength(1);
+		expect(result[0]).toEqual({ uuid: 'uuid-fire-1', name: 'Ember', img: 'fire.png' });
+	});
+
+	it('collects removals from multiple rule arrays', () => {
+		const rules1: RulesArray = [{ type: 'removeSpells', uuids: ['uuid-fire-1'] }];
+		const rules2: RulesArray = [{ type: 'removeSpells', uuids: ['uuid-ice-1'] }];
+		const owned = [
+			makeOwnedSpell({ compendiumSource: 'uuid-fire-1', name: 'Ember' }),
+			makeOwnedSpell({ compendiumSource: 'uuid-ice-1', name: 'Frost' }),
+		];
+		const result = collectSpellRemovals([rules1, rules2], owned);
+		expect(result).toHaveLength(2);
+		expect(result.map((r) => r.uuid).sort()).toEqual(['uuid-fire-1', 'uuid-ice-1']);
+	});
+
+	it('deduplicates when multiple rules target the same UUID', () => {
+		const rules1: RulesArray = [{ type: 'removeSpells', uuids: ['uuid-fire-1'] }];
+		const rules2: RulesArray = [{ type: 'removeSpells', uuids: ['uuid-fire-1'] }];
+		const owned = [makeOwnedSpell({ compendiumSource: 'uuid-fire-1', name: 'Ember' })];
+		const result = collectSpellRemovals([rules1, rules2], owned);
+		expect(result).toHaveLength(1);
+	});
+
+	it('deduplicates when the same UUID appears twice in one rule', () => {
+		const rules: RulesArray = [{ type: 'removeSpells', uuids: ['uuid-fire-1', 'uuid-fire-1'] }];
+		const owned = [makeOwnedSpell({ compendiumSource: 'uuid-fire-1', name: 'Ember' })];
+		const result = collectSpellRemovals([rules], owned);
+		expect(result).toHaveLength(1);
+	});
+
+	it('only removes matching spells and preserves others', () => {
+		const rules: RulesArray = [{ type: 'removeSpells', uuids: ['uuid-fire-1'] }];
+		const owned = [
+			makeOwnedSpell({ compendiumSource: 'uuid-fire-1', name: 'Ember' }),
+			makeOwnedSpell({ compendiumSource: 'uuid-ice-1', name: 'Frost' }),
+		];
+		const result = collectSpellRemovals([rules], owned);
+		expect(result).toHaveLength(1);
+		expect(result[0].name).toBe('Ember');
+	});
+
+	it('uses fallback name and img when spell has none', () => {
+		const rules: RulesArray = [{ type: 'removeSpells', uuids: ['uuid-fire-1'] }];
+		const owned = [{ _stats: { compendiumSource: 'uuid-fire-1' } }];
+		const result = collectSpellRemovals([rules], owned);
+		expect(result[0].name).toBe('');
+		expect(result[0].img).toBe('icons/svg/item-bag.svg');
+	});
+
+	it('skips non-removeSpells rules', () => {
+		const rules: RulesArray = [
+			{ type: 'grantSpells', schools: ['fire'] },
+			{ type: 'removeSpells', uuids: ['uuid-ice-1'] },
+		];
+		const owned = [makeOwnedSpell({ compendiumSource: 'uuid-ice-1', name: 'Frost' })];
+		const result = collectSpellRemovals([rules], owned);
+		expect(result).toHaveLength(1);
+		expect(result[0].uuid).toBe('uuid-ice-1');
+	});
+
+	it('returns empty array when rules have no uuids field', () => {
+		const rules: RulesArray = [{ type: 'removeSpells' }];
+		const owned = [makeOwnedSpell({ compendiumSource: 'uuid-fire-1', name: 'Ember' })];
+		expect(collectSpellRemovals([rules], owned)).toEqual([]);
 	});
 });

--- a/src/view/dialogs/spellGrantUtils.test.ts
+++ b/src/view/dialogs/spellGrantUtils.test.ts
@@ -5,10 +5,14 @@ import type { SpellIndex, SpellIndexEntry } from '#utils/getSpells.js';
 import type { RulesArray } from './spellGrantUtils.js';
 import {
 	collectKnownSchools,
+	collectSchoolRemovals,
 	collectSpellGrants,
 	collectSpellRemovals,
+	collectSpellRestrictions,
 	predicatePassesAtLevel,
 	resolveSchools,
+	retagEffectsDamageType,
+	schoolToDamageType,
 } from './spellGrantUtils.js';
 
 function createSpellEntry(
@@ -737,5 +741,224 @@ describe('collectSpellRemovals', () => {
 		const rules: RulesArray = [{ type: 'removeSpells' }];
 		const owned = [makeOwnedSpell({ compendiumSource: 'uuid-fire-1', name: 'Ember' })];
 		expect(collectSpellRemovals([rules], owned)).toEqual([]);
+	});
+});
+
+describe('schoolToDamageType', () => {
+	it('maps elemental schools to their damage type (ice → cold)', () => {
+		expect(schoolToDamageType('fire')).toBe('fire');
+		expect(schoolToDamageType('ice')).toBe('cold');
+		expect(schoolToDamageType('lightning')).toBe('lightning');
+	});
+
+	it('returns null for a non-elemental school', () => {
+		expect(schoolToDamageType('radiant')).toBeNull();
+	});
+});
+
+describe('collectSpellRestrictions', () => {
+	it('returns an inactive restriction when no rules are present', () => {
+		const result = collectSpellRestrictions([[{ type: 'grantSpells', schools: ['fire'] }]]);
+		expect(result.active).toBe(false);
+		expect(result.allowedSchools.size).toBe(0);
+		expect(result.exceptionFromSchools).toEqual([]);
+		expect(result.exceptionCount).toBe(0);
+	});
+
+	it('collects allowed and exception schools from a restrictSpellSchools rule', () => {
+		const rules: RulesArray = [
+			{
+				type: 'restrictSpellSchools',
+				allowedSchools: ['fire'],
+				exceptionFromSchools: ['ice', 'lightning'],
+				exceptionCount: 1,
+			},
+		];
+		const result = collectSpellRestrictions([rules]);
+		expect(result.active).toBe(true);
+		expect([...result.allowedSchools]).toEqual(['fire']);
+		expect(result.exceptionFromSchools.sort()).toEqual(['ice', 'lightning']);
+		expect(result.exceptionCount).toBe(1);
+	});
+
+	it('unions schools and sums exception counts across multiple rules', () => {
+		const rules1: RulesArray = [
+			{
+				type: 'restrictSpellSchools',
+				allowedSchools: ['fire'],
+				exceptionFromSchools: ['ice'],
+				exceptionCount: 1,
+			},
+		];
+		const rules2: RulesArray = [
+			{
+				type: 'restrictSpellSchools',
+				allowedSchools: ['lightning'],
+				exceptionFromSchools: ['ice'],
+				exceptionCount: 2,
+			},
+		];
+		const result = collectSpellRestrictions([rules1, rules2]);
+		expect([...result.allowedSchools].sort()).toEqual(['fire', 'lightning']);
+		expect(result.exceptionFromSchools).toEqual(['ice']);
+		expect(result.exceptionCount).toBe(3);
+	});
+});
+
+describe('collectSchoolRemovals', () => {
+	function makeOwnedSpell(overrides: {
+		compendiumSource?: string;
+		name?: string;
+		school?: string;
+	}) {
+		return {
+			name: overrides.name ?? 'A Spell',
+			img: 'icons/svg/item-bag.svg',
+			system: { school: overrides.school ?? 'fire' },
+			_stats: overrides.compendiumSource
+				? { compendiumSource: overrides.compendiumSource }
+				: undefined,
+		};
+	}
+
+	it('returns empty array when allowedSchools is empty (no active restriction)', () => {
+		const owned = [makeOwnedSpell({ compendiumSource: 'ice-1', school: 'ice' })];
+		expect(collectSchoolRemovals(owned, new Set())).toEqual([]);
+	});
+
+	it('removes automation spells outside the allowed schools', () => {
+		const owned = [
+			makeOwnedSpell({ compendiumSource: 'fire-1', school: 'fire', name: 'Ember' }),
+			makeOwnedSpell({ compendiumSource: 'ice-1', school: 'ice', name: 'Frost' }),
+			makeOwnedSpell({ compendiumSource: 'light-1', school: 'lightning', name: 'Zap' }),
+		];
+		const result = collectSchoolRemovals(owned, new Set(['fire']));
+		expect(result.map((r) => r.uuid).sort()).toEqual(['ice-1', 'light-1']);
+	});
+
+	it('spares chosen keep-and-convert exceptions', () => {
+		const owned = [
+			makeOwnedSpell({ compendiumSource: 'ice-1', school: 'ice', name: 'Frost' }),
+			makeOwnedSpell({ compendiumSource: 'ice-2', school: 'ice', name: 'Ice Shard' }),
+		];
+		const result = collectSchoolRemovals(owned, new Set(['fire']), new Set(['ice-1']));
+		expect(result.map((r) => r.uuid)).toEqual(['ice-2']);
+	});
+
+	it('never targets manual spells without a compendiumSource', () => {
+		const owned = [{ name: 'Manual', img: 'x.png', system: { school: 'ice' }, _stats: undefined }];
+		expect(collectSchoolRemovals(owned, new Set(['fire']))).toEqual([]);
+	});
+});
+
+describe('collectSpellGrants with allowedSchools restriction', () => {
+	const spells = [
+		createSpellEntry({ uuid: 'fire-t2', name: 'Fireball', school: 'fire', tier: 2 }),
+		createSpellEntry({ uuid: 'ice-t2', name: 'Ice Spike', school: 'ice', tier: 2 }),
+		createSpellEntry({ uuid: 'light-t2', name: 'Bolt', school: 'lightning', tier: 2 }),
+	];
+
+	it('filters auto-granted spells down to the allowed schools', () => {
+		const index = createSpellIndex(spells);
+		const rules: RulesArray = [
+			{
+				type: 'grantSpells',
+				schools: ['fire', 'ice', 'lightning'],
+				tiers: [2],
+				mode: 'auto',
+				predicate: { level: { min: 4 } },
+			},
+		];
+		const result = collectSpellGrants(
+			[rules],
+			index,
+			'mage',
+			4,
+			new Set(),
+			new Set(),
+			new Set(['fire']),
+		);
+		expect(result.autoGrant.map((s) => s.uuid)).toEqual(['fire-t2']);
+	});
+
+	it('grants everything when no restriction is passed', () => {
+		const index = createSpellIndex(spells);
+		const rules: RulesArray = [
+			{
+				type: 'grantSpells',
+				schools: ['fire', 'ice', 'lightning'],
+				tiers: [2],
+				mode: 'auto',
+				predicate: { level: { min: 4 } },
+			},
+		];
+		const result = collectSpellGrants([rules], index, 'mage', 4, new Set(), new Set());
+		expect(result.autoGrant.map((s) => s.uuid).sort()).toEqual(['fire-t2', 'ice-t2', 'light-t2']);
+	});
+
+	it('restricts selectSchool options to the allowed schools', () => {
+		const index = createSpellIndex(spells);
+		const rules: RulesArray = [
+			{
+				id: 'mastery',
+				type: 'grantSpells',
+				schools: ['fire', 'ice', 'lightning'],
+				tiers: [2],
+				mode: 'selectSchool',
+				count: 1,
+				predicate: { level: { min: 4 } },
+			},
+		];
+		const result = collectSpellGrants(
+			[rules],
+			index,
+			'mage',
+			4,
+			new Set(),
+			new Set(),
+			new Set(['fire']),
+		);
+		expect(result.schoolSelections).toHaveLength(1);
+		expect(result.schoolSelections[0].availableSchools).toEqual(['fire']);
+	});
+});
+
+describe('retagEffectsDamageType', () => {
+	it('remaps elemental damage types nested under saving-throw outcomes', () => {
+		const effects = [
+			{
+				type: 'savingThrow',
+				on: {
+					failedSave: [{ type: 'damage', damageType: 'cold', formula: '2d6' }],
+					passedSave: [{ type: 'note', text: 'half' }],
+				},
+			},
+		];
+		const result = retagEffectsDamageType(effects, 'fire') as typeof effects;
+		expect(result[0].on.failedSave[0].damageType).toBe('fire');
+		// Non-damage nodes are untouched.
+		expect((result[0].on.passedSave[0] as { text: string }).text).toBe('half');
+	});
+
+	it('remaps a top-level damage node', () => {
+		const effects = [{ type: 'damage', damageType: 'lightning', formula: '3d8' }];
+		const result = retagEffectsDamageType(effects, 'cold') as Array<{ damageType: string }>;
+		expect(result[0].damageType).toBe('cold');
+	});
+
+	it('leaves non-elemental damage types untouched', () => {
+		const effects = [{ type: 'damage', damageType: 'radiant', formula: '1d6' }];
+		const result = retagEffectsDamageType(effects, 'fire') as Array<{ damageType: string }>;
+		expect(result[0].damageType).toBe('radiant');
+	});
+
+	it('does not mutate the original effects array', () => {
+		const effects = [{ type: 'damage', damageType: 'fire' }];
+		retagEffectsDamageType(effects, 'cold');
+		expect(effects[0].damageType).toBe('fire');
+	});
+
+	it('returns an empty array for non-array input', () => {
+		expect(retagEffectsDamageType(undefined, 'fire')).toEqual([]);
 	});
 });

--- a/src/view/dialogs/spellGrantUtils.test.ts
+++ b/src/view/dialogs/spellGrantUtils.test.ts
@@ -6,6 +6,7 @@ import type { RulesArray } from './spellGrantUtils.js';
 import {
 	collectKnownSchools,
 	collectSpellGrants,
+	collectSpellRemovals,
 	predicatePassesAtLevel,
 	resolveSchools,
 } from './spellGrantUtils.js';
@@ -687,5 +688,113 @@ describe('collectSpellGrants', () => {
 			expect(result.schoolSelections).toHaveLength(1);
 			expect(result.schoolSelections[0].ruleId).toBe('school-choice-1');
 		});
+	});
+});
+
+describe('collectSpellRemovals', () => {
+	function makeOwnedSpell(overrides: { compendiumSource?: string; name?: string; img?: string }) {
+		return {
+			name: overrides.name ?? 'A Spell',
+			img: overrides.img ?? 'icons/svg/item-bag.svg',
+			_stats: overrides.compendiumSource
+				? { compendiumSource: overrides.compendiumSource }
+				: undefined,
+		};
+	}
+
+	it('returns empty array when no removeSpells rules exist', () => {
+		const rules: RulesArray = [{ type: 'grantSpells', schools: ['fire'] }];
+		const owned = [makeOwnedSpell({ compendiumSource: 'uuid-fire-1', name: 'Ember' })];
+		expect(collectSpellRemovals([rules], owned)).toEqual([]);
+	});
+
+	it('returns empty array when owned spells list is empty', () => {
+		const rules: RulesArray = [{ type: 'removeSpells', uuids: ['uuid-fire-1'] }];
+		expect(collectSpellRemovals([rules], [])).toEqual([]);
+	});
+
+	it('returns empty array when no owned spell matches the removal UUIDs', () => {
+		const rules: RulesArray = [{ type: 'removeSpells', uuids: ['uuid-ice-1'] }];
+		const owned = [makeOwnedSpell({ compendiumSource: 'uuid-fire-1', name: 'Ember' })];
+		expect(collectSpellRemovals([rules], owned)).toEqual([]);
+	});
+
+	it('does not remove spells without a compendiumSource', () => {
+		const rules: RulesArray = [{ type: 'removeSpells', uuids: ['uuid-fire-1'] }];
+		const owned = [{ name: 'Manual Spell', img: 'icons/svg/item-bag.svg', _stats: undefined }];
+		expect(collectSpellRemovals([rules], owned)).toEqual([]);
+	});
+
+	it('matches and returns a spell whose compendiumSource is in the removal UUIDs', () => {
+		const rules: RulesArray = [{ type: 'removeSpells', uuids: ['uuid-fire-1'] }];
+		const owned = [
+			makeOwnedSpell({ compendiumSource: 'uuid-fire-1', name: 'Ember', img: 'fire.png' }),
+		];
+		const result = collectSpellRemovals([rules], owned);
+		expect(result).toHaveLength(1);
+		expect(result[0]).toEqual({ uuid: 'uuid-fire-1', name: 'Ember', img: 'fire.png' });
+	});
+
+	it('collects removals from multiple rule arrays', () => {
+		const rules1: RulesArray = [{ type: 'removeSpells', uuids: ['uuid-fire-1'] }];
+		const rules2: RulesArray = [{ type: 'removeSpells', uuids: ['uuid-ice-1'] }];
+		const owned = [
+			makeOwnedSpell({ compendiumSource: 'uuid-fire-1', name: 'Ember' }),
+			makeOwnedSpell({ compendiumSource: 'uuid-ice-1', name: 'Frost' }),
+		];
+		const result = collectSpellRemovals([rules1, rules2], owned);
+		expect(result).toHaveLength(2);
+		expect(result.map((r) => r.uuid).sort()).toEqual(['uuid-fire-1', 'uuid-ice-1']);
+	});
+
+	it('deduplicates when multiple rules target the same UUID', () => {
+		const rules1: RulesArray = [{ type: 'removeSpells', uuids: ['uuid-fire-1'] }];
+		const rules2: RulesArray = [{ type: 'removeSpells', uuids: ['uuid-fire-1'] }];
+		const owned = [makeOwnedSpell({ compendiumSource: 'uuid-fire-1', name: 'Ember' })];
+		const result = collectSpellRemovals([rules1, rules2], owned);
+		expect(result).toHaveLength(1);
+	});
+
+	it('deduplicates when the same UUID appears twice in one rule', () => {
+		const rules: RulesArray = [{ type: 'removeSpells', uuids: ['uuid-fire-1', 'uuid-fire-1'] }];
+		const owned = [makeOwnedSpell({ compendiumSource: 'uuid-fire-1', name: 'Ember' })];
+		const result = collectSpellRemovals([rules], owned);
+		expect(result).toHaveLength(1);
+	});
+
+	it('only removes matching spells and preserves others', () => {
+		const rules: RulesArray = [{ type: 'removeSpells', uuids: ['uuid-fire-1'] }];
+		const owned = [
+			makeOwnedSpell({ compendiumSource: 'uuid-fire-1', name: 'Ember' }),
+			makeOwnedSpell({ compendiumSource: 'uuid-ice-1', name: 'Frost' }),
+		];
+		const result = collectSpellRemovals([rules], owned);
+		expect(result).toHaveLength(1);
+		expect(result[0].name).toBe('Ember');
+	});
+
+	it('uses fallback name and img when spell has none', () => {
+		const rules: RulesArray = [{ type: 'removeSpells', uuids: ['uuid-fire-1'] }];
+		const owned = [{ _stats: { compendiumSource: 'uuid-fire-1' } }];
+		const result = collectSpellRemovals([rules], owned);
+		expect(result[0].name).toBe('');
+		expect(result[0].img).toBe('icons/svg/item-bag.svg');
+	});
+
+	it('skips non-removeSpells rules', () => {
+		const rules: RulesArray = [
+			{ type: 'grantSpells', schools: ['fire'] },
+			{ type: 'removeSpells', uuids: ['uuid-ice-1'] },
+		];
+		const owned = [makeOwnedSpell({ compendiumSource: 'uuid-ice-1', name: 'Frost' })];
+		const result = collectSpellRemovals([rules], owned);
+		expect(result).toHaveLength(1);
+		expect(result[0].uuid).toBe('uuid-ice-1');
+	});
+
+	it('returns empty array when rules have no uuids field', () => {
+		const rules: RulesArray = [{ type: 'removeSpells' }];
+		const owned = [makeOwnedSpell({ compendiumSource: 'uuid-fire-1', name: 'Ember' })];
+		expect(collectSpellRemovals([rules], owned)).toEqual([]);
 	});
 });

--- a/src/view/dialogs/spellGrantUtils.test.ts
+++ b/src/view/dialogs/spellGrantUtils.test.ts
@@ -5,10 +5,14 @@ import type { SpellIndex, SpellIndexEntry } from '#utils/getSpells.js';
 import type { RulesArray } from './spellGrantUtils.js';
 import {
 	collectKnownSchools,
+	collectSchoolRemovals,
 	collectSpellGrants,
 	collectSpellRemovals,
+	collectSpellRestrictions,
 	predicatePassesAtLevel,
 	resolveSchools,
+	retagEffectsDamageType,
+	schoolToDamageType,
 } from './spellGrantUtils.js';
 
 function createSpellEntry(
@@ -796,5 +800,224 @@ describe('collectSpellRemovals', () => {
 		const rules: RulesArray = [{ type: 'removeSpells' }];
 		const owned = [makeOwnedSpell({ compendiumSource: 'uuid-fire-1', name: 'Ember' })];
 		expect(collectSpellRemovals([rules], owned)).toEqual([]);
+	});
+});
+
+describe('schoolToDamageType', () => {
+	it('maps elemental schools to their damage type (ice → cold)', () => {
+		expect(schoolToDamageType('fire')).toBe('fire');
+		expect(schoolToDamageType('ice')).toBe('cold');
+		expect(schoolToDamageType('lightning')).toBe('lightning');
+	});
+
+	it('returns null for a non-elemental school', () => {
+		expect(schoolToDamageType('radiant')).toBeNull();
+	});
+});
+
+describe('collectSpellRestrictions', () => {
+	it('returns an inactive restriction when no rules are present', () => {
+		const result = collectSpellRestrictions([[{ type: 'grantSpells', schools: ['fire'] }]]);
+		expect(result.active).toBe(false);
+		expect(result.allowedSchools.size).toBe(0);
+		expect(result.exceptionFromSchools).toEqual([]);
+		expect(result.exceptionCount).toBe(0);
+	});
+
+	it('collects allowed and exception schools from a restrictSpellSchools rule', () => {
+		const rules: RulesArray = [
+			{
+				type: 'restrictSpellSchools',
+				allowedSchools: ['fire'],
+				exceptionFromSchools: ['ice', 'lightning'],
+				exceptionCount: 1,
+			},
+		];
+		const result = collectSpellRestrictions([rules]);
+		expect(result.active).toBe(true);
+		expect([...result.allowedSchools]).toEqual(['fire']);
+		expect(result.exceptionFromSchools.sort()).toEqual(['ice', 'lightning']);
+		expect(result.exceptionCount).toBe(1);
+	});
+
+	it('unions schools and sums exception counts across multiple rules', () => {
+		const rules1: RulesArray = [
+			{
+				type: 'restrictSpellSchools',
+				allowedSchools: ['fire'],
+				exceptionFromSchools: ['ice'],
+				exceptionCount: 1,
+			},
+		];
+		const rules2: RulesArray = [
+			{
+				type: 'restrictSpellSchools',
+				allowedSchools: ['lightning'],
+				exceptionFromSchools: ['ice'],
+				exceptionCount: 2,
+			},
+		];
+		const result = collectSpellRestrictions([rules1, rules2]);
+		expect([...result.allowedSchools].sort()).toEqual(['fire', 'lightning']);
+		expect(result.exceptionFromSchools).toEqual(['ice']);
+		expect(result.exceptionCount).toBe(3);
+	});
+});
+
+describe('collectSchoolRemovals', () => {
+	function makeOwnedSpell(overrides: {
+		compendiumSource?: string;
+		name?: string;
+		school?: string;
+	}) {
+		return {
+			name: overrides.name ?? 'A Spell',
+			img: 'icons/svg/item-bag.svg',
+			system: { school: overrides.school ?? 'fire' },
+			_stats: overrides.compendiumSource
+				? { compendiumSource: overrides.compendiumSource }
+				: undefined,
+		};
+	}
+
+	it('returns empty array when allowedSchools is empty (no active restriction)', () => {
+		const owned = [makeOwnedSpell({ compendiumSource: 'ice-1', school: 'ice' })];
+		expect(collectSchoolRemovals(owned, new Set())).toEqual([]);
+	});
+
+	it('removes automation spells outside the allowed schools', () => {
+		const owned = [
+			makeOwnedSpell({ compendiumSource: 'fire-1', school: 'fire', name: 'Ember' }),
+			makeOwnedSpell({ compendiumSource: 'ice-1', school: 'ice', name: 'Frost' }),
+			makeOwnedSpell({ compendiumSource: 'light-1', school: 'lightning', name: 'Zap' }),
+		];
+		const result = collectSchoolRemovals(owned, new Set(['fire']));
+		expect(result.map((r) => r.uuid).sort()).toEqual(['ice-1', 'light-1']);
+	});
+
+	it('spares chosen keep-and-convert exceptions', () => {
+		const owned = [
+			makeOwnedSpell({ compendiumSource: 'ice-1', school: 'ice', name: 'Frost' }),
+			makeOwnedSpell({ compendiumSource: 'ice-2', school: 'ice', name: 'Ice Shard' }),
+		];
+		const result = collectSchoolRemovals(owned, new Set(['fire']), new Set(['ice-1']));
+		expect(result.map((r) => r.uuid)).toEqual(['ice-2']);
+	});
+
+	it('never targets manual spells without a compendiumSource', () => {
+		const owned = [{ name: 'Manual', img: 'x.png', system: { school: 'ice' }, _stats: undefined }];
+		expect(collectSchoolRemovals(owned, new Set(['fire']))).toEqual([]);
+	});
+});
+
+describe('collectSpellGrants with allowedSchools restriction', () => {
+	const spells = [
+		createSpellEntry({ uuid: 'fire-t2', name: 'Fireball', school: 'fire', tier: 2 }),
+		createSpellEntry({ uuid: 'ice-t2', name: 'Ice Spike', school: 'ice', tier: 2 }),
+		createSpellEntry({ uuid: 'light-t2', name: 'Bolt', school: 'lightning', tier: 2 }),
+	];
+
+	it('filters auto-granted spells down to the allowed schools', () => {
+		const index = createSpellIndex(spells);
+		const rules: RulesArray = [
+			{
+				type: 'grantSpells',
+				schools: ['fire', 'ice', 'lightning'],
+				tiers: [2],
+				mode: 'auto',
+				predicate: { level: { min: 4 } },
+			},
+		];
+		const result = collectSpellGrants(
+			[rules],
+			index,
+			'mage',
+			4,
+			new Set(),
+			new Set(),
+			new Set(['fire']),
+		);
+		expect(result.autoGrant.map((s) => s.uuid)).toEqual(['fire-t2']);
+	});
+
+	it('grants everything when no restriction is passed', () => {
+		const index = createSpellIndex(spells);
+		const rules: RulesArray = [
+			{
+				type: 'grantSpells',
+				schools: ['fire', 'ice', 'lightning'],
+				tiers: [2],
+				mode: 'auto',
+				predicate: { level: { min: 4 } },
+			},
+		];
+		const result = collectSpellGrants([rules], index, 'mage', 4, new Set(), new Set());
+		expect(result.autoGrant.map((s) => s.uuid).sort()).toEqual(['fire-t2', 'ice-t2', 'light-t2']);
+	});
+
+	it('restricts selectSchool options to the allowed schools', () => {
+		const index = createSpellIndex(spells);
+		const rules: RulesArray = [
+			{
+				id: 'mastery',
+				type: 'grantSpells',
+				schools: ['fire', 'ice', 'lightning'],
+				tiers: [2],
+				mode: 'selectSchool',
+				count: 1,
+				predicate: { level: { min: 4 } },
+			},
+		];
+		const result = collectSpellGrants(
+			[rules],
+			index,
+			'mage',
+			4,
+			new Set(),
+			new Set(),
+			new Set(['fire']),
+		);
+		expect(result.schoolSelections).toHaveLength(1);
+		expect(result.schoolSelections[0].availableSchools).toEqual(['fire']);
+	});
+});
+
+describe('retagEffectsDamageType', () => {
+	it('remaps elemental damage types nested under saving-throw outcomes', () => {
+		const effects = [
+			{
+				type: 'savingThrow',
+				on: {
+					failedSave: [{ type: 'damage', damageType: 'cold', formula: '2d6' }],
+					passedSave: [{ type: 'note', text: 'half' }],
+				},
+			},
+		];
+		const result = retagEffectsDamageType(effects, 'fire') as typeof effects;
+		expect(result[0].on.failedSave[0].damageType).toBe('fire');
+		// Non-damage nodes are untouched.
+		expect((result[0].on.passedSave[0] as { text: string }).text).toBe('half');
+	});
+
+	it('remaps a top-level damage node', () => {
+		const effects = [{ type: 'damage', damageType: 'lightning', formula: '3d8' }];
+		const result = retagEffectsDamageType(effects, 'cold') as Array<{ damageType: string }>;
+		expect(result[0].damageType).toBe('cold');
+	});
+
+	it('leaves non-elemental damage types untouched', () => {
+		const effects = [{ type: 'damage', damageType: 'radiant', formula: '1d6' }];
+		const result = retagEffectsDamageType(effects, 'fire') as Array<{ damageType: string }>;
+		expect(result[0].damageType).toBe('radiant');
+	});
+
+	it('does not mutate the original effects array', () => {
+		const effects = [{ type: 'damage', damageType: 'fire' }];
+		retagEffectsDamageType(effects, 'cold');
+		expect(effects[0].damageType).toBe('fire');
+	});
+
+	it('returns an empty array for non-array input', () => {
+		expect(retagEffectsDamageType(undefined, 'fire')).toEqual([]);
 	});
 });

--- a/src/view/dialogs/spellGrantUtils.test.ts
+++ b/src/view/dialogs/spellGrantUtils.test.ts
@@ -11,8 +11,6 @@ import {
 	collectSpellRestrictions,
 	predicatePassesAtLevel,
 	resolveSchools,
-	retagEffectsDamageType,
-	schoolToDamageType,
 } from './spellGrantUtils.js';
 
 function createSpellEntry(
@@ -803,18 +801,6 @@ describe('collectSpellRemovals', () => {
 	});
 });
 
-describe('schoolToDamageType', () => {
-	it('maps elemental schools to their damage type (ice → cold)', () => {
-		expect(schoolToDamageType('fire')).toBe('fire');
-		expect(schoolToDamageType('ice')).toBe('cold');
-		expect(schoolToDamageType('lightning')).toBe('lightning');
-	});
-
-	it('returns null for a non-elemental school', () => {
-		expect(schoolToDamageType('radiant')).toBeNull();
-	});
-});
-
 describe('collectSpellRestrictions', () => {
 	it('returns an inactive restriction when no rules are present', () => {
 		const result = collectSpellRestrictions([[{ type: 'grantSpells', schools: ['fire'] }]]);
@@ -979,45 +965,5 @@ describe('collectSpellGrants with allowedSchools restriction', () => {
 		);
 		expect(result.schoolSelections).toHaveLength(1);
 		expect(result.schoolSelections[0].availableSchools).toEqual(['fire']);
-	});
-});
-
-describe('retagEffectsDamageType', () => {
-	it('remaps elemental damage types nested under saving-throw outcomes', () => {
-		const effects = [
-			{
-				type: 'savingThrow',
-				on: {
-					failedSave: [{ type: 'damage', damageType: 'cold', formula: '2d6' }],
-					passedSave: [{ type: 'note', text: 'half' }],
-				},
-			},
-		];
-		const result = retagEffectsDamageType(effects, 'fire') as typeof effects;
-		expect(result[0].on.failedSave[0].damageType).toBe('fire');
-		// Non-damage nodes are untouched.
-		expect((result[0].on.passedSave[0] as { text: string }).text).toBe('half');
-	});
-
-	it('remaps a top-level damage node', () => {
-		const effects = [{ type: 'damage', damageType: 'lightning', formula: '3d8' }];
-		const result = retagEffectsDamageType(effects, 'cold') as Array<{ damageType: string }>;
-		expect(result[0].damageType).toBe('cold');
-	});
-
-	it('leaves non-elemental damage types untouched', () => {
-		const effects = [{ type: 'damage', damageType: 'radiant', formula: '1d6' }];
-		const result = retagEffectsDamageType(effects, 'fire') as Array<{ damageType: string }>;
-		expect(result[0].damageType).toBe('radiant');
-	});
-
-	it('does not mutate the original effects array', () => {
-		const effects = [{ type: 'damage', damageType: 'fire' }];
-		retagEffectsDamageType(effects, 'cold');
-		expect(effects[0].damageType).toBe('fire');
-	});
-
-	it('returns an empty array for non-array input', () => {
-		expect(retagEffectsDamageType(undefined, 'fire')).toEqual([]);
 	});
 });

--- a/src/view/dialogs/spellGrantUtils.ts
+++ b/src/view/dialogs/spellGrantUtils.ts
@@ -4,6 +4,13 @@ import localize from '#utils/localize.ts';
 
 import type { SchoolSelectionGroup, SpellSelectionGroup } from './characterCreation/types.js';
 
+/** A spell that will be removed during subclass selection */
+export interface SpellRemovalEntry {
+	uuid: string;
+	name: string;
+	img: string;
+}
+
 /** Result of processing grantSpells rules */
 export interface SpellGrantResult {
 	autoGrant: SpellIndexEntry[];
@@ -187,4 +194,50 @@ export function collectSpellGrants(
 	}
 
 	return { autoGrant, schoolSelections, spellSelections };
+}
+
+/**
+ * Collects spells to remove based on removeSpells rules on features being granted.
+ * Only matches spells that came from automation (have a compendiumSource matching a rule UUID).
+ * Manual player spells without a compendiumSource are never targeted.
+ */
+export function collectSpellRemovals(
+	rulesArrays: RulesArray[],
+	ownedSpells: Array<{
+		name?: string;
+		img?: string;
+		_stats?: { compendiumSource?: string };
+	}>,
+): SpellRemovalEntry[] {
+	const removalUuids = new Set<string>();
+
+	for (const rules of rulesArrays) {
+		for (const rule of rules) {
+			if (rule.type !== 'removeSpells') continue;
+			const uuids = rule.uuids as string[] | undefined;
+			if (!uuids) continue;
+			for (const uuid of uuids) {
+				removalUuids.add(uuid);
+			}
+		}
+	}
+
+	if (removalUuids.size === 0) return [];
+
+	const spellsToRemove: SpellRemovalEntry[] = [];
+	const seenUuids = new Set<string>();
+
+	for (const spell of ownedSpells) {
+		const source = spell._stats?.compendiumSource;
+		if (!source || !removalUuids.has(source)) continue;
+		if (seenUuids.has(source)) continue;
+		seenUuids.add(source);
+		spellsToRemove.push({
+			uuid: source,
+			name: spell.name ?? '',
+			img: spell.img ?? 'icons/svg/item-bag.svg',
+		});
+	}
+
+	return spellsToRemove;
 }

--- a/src/view/dialogs/spellGrantUtils.ts
+++ b/src/view/dialogs/spellGrantUtils.ts
@@ -11,6 +11,103 @@ export interface SpellRemovalEntry {
 	img: string;
 }
 
+/**
+ * Maps a spell school to the damage type its spells deal. Used when retagging a
+ * "keep and convert" exception spell so its elemental damage matches the new
+ * school. Note the mapping is not identity: the Ice school deals `cold` damage.
+ */
+export const SCHOOL_TO_DAMAGE_TYPE: Record<string, string> = {
+	fire: 'fire',
+	ice: 'cold',
+	lightning: 'lightning',
+};
+
+/** The elemental damage types that a conversion may rewrite. */
+const ELEMENTAL_DAMAGE_TYPES = new Set(Object.values(SCHOOL_TO_DAMAGE_TYPE));
+
+/** Resolves the damage type for a school, or null when the school is non-elemental. */
+export function schoolToDamageType(school: string): string | null {
+	return SCHOOL_TO_DAMAGE_TYPE[school] ?? null;
+}
+
+/**
+ * Active spell-school restriction collected from restrictSpellSchools rules.
+ * `allowedSchools` persists across levels (derived from all active rules), while
+ * the exception fields describe the one-time "keep and convert" choice.
+ */
+export interface SpellRestriction {
+	active: boolean;
+	allowedSchools: Set<string>;
+	exceptionFromSchools: string[];
+	exceptionCount: number;
+}
+
+/**
+ * Collects the active spell-school restriction from restrictSpellSchools rules.
+ * Multiple rules union their allowed/exception schools; exception counts sum.
+ */
+export function collectSpellRestrictions(rulesArrays: RulesArray[]): SpellRestriction {
+	const allowedSchools = new Set<string>();
+	const exceptionFromSchools = new Set<string>();
+	let exceptionCount = 0;
+	let active = false;
+
+	for (const rules of rulesArrays) {
+		for (const rule of rules) {
+			if (rule.type !== 'restrictSpellSchools') continue;
+			active = true;
+			for (const s of (rule.allowedSchools as string[] | undefined) ?? []) allowedSchools.add(s);
+			for (const s of (rule.exceptionFromSchools as string[] | undefined) ?? [])
+				exceptionFromSchools.add(s);
+			exceptionCount += (rule.exceptionCount as number | undefined) ?? 0;
+		}
+	}
+
+	return {
+		active,
+		allowedSchools,
+		exceptionFromSchools: [...exceptionFromSchools],
+		exceptionCount,
+	};
+}
+
+/**
+ * Deep-clones a spell's `activation.effects` array, remapping any elemental
+ * damage type (fire/cold/lightning) to `toDamageType`. Non-elemental damage
+ * (radiant, necrotic, physical, …) is left untouched. Recurses into the nested
+ * `on.<outcome>` effect arrays produced by saving-throw and attack effects.
+ */
+export function retagEffectsDamageType(effects: unknown, toDamageType: string): unknown[] {
+	if (!Array.isArray(effects)) return [];
+
+	const remapNode = (node: unknown): unknown => {
+		if (!node || typeof node !== 'object') return node;
+		const clone: Record<string, unknown> = { ...(node as Record<string, unknown>) };
+
+		if (
+			typeof clone.damageType === 'string' &&
+			ELEMENTAL_DAMAGE_TYPES.has(clone.damageType as string)
+		) {
+			clone.damageType = toDamageType;
+		}
+
+		if (clone.on && typeof clone.on === 'object') {
+			const on = clone.on as Record<string, unknown>;
+			const newOn: Record<string, unknown> = { ...on };
+			for (const [outcome, children] of Object.entries(on)) {
+				if (Array.isArray(children)) {
+					newOn[outcome] = children.map(remapNode);
+				}
+			}
+			clone.on = newOn;
+		}
+
+		return clone;
+	};
+
+	return effects.map(remapNode);
+}
+
 /** Result of processing grantSpells rules */
 export interface SpellGrantResult {
 	autoGrant: SpellIndexEntry[];
@@ -105,12 +202,19 @@ export function collectSpellGrants(
 	targetLevel: number,
 	ownedSpellUuids: Set<string>,
 	knownSchools: Set<string>,
+	allowedSchools?: Set<string>,
 ): SpellGrantResult {
 	const autoGrant: SpellIndexEntry[] = [];
 	const schoolSelections: SchoolSelectionGroup[] = [];
 	const spellSelections: SpellSelectionGroup[] = [];
 	const seenUuids = new Set<string>();
 	const uuidLookup = buildUuidLookup(spellIndex);
+
+	// An active school restriction ("you can only cast fire spells from now on")
+	// filters every grant down to the allowed schools, so disallowed schools are
+	// never re-granted at later levels.
+	const restricted = !!allowedSchools && allowedSchools.size > 0;
+	const schoolAllowed = (school: string) => !restricted || allowedSchools!.has(school);
 
 	for (const rules of rulesArrays) {
 		for (const rule of rules) {
@@ -129,7 +233,7 @@ export function collectSpellGrants(
 						if (seenUuids.has(uuid) || ownedSpellUuids.has(uuid)) continue;
 						seenUuids.add(uuid);
 						const spell = uuidLookup.get(uuid);
-						if (spell) autoGrant.push(spell);
+						if (spell && schoolAllowed(spell.school)) autoGrant.push(spell);
 					}
 				} else if (resolvedSchools.length > 0) {
 					const spells = getSpellsFromIndex(spellIndex, resolvedSchools, tiers, {
@@ -138,14 +242,17 @@ export function collectSpellGrants(
 					});
 					for (const spell of spells) {
 						if (seenUuids.has(spell.uuid) || ownedSpellUuids.has(spell.uuid)) continue;
+						if (!schoolAllowed(spell.school)) continue;
 						seenUuids.add(spell.uuid);
 						autoGrant.push(spell);
 					}
 				}
 			} else if (mode === 'selectSchool' && resolvedSchools.length > 0) {
 				// Filter out schools where the character already owns all matching spells
-				// (i.e., that school was already selected at a previous level)
+				// (i.e., that school was already selected at a previous level), and any
+				// school excluded by an active restriction.
 				const availableSchools = resolvedSchools.filter((school) => {
+					if (!schoolAllowed(school)) return false;
 					const schoolSpells = getSpellsFromIndex(spellIndex, [school], tiers, {
 						utilityOnly,
 						forClass: classIdentifier,
@@ -172,6 +279,7 @@ export function collectSpellGrants(
 
 				// Create one selection group per school so the player picks count from each
 				for (const school of resolvedSchools) {
+					if (!schoolAllowed(school)) continue;
 					const availableSpells = getSpellsFromIndex(spellIndex, [school], tiers, {
 						utilityOnly,
 						forClass: classIdentifier,
@@ -231,6 +339,46 @@ export function collectSpellRemovals(
 		const source = spell._stats?.compendiumSource;
 		if (!source || !removalUuids.has(source)) continue;
 		if (seenUuids.has(source)) continue;
+		seenUuids.add(source);
+		spellsToRemove.push({
+			uuid: source,
+			name: spell.name ?? '',
+			img: spell.img ?? 'icons/svg/item-bag.svg',
+		});
+	}
+
+	return spellsToRemove;
+}
+
+/** Owned-spell shape used for school-based removal (needs the spell's school). */
+export interface OwnedSpellForRemoval {
+	name?: string;
+	img?: string;
+	system?: { school?: string };
+	_stats?: { compendiumSource?: string };
+}
+
+/**
+ * Collects automation-granted spells to remove because their school is not in
+ * `allowedSchools` (the persistent restriction). Spells whose compendiumSource
+ * is in `keepUuids` — the player's chosen "keep and convert" exceptions — are
+ * spared. Manual spells (no compendiumSource) are never targeted.
+ */
+export function collectSchoolRemovals(
+	ownedSpells: OwnedSpellForRemoval[],
+	allowedSchools: Set<string>,
+	keepUuids: Set<string> = new Set(),
+): SpellRemovalEntry[] {
+	if (allowedSchools.size === 0) return [];
+
+	const spellsToRemove: SpellRemovalEntry[] = [];
+	const seenUuids = new Set<string>();
+
+	for (const spell of ownedSpells) {
+		const source = spell._stats?.compendiumSource;
+		if (!source || keepUuids.has(source) || seenUuids.has(source)) continue;
+		const school = spell.system?.school ?? '';
+		if (allowedSchools.has(school)) continue;
 		seenUuids.add(source);
 		spellsToRemove.push({
 			uuid: source,

--- a/src/view/dialogs/spellGrantUtils.ts
+++ b/src/view/dialogs/spellGrantUtils.ts
@@ -11,6 +11,103 @@ export interface SpellRemovalEntry {
 	img: string;
 }
 
+/**
+ * Maps a spell school to the damage type its spells deal. Used when retagging a
+ * "keep and convert" exception spell so its elemental damage matches the new
+ * school. Note the mapping is not identity: the Ice school deals `cold` damage.
+ */
+export const SCHOOL_TO_DAMAGE_TYPE: Record<string, string> = {
+	fire: 'fire',
+	ice: 'cold',
+	lightning: 'lightning',
+};
+
+/** The elemental damage types that a conversion may rewrite. */
+const ELEMENTAL_DAMAGE_TYPES = new Set(Object.values(SCHOOL_TO_DAMAGE_TYPE));
+
+/** Resolves the damage type for a school, or null when the school is non-elemental. */
+export function schoolToDamageType(school: string): string | null {
+	return SCHOOL_TO_DAMAGE_TYPE[school] ?? null;
+}
+
+/**
+ * Active spell-school restriction collected from restrictSpellSchools rules.
+ * `allowedSchools` persists across levels (derived from all active rules), while
+ * the exception fields describe the one-time "keep and convert" choice.
+ */
+export interface SpellRestriction {
+	active: boolean;
+	allowedSchools: Set<string>;
+	exceptionFromSchools: string[];
+	exceptionCount: number;
+}
+
+/**
+ * Collects the active spell-school restriction from restrictSpellSchools rules.
+ * Multiple rules union their allowed/exception schools; exception counts sum.
+ */
+export function collectSpellRestrictions(rulesArrays: RulesArray[]): SpellRestriction {
+	const allowedSchools = new Set<string>();
+	const exceptionFromSchools = new Set<string>();
+	let exceptionCount = 0;
+	let active = false;
+
+	for (const rules of rulesArrays) {
+		for (const rule of rules) {
+			if (rule.type !== 'restrictSpellSchools') continue;
+			active = true;
+			for (const s of (rule.allowedSchools as string[] | undefined) ?? []) allowedSchools.add(s);
+			for (const s of (rule.exceptionFromSchools as string[] | undefined) ?? [])
+				exceptionFromSchools.add(s);
+			exceptionCount += (rule.exceptionCount as number | undefined) ?? 0;
+		}
+	}
+
+	return {
+		active,
+		allowedSchools,
+		exceptionFromSchools: [...exceptionFromSchools],
+		exceptionCount,
+	};
+}
+
+/**
+ * Deep-clones a spell's `activation.effects` array, remapping any elemental
+ * damage type (fire/cold/lightning) to `toDamageType`. Non-elemental damage
+ * (radiant, necrotic, physical, …) is left untouched. Recurses into the nested
+ * `on.<outcome>` effect arrays produced by saving-throw and attack effects.
+ */
+export function retagEffectsDamageType(effects: unknown, toDamageType: string): unknown[] {
+	if (!Array.isArray(effects)) return [];
+
+	const remapNode = (node: unknown): unknown => {
+		if (!node || typeof node !== 'object') return node;
+		const clone: Record<string, unknown> = { ...(node as Record<string, unknown>) };
+
+		if (
+			typeof clone.damageType === 'string' &&
+			ELEMENTAL_DAMAGE_TYPES.has(clone.damageType as string)
+		) {
+			clone.damageType = toDamageType;
+		}
+
+		if (clone.on && typeof clone.on === 'object') {
+			const on = clone.on as Record<string, unknown>;
+			const newOn: Record<string, unknown> = { ...on };
+			for (const [outcome, children] of Object.entries(on)) {
+				if (Array.isArray(children)) {
+					newOn[outcome] = children.map(remapNode);
+				}
+			}
+			clone.on = newOn;
+		}
+
+		return clone;
+	};
+
+	return effects.map(remapNode);
+}
+
 /** Result of processing grantSpells rules */
 export interface SpellGrantResult {
 	autoGrant: SpellIndexEntry[];
@@ -105,6 +202,7 @@ export function collectSpellGrants(
 	targetLevel: number,
 	ownedSpellUuids: Set<string>,
 	knownSchools: Set<string>,
+	allowedSchools?: Set<string>,
 ): SpellGrantResult {
 	const autoGrant: SpellIndexEntry[] = [];
 	const schoolSelections: SchoolSelectionGroup[] = [];
@@ -116,6 +214,12 @@ export function collectSpellGrants(
 	// dialog — collapse repeats into the first occurrence instead.
 	const seenSelectionKeys = new Set<string>();
 	const uuidLookup = buildUuidLookup(spellIndex);
+
+	// An active school restriction ("you can only cast fire spells from now on")
+	// filters every grant down to the allowed schools, so disallowed schools are
+	// never re-granted at later levels.
+	const restricted = !!allowedSchools && allowedSchools.size > 0;
+	const schoolAllowed = (school: string) => !restricted || allowedSchools!.has(school);
 
 	for (const rules of rulesArrays) {
 		for (const rule of rules) {
@@ -134,7 +238,7 @@ export function collectSpellGrants(
 						if (seenUuids.has(uuid) || ownedSpellUuids.has(uuid)) continue;
 						seenUuids.add(uuid);
 						const spell = uuidLookup.get(uuid);
-						if (spell) autoGrant.push(spell);
+						if (spell && schoolAllowed(spell.school)) autoGrant.push(spell);
 					}
 				} else if (resolvedSchools.length > 0) {
 					const spells = getSpellsFromIndex(spellIndex, resolvedSchools, tiers, {
@@ -143,14 +247,17 @@ export function collectSpellGrants(
 					});
 					for (const spell of spells) {
 						if (seenUuids.has(spell.uuid) || ownedSpellUuids.has(spell.uuid)) continue;
+						if (!schoolAllowed(spell.school)) continue;
 						seenUuids.add(spell.uuid);
 						autoGrant.push(spell);
 					}
 				}
 			} else if (mode === 'selectSchool' && resolvedSchools.length > 0) {
 				// Filter out schools where the character already owns all matching spells
-				// (i.e., that school was already selected at a previous level)
+				// (i.e., that school was already selected at a previous level), and any
+				// school excluded by an active restriction.
 				const availableSchools = resolvedSchools.filter((school) => {
+					if (!schoolAllowed(school)) return false;
 					const schoolSpells = getSpellsFromIndex(spellIndex, [school], tiers, {
 						utilityOnly,
 						forClass: classIdentifier,
@@ -179,6 +286,7 @@ export function collectSpellGrants(
 
 				// Create one selection group per school so the player picks count from each
 				for (const school of resolvedSchools) {
+					if (!schoolAllowed(school)) continue;
 					const availableSpells = getSpellsFromIndex(spellIndex, [school], tiers, {
 						utilityOnly,
 						forClass: classIdentifier,
@@ -239,6 +347,46 @@ export function collectSpellRemovals(
 		const source = spell._stats?.compendiumSource;
 		if (!source || !removalUuids.has(source)) continue;
 		if (seenUuids.has(source)) continue;
+		seenUuids.add(source);
+		spellsToRemove.push({
+			uuid: source,
+			name: spell.name ?? '',
+			img: spell.img ?? 'icons/svg/item-bag.svg',
+		});
+	}
+
+	return spellsToRemove;
+}
+
+/** Owned-spell shape used for school-based removal (needs the spell's school). */
+export interface OwnedSpellForRemoval {
+	name?: string;
+	img?: string;
+	system?: { school?: string };
+	_stats?: { compendiumSource?: string };
+}
+
+/**
+ * Collects automation-granted spells to remove because their school is not in
+ * `allowedSchools` (the persistent restriction). Spells whose compendiumSource
+ * is in `keepUuids` — the player's chosen "keep and convert" exceptions — are
+ * spared. Manual spells (no compendiumSource) are never targeted.
+ */
+export function collectSchoolRemovals(
+	ownedSpells: OwnedSpellForRemoval[],
+	allowedSchools: Set<string>,
+	keepUuids: Set<string> = new Set(),
+): SpellRemovalEntry[] {
+	if (allowedSchools.size === 0) return [];
+
+	const spellsToRemove: SpellRemovalEntry[] = [];
+	const seenUuids = new Set<string>();
+
+	for (const spell of ownedSpells) {
+		const source = spell._stats?.compendiumSource;
+		if (!source || keepUuids.has(source) || seenUuids.has(source)) continue;
+		const school = spell.system?.school ?? '';
+		if (allowedSchools.has(school)) continue;
 		seenUuids.add(source);
 		spellsToRemove.push({
 			uuid: source,

--- a/src/view/dialogs/spellGrantUtils.ts
+++ b/src/view/dialogs/spellGrantUtils.ts
@@ -12,25 +12,6 @@ export interface SpellRemovalEntry {
 }
 
 /**
- * Maps a spell school to the damage type its spells deal. Used when retagging a
- * "keep and convert" exception spell so its elemental damage matches the new
- * school. Note the mapping is not identity: the Ice school deals `cold` damage.
- */
-export const SCHOOL_TO_DAMAGE_TYPE: Record<string, string> = {
-	fire: 'fire',
-	ice: 'cold',
-	lightning: 'lightning',
-};
-
-/** The elemental damage types that a conversion may rewrite. */
-const ELEMENTAL_DAMAGE_TYPES = new Set(Object.values(SCHOOL_TO_DAMAGE_TYPE));
-
-/** Resolves the damage type for a school, or null when the school is non-elemental. */
-export function schoolToDamageType(school: string): string | null {
-	return SCHOOL_TO_DAMAGE_TYPE[school] ?? null;
-}
-
-/**
  * Active spell-school restriction collected from restrictSpellSchools rules.
  * `allowedSchools` persists across levels (derived from all active rules), while
  * the exception fields describe the one-time "keep and convert" choice.
@@ -56,9 +37,10 @@ export function collectSpellRestrictions(rulesArrays: RulesArray[]): SpellRestri
 		for (const rule of rules) {
 			if (rule.type !== 'restrictSpellSchools') continue;
 			active = true;
-			for (const s of (rule.allowedSchools as string[] | undefined) ?? []) allowedSchools.add(s);
-			for (const s of (rule.exceptionFromSchools as string[] | undefined) ?? [])
-				exceptionFromSchools.add(s);
+			for (const school of (rule.allowedSchools as string[] | undefined) ?? [])
+				allowedSchools.add(school);
+			for (const school of (rule.exceptionFromSchools as string[] | undefined) ?? [])
+				exceptionFromSchools.add(school);
 			exceptionCount += (rule.exceptionCount as number | undefined) ?? 0;
 		}
 	}
@@ -69,43 +51,6 @@ export function collectSpellRestrictions(rulesArrays: RulesArray[]): SpellRestri
 		exceptionFromSchools: [...exceptionFromSchools],
 		exceptionCount,
 	};
-}
-
-/**
- * Deep-clones a spell's `activation.effects` array, remapping any elemental
- * damage type (fire/cold/lightning) to `toDamageType`. Non-elemental damage
- * (radiant, necrotic, physical, …) is left untouched. Recurses into the nested
- * `on.<outcome>` effect arrays produced by saving-throw and attack effects.
- */
-export function retagEffectsDamageType(effects: unknown, toDamageType: string): unknown[] {
-	if (!Array.isArray(effects)) return [];
-
-	const remapNode = (node: unknown): unknown => {
-		if (!node || typeof node !== 'object') return node;
-		const clone: Record<string, unknown> = { ...(node as Record<string, unknown>) };
-
-		if (
-			typeof clone.damageType === 'string' &&
-			ELEMENTAL_DAMAGE_TYPES.has(clone.damageType as string)
-		) {
-			clone.damageType = toDamageType;
-		}
-
-		if (clone.on && typeof clone.on === 'object') {
-			const on = clone.on as Record<string, unknown>;
-			const newOn: Record<string, unknown> = { ...on };
-			for (const [outcome, children] of Object.entries(on)) {
-				if (Array.isArray(children)) {
-					newOn[outcome] = children.map(remapNode);
-				}
-			}
-			clone.on = newOn;
-		}
-
-		return clone;
-	};
-
-	return effects.map(remapNode);
 }
 
 /** Result of processing grantSpells rules */

--- a/src/view/dialogs/spellGrantUtils.ts
+++ b/src/view/dialogs/spellGrantUtils.ts
@@ -4,6 +4,13 @@ import localize from '#utils/localize.ts';
 
 import type { SchoolSelectionGroup, SpellSelectionGroup } from './characterCreation/types.js';
 
+/** A spell that will be removed during subclass selection */
+export interface SpellRemovalEntry {
+	uuid: string;
+	name: string;
+	img: string;
+}
+
 /** Result of processing grantSpells rules */
 export interface SpellGrantResult {
 	autoGrant: SpellIndexEntry[];
@@ -195,4 +202,50 @@ export function collectSpellGrants(
 	}
 
 	return { autoGrant, schoolSelections, spellSelections };
+}
+
+/**
+ * Collects spells to remove based on removeSpells rules on features being granted.
+ * Only matches spells that came from automation (have a compendiumSource matching a rule UUID).
+ * Manual player spells without a compendiumSource are never targeted.
+ */
+export function collectSpellRemovals(
+	rulesArrays: RulesArray[],
+	ownedSpells: Array<{
+		name?: string;
+		img?: string;
+		_stats?: { compendiumSource?: string };
+	}>,
+): SpellRemovalEntry[] {
+	const removalUuids = new Set<string>();
+
+	for (const rules of rulesArrays) {
+		for (const rule of rules) {
+			if (rule.type !== 'removeSpells') continue;
+			const uuids = rule.uuids as string[] | undefined;
+			if (!uuids) continue;
+			for (const uuid of uuids) {
+				removalUuids.add(uuid);
+			}
+		}
+	}
+
+	if (removalUuids.size === 0) return [];
+
+	const spellsToRemove: SpellRemovalEntry[] = [];
+	const seenUuids = new Set<string>();
+
+	for (const spell of ownedSpells) {
+		const source = spell._stats?.compendiumSource;
+		if (!source || !removalUuids.has(source)) continue;
+		if (seenUuids.has(source)) continue;
+		seenUuids.add(source);
+		spellsToRemove.push({
+			uuid: source,
+			name: spell.name ?? '',
+			img: spell.img ?? 'icons/svg/item-bag.svg',
+		});
+	}
+
+	return spellsToRemove;
 }

--- a/types/components/LevelUpSpellGrants.d.ts
+++ b/types/components/LevelUpSpellGrants.d.ts
@@ -3,6 +3,7 @@ import type {
 	SchoolSelectionGroup,
 	SpellSelectionGroup,
 } from '../../src/view/dialogs/characterCreation/types.js';
+import type { SpellRemovalEntry } from '../../src/view/dialogs/spellGrantUtils.js';
 
 export interface LevelUpSpellGrantsProps {
 	spells: SpellIndexEntry[];
@@ -12,6 +13,7 @@ export interface LevelUpSpellGrantsProps {
 	selectedSchools: Map<string, string[]>;
 	selectedSpells: Map<string, string[]>;
 	confirmedSchools: Set<string>;
+	spellsToRemove: SpellRemovalEntry[];
 	onSchoolsChange: (schools: Map<string, string[]>) => void;
 	onSpellsChange: (spells: Map<string, string[]>) => void;
 	onConfirmedChange: (confirmed: Set<string>) => void;

--- a/types/components/LevelUpSpellGrants.d.ts
+++ b/types/components/LevelUpSpellGrants.d.ts
@@ -14,7 +14,10 @@ export interface LevelUpSpellGrantsProps {
 	selectedSpells: Map<string, string[]>;
 	confirmedSchools: Set<string>;
 	spellsToRemove: SpellRemovalEntry[];
+	exceptionSelections: SpellSelectionGroup[];
+	selectedExceptions: Map<string, string[]>;
 	onSchoolsChange: (schools: Map<string, string[]>) => void;
 	onSpellsChange: (spells: Map<string, string[]>) => void;
+	onExceptionsChange: (spells: Map<string, string[]>) => void;
 	onConfirmedChange: (confirmed: Set<string>) => void;
 }


### PR DESCRIPTION
## Summary

- Adds a new `removeSpells` rule type that features can use to declare spells to remove from the actor when the feature is granted during subclass selection
- Spell removals are processed before grants (preventing a remove-then-regrant collision), and only target automation-managed spells (`_stats.compendiumSource` match) — manual player spells are never touched
- Removed spells are stored as `{ uuid, name, img }` in the level-up history and re-created from compendium on level-down, fully reversing the change

## Changes

**New:**
- `src/models/rules/removeSpells.ts` — generic `removeSpells` rule type registered alongside `grantSpells`

**Modified:**
- `src/view/dialogs/spellGrantUtils.ts` — `collectSpellRemovals()` utility + `SpellRemovalEntry` type
- `src/view/dialogs/CharacterLevelUpDialogState.svelte.ts` — collects removals from features being granted; passes `removedSpellUuids` in submit payload; exposes `spellsToRemove` for UI
- `src/documents/actor/character.ts` — applies removals in `triggerLevelUp`, restores them in `revertLastLevelUp`; adds `removedSpells` to `LevelUpDialogData` and `LevelUpHistoryEntry`
- `src/models/actor/CharacterDataModel.ts` — adds `removedSpells` schema field and `LevelUpHistoryEntry.removedSpells` type
- `src/view/dialogs/CharacterLevelDownDialog{State}.svelte{.ts}` — shows "Spells Restored" section listing spells coming back on revert
- `src/view/dialogs/components/levelUpHelper/LevelUpSpellGrants.svelte{.ts}` — shows "Spells Removed by Subclass" informational section in the level-up dialog
- `src/config/registerRulesConfig.ts`, `public/lang/en.json` — registration and localization

## Test plan

- [x] `pnpm check` passes (format, lint, circular deps, types, 835 tests)
- [x] `collectSpellRemovals` covered by 10 new unit tests in `spellGrantUtils.test.ts`
- [ ] Manual: create a feature with a `removeSpells` rule, select a subclass that grants that feature at level 3, verify the targeted spell is removed and listed in the dialog
- [ ] Manual: level down from 3, verify the removed spell is restored and shown in the level-down dialog
- [ ] Manual: manually-added spell with the same UUID is NOT removed (requires `_stats.compendiumSource` match)

Closes #702