### PR TITLE
feat(rules): add conditionImmunity rule type

### DIFF
--- a/packs/backgrounds/core/fearless.json
+++ b/packs/backgrounds/core/fearless.json
@@ -27,6 +27,16 @@
 				"priority": 1,
 				"formula": "-1",
 				"mode": "add"
+			},
+			{
+				"type": "conditionImmunity",
+				"disabled": false,
+				"id": "fearless-frightened-immunity",
+				"identifier": "",
+				"label": "Fearless",
+				"predicate": {},
+				"priority": 1,
+				"conditions": ["frightened"]
 			}
 		],
 		"description": "<p>You are immune to the Frightened condition. +1 Initiative. –1 Armor.</p><hr><p>+1 Initiative [A]</p><p>-1 Armor [A]</p>"

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -538,6 +538,7 @@
 			"applyCondition": "Apply Condition",
 			"armorClass": "Armor Class",
 			"combatMana": "Combat Mana",
+			"conditionImmunity": "Condition Immunity",
 			"grantItem": "Item",
 			"grantProficiency": "Proficiency",
 			"grantSpells": "Spells",

--- a/src/config/registerRulesConfig.ts
+++ b/src/config/registerRulesConfig.ts
@@ -2,6 +2,7 @@ import { AbilityBonusRule } from '../models/rules/abilityBonus.js';
 import { ApplyConditionRule } from '../models/rules/applyCondition.js';
 import { ArmorClassRule } from '../models/rules/armorClass.js';
 import { CombatManaRule } from '../models/rules/combatMana.js';
+import { ConditionImmunityRule } from '../models/rules/conditionImmunity.js';
 import { ItemGrantRule } from '../models/rules/grantItem.js';
 import { GrantProficiencyRule } from '../models/rules/grantProficiencies.ts';
 import { GrantSpellsRule } from '../models/rules/grantSpells.js';
@@ -29,6 +30,7 @@ export default function registerRulesConfig() {
 		applyCondition: 'NIMBLE.ruleTypes.applyCondition',
 		armorClass: 'NIMBLE.ruleTypes.armorClass',
 		combatMana: 'NIMBLE.ruleTypes.combatMana',
+		conditionImmunity: 'NIMBLE.ruleTypes.conditionImmunity',
 		grantItem: 'NIMBLE.ruleTypes.grantItem',
 		grantProficiency: 'NIMBLE.ruleTypes.grantProficiency',
 		grantSpells: 'NIMBLE.ruleTypes.grantSpells',
@@ -56,6 +58,7 @@ export default function registerRulesConfig() {
 		applyCondition: ApplyConditionRule,
 		armorClass: ArmorClassRule,
 		combatMana: CombatManaRule,
+		conditionImmunity: ConditionImmunityRule,
 		grantItem: ItemGrantRule,
 		grantProficiency: GrantProficiencyRule,
 		grantSpells: GrantSpellsRule,

--- a/src/hooks/automaticConditions.ts
+++ b/src/hooks/automaticConditions.ts
@@ -1,4 +1,5 @@
 import type { NimbleBaseActor } from '../documents/actor/base.svelte.js';
+import { isConditionImmune } from './conditionImmunityGuard.js';
 
 interface AutomaticConditionContext {
 	automaticConditionSource?: string; // Track source of automatic conditions
@@ -49,8 +50,9 @@ export const handleAutomaticConditionApplication = {
 		try {
 			const actor = document.parent as NimbleBaseActor;
 
-			// Apply the automatic conditions
+			// Apply the automatic conditions (skip if actor is immune)
 			for (const conditionId of options.automaticConditionsToApply) {
+				if (isConditionImmune(actor, conditionId)) continue;
 				await actor.toggleStatusEffect(conditionId, {
 					overlay: false,
 					automaticConditionSource: document.id,

--- a/src/hooks/conditionImmunityGuard.ts
+++ b/src/hooks/conditionImmunityGuard.ts
@@ -1,0 +1,27 @@
+/**
+ * Hook listener for nimble.preApplyCondition that blocks conditions
+ * the target actor is immune to. Immunity is populated by
+ * ConditionImmunityRule during data preparation.
+ */
+export function conditionImmunityGuard(context: {
+	target: { system?: { conditionImmunities?: Set<string> } };
+	condition: string;
+}): boolean | undefined {
+	const immunities = (context.target.system as { conditionImmunities?: Set<string> } | undefined)
+		?.conditionImmunities;
+	if (immunities?.has(context.condition)) return false;
+	return undefined;
+}
+
+/**
+ * Check whether an actor is immune to a given condition.
+ * Used by automaticConditions.ts to guard the direct toggleStatusEffect path.
+ */
+export function isConditionImmune(
+	actor: { system?: unknown } | null | undefined,
+	conditionId: string,
+): boolean {
+	const immunities = (actor?.system as { conditionImmunities?: Set<string> } | undefined)
+		?.conditionImmunities;
+	return immunities?.has(conditionId) ?? false;
+}

--- a/src/models/rules/conditionImmunity.test.ts
+++ b/src/models/rules/conditionImmunity.test.ts
@@ -1,0 +1,214 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { conditionImmunityGuard, isConditionImmune } from '../../hooks/conditionImmunityGuard.js';
+import { ConditionImmunityRule } from './conditionImmunity.js';
+
+interface MockActor {
+	system: {
+		conditionImmunities?: Set<string>;
+	};
+	getRollData: ReturnType<typeof vi.fn>;
+}
+
+interface MockItem {
+	isEmbedded: boolean;
+	actor: MockActor;
+	name: string;
+	uuid: string;
+}
+
+function createMockActor(): MockActor {
+	return {
+		system: {},
+		getRollData: vi.fn(() => ({})),
+	};
+}
+
+function createMockItem(actor: MockActor, isEmbedded = true): MockItem {
+	return {
+		isEmbedded,
+		actor,
+		name: 'Test Item',
+		uuid: 'test-item-uuid',
+	};
+}
+
+function createConditionImmunityRule(
+	config: {
+		conditions?: string[];
+		disabled?: boolean;
+	},
+	actor: MockActor,
+	itemOptions?: { isEmbedded?: boolean },
+): ConditionImmunityRule {
+	const item = createMockItem(actor, itemOptions?.isEmbedded ?? true);
+
+	const sourceData = {
+		conditions: config.conditions ?? ['frightened'],
+		disabled: config.disabled ?? false,
+		label: 'Test Rule',
+		id: 'test-rule-id',
+		identifier: '',
+		priority: 1,
+		predicate: {},
+		type: 'conditionImmunity',
+	};
+
+	const rule = new ConditionImmunityRule(
+		sourceData as foundry.data.fields.SchemaField.CreateData<
+			ConditionImmunityRule['schema']['fields']
+		>,
+		{ parent: item as unknown as foundry.abstract.DataModel.Any, strict: false },
+	);
+
+	(rule as any).conditions = config.conditions ?? ['frightened'];
+	(rule as any).disabled = config.disabled ?? false;
+
+	Object.defineProperty(rule, 'item', {
+		get: () => item,
+		configurable: true,
+	});
+
+	Object.defineProperty(rule, '_predicate', {
+		get: () => ({ size: 0 }),
+		configurable: true,
+	});
+
+	return rule;
+}
+
+describe('ConditionImmunityRule', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe('afterPrepareData', () => {
+		it('should add condition to the actor conditionImmunities set', () => {
+			const actor = createMockActor();
+			const rule = createConditionImmunityRule({ conditions: ['frightened'] }, actor);
+
+			rule.afterPrepareData();
+
+			expect(actor.system.conditionImmunities).toBeInstanceOf(Set);
+			expect(actor.system.conditionImmunities!.has('frightened')).toBe(true);
+		});
+
+		it('should add multiple conditions from a single rule', () => {
+			const actor = createMockActor();
+			const rule = createConditionImmunityRule({ conditions: ['frightened', 'charmed'] }, actor);
+
+			rule.afterPrepareData();
+
+			expect(actor.system.conditionImmunities!.has('frightened')).toBe(true);
+			expect(actor.system.conditionImmunities!.has('charmed')).toBe(true);
+			expect(actor.system.conditionImmunities!.size).toBe(2);
+		});
+
+		it('should stack immunities from multiple rules', () => {
+			const actor = createMockActor();
+			const rule1 = createConditionImmunityRule({ conditions: ['frightened'] }, actor);
+			const rule2 = createConditionImmunityRule({ conditions: ['stunned'] }, actor);
+
+			rule1.afterPrepareData();
+			rule2.afterPrepareData();
+
+			expect(actor.system.conditionImmunities!.has('frightened')).toBe(true);
+			expect(actor.system.conditionImmunities!.has('stunned')).toBe(true);
+			expect(actor.system.conditionImmunities!.size).toBe(2);
+		});
+
+		it('should handle duplicate conditions gracefully', () => {
+			const actor = createMockActor();
+			const rule1 = createConditionImmunityRule({ conditions: ['frightened'] }, actor);
+			const rule2 = createConditionImmunityRule({ conditions: ['frightened'] }, actor);
+
+			rule1.afterPrepareData();
+			rule2.afterPrepareData();
+
+			expect(actor.system.conditionImmunities!.size).toBe(1);
+		});
+
+		it('should not modify actor when item is not embedded', () => {
+			const actor = createMockActor();
+			const rule = createConditionImmunityRule({ conditions: ['frightened'] }, actor, {
+				isEmbedded: false,
+			});
+
+			rule.afterPrepareData();
+
+			expect(actor.system.conditionImmunities).toBeUndefined();
+		});
+
+		it('should not modify actor when rule is disabled', () => {
+			const actor = createMockActor();
+			const rule = createConditionImmunityRule(
+				{ conditions: ['frightened'], disabled: true },
+				actor,
+			);
+
+			rule.afterPrepareData();
+
+			expect(actor.system.conditionImmunities).toBeUndefined();
+		});
+
+		it('should not modify actor when conditions array is empty', () => {
+			const actor = createMockActor();
+			const rule = createConditionImmunityRule({ conditions: [] }, actor);
+
+			rule.afterPrepareData();
+
+			expect(actor.system.conditionImmunities).toBeUndefined();
+		});
+	});
+
+	describe('schema', () => {
+		it('should define the correct schema fields', () => {
+			const schema = ConditionImmunityRule.defineSchema();
+
+			expect(schema).toHaveProperty('conditions');
+			expect(schema).toHaveProperty('type');
+			expect(schema).toHaveProperty('disabled');
+			expect(schema).toHaveProperty('label');
+		});
+	});
+});
+
+describe('conditionImmunityGuard', () => {
+	it('should return false for immune conditions', () => {
+		const target = { system: { conditionImmunities: new Set(['frightened']) } };
+		const result = conditionImmunityGuard({ target, condition: 'frightened' });
+		expect(result).toBe(false);
+	});
+
+	it('should return undefined for non-immune conditions', () => {
+		const target = { system: { conditionImmunities: new Set(['frightened']) } };
+		const result = conditionImmunityGuard({ target, condition: 'stunned' });
+		expect(result).toBeUndefined();
+	});
+
+	it('should return undefined when actor has no immunities', () => {
+		const target = { system: {} };
+		const result = conditionImmunityGuard({ target, condition: 'frightened' });
+		expect(result).toBeUndefined();
+	});
+});
+
+describe('isConditionImmune', () => {
+	it('should return true for immune conditions', () => {
+		const actor = { system: { conditionImmunities: new Set(['frightened']) } };
+		expect(isConditionImmune(actor, 'frightened')).toBe(true);
+	});
+
+	it('should return false for non-immune conditions', () => {
+		const actor = { system: { conditionImmunities: new Set(['frightened']) } };
+		expect(isConditionImmune(actor, 'stunned')).toBe(false);
+	});
+
+	it('should return false for null actor', () => {
+		expect(isConditionImmune(null, 'frightened')).toBe(false);
+	});
+
+	it('should return false when actor has no immunities', () => {
+		const actor = { system: {} };
+		expect(isConditionImmune(actor, 'frightened')).toBe(false);
+	});
+});

--- a/src/models/rules/conditionImmunity.ts
+++ b/src/models/rules/conditionImmunity.ts
@@ -1,0 +1,63 @@
+import { NimbleBaseRule } from './base.js';
+
+function schema() {
+	const { fields } = foundry.data;
+
+	return {
+		conditions: new fields.ArrayField(
+			new fields.StringField({ required: true, nullable: false, blank: false }),
+			{ required: true, nullable: false, initial: [] },
+		),
+		type: new fields.StringField({ required: true, nullable: false, initial: 'conditionImmunity' }),
+	};
+}
+
+declare namespace ConditionImmunityRule {
+	type Schema = NimbleBaseRule.Schema & ReturnType<typeof schema>;
+}
+
+interface ActorSystem {
+	system: {
+		conditionImmunities?: Set<string>;
+	};
+}
+
+/**
+ * Rule that grants immunity to one or more conditions.
+ * Immune conditions are accumulated in a Set on the actor and checked
+ * by the nimble.preApplyCondition hook listener to block application.
+ */
+class ConditionImmunityRule extends NimbleBaseRule<ConditionImmunityRule.Schema> {
+	declare conditions: string[];
+
+	static override defineSchema(): ConditionImmunityRule.Schema {
+		return {
+			...NimbleBaseRule.defineSchema(),
+			...schema(),
+		};
+	}
+
+	override tooltipInfo(): string {
+		return super.tooltipInfo(new Map([['conditions', 'string[]']]));
+	}
+
+	override afterPrepareData(): void {
+		const { item } = this;
+		if (!item.isEmbedded) return;
+		if (!this.test()) return;
+		if (this.conditions.length === 0) return;
+
+		const { actor } = item;
+		const actorSystem = actor as object as ActorSystem;
+
+		if (!actorSystem.system.conditionImmunities) {
+			foundry.utils.setProperty(actor.system, 'conditionImmunities', new Set<string>());
+		}
+
+		for (const condition of this.conditions) {
+			actorSystem.system.conditionImmunities!.add(condition);
+		}
+	}
+}
+
+export { ConditionImmunityRule };

--- a/src/nimble.ts
+++ b/src/nimble.ts
@@ -3,6 +3,7 @@ import canvasInit from './hooks/canvasInit.js';
 import registerCombatantDefeatSync from './hooks/combatantHooks/combatantDefeatSync.js';
 import registerCombatantHealthStateSync from './hooks/combatantHooks/combatantHealthStateSync.js';
 import registerTokenCombatantSync from './hooks/combatantHooks/tokenCombatantSync.js';
+import { conditionImmunityGuard } from './hooks/conditionImmunityGuard.js';
 import { hotbarDrop as onHotbarDrop } from './hooks/hotBarDrop.js';
 import i18nInit from './hooks/i18nInit.js';
 import init from './hooks/init.js';
@@ -84,6 +85,12 @@ type HookFn = (...args: object[]) => undefined | boolean | Promise<undefined | b
 (Hooks.on as (event: string, fn: HookFn) => number)(
 	'deleteActiveEffect',
 	handleAutomaticConditionApplication.postDelete as object as HookFn,
+);
+
+// Condition immunity — block protected conditions before application
+(Hooks.on as (event: string, fn: HookFn) => number)(
+	'nimble.preApplyCondition',
+	conditionImmunityGuard as object as HookFn,
 );
 
 Hooks.on('hotbarDrop', onHotbarDrop);


### PR DESCRIPTION
## Summary

Adds a `conditionImmunity` rule type that grants immunity to one or more conditions. The rule populates a `Set<string>` on the actor during data prep, and a global `nimble.preApplyCondition` hook listener blocks immune conditions. The automatic condition triggering path is also guarded.

## Changes

- New `ConditionImmunityRule` with `conditions` array schema field
- `conditionImmunityGuard` hook listener registered on `nimble.preApplyCondition` — returns `false` to block immune conditions
- `isConditionImmune()` utility for checking immunity outside the hook path
- `automaticConditions.ts` postCreate handler checks immunity before applying triggered conditions
- Fearless background wired with `conditionImmunity: ["frightened"]`
- 15 new tests (rule lifecycle, hook guard, utility)

## Test Plan

- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] Create a character with Fearless background — verify `actor.system.conditionImmunities` contains `"frightened"` (browser console: `game.actors.getName('name').system.conditionImmunities`)
- [x] Add an `applyCondition` rule with `trigger: 'onTurnStart'` and `condition: 'frightened'` — advance to their turn — frightened should NOT apply
- [x] Same setup on a character WITHOUT Fearless — frightened SHOULD apply
- [x] Non-immune conditions (e.g. stunned) still apply normally to immune characters
- [x] Rule editor shows "Condition Immunity" as a rule type with `conditions` field

**Notes for reviewers:**
- Direct `toggleStatusEffect` calls (e.g. token HUD, chat card condition buttons) bypass the hook — this is a pre-existing design pattern, not a gap introduced here
- As more foundation rule types land, the inline `actor.system` type assertions will accumulate — a shared `NimbleActorDerivedData` interface may be worth extracting once 3-4 more properties exist

## Checklist

- [x] Added or updated unit tests
- [x] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [x] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** yes
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues

Closes #585