### PR TITLE
chore: add QuestLuminary Patreon link for Trevor Carlston

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,11 +55,6 @@
 			"url": "https://ko-fi.com/questluminary"
 		},
 		{
-			"name": "Phillip Best",
-			"email": "me@phillip.best",
-			"url": "https://bio.link/philbest"
-		},
-		{
 			"name": "NekroDarkmoon",
 			"url": "https://github.com/NekroDarkmoon/"
 		}
@@ -67,11 +62,7 @@
 	"funding": [
 		{
 			"type": "patreon",
-			"url": "https://www.patreon.com/ForgemasterModules"
-		},
-		{
-			"type": "individual",
-			"url": "https://ko-fi.com/philbest"
+			"url": "https://www.patreon.com/cw/QuestLuminary"
 		},
 		{
 			"type": "individual",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,11 @@
 			"url": "https://ko-fi.com/questluminary"
 		},
 		{
+			"name": "Phillip Best",
+			"email": "me@phillip.best",
+			"url": "https://bio.link/philbest"
+		},
+		{
 			"name": "NekroDarkmoon",
 			"url": "https://github.com/NekroDarkmoon/"
 		}
@@ -62,7 +67,11 @@
 	"funding": [
 		{
 			"type": "patreon",
-			"url": "https://www.patreon.com/cw/QuestLuminary"
+			"url": "https://www.patreon.com/QuestLuminary"
+		},
+		{
+			"type": "individual",
+			"url": "https://ko-fi.com/philbest"
 		},
 		{
 			"type": "individual",

--- a/public/system.json
+++ b/public/system.json
@@ -10,15 +10,7 @@
 			"email": "trevlar@questluminary.com",
 			"discord": "questluminary",
 			"ko-fi": "questluminary",
-			"patreon": ""
-		},
-		{
-			"name": "Phillip Best",
-			"url": "https://bio.link/philbest",
-			"email": "me@phillip.best",
-			"discord": "philbest",
-			"ko-fi": "philbest",
-			"patreon": "ForgemasterModules"
+			"patreon": "QuestLuminary"
 		},
 		{
 			"name": "NekroDarkmoon",

--- a/public/system.json
+++ b/public/system.json
@@ -13,6 +13,14 @@
 			"patreon": "QuestLuminary"
 		},
 		{
+			"name": "Phillip Best",
+			"url": "https://bio.link/philbest",
+			"email": "me@phillip.best",
+			"discord": "philbest",
+			"ko-fi": "philbest",
+			"patreon": "ForgemasterModules"
+		},
+		{
 			"name": "NekroDarkmoon",
 			"url": "https://github.com/NekroDarkmoon/",
 			"discord": "nekrodarkmoon",


### PR DESCRIPTION
## Summary
- Added `QuestLuminary` as the Patreon creator for Trevor Carlston in `public/system.json`
- Updated the project-level Patreon funding URL in `package.json` from `ForgemasterModules` to `QuestLuminary`