### PR TITLE
feat(classFeatures): add automation rules to seven features across six classes

### DIFF
--- a/packs/classFeatures/core/hunter/hunter-subclasses/keeper-of-the-wildheart/impressive-form.json
+++ b/packs/classFeatures/core/hunter/hunter-subclasses/keeper-of-the-wildheart/impressive-form.json
@@ -6,7 +6,21 @@
 	"system": {
 		"macro": "",
 		"identifier": "",
-		"rules": [],
+		"rules": [
+			{
+				"id": "impressive-form-hp",
+				"type": "maxHpBonus",
+				"value": 5,
+				"perLevel": false,
+				"label": "Impressive Form"
+			},
+			{
+				"id": "impressive-form-hd",
+				"type": "incrementHitDice",
+				"value": "1",
+				"label": "Impressive Form"
+			}
+		],
 		"activation": {
 			"acquireTargetsFromTemplate": false,
 			"cost": {

--- a/packs/classFeatures/core/mage/mage-subclasses/invoker-of-chaos/tempest-mage.json
+++ b/packs/classFeatures/core/mage/mage-subclasses/invoker-of-chaos/tempest-mage.json
@@ -6,7 +6,38 @@
 	"system": {
 		"macro": "",
 		"identifier": "",
-		"rules": [],
+		"rules": [
+			{
+				"id": "tempest-mage-cantrip",
+				"type": "grantSpells",
+				"schools": [
+					"wind"
+				],
+				"tiers": [
+					0
+				],
+				"mode": "selectSpell",
+				"count": 1,
+				"utilityOnly": false,
+				"label": "Choose a Wind Cantrip"
+			},
+			{
+				"id": "tempest-mage-tier1",
+				"type": "grantSpells",
+				"schools": [
+					"wind"
+				],
+				"tiers": [
+					1,
+					2,
+					3
+				],
+				"mode": "selectSpell",
+				"count": 1,
+				"utilityOnly": false,
+				"label": "Choose a Tier 1-3 Wind Spell"
+			}
+		],
 		"activation": {
 			"acquireTargetsFromTemplate": false,
 			"cost": {

--- a/packs/classFeatures/core/mage/mage-subclasses/invoker-of-control/at-any-cost.json
+++ b/packs/classFeatures/core/mage/mage-subclasses/invoker-of-control/at-any-cost.json
@@ -6,7 +6,38 @@
 	"system": {
 		"macro": "",
 		"identifier": "",
-		"rules": [],
+		"rules": [
+			{
+				"id": "at-any-cost-cantrip",
+				"type": "grantSpells",
+				"schools": [
+					"necrotic"
+				],
+				"tiers": [
+					0
+				],
+				"mode": "selectSpell",
+				"count": 1,
+				"utilityOnly": false,
+				"label": "Choose a Necrotic Cantrip"
+			},
+			{
+				"id": "at-any-cost-tier1",
+				"type": "grantSpells",
+				"schools": [
+					"necrotic"
+				],
+				"tiers": [
+					1,
+					2,
+					3
+				],
+				"mode": "selectSpell",
+				"count": 1,
+				"utilityOnly": false,
+				"label": "Choose a Tier 1-3 Necrotic Spell"
+			}
+		],
 		"activation": {
 			"acquireTargetsFromTemplate": false,
 			"cost": {

--- a/packs/classFeatures/core/shadowmancer/shadowmancer-progression/shadowmastery.json
+++ b/packs/classFeatures/core/shadowmancer/shadowmancer-progression/shadowmastery.json
@@ -6,7 +6,64 @@
 	"system": {
 		"macro": "",
 		"identifier": "",
-		"rules": [],
+		"rules": [
+			{
+				"id": "shadowmastery-l6",
+				"type": "grantSpells",
+				"schools": [
+					"necrotic"
+				],
+				"tiers": [
+					0
+				],
+				"mode": "selectSpell",
+				"count": 1,
+				"utilityOnly": true,
+				"label": "Shadowmastery: Necrotic Utility Spell",
+				"predicate": {
+					"level": {
+						"min": 6
+					}
+				}
+			},
+			{
+				"id": "shadowmastery-l8",
+				"type": "grantSpells",
+				"schools": [
+					"necrotic"
+				],
+				"tiers": [
+					0
+				],
+				"mode": "selectSpell",
+				"count": 1,
+				"utilityOnly": true,
+				"label": "Shadowmastery (2): Necrotic Utility Spell",
+				"predicate": {
+					"level": {
+						"min": 8
+					}
+				}
+			},
+			{
+				"id": "shadowmastery-l14",
+				"type": "grantSpells",
+				"schools": [
+					"necrotic"
+				],
+				"tiers": [
+					0
+				],
+				"mode": "auto",
+				"utilityOnly": true,
+				"label": "Shadowmastery (3): All Necrotic Utility Spells",
+				"predicate": {
+					"level": {
+						"min": 14
+					}
+				}
+			}
+		],
 		"activation": {
 			"acquireTargetsFromTemplate": false,
 			"cost": {
@@ -33,7 +90,7 @@
 				"width": 1
 			}
 		},
-		"description": "<p>Choose 1 Necrotic Utility Spell.</p><hr><p>Level 8: Choose 1 more Necrotic Utility Spell</p><p>Level 14: Choose 1 more Necrotic Utility Spell</p>",
+		"description": "<p>Choose 1 Necrotic Utility Spell.</p><hr><p>Level 8: Choose 1 more Necrotic Utility Spell</p><p>Level 14: You know all Necrotic Utility Spells.</p>",
 		"featureType": "class",
 		"class": "shadowmancer",
 		"group": "shadowmancer-progression",

--- a/packs/classFeatures/core/shepherd/shepherd-progression/master-of-twilight.json
+++ b/packs/classFeatures/core/shepherd/shepherd-progression/master-of-twilight.json
@@ -92,10 +92,9 @@
 				"tiers": [
 					0
 				],
-				"mode": "selectSpell",
-				"count": 1,
+				"mode": "auto",
 				"utilityOnly": true,
-				"label": "Master of Twilight (3): Radiant Utility Spell",
+				"label": "Master of Twilight (3): All Radiant Utility Spells",
 				"predicate": {
 					"level": {
 						"min": 11
@@ -111,10 +110,9 @@
 				"tiers": [
 					0
 				],
-				"mode": "selectSpell",
-				"count": 1,
+				"mode": "auto",
 				"utilityOnly": true,
-				"label": "Master of Twilight (3): Necrotic Utility Spell",
+				"label": "Master of Twilight (3): All Necrotic Utility Spells",
 				"predicate": {
 					"level": {
 						"min": 11
@@ -148,7 +146,7 @@
 				"width": 1
 			}
 		},
-		"description": "<p>Choose 1 Necrotic and 1 Radiant Utility Spell.</p><hr><p>Level 6: Choose a 2nd of each</p><p>Level 11: Choose a 3rd of each</p>",
+		"description": "<p>Choose 1 Necrotic and 1 Radiant Utility Spell.</p><hr><p>Level 6: Choose a 2nd of each</p><p>Level 11: You know all Necrotic and Radiant Utility Spells.</p>",
 		"featureType": "class",
 		"class": "shepherd",
 		"group": "shepherd-progression",

--- a/packs/classFeatures/core/shepherd/shepherd-progression/master-of-twilight.json
+++ b/packs/classFeatures/core/shepherd/shepherd-progression/master-of-twilight.json
@@ -6,7 +6,122 @@
 	"system": {
 		"macro": "",
 		"identifier": "",
-		"rules": [],
+		"rules": [
+			{
+				"id": "master-twilight-radiant-l3",
+				"type": "grantSpells",
+				"schools": [
+					"radiant"
+				],
+				"tiers": [
+					0
+				],
+				"mode": "selectSpell",
+				"count": 1,
+				"utilityOnly": true,
+				"label": "Master of Twilight: Radiant Utility Spell",
+				"predicate": {
+					"level": {
+						"min": 3
+					}
+				}
+			},
+			{
+				"id": "master-twilight-necrotic-l3",
+				"type": "grantSpells",
+				"schools": [
+					"necrotic"
+				],
+				"tiers": [
+					0
+				],
+				"mode": "selectSpell",
+				"count": 1,
+				"utilityOnly": true,
+				"label": "Master of Twilight: Necrotic Utility Spell",
+				"predicate": {
+					"level": {
+						"min": 3
+					}
+				}
+			},
+			{
+				"id": "master-twilight-radiant-l6",
+				"type": "grantSpells",
+				"schools": [
+					"radiant"
+				],
+				"tiers": [
+					0
+				],
+				"mode": "selectSpell",
+				"count": 1,
+				"utilityOnly": true,
+				"label": "Master of Twilight (2): Radiant Utility Spell",
+				"predicate": {
+					"level": {
+						"min": 6
+					}
+				}
+			},
+			{
+				"id": "master-twilight-necrotic-l6",
+				"type": "grantSpells",
+				"schools": [
+					"necrotic"
+				],
+				"tiers": [
+					0
+				],
+				"mode": "selectSpell",
+				"count": 1,
+				"utilityOnly": true,
+				"label": "Master of Twilight (2): Necrotic Utility Spell",
+				"predicate": {
+					"level": {
+						"min": 6
+					}
+				}
+			},
+			{
+				"id": "master-twilight-radiant-l11",
+				"type": "grantSpells",
+				"schools": [
+					"radiant"
+				],
+				"tiers": [
+					0
+				],
+				"mode": "selectSpell",
+				"count": 1,
+				"utilityOnly": true,
+				"label": "Master of Twilight (3): Radiant Utility Spell",
+				"predicate": {
+					"level": {
+						"min": 11
+					}
+				}
+			},
+			{
+				"id": "master-twilight-necrotic-l11",
+				"type": "grantSpells",
+				"schools": [
+					"necrotic"
+				],
+				"tiers": [
+					0
+				],
+				"mode": "selectSpell",
+				"count": 1,
+				"utilityOnly": true,
+				"label": "Master of Twilight (3): Necrotic Utility Spell",
+				"predicate": {
+					"level": {
+						"min": 11
+					}
+				}
+			}
+		],
 		"activation": {
 			"acquireTargetsFromTemplate": false,
 			"cost": {

--- a/packs/classFeatures/core/songweaver/songweaver-progression/windbag.json
+++ b/packs/classFeatures/core/songweaver/songweaver-progression/windbag.json
@@ -6,7 +6,26 @@
 	"system": {
 		"macro": "",
 		"identifier": "",
-		"rules": [],
+		"rules": [
+			{
+				"id": "windbag-l14-all-utility",
+				"type": "grantSpells",
+				"schools": [
+					"known"
+				],
+				"tiers": [
+					0
+				],
+				"mode": "auto",
+				"utilityOnly": true,
+				"label": "Windbag (3): All Utility Spells from Known Schools",
+				"predicate": {
+					"level": {
+						"min": 14
+					}
+				}
+			}
+		],
 		"activation": {
 			"acquireTargetsFromTemplate": false,
 			"cost": {

--- a/packs/classFeatures/core/zephyr/zephyr-progression/iron-defense.json
+++ b/packs/classFeatures/core/zephyr/zephyr-progression/iron-defense.json
@@ -6,7 +6,31 @@
 	"system": {
 		"macro": "",
 		"identifier": "",
-		"rules": [],
+		"rules": [
+			{
+				"id": "iron-defense-l1",
+				"type": "armorClass",
+				"mode": "override",
+				"formula": "@dexterity + @strength",
+				"label": "Iron Defense",
+				"predicate": {
+					"armor": "unarmored"
+				}
+			},
+			{
+				"id": "iron-defense-l13",
+				"type": "armorClass",
+				"mode": "multiply",
+				"formula": "2",
+				"label": "Iron Defense (2)",
+				"predicate": {
+					"armor": "unarmored",
+					"level": {
+						"min": 13
+					}
+				}
+			}
+		],
 		"activation": {
 			"acquireTargetsFromTemplate": false,
 			"cost": {

--- a/packs/classFeatures/core/zephyr/zephyr-progression/iron-defense.json
+++ b/packs/classFeatures/core/zephyr/zephyr-progression/iron-defense.json
@@ -64,7 +64,8 @@
 		"gainedAtLevel": 1,
 		"subclass": false,
 		"gainedAtLevels": [
-			1
+			1,
+			13
 		]
 	},
 	"effects": [],

--- a/packs/spells/core/radiant/lifebinding-spirit.json
+++ b/packs/spells/core/radiant/lifebinding-spirit.json
@@ -50,7 +50,9 @@
 		},
 		"school": "radiant",
 		"tier": 1,
-		"classes": ["shepherd"]
+		"classes": [
+			"shepherd"
+		]
 	},
 	"effects": [],
 	"folder": null,


### PR DESCRIPTION
## Summary

Adds rules to 7 class features across 6 classes.

## Changes

- **Hunter Wild Heart Impressive Form** — +5 max HP, Hit Dice incremented one step.
- **Mage At Any Cost (L7, Invoker of Control)** — grants one necrotic cantrip and one necrotic tier 1-3 spell.
- **Mage Tempest Mage (L7, Invoker of Chaos)** — grants one wind cantrip and one wind tier 1-3 spell.
- **Shadowmancer Shadowmastery** — one necrotic utility spell at L6 and L8; all necrotic utility spells at L14.
- **Shepherd Master of Twilight** — one radiant + one necrotic utility spell at L3 and L6; all radiant and necrotic utility spells at L11.
- **Songweaver Windbag(3)** — all utility spells from known schools at L14.
- **Zephyr Iron Defense** — AC equals DEX + STR while unarmored; doubled at L13.

## Test Plan

1. `pnpm build:compendia` — 13 packs / 882 documents / 0 errors.
2. In Foundry, on a fresh character of each class:
   - **Hunter Wild Heart at L3+** — max HP shows +5; Hit Dice display as d10.
   - **Mage Invoker of Control at L7** — prompts for one necrotic cantrip and one necrotic tier 1-3 spell.
   - **Mage Invoker of Chaos at L7** — same pattern for wind school.
   - **Shadowmancer at L6/L8** — prompts for one necrotic utility spell each. At L14, all remaining necrotic utility cantrips appear automatically.
   - **Shepherd at L3/L6** — prompts for one radiant + one necrotic utility spell at each level. At L11, all remaining radiant + necrotic utility cantrips appear automatically.
   - **Songweaver at L14** — all utility cantrips from schools the character already knows appear automatically.
   - **Zephyr at L1 (unarmored)** — AC equals DEX + STR. At L13 (unarmored), AC is doubled.

## Checklist

- [ ] Added or updated unit tests
- [x] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [ ] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** **yes**
- [x] **If yes:** I have reviewed all AI-generated code against the repo's STYLE_GUIDE.md and AGENTS.md

## Related Issues

Closes #400, #628, #629, #374.

Ticks bullets in:

- **#643 Shadowmancer Progression** — Shadowmastery (L6 / L8 / L14)
- **#652 Shepherd Progression** — Master of Twilight (L3 / L6 / L11)
- **#660 Songweaver Progression** — Windbag(3) L14
- **#676 Zephyr Progression** — Iron Defense (L1 / L13)

### Companion bookkeeping (outside this diff)

- **#621 closed** — already done in pre-PR `dev`.
- **#600 reopened** with the Mighty Endurance bullet ticked (was incorrectly closed).
- **28 already-done bullets** ticked across #590, #592, #599, #627, #634, #643, #652, #660, #667, #676.