### PR TITLE
feat(features-tab): group class features, collapsible cards, level badges (#570)

### DIFF
--- a/src/view/sheets/pages/PlayerCharacterFeaturesTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterFeaturesTab.svelte
@@ -72,10 +72,16 @@
 		sheet.clearDroppedItemFlash(itemId);
 	}
 
+	function getEffectiveLevel(item): number {
+		return (
+			item.reactive.system?.gainedAtLevel ?? item.reactive.system?.gainedAtLevels?.[0] ?? Infinity
+		);
+	}
+
 	function sortFeatureItems(items) {
 		return [...items].sort((a, b) => {
-			const levelA = a.reactive.system?.gainedAtLevel ?? Infinity;
-			const levelB = b.reactive.system?.gainedAtLevel ?? Infinity;
+			const levelA = getEffectiveLevel(a);
+			const levelB = getEffectiveLevel(b);
 			if (levelA !== levelB) return levelA - levelB;
 			return (a.reactive.sort ?? 0) - (b.reactive.sort ?? 0);
 		});
@@ -213,10 +219,8 @@
 								{item.reactive.name}
 							</h4>
 
-							{#if item.reactive.system?.gainedAtLevel != null}
-								<span class="nimble-feature-card__level"
-									>Lv. {item.reactive.system.gainedAtLevel}</span
-								>
+							{#if getEffectiveLevel(item) !== Infinity}
+								<span class="nimble-feature-card__level">Lv. {getEffectiveLevel(item)}</span>
 							{/if}
 
 							{#if editingEnabled}
@@ -319,9 +323,9 @@
 											{subclass.reactive.name}
 										</h4>
 
-										{#if subclass.reactive.system?.gainedAtLevel != null}
+										{#if getEffectiveLevel(subclass) !== Infinity}
 											<span class="nimble-feature-card__level"
-												>Lv. {subclass.reactive.system.gainedAtLevel}</span
+												>Lv. {getEffectiveLevel(subclass)}</span
 											>
 										{/if}
 

--- a/src/view/sheets/pages/PlayerCharacterFeaturesTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterFeaturesTab.svelte
@@ -4,14 +4,7 @@
 	import type { Readable } from 'svelte/store';
 	import filterItems from '../../dataPreparationHelpers/filterItems.js';
 	import { getContext } from 'svelte';
-	import prepareAncestryTooltip from '../../dataPreparationHelpers/documentTooltips/prepareAncestryTooltip.js';
-	import prepareClassTooltip from '../../dataPreparationHelpers/documentTooltips/prepareClassTooltip.js';
-	import prepareSubclassTooltip from '../../dataPreparationHelpers/documentTooltips/prepareSubclassTooltip.js';
-	import prepareBoonTooltip from '../../dataPreparationHelpers/documentTooltips/prepareBoonTooltip.js';
-	import prepareBackgroundTooltip from '../../dataPreparationHelpers/documentTooltips/prepareBackgroundTooltip.js';
-	import prepareFeatureTooltip from '../../dataPreparationHelpers/documentTooltips/prepareFeatureTooltip.js';
 	import shouldFlashDroppedItem from '../../../utils/shouldFlashDroppedItem.js';
-	import sortItems from '../../../utils/sortItems.js';
 	import {
 		DROP_ITEM_FLASH_ANIMATION_NAME,
 		getDroppedItemFlashIds,
@@ -38,16 +31,26 @@
 		await actor.deleteItem(id);
 	}
 
-	function getFeatureMetadata(_item) {
-		return null;
+	function formatGroupName(name: string): string {
+		return name
+			.split('-')
+			.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+			.join(' ');
 	}
 
 	function groupItemsByType(items) {
 		return items.reduce((categories, item) => {
 			const { type: itemType } = item.reactive;
 
-			categories[itemType] ??= [];
-			categories[itemType].push(item);
+			if (itemType === 'feature') {
+				const group = item.reactive.system.group;
+				const bucket = group || 'feature';
+				categories[bucket] ??= [];
+				categories[bucket].push(item);
+			} else {
+				categories[itemType] ??= [];
+				categories[itemType].push(item);
+			}
 
 			return categories;
 		}, {});
@@ -64,72 +67,53 @@
 		}, {});
 	}
 
-	const tooltipCache = new Map();
-
-	async function prepareItemTooltip(item) {
-		const cacheKey = item.reactive._id;
-		if (tooltipCache.has(cacheKey)) {
-			return tooltipCache.get(cacheKey);
-		}
-
-		let tooltip = null;
-		switch (item.type) {
-			case 'ancestry':
-				tooltip = await prepareAncestryTooltip(item.reactive);
-				break;
-			case 'background':
-				tooltip = await prepareBackgroundTooltip(item.reactive);
-				break;
-			case 'boon':
-				tooltip = await prepareBoonTooltip(item.reactive);
-				break;
-			case 'class':
-				tooltip = await prepareClassTooltip(item.reactive);
-				break;
-			case 'feature':
-				tooltip = await prepareFeatureTooltip(item.reactive);
-				break;
-			case 'subclass':
-				tooltip = await prepareSubclassTooltip(item.reactive);
-				break;
-		}
-
-		if (tooltip) {
-			tooltipCache.set(cacheKey, tooltip);
-		}
-		return tooltip;
-	}
-
-	function getItemTooltip(item) {
-		const cacheKey = item.reactive._id;
-		return tooltipCache.get(cacheKey) || '';
-	}
-
-	function handleTooltipMouseEnter(event, item) {
-		const element = event.currentTarget;
-		if (!tooltipCache.has(item.reactive._id)) {
-			prepareItemTooltip(item).then((tooltip) => {
-				if (tooltip) {
-					element.setAttribute('data-tooltip', tooltip);
-				}
-			});
-		}
-	}
-
 	function handleDropFlashAnimationEnd(event: AnimationEvent, itemId: string) {
 		if (event.animationName !== DROP_ITEM_FLASH_ANIMATION_NAME) return;
 		sheet.clearDroppedItemFlash(itemId);
+	}
+
+	function sortFeatureItems(items) {
+		return [...items].sort((a, b) => {
+			const levelA = a.reactive.system?.gainedAtLevel ?? Infinity;
+			const levelB = b.reactive.system?.gainedAtLevel ?? Infinity;
+			if (levelA !== levelB) return levelA - levelB;
+			return (a.reactive.sort ?? 0) - (b.reactive.sort ?? 0);
+		});
 	}
 
 	function sortItemCategories(
 		[categoryA]: [string, unknown],
 		[categoryB]: [string, unknown],
 	): number {
-		return validTypes.indexOf(categoryA) - validTypes.indexOf(categoryB);
+		const classOrder = validTypes.indexOf('class');
+
+		const getOrder = (cat: string): number => {
+			const idx = validTypes.indexOf(cat);
+			if (idx !== -1) return idx;
+			// Feature groups (non-empty system.group) sort just after 'class'
+			return classOrder + 0.5;
+		};
+
+		const orderA = getOrder(categoryA);
+		const orderB = getOrder(categoryB);
+
+		if (orderA !== orderB) return orderA - orderB;
+		return categoryA.localeCompare(categoryB);
+	}
+
+	// Local collapse state — resets when the sheet is closed/reopened
+	let collapsedState = $state<Record<string, boolean>>({});
+
+	function toggleCollapsed(itemId: string): void {
+		collapsedState[itemId] = !(collapsedState[itemId] ?? true);
+	}
+
+	function isCollapsed(itemId: string): boolean {
+		return collapsedState[itemId] ?? true;
 	}
 
 	// IMPORTANT: The order of these strings is used for sorting purposes.
-	const validTypes = ['feature', 'boon', 'ancestry', 'background', 'class'];
+	const validTypes = ['class', 'feature', 'ancestry', 'background', 'boon'];
 	const { featureTypeHeadings } = CONFIG.NIMBLE;
 
 	let actor = getContext<NimbleCharacter>('actor');
@@ -144,26 +128,6 @@
 	let categorizedItems = $derived(groupItemsByType(items));
 	let subclasses = $derived(filterItems(actor.reactive, 'subclass', searchTerm));
 	let categorizedSubclasses = $derived(groupSubclassesByParentClass(subclasses));
-
-	// Invalidate tooltip cache when items change (e.g., name or properties modified)
-	$effect(() => {
-		// Track changes in regular items
-		items.forEach((item) => {
-			// Access reactive properties to track changes
-			void item.reactive.name;
-			void item.reactive.img;
-			void item.reactive.system;
-			// Clear the cache entry so it will be regenerated on next hover
-			tooltipCache.delete(item.reactive._id);
-		});
-		// Track changes in subclasses
-		subclasses.forEach((subclass) => {
-			void subclass.reactive.name;
-			void subclass.reactive.img;
-			void subclass.reactive.system;
-			tooltipCache.delete(subclass.reactive._id);
-		});
-	});
 
 	// Settings
 	let flags = $derived(actor.reactive.flags.nimble);
@@ -192,135 +156,218 @@
 		<div>
 			<header>
 				<h3 class="nimble-heading" data-heading-variant="section">
-					{featureTypeHeadings[categoryName] ?? categoryName}
+					{featureTypeHeadings[categoryName] ?? formatGroupName(categoryName)}
 				</h3>
 			</header>
 
 			<ul class="nimble-item-list">
-				{#each sortItems(itemCategory) as item (item.reactive._id)}
-					{@const metadata = getFeatureMetadata(item)}
-
-					<!-- svelte-ignore a11y_no_noninteractive_element_to_interactive_role  -->
-					<!-- svelte-ignore  a11y_click_events_have_key_events -->
+				{#each sortFeatureItems(itemCategory) as item (item.reactive._id)}
 					<li
-						class="nimble-document-card nimble-document-card--no-meta"
-						class:nimble-document-card--no-image={!showEmbeddedDocumentImages}
-						class:nimble-document-card--no-meta={!metadata}
-						class:nimble-document-card--drop-flash={shouldFlashDroppedItem(
+						class="nimble-feature-card"
+						class:nimble-feature-card--drop-flash={shouldFlashDroppedItem(
 							droppedItemFlashIds,
 							item.reactive._id,
 						)}
 						data-item-id={item.reactive._id}
-						data-tooltip={getItemTooltip(item)}
-						data-tooltip-class="nimble-tooltip nimble-tooltip--item"
-						data-tooltip-direction="LEFT"
 						draggable="true"
-						role="button"
 						ondragstart={(event) => sheet._onDragStart(event)}
 						onanimationend={(event) => handleDropFlashAnimationEnd(event, item.reactive._id)}
-						onmouseenter={(event) => handleTooltipMouseEnter(event, item)}
-						onclick={() => actor.activateItem(item.reactive._id)}
 					>
-						<header class="u-semantic-only">
+						<!-- svelte-ignore a11y_no_noninteractive_element_to_interactive_role -->
+						<!-- svelte-ignore a11y_click_events_have_key_events -->
+						<div
+							class="nimble-feature-card__header"
+							role="button"
+							tabindex="0"
+							aria-expanded={!isCollapsed(item.reactive._id)}
+							onclick={() => toggleCollapsed(item.reactive._id)}
+							onkeydown={(e) => {
+								if (e.key === 'Enter' || e.key === ' ') {
+									e.preventDefault();
+									toggleCollapsed(item.reactive._id);
+								}
+							}}
+						>
 							{#if showEmbeddedDocumentImages}
-								<div class="nimble-document-card__img-wrapper">
+								<div class="nimble-feature-card__img-wrapper">
 									<img
-										class="nimble-document-card__img"
+										class="nimble-feature-card__img"
 										src={item.reactive.img}
 										alt={item.reactive.name}
 									/>
+									<button
+										class="nimble-feature-card__img-activate"
+										type="button"
+										aria-label="Send {item.reactive.name} to chat"
+										onclick={(event) => {
+											event.stopPropagation();
+											actor.activateItem(item.reactive._id);
+										}}
+									>
+										<i class="fa-solid fa-comment"></i>
+									</button>
 								</div>
 							{/if}
 
-							<h4 class="nimble-document-card__name nimble-heading" data-heading-variant="item">
+							<h4 class="nimble-feature-card__name nimble-heading" data-heading-variant="item">
 								{item.reactive.name}
 							</h4>
 
-							<button
-								class="nimble-button"
-								style="grid-area: configureButton"
-								data-button-variant="icon"
-								type="button"
-								aria-label="Configure {item.reactive.name}"
-								onclick={(event) => configureItem(event, item._id)}
-							>
-								<i class="fa-solid fa-edit"></i>
-							</button>
+							{#if item.reactive.system?.gainedAtLevel != null}
+								<span class="nimble-feature-card__level"
+									>Lv. {item.reactive.system.gainedAtLevel}</span
+								>
+							{/if}
 
-							<button
-								class="nimble-button"
-								style="grid-area: deleteButton"
-								data-button-variant="icon"
-								type="button"
-								aria-label="Delete {item.reactive.name}"
-								onclick={(event) => deleteItem(event, item._id)}
+							{#if editingEnabled}
+								<button
+									class="nimble-button"
+									data-button-variant="icon"
+									type="button"
+									aria-label="Configure {item.reactive.name}"
+									onclick={(event) => configureItem(event, item._id)}
+								>
+									<i class="fa-solid fa-edit"></i>
+								</button>
+
+								<button
+									class="nimble-button"
+									data-button-variant="icon"
+									type="button"
+									aria-label="Delete {item.reactive.name}"
+									onclick={(event) => deleteItem(event, item._id)}
+								>
+									<i class="fa-solid fa-trash"></i>
+								</button>
+							{/if}
+
+							<span
+								class="nimble-feature-card__chevron"
+								class:nimble-feature-card__chevron--collapsed={isCollapsed(item.reactive._id)}
+								aria-hidden="true"
 							>
-								<i class="fa-solid fa-trash"></i>
-							</button>
-						</header>
+								<i class="fa-solid fa-chevron-down"></i>
+							</span>
+						</div>
+
+						<div
+							class="nimble-feature-card__body"
+							class:nimble-feature-card__body--collapsed={isCollapsed(item.reactive._id)}
+						>
+							<div class="nimble-feature-card__description">
+								{#await foundry.applications.ux.TextEditor.implementation.enrichHTML(item.reactive.system?.description || '') then description}
+									{@html description}
+								{/await}
+							</div>
+						</div>
 					</li>
 					{#if categoryName === 'class' && categorizedSubclasses[item.reactive.system.identifier]?.length}
 						<ul class="nimble-item-list nimble-item-list--sublist">
 							{#each categorizedSubclasses[item.reactive.system.identifier] as subclass}
-								{@const metadata = getFeatureMetadata(subclass)}
-
-								<!-- svelte-ignore a11y_no_noninteractive_element_to_interactive_role -->
-								<!-- svelte-ignore a11y_click_events_have_key_events -->
 								<li
-									class="nimble-document-card nimble-document-card--no-meta"
-									class:nimble-document-card--no-image={!showEmbeddedDocumentImages}
-									class:nimble-document-card--no-meta={!metadata}
-									class:nimble-document-card--drop-flash={shouldFlashDroppedItem(
+									class="nimble-feature-card"
+									class:nimble-feature-card--drop-flash={shouldFlashDroppedItem(
 										droppedItemFlashIds,
 										subclass.reactive._id,
 									)}
 									data-item-id={subclass.reactive._id}
-									data-tooltip={getItemTooltip(subclass)}
-									data-tooltip-class="nimble-tooltip nimble-tooltip--item"
-									data-tooltip-direction="LEFT"
 									draggable="true"
-									role="button"
 									ondragstart={(event) => sheet._onDragStart(event)}
 									onanimationend={(event) =>
 										handleDropFlashAnimationEnd(event, subclass.reactive._id)}
-									onmouseenter={(event) => handleTooltipMouseEnter(event, subclass)}
-									onclick={() => actor.activateItem(subclass._id)}
 								>
-									{#if showEmbeddedDocumentImages}
-										<div class="nimble-document-card__img-wrapper">
-											<img
-												class="nimble-document-card__img"
-												src={subclass.reactive.img}
-												alt={subclass.reactive.name}
-											/>
+									<!-- svelte-ignore a11y_no_noninteractive_element_to_interactive_role -->
+									<!-- svelte-ignore a11y_click_events_have_key_events -->
+									<div
+										class="nimble-feature-card__header"
+										role="button"
+										tabindex="0"
+										aria-expanded={!isCollapsed(subclass.reactive._id)}
+										onclick={() => toggleCollapsed(subclass.reactive._id)}
+										onkeydown={(e) => {
+											if (e.key === 'Enter' || e.key === ' ') {
+												e.preventDefault();
+												toggleCollapsed(subclass.reactive._id);
+											}
+										}}
+									>
+										{#if showEmbeddedDocumentImages}
+											<div class="nimble-feature-card__img-wrapper">
+												<img
+													class="nimble-feature-card__img"
+													src={subclass.reactive.img}
+													alt={subclass.reactive.name}
+												/>
+												<button
+													class="nimble-feature-card__img-activate"
+													type="button"
+													aria-label="Send {subclass.reactive.name} to chat"
+													onclick={(event) => {
+														event.stopPropagation();
+														actor.activateItem(subclass._id);
+													}}
+												>
+													<i class="fa-solid fa-comment"></i>
+												</button>
+											</div>
+										{/if}
+
+										<h4
+											class="nimble-feature-card__name nimble-heading"
+											data-heading-variant="item"
+										>
+											{subclass.reactive.name}
+										</h4>
+
+										{#if subclass.reactive.system?.gainedAtLevel != null}
+											<span class="nimble-feature-card__level"
+												>Lv. {subclass.reactive.system.gainedAtLevel}</span
+											>
+										{/if}
+
+										{#if editingEnabled}
+											<button
+												class="nimble-button"
+												data-button-variant="icon"
+												type="button"
+												aria-label="Configure {subclass.reactive.name}"
+												onclick={(event) => configureItem(event, subclass._id)}
+											>
+												<i class="fa-solid fa-edit"></i>
+											</button>
+
+											<button
+												class="nimble-button"
+												data-button-variant="icon"
+												type="button"
+												aria-label="Delete {subclass.reactive.name}"
+												onclick={(event) => deleteItem(event, subclass._id)}
+											>
+												<i class="fa-solid fa-trash"></i>
+											</button>
+										{/if}
+
+										<span
+											class="nimble-feature-card__chevron"
+											class:nimble-feature-card__chevron--collapsed={isCollapsed(
+												subclass.reactive._id,
+											)}
+											aria-hidden="true"
+										>
+											<i class="fa-solid fa-chevron-down"></i>
+										</span>
+									</div>
+
+									<div
+										class="nimble-feature-card__body"
+										class:nimble-feature-card__body--collapsed={isCollapsed(subclass.reactive._id)}
+									>
+										<div class="nimble-feature-card__description">
+											{#await foundry.applications.ux.TextEditor.implementation.enrichHTML(subclass.reactive.system?.description || '') then description}
+												{@html description}
+											{/await}
 										</div>
-									{/if}
-
-									<h4 class="nimble-document-card__name nimble-heading" data-heading-variant="item">
-										{subclass.reactive.name}
-									</h4>
-
-									<button
-										class="nimble-button"
-										style="grid-area: configureButton"
-										data-button-variant="icon"
-										type="button"
-										aria-label="Configure {subclass.reactive.name}"
-										onclick={(event) => configureItem(event, subclass._id)}
-									>
-										<i class="fa-solid fa-edit"></i>
-									</button>
-
-									<button
-										class="nimble-button"
-										style="grid-area: deleteButton"
-										data-button-variant="icon"
-										type="button"
-										aria-label="Delete {subclass.reactive.name}"
-										onclick={(event) => deleteItem(event, subclass._id)}
-									>
-										<i class="fa-solid fa-trash"></i>
-									</button>
+									</div>
 								</li>
 							{/each}
 						</ul>
@@ -343,6 +390,161 @@
 		&--sublist {
 			margin-block-start: 0;
 			margin-inline-start: 1rem;
+		}
+	}
+
+	.nimble-feature-card {
+		--nimble-heading-color: var(--nimble-card-text-color);
+
+		background: var(--nimble-card-background-color);
+		border: 1px solid var(--nimble-card-border-color);
+		border-radius: 4px;
+		box-shadow: var(--nimble-box-shadow);
+		color: var(--nimble-card-text-color);
+		overflow: hidden;
+		transition: var(--nimble-standard-transition);
+
+		&--drop-flash {
+			position: relative;
+			animation: nimble-drop-item-flash 2.5s ease-in-out forwards;
+		}
+	}
+
+	.nimble-feature-card__header {
+		display: flex;
+		align-items: center;
+		gap: 0.125rem;
+		min-height: 2rem;
+		padding-inline-end: 0.25rem;
+		cursor: pointer;
+
+		&:focus-visible {
+			outline: 2px solid var(--nimble-accent-color);
+			outline-offset: -2px;
+		}
+	}
+
+	.nimble-feature-card__img-wrapper {
+		position: relative;
+		flex-shrink: 0;
+		height: 2rem;
+		width: 2rem;
+		margin-inline-end: 0.5rem;
+
+		&::after {
+			content: '';
+			position: absolute;
+			inset: 0;
+			right: -1px;
+			border-right: 1px solid var(--nimble-card-border-color);
+			pointer-events: none;
+			z-index: 1;
+		}
+	}
+
+	.nimble-feature-card__img {
+		width: 100%;
+		height: 100%;
+		border: 0;
+		border-radius: 0;
+		background-color: rgba(0, 0, 0, 0.7);
+		object-fit: cover;
+		object-position: center;
+
+		&[src$='.svg' i] {
+			padding: 0.2rem;
+		}
+	}
+
+	.nimble-feature-card__img-activate {
+		position: absolute;
+		inset: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: rgba(0, 0, 0, 0.55);
+		border: 0;
+		color: white;
+		cursor: pointer;
+		font-size: var(--nimble-sm-text);
+		opacity: 0;
+		padding: 0;
+		transition: opacity var(--nimble-standard-transition);
+		z-index: 2;
+
+		&:hover,
+		&:focus-visible {
+			opacity: 1;
+			outline: none;
+		}
+	}
+
+	.nimble-feature-card__name {
+		flex: 1;
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		line-height: 1;
+		color: var(--nimble-card-text-color);
+	}
+
+	.nimble-feature-card__level {
+		flex-shrink: 0;
+		font-size: var(--nimble-xs-text, 0.65rem);
+		color: var(--nimble-medium-text-color);
+		white-space: nowrap;
+	}
+
+	.nimble-feature-card__chevron {
+		flex-shrink: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 1.5rem;
+		color: var(--nimble-medium-text-color);
+		font-size: var(--nimble-sm-text);
+
+		i {
+			display: inline-block;
+			transition: transform 250ms ease-out;
+		}
+
+		&--collapsed i {
+			transform: rotateX(180deg);
+		}
+	}
+
+	.nimble-feature-card__body {
+		overflow: hidden;
+	}
+
+	.nimble-feature-card__description {
+		padding: 0.5rem;
+		font-size: var(--nimble-md-text);
+		line-height: 1.5;
+		border-top: 1px solid var(--nimble-card-border-color);
+		transition:
+			max-height 250ms ease-out,
+			padding 250ms ease-out,
+			opacity 250ms ease-out,
+			border-color 250ms ease-out;
+		max-height: 600px;
+		opacity: 1;
+
+		.nimble-feature-card__body--collapsed & {
+			max-height: 0;
+			padding-block: 0;
+			opacity: 0;
+			border-top-color: transparent;
+		}
+
+		:global(p) {
+			margin-block: 0;
+
+			& + :global(p) {
+				margin-block-start: 0.5rem;
+			}
 		}
 	}
 

--- a/src/view/sheets/pages/PlayerCharacterFeaturesTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterFeaturesTab.svelte
@@ -47,15 +47,11 @@
 			const { type: itemType } = item.reactive;
 
 			if (itemType === 'feature') {
-				const group = item.reactive.system.group;
-				if (item.reactive.system.subclass) {
-					const bucket = `subclass-group:${group || 'default'}`;
-					categories[bucket] ??= [];
-					categories[bucket].push(item);
-				} else {
-					const bucket = group || 'feature';
-					categories[bucket] ??= [];
-					categories[bucket].push(item);
+				// Grouped class features and subclass features are rendered nested under their
+				// parent card — only ungrouped features get their own top-level section here.
+				if (!item.reactive.system.group && !item.reactive.system.subclass) {
+					categories['feature'] ??= [];
+					categories['feature'].push(item);
 				}
 			} else {
 				categories[itemType] ??= [];
@@ -95,20 +91,8 @@
 		[categoryA]: [string, unknown],
 		[categoryB]: [string, unknown],
 	): number {
-		const classOrder = validTypes.indexOf('class');
-		const subclassOrder = validTypes.indexOf('subclass');
-
-		const getOrder = (cat: string): number => {
-			const idx = validTypes.indexOf(cat);
-			if (idx !== -1) return idx;
-			// Subclass feature groups sort just after 'subclass' (but are rendered inline, not as sections)
-			if (cat.startsWith('subclass-group:')) return subclassOrder + 0.5;
-			// Class feature groups sort just after 'class'
-			return classOrder + 0.5;
-		};
-
-		const orderA = getOrder(categoryA);
-		const orderB = getOrder(categoryB);
+		const orderA = validTypes.indexOf(categoryA);
+		const orderB = validTypes.indexOf(categoryB);
 
 		if (orderA !== orderB) return orderA - orderB;
 		return categoryA.localeCompare(categoryB);
@@ -147,12 +131,22 @@
 	let items = $derived(filterItems(actor.reactive, validTypes, searchTerm));
 	let categorizedItems = $derived(groupItemsByType(items));
 
-	// All subclass feature items collected and sorted by level — rendered nested under the subclass section
+	// Class features (grouped, non-subclass) sorted by level — rendered nested under the class card
+	let classFeatureItems = $derived(
+		sortFeatureItems(
+			items.filter(
+				(item) =>
+					item.reactive.type === 'feature' &&
+					item.reactive.system.group &&
+					!item.reactive.system.subclass,
+			),
+		),
+	);
+
+	// Subclass features sorted by level — rendered nested under the subclass card
 	let subclassFeatureItems = $derived(
 		sortFeatureItems(
-			Object.entries(categorizedItems)
-				.filter(([key]) => key.startsWith('subclass-group:'))
-				.flatMap(([, groupItems]) => groupItems),
+			items.filter((item) => item.reactive.type === 'feature' && item.reactive.system.subclass),
 		),
 	);
 
@@ -285,29 +279,35 @@
 
 <section class="nimble-sheet__body nimble-sheet__body--player-character">
 	{#each Object.entries(categorizedItems).sort(sortItemCategories) as [categoryName, itemCategory]}
-		{#if !categoryName.startsWith('subclass-group:')}
-			<div>
-				<header>
-					<h3 class="nimble-heading" data-heading-variant="section">
-						{getCategoryHeading(categoryName)}
-					</h3>
-				</header>
+		<div>
+			<header>
+				<h3 class="nimble-heading" data-heading-variant="section">
+					{getCategoryHeading(categoryName)}
+				</h3>
+			</header>
 
-				<ul class="nimble-item-list">
-					{#each sortFeatureItems(itemCategory) as item (item.reactive._id)}
+			<ul class="nimble-item-list">
+				{#each sortFeatureItems(itemCategory) as item (item.reactive._id)}
+					{@render featureCard(item)}
+				{/each}
+			</ul>
+
+			{#if categoryName === 'class' && classFeatureItems.length}
+				<ul class="nimble-item-list nimble-item-list--sublist">
+					{#each classFeatureItems as item (item.reactive._id)}
 						{@render featureCard(item)}
 					{/each}
 				</ul>
+			{/if}
 
-				{#if categoryName === 'subclass' && subclassFeatureItems.length}
-					<ul class="nimble-item-list nimble-item-list--sublist">
-						{#each subclassFeatureItems as item (item.reactive._id)}
-							{@render featureCard(item)}
-						{/each}
-					</ul>
-				{/if}
-			</div>
-		{/if}
+			{#if categoryName === 'subclass' && subclassFeatureItems.length}
+				<ul class="nimble-item-list nimble-item-list--sublist">
+					{#each subclassFeatureItems as item (item.reactive._id)}
+						{@render featureCard(item)}
+					{/each}
+				</ul>
+			{/if}
+		</div>
 	{/each}
 </section>
 

--- a/src/view/sheets/pages/PlayerCharacterFeaturesTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterFeaturesTab.svelte
@@ -256,13 +256,15 @@
 		<SearchBar bind:searchTerm />
 
 		<button
-			class="nimble-button {allExpanded ? 'fa-solid fa-angles-up' : 'fa-solid fa-angles-down'}"
+			class="nimble-button"
 			data-button-variant="basic"
 			type="button"
 			aria-label={allExpanded ? 'Collapse All' : 'Expand All'}
 			data-tooltip={allExpanded ? 'Collapse All' : 'Expand All'}
 			onclick={toggleAllExpanded}
-		></button>
+		>
+			<i class="fa-solid {allExpanded ? 'fa-compress' : 'fa-expand'}"></i>
+		</button>
 
 		{#if editingEnabled}
 			<button

--- a/src/view/sheets/pages/PlayerCharacterFeaturesTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterFeaturesTab.svelte
@@ -38,30 +38,29 @@
 			.join(' ');
 	}
 
+	function getCategoryHeading(categoryName: string): string {
+		return featureTypeHeadings[categoryName] ?? formatGroupName(categoryName);
+	}
+
 	function groupItemsByType(items) {
 		return items.reduce((categories, item) => {
 			const { type: itemType } = item.reactive;
 
 			if (itemType === 'feature') {
 				const group = item.reactive.system.group;
-				const bucket = group || 'feature';
-				categories[bucket] ??= [];
-				categories[bucket].push(item);
+				if (item.reactive.system.subclass) {
+					const bucket = `subclass-group:${group || 'default'}`;
+					categories[bucket] ??= [];
+					categories[bucket].push(item);
+				} else {
+					const bucket = group || 'feature';
+					categories[bucket] ??= [];
+					categories[bucket].push(item);
+				}
 			} else {
 				categories[itemType] ??= [];
 				categories[itemType].push(item);
 			}
-
-			return categories;
-		}, {});
-	}
-
-	function groupSubclassesByParentClass(subclasses) {
-		return subclasses.reduce((categories, subclass) => {
-			const { parentClass } = subclass.reactive.system;
-
-			categories[parentClass] ??= [];
-			categories[parentClass].push(subclass);
 
 			return categories;
 		}, {});
@@ -73,9 +72,14 @@
 	}
 
 	function getEffectiveLevel(item): number {
-		return (
-			item.reactive.system?.gainedAtLevel ?? item.reactive.system?.gainedAtLevels?.[0] ?? Infinity
+		const explicit = item.reactive.system?.gainedAtLevel;
+		if (explicit != null) return explicit;
+		const levels = item.reactive.system?.gainedAtLevels;
+		if (levels?.length) return Math.min(...levels);
+		console.warn(
+			`[Nimble] Feature "${item.reactive.name}" has no level data — gainedAtLevel: ${explicit}, gainedAtLevels: ${JSON.stringify(levels)}`,
 		);
+		return Infinity;
 	}
 
 	function sortFeatureItems(items) {
@@ -92,11 +96,14 @@
 		[categoryB]: [string, unknown],
 	): number {
 		const classOrder = validTypes.indexOf('class');
+		const subclassOrder = validTypes.indexOf('subclass');
 
 		const getOrder = (cat: string): number => {
 			const idx = validTypes.indexOf(cat);
 			if (idx !== -1) return idx;
-			// Feature groups (non-empty system.group) sort just after 'class'
+			// Subclass feature groups sort just after 'subclass' (but are rendered inline, not as sections)
+			if (cat.startsWith('subclass-group:')) return subclassOrder + 0.5;
+			// Class feature groups sort just after 'class'
 			return classOrder + 0.5;
 		};
 
@@ -109,17 +116,24 @@
 
 	// Local collapse state — resets when the sheet is closed/reopened
 	let collapsedState = $state<Record<string, boolean>>({});
+	let allExpanded = $state(false);
+
+	function toggleAllExpanded(): void {
+		allExpanded = !allExpanded;
+		collapsedState = {};
+	}
 
 	function toggleCollapsed(itemId: string): void {
-		collapsedState[itemId] = !(collapsedState[itemId] ?? true);
+		collapsedState[itemId] = !isCollapsed(itemId);
 	}
 
 	function isCollapsed(itemId: string): boolean {
-		return collapsedState[itemId] ?? true;
+		if (itemId in collapsedState) return collapsedState[itemId];
+		return !allExpanded;
 	}
 
 	// IMPORTANT: The order of these strings is used for sorting purposes.
-	const validTypes = ['class', 'feature', 'ancestry', 'background', 'boon'];
+	const validTypes = ['class', 'subclass', 'feature', 'ancestry', 'background', 'boon'];
 	const { featureTypeHeadings } = CONFIG.NIMBLE;
 
 	let actor = getContext<NimbleCharacter>('actor');
@@ -132,17 +146,129 @@
 	let searchTerm = $state('');
 	let items = $derived(filterItems(actor.reactive, validTypes, searchTerm));
 	let categorizedItems = $derived(groupItemsByType(items));
-	let subclasses = $derived(filterItems(actor.reactive, 'subclass', searchTerm));
-	let categorizedSubclasses = $derived(groupSubclassesByParentClass(subclasses));
+
+	// All subclass feature items collected and sorted by level — rendered nested under the subclass section
+	let subclassFeatureItems = $derived(
+		sortFeatureItems(
+			Object.entries(categorizedItems)
+				.filter(([key]) => key.startsWith('subclass-group:'))
+				.flatMap(([, groupItems]) => groupItems),
+		),
+	);
 
 	// Settings
 	let flags = $derived(actor.reactive.flags.nimble);
 	let showEmbeddedDocumentImages = $derived(flags?.showEmbeddedDocumentImages ?? true);
 </script>
 
+{#snippet featureCard(item)}
+	<li
+		class="nimble-feature-card"
+		class:nimble-feature-card--drop-flash={shouldFlashDroppedItem(
+			droppedItemFlashIds,
+			item.reactive._id,
+		)}
+		data-item-id={item.reactive._id}
+		draggable="true"
+		ondragstart={(event) => sheet._onDragStart(event)}
+		onanimationend={(event) => handleDropFlashAnimationEnd(event, item.reactive._id)}
+	>
+		<!-- svelte-ignore a11y_no_noninteractive_element_to_interactive_role -->
+		<!-- svelte-ignore a11y_click_events_have_key_events -->
+		<div
+			class="nimble-feature-card__header"
+			role="button"
+			tabindex="0"
+			aria-expanded={!isCollapsed(item.reactive._id)}
+			onclick={() => toggleCollapsed(item.reactive._id)}
+			onkeydown={(e) => {
+				if (e.key === 'Enter' || e.key === ' ') {
+					e.preventDefault();
+					toggleCollapsed(item.reactive._id);
+				}
+			}}
+		>
+			{#if showEmbeddedDocumentImages}
+				<div class="nimble-feature-card__img-wrapper">
+					<img class="nimble-feature-card__img" src={item.reactive.img} alt={item.reactive.name} />
+					<button
+						class="nimble-feature-card__img-activate"
+						type="button"
+						aria-label="Send {item.reactive.name} to chat"
+						onclick={(event) => {
+							event.stopPropagation();
+							actor.activateItem(item.reactive._id);
+						}}
+					>
+						<i class="fa-solid fa-comment"></i>
+					</button>
+				</div>
+			{/if}
+
+			<h4 class="nimble-feature-card__name nimble-heading" data-heading-variant="item">
+				{item.reactive.name}
+			</h4>
+
+			{#if getEffectiveLevel(item) !== Infinity}
+				<span class="nimble-feature-card__level">Lv. {getEffectiveLevel(item)}</span>
+			{/if}
+
+			{#if editingEnabled}
+				<button
+					class="nimble-button"
+					data-button-variant="icon"
+					type="button"
+					aria-label="Configure {item.reactive.name}"
+					onclick={(event) => configureItem(event, item._id)}
+				>
+					<i class="fa-solid fa-edit"></i>
+				</button>
+
+				<button
+					class="nimble-button"
+					data-button-variant="icon"
+					type="button"
+					aria-label="Delete {item.reactive.name}"
+					onclick={(event) => deleteItem(event, item._id)}
+				>
+					<i class="fa-solid fa-trash"></i>
+				</button>
+			{/if}
+
+			<span
+				class="nimble-feature-card__chevron"
+				class:nimble-feature-card__chevron--collapsed={isCollapsed(item.reactive._id)}
+				aria-hidden="true"
+			>
+				<i class="fa-solid fa-chevron-down"></i>
+			</span>
+		</div>
+
+		<div
+			class="nimble-feature-card__body"
+			class:nimble-feature-card__body--collapsed={isCollapsed(item.reactive._id)}
+		>
+			<div class="nimble-feature-card__description">
+				{#await foundry.applications.ux.TextEditor.implementation.enrichHTML(item.reactive.system?.description || '') then description}
+					{@html description}
+				{/await}
+			</div>
+		</div>
+	</li>
+{/snippet}
+
 <header class="nimble-sheet__static nimble-sheet__static--features">
 	<div class="nimble-search-wrapper">
 		<SearchBar bind:searchTerm />
+
+		<button
+			class="nimble-button {allExpanded ? 'fa-solid fa-angles-up' : 'fa-solid fa-angles-down'}"
+			data-button-variant="basic"
+			type="button"
+			aria-label={allExpanded ? 'Collapse All' : 'Expand All'}
+			data-tooltip={allExpanded ? 'Collapse All' : 'Expand All'}
+			onclick={toggleAllExpanded}
+		></button>
 
 		{#if editingEnabled}
 			<button
@@ -159,226 +285,29 @@
 
 <section class="nimble-sheet__body nimble-sheet__body--player-character">
 	{#each Object.entries(categorizedItems).sort(sortItemCategories) as [categoryName, itemCategory]}
-		<div>
-			<header>
-				<h3 class="nimble-heading" data-heading-variant="section">
-					{featureTypeHeadings[categoryName] ?? formatGroupName(categoryName)}
-				</h3>
-			</header>
+		{#if !categoryName.startsWith('subclass-group:')}
+			<div>
+				<header>
+					<h3 class="nimble-heading" data-heading-variant="section">
+						{getCategoryHeading(categoryName)}
+					</h3>
+				</header>
 
-			<ul class="nimble-item-list">
-				{#each sortFeatureItems(itemCategory) as item (item.reactive._id)}
-					<li
-						class="nimble-feature-card"
-						class:nimble-feature-card--drop-flash={shouldFlashDroppedItem(
-							droppedItemFlashIds,
-							item.reactive._id,
-						)}
-						data-item-id={item.reactive._id}
-						draggable="true"
-						ondragstart={(event) => sheet._onDragStart(event)}
-						onanimationend={(event) => handleDropFlashAnimationEnd(event, item.reactive._id)}
-					>
-						<!-- svelte-ignore a11y_no_noninteractive_element_to_interactive_role -->
-						<!-- svelte-ignore a11y_click_events_have_key_events -->
-						<div
-							class="nimble-feature-card__header"
-							role="button"
-							tabindex="0"
-							aria-expanded={!isCollapsed(item.reactive._id)}
-							onclick={() => toggleCollapsed(item.reactive._id)}
-							onkeydown={(e) => {
-								if (e.key === 'Enter' || e.key === ' ') {
-									e.preventDefault();
-									toggleCollapsed(item.reactive._id);
-								}
-							}}
-						>
-							{#if showEmbeddedDocumentImages}
-								<div class="nimble-feature-card__img-wrapper">
-									<img
-										class="nimble-feature-card__img"
-										src={item.reactive.img}
-										alt={item.reactive.name}
-									/>
-									<button
-										class="nimble-feature-card__img-activate"
-										type="button"
-										aria-label="Send {item.reactive.name} to chat"
-										onclick={(event) => {
-											event.stopPropagation();
-											actor.activateItem(item.reactive._id);
-										}}
-									>
-										<i class="fa-solid fa-comment"></i>
-									</button>
-								</div>
-							{/if}
+				<ul class="nimble-item-list">
+					{#each sortFeatureItems(itemCategory) as item (item.reactive._id)}
+						{@render featureCard(item)}
+					{/each}
+				</ul>
 
-							<h4 class="nimble-feature-card__name nimble-heading" data-heading-variant="item">
-								{item.reactive.name}
-							</h4>
-
-							{#if getEffectiveLevel(item) !== Infinity}
-								<span class="nimble-feature-card__level">Lv. {getEffectiveLevel(item)}</span>
-							{/if}
-
-							{#if editingEnabled}
-								<button
-									class="nimble-button"
-									data-button-variant="icon"
-									type="button"
-									aria-label="Configure {item.reactive.name}"
-									onclick={(event) => configureItem(event, item._id)}
-								>
-									<i class="fa-solid fa-edit"></i>
-								</button>
-
-								<button
-									class="nimble-button"
-									data-button-variant="icon"
-									type="button"
-									aria-label="Delete {item.reactive.name}"
-									onclick={(event) => deleteItem(event, item._id)}
-								>
-									<i class="fa-solid fa-trash"></i>
-								</button>
-							{/if}
-
-							<span
-								class="nimble-feature-card__chevron"
-								class:nimble-feature-card__chevron--collapsed={isCollapsed(item.reactive._id)}
-								aria-hidden="true"
-							>
-								<i class="fa-solid fa-chevron-down"></i>
-							</span>
-						</div>
-
-						<div
-							class="nimble-feature-card__body"
-							class:nimble-feature-card__body--collapsed={isCollapsed(item.reactive._id)}
-						>
-							<div class="nimble-feature-card__description">
-								{#await foundry.applications.ux.TextEditor.implementation.enrichHTML(item.reactive.system?.description || '') then description}
-									{@html description}
-								{/await}
-							</div>
-						</div>
-					</li>
-					{#if categoryName === 'class' && categorizedSubclasses[item.reactive.system.identifier]?.length}
-						<ul class="nimble-item-list nimble-item-list--sublist">
-							{#each categorizedSubclasses[item.reactive.system.identifier] as subclass}
-								<li
-									class="nimble-feature-card"
-									class:nimble-feature-card--drop-flash={shouldFlashDroppedItem(
-										droppedItemFlashIds,
-										subclass.reactive._id,
-									)}
-									data-item-id={subclass.reactive._id}
-									draggable="true"
-									ondragstart={(event) => sheet._onDragStart(event)}
-									onanimationend={(event) =>
-										handleDropFlashAnimationEnd(event, subclass.reactive._id)}
-								>
-									<!-- svelte-ignore a11y_no_noninteractive_element_to_interactive_role -->
-									<!-- svelte-ignore a11y_click_events_have_key_events -->
-									<div
-										class="nimble-feature-card__header"
-										role="button"
-										tabindex="0"
-										aria-expanded={!isCollapsed(subclass.reactive._id)}
-										onclick={() => toggleCollapsed(subclass.reactive._id)}
-										onkeydown={(e) => {
-											if (e.key === 'Enter' || e.key === ' ') {
-												e.preventDefault();
-												toggleCollapsed(subclass.reactive._id);
-											}
-										}}
-									>
-										{#if showEmbeddedDocumentImages}
-											<div class="nimble-feature-card__img-wrapper">
-												<img
-													class="nimble-feature-card__img"
-													src={subclass.reactive.img}
-													alt={subclass.reactive.name}
-												/>
-												<button
-													class="nimble-feature-card__img-activate"
-													type="button"
-													aria-label="Send {subclass.reactive.name} to chat"
-													onclick={(event) => {
-														event.stopPropagation();
-														actor.activateItem(subclass._id);
-													}}
-												>
-													<i class="fa-solid fa-comment"></i>
-												</button>
-											</div>
-										{/if}
-
-										<h4
-											class="nimble-feature-card__name nimble-heading"
-											data-heading-variant="item"
-										>
-											{subclass.reactive.name}
-										</h4>
-
-										{#if getEffectiveLevel(subclass) !== Infinity}
-											<span class="nimble-feature-card__level"
-												>Lv. {getEffectiveLevel(subclass)}</span
-											>
-										{/if}
-
-										{#if editingEnabled}
-											<button
-												class="nimble-button"
-												data-button-variant="icon"
-												type="button"
-												aria-label="Configure {subclass.reactive.name}"
-												onclick={(event) => configureItem(event, subclass._id)}
-											>
-												<i class="fa-solid fa-edit"></i>
-											</button>
-
-											<button
-												class="nimble-button"
-												data-button-variant="icon"
-												type="button"
-												aria-label="Delete {subclass.reactive.name}"
-												onclick={(event) => deleteItem(event, subclass._id)}
-											>
-												<i class="fa-solid fa-trash"></i>
-											</button>
-										{/if}
-
-										<span
-											class="nimble-feature-card__chevron"
-											class:nimble-feature-card__chevron--collapsed={isCollapsed(
-												subclass.reactive._id,
-											)}
-											aria-hidden="true"
-										>
-											<i class="fa-solid fa-chevron-down"></i>
-										</span>
-									</div>
-
-									<div
-										class="nimble-feature-card__body"
-										class:nimble-feature-card__body--collapsed={isCollapsed(subclass.reactive._id)}
-									>
-										<div class="nimble-feature-card__description">
-											{#await foundry.applications.ux.TextEditor.implementation.enrichHTML(subclass.reactive.system?.description || '') then description}
-												{@html description}
-											{/await}
-										</div>
-									</div>
-								</li>
-							{/each}
-						</ul>
-					{/if}
-				{/each}
-			</ul>
-		</div>
+				{#if categoryName === 'subclass' && subclassFeatureItems.length}
+					<ul class="nimble-item-list nimble-item-list--sublist">
+						{#each subclassFeatureItems as item (item.reactive._id)}
+							{@render featureCard(item)}
+						{/each}
+					</ul>
+				{/if}
+			</div>
+		{/if}
 	{/each}
 </section>
 


### PR DESCRIPTION

<img width="386" height="699" alt="Screenshot 2026-04-27 at 9 46 12 PM" src="https://github.com/user-attachments/assets/b5641e95-5c7e-4ec3-9b98-943d71a3425f" />
<img width="371" height="655" alt="Screenshot 2026-04-27 at 9 45 27 PM" src="https://github.com/user-attachments/assets/f3ca2263-b41f-49fd-9cad-768b1e59c6d4" />


## Summary

- **Group features by `system.group`** — class feature sets (e.g. Lesser Invocations) now appear under their own headings instead of all landing under "Class Features"
- **Class section first** — sort order changed to `class → feature groups → feature → ancestry → background → boon` so the class item, its subclass, and its feature groups are visually connected
- **Collapsible feature cards** — clicking the card header expands/collapses an enriched HTML description with a smooth `max-height` + opacity animation and a chevron indicator; replaces the previous tooltip system
- **Image hover → chat** — hovering the card image reveals a chat icon button that calls `actor.activateItem()`; the rest of the card no longer activates the item on click
- **Sort by `gainedAtLevel`** — features within each group sort by the level they were granted (ascending), with Foundry's `sort` field as tiebreaker
- **"Lv. N" badge** — feature cards with a `gainedAtLevel` value display a small muted level indicator in the header

## Test plan

- [ ] Open a PC sheet on a character with a class, subclass, and class features; verify class section appears at the top with subclass nested below the class item, and feature groups appear directly under
- [ ] Verify feature groups sort by `gainedAtLevel` ascending within each group
- [ ] Verify features without a `gainedAtLevel` value do not show a level badge
- [ ] Click a feature card header to expand; click again to collapse — animation should be smooth
- [ ] Hover the card image to reveal the chat button; click it to send to chat; confirm the rest of the header does not also trigger activation
- [ ] Confirm edit/delete buttons only appear when editing is enabled
- [ ] Search bar filters features as expected
- [ ] Drop an item onto the sheet and confirm the drop-flash animation plays