### PR TITLE
fix(compendium): restrict Lifebinding Spirit spell to Shepherd only

### DIFF
--- a/packs/spells/core/radiant/lifebinding-spirit.json
+++ b/packs/spells/core/radiant/lifebinding-spirit.json
@@ -49,7 +49,8 @@
 			"selected": []
 		},
 		"school": "radiant",
-		"tier": 1
+		"tier": 1,
+		"classes": ["shepherd"]
 	},
 	"effects": [],
 	"folder": null,


### PR DESCRIPTION
## Summary
- Adds `"classes": ["shepherd"]` to `packs/spells/core/radiant/lifebinding-spirit.json`
- Uses the existing class restriction system in `SpellDataModel` and `getSpellsFromIndex` — no code changes needed
- Non-Shepherd classes will no longer be offered this spell during character creation or spell grants

Closes #566

## Test plan
- [ ] Create a non-Shepherd character and verify Lifebinding Spirit does not appear in radiant spell selections
- [ ] Create a Shepherd character and verify Lifebinding Spirit still appears in radiant spell selections