### PR TITLE
ci: rolling dev release on push to dev

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -39,6 +39,9 @@ jobs:
     - name: Install Dependencies
       run: pnpm install --frozen-lockfile
 
+    - name: Rebrand for dev build
+      run: node ./build/dev-rebrand.mjs
+
     - name: Build System
       run: pnpm build
 
@@ -60,11 +63,11 @@ jobs:
         version: ${{ steps.dev_version.outputs.version }}
         url: https://github.com/${{ github.repository }}
         manifest: https://github.com/${{ github.repository }}/releases/download/${{ env.dev_tag }}/system.json
-        download: https://github.com/${{ github.repository }}/releases/download/${{ env.dev_tag }}/nimble.zip
+        download: https://github.com/${{ github.repository }}/releases/download/${{ env.dev_tag }}/nimble-dev.zip
 
     - name: Zip Files
       working-directory: ./dist
-      run: zip -r ./nimble.zip ./*
+      run: zip -r ./nimble-dev.zip ./*
 
     - name: Update Rolling Dev Release
       uses: ncipollo/release-action@v1
@@ -77,7 +80,7 @@ jobs:
         prerelease: true
         makeLatest: false
         token: ${{ secrets.GITHUB_TOKEN }}
-        artifacts: './dist/system.json,./dist/nimble.zip'
+        artifacts: './dist/system.json,./dist/nimble-dev.zip'
         body: |
           Rolling development build from the `dev` branch. **Unstable — for testing only.**
 

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -1,0 +1,91 @@
+name: Nimble - Rolling Dev Release
+
+on:
+  push:
+    branches: [dev]
+  workflow_dispatch:
+
+concurrency:
+  group: dev-release
+  cancel-in-progress: true
+
+env:
+  node_version: 22
+  dev_tag: latest-dev
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Use Node.js ${{ env.node_version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ env.node_version }}
+
+    - name: Install pnpm
+      uses: pnpm/action-setup@v4
+
+    - name: Cache pnpm store
+      uses: actions/cache@v4
+      with:
+        path: ~/.local/share/pnpm/store/v10
+        key: pnpm-dev-${{ github.sha }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+        restore-keys: |
+          pnpm-dev-
+
+    - name: Install Dependencies
+      run: pnpm install --frozen-lockfile
+
+    - name: Build System
+      run: pnpm build
+
+    - name: Compute dev version
+      id: dev_version
+      run: |
+        base_version=$(node -p "require('./package.json').version")
+        short_sha=$(echo "${{ github.sha }}" | cut -c1-7)
+        dev_version="${base_version}-dev.${{ github.run_number }}+${short_sha}"
+        echo "version=${dev_version}" >> "$GITHUB_OUTPUT"
+        echo "short_sha=${short_sha}" >> "$GITHUB_OUTPUT"
+        echo "Dev version: ${dev_version}"
+
+    - name: Substitute Manifest and Download Links For Dev Build
+      uses: microsoft/variable-substitution@v1
+      with:
+        files: './dist/system.json'
+      env:
+        version: ${{ steps.dev_version.outputs.version }}
+        url: https://github.com/${{ github.repository }}
+        manifest: https://github.com/${{ github.repository }}/releases/download/${{ env.dev_tag }}/system.json
+        download: https://github.com/${{ github.repository }}/releases/download/${{ env.dev_tag }}/nimble.zip
+
+    - name: Zip Files
+      working-directory: ./dist
+      run: zip -r ./nimble.zip ./*
+
+    - name: Update Rolling Dev Release
+      uses: ncipollo/release-action@v1
+      with:
+        tag: ${{ env.dev_tag }}
+        commit: ${{ github.sha }}
+        name: Development Build
+        allowUpdates: true
+        removeArtifacts: true
+        prerelease: true
+        makeLatest: false
+        token: ${{ secrets.GITHUB_TOKEN }}
+        artifacts: './dist/system.json,./dist/nimble.zip'
+        body: |
+          Rolling development build from the `dev` branch. **Unstable — for testing only.**
+
+          - Version: `${{ steps.dev_version.outputs.version }}`
+          - Commit: [`${{ steps.dev_version.outputs.short_sha }}`](https://github.com/${{ github.repository }}/commit/${{ github.sha }})
+          - Built: ${{ github.event.head_commit.timestamp }}
+
+          Install in Foundry via Manifest URL:
+          ```
+          https://github.com/${{ github.repository }}/releases/download/${{ env.dev_tag }}/system.json
+          ```

--- a/build/dev-rebrand.mjs
+++ b/build/dev-rebrand.mjs
@@ -1,0 +1,58 @@
+/* eslint-disable no-console */
+/**
+ * Rebrands the system from `nimble` to `nimble-dev` so the rolling dev release
+ * can be installed in Foundry side-by-side with the stable `nimble` system.
+ * CI-only: invoked by .github/workflows/dev-release.yml *before* `pnpm build`,
+ * so the LevelDB compendia produced by the build already contain the rewritten
+ * references. The script mutates tracked files in-place — it must NEVER run
+ * against a working tree whose changes you intend to keep.
+ *
+ * What gets rewritten:
+ *
+ *   1. public/system.json
+ *      - `id`           → "nimble-dev"   (Foundry installs to Data/systems/<id>/)
+ *      - `title`        → "Nimble (Dev)" (so the dev install is visually
+ *                                         distinguishable in Foundry's UI)
+ *      - `packs[*].system` → "nimble-dev" (Foundry rejects packs whose
+ *                                          `system` field doesn't match the
+ *                                          system id)
+ *
+ *   2. packs/**\/*.json (compendium document sources)
+ *      - `Compendium.nimble.<pack>.<docId>` → `Compendium.nimble-dev.<pack>.<docId>`
+ *        Foundry resolves compendium UUIDs by system id; without this rewrite,
+ *        cross-pack references (class progressions linking to spells, etc.)
+ *        would dangle under the dev install.
+ *
+ * Idempotent: the regex `Compendium\.nimble\.` requires a literal dot after
+ * `nimble`, so it does not match the already-rewritten `Compendium.nimble-dev.`.
+ * Running the script twice is a no-op on the second pass.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { glob } from 'glob';
+
+const STABLE_ID = 'nimble';
+const DEV_ID = 'nimble-dev';
+const DEV_TITLE = 'Nimble (Dev)';
+
+const manifestPath = 'public/system.json';
+const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+manifest.id = DEV_ID;
+manifest.title = DEV_TITLE;
+for (const pack of manifest.packs) {
+	if (pack.system === STABLE_ID) pack.system = DEV_ID;
+}
+writeFileSync(manifestPath, `${JSON.stringify(manifest, null, '\t')}\n`);
+console.log(`[rebrand] Updated ${manifestPath} (id=${DEV_ID}, title="${DEV_TITLE}")`);
+
+const packFiles = await glob('packs/**/*.json');
+const uuidPattern = /Compendium\.nimble\./g;
+let touched = 0;
+for (const file of packFiles) {
+	const original = readFileSync(file, 'utf8');
+	if (!uuidPattern.test(original)) continue;
+	const updated = original.replace(uuidPattern, `Compendium.${DEV_ID}.`);
+	writeFileSync(file, updated);
+	touched++;
+}
+console.log(`[rebrand] Rewrote Compendium UUIDs in ${touched} pack files`);


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that maintains a single permanent prerelease (tagged `latest-dev`) whose assets are rebuilt and replaced on every push to `dev`. The dev build is rebranded to system id `nimble-dev` so it installs into `Data/systems/nimble-dev/` and coexists with the stable `nimble` system — testers can run both side-by-side.

## Changes

- New workflow `.github/workflows/dev-release.yml` triggered on push to `dev` (and `workflow_dispatch`).
- New `build/dev-rebrand.mjs`, run in CI before `pnpm build`. It rewrites `public/system.json` (`id` → `nimble-dev`, `title` → `Nimble (Dev)`, `packs[*].system` → `nimble-dev`) and replaces every `Compendium.nimble.<...>` UUID in `packs/**/*.json` with `Compendium.nimble-dev.<...>`, so cross-pack references in the LevelDB output resolve under the dev install.
- Dev version is computed as `{base}-dev.{run_number}+{shortSha}`. Monotonic via `run_number` so Foundry's `isNewerVersion` always reports newer; `+{shortSha}` is semver build metadata for traceability.
- Post-build `microsoft/variable-substitution@v1` writes `version`, `manifest`, and `download` URLs into `dist/system.json`.
- Asset published as `nimble-dev.zip` via `ncipollo/release-action@v1` with `allowUpdates`, `removeArtifacts`, `prerelease: true`, and `makeLatest: false` so `releases/latest` keeps pointing at the stable release.
- Skips the FoundryVTT package-registry publish step — dev builds must not appear in the official package list.
- Concurrency group `dev-release` with `cancel-in-progress: true` avoids races on rapid pushes.

## Test Plan

After merging, push a commit to `dev` and verify:

1. The "Nimble - Rolling Dev Release" workflow run succeeds.
2. A prerelease named "Development Build" exists at tag `latest-dev` with `system.json` and `nimble-dev.zip` attached, and the previous build's assets are gone.
3. Downloading `https://github.com/Nimble-Co/FoundryVTT-Nimble/releases/download/latest-dev/system.json` shows `id: "nimble-dev"`, `title: "Nimble (Dev)"`, the templated dev version, every `packs[*].system` set to `nimble-dev`, and the `releases/download/latest-dev/...` URLs.
4. `https://github.com/Nimble-Co/FoundryVTT-Nimble/releases/latest/download/system.json` still resolves to the stable release, not the dev prerelease.
5. Install in Foundry via the dev manifest URL alongside an existing stable `nimble` install. Both appear in the system list, neither overwrites the other, and dev compendium cross-references (e.g. class → spell links) resolve.
6. Push another commit to `dev`; confirm Foundry's update check offers the new build and the existing `latest-dev` release is updated in place.
7. The FoundryVTT package page for Nimble has not been updated by the dev workflow.

## Checklist

- [ ] Added or updated unit tests
- [x] PR targets the `dev` branch
- [ ] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [ ] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** yes
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues