### PR TITLE
fix(build): make system id configurable for nimble-dev coexistence

### DIFF
--- a/build/dev-rebrand.mjs
+++ b/build/dev-rebrand.mjs
@@ -24,9 +24,16 @@
  *        Foundry resolves compendium UUIDs by system id; without this rewrite,
  *        cross-pack references (class progressions linking to spells, etc.)
  *        would dangle under the dev install.
+ *      - `systems/nimble/<asset>` → `systems/nimble-dev/<asset>`
+ *        Document `img`/`src` fields point at class images, monster portraits,
+ *        and other system assets. Without this rewrite, every Foundry document
+ *        loaded from a compendium would 404 on its image under the dev install.
  *
- * Idempotent: the regex `Compendium\.nimble\.` requires a literal dot after
- * `nimble`, so it does not match the already-rewritten `Compendium.nimble-dev.`.
+ * SCSS namespacing (`.system-#{system-id()}`) is handled by a sass function
+ * registered in `vite.config.mts` — no rebrand work needed here.
+ *
+ * Idempotent: every regex requires a non-`-` boundary immediately after
+ * `nimble`, so they don't match the already-rewritten `nimble-dev` form.
  * Running the script twice is a no-op on the second pass.
  */
 
@@ -50,14 +57,27 @@ if (typeof manifest.background === 'string') {
 writeFileSync(manifestPath, `${JSON.stringify(manifest, null, '\t')}\n`);
 console.log(`[rebrand] Updated ${manifestPath} (id=${DEV_ID}, title="${DEV_TITLE}")`);
 
-const packFiles = await glob('packs/**/*.json');
-const uuidPattern = /Compendium\.nimble\./g;
-let touched = 0;
-for (const file of packFiles) {
-	const original = readFileSync(file, 'utf8');
-	if (!uuidPattern.test(original)) continue;
-	const updated = original.replace(uuidPattern, `Compendium.${DEV_ID}.`);
-	writeFileSync(file, updated);
-	touched++;
+async function rewriteFiles(globPattern, replacements, label) {
+	const files = await glob(globPattern);
+	let touched = 0;
+	for (const file of files) {
+		const original = readFileSync(file, 'utf8');
+		let updated = original;
+		for (const [pattern, replacement] of replacements) {
+			updated = updated.replace(pattern, replacement);
+		}
+		if (updated === original) continue;
+		writeFileSync(file, updated);
+		touched++;
+	}
+	console.log(`[rebrand] Rewrote ${touched} ${label}`);
 }
-console.log(`[rebrand] Rewrote Compendium UUIDs in ${touched} pack files`);
+
+await rewriteFiles(
+	'packs/**/*.json',
+	[
+		[/Compendium\.nimble\./g, `Compendium.${DEV_ID}.`],
+		[/systems\/nimble\//g, `systems/${DEV_ID}/`],
+	],
+	'pack files (Compendium UUIDs + asset paths)',
+);

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,17 +1,37 @@
+import { readFileSync } from 'node:fs';
 import { sveltePreprocess } from 'svelte-preprocess';
 
+const systemJson = JSON.parse(readFileSync('./public/system.json', 'utf8'));
+
+// Mirrors the namespace rewrite registered in vite.config.mts so IDE tooling
+// (svelte-check, the Svelte VSCode extension, etc.) — which reads this file
+// rather than Vite's config — sees the rebranded selectors. Without it,
+// .system-nimble would appear unmodified in tooling-driven SCSS compilation.
+const NAMESPACE_PATTERN = /\.system-nimble\b(?!-)/g;
+const namespaceReplacement = `.system-${systemJson.id}`;
+const rewriteNamespace = (source) => source.replace(NAMESPACE_PATTERN, namespaceReplacement);
+
 const config = {
-  compilerOptions: {
-    runes: true
-  },
-  preprocess: sveltePreprocess({
-    scss: {
-      prependData: '@import "src/scss/base/_functions.scss";'
-    },
-    typescript: {
-      tsconfigFile: './tsconfig.json'
-    }
-  })
+	compilerOptions: {
+		runes: true,
+	},
+	preprocess: [
+		{
+			name: 'system-namespace-rewrite',
+			style({ content, attributes }) {
+				if (attributes.lang !== 'scss' && attributes.lang !== 'sass') return;
+				return { code: rewriteNamespace(content) };
+			},
+		},
+		sveltePreprocess({
+			scss: {
+				prependData: '@import "src/scss/base/_functions.scss";',
+			},
+			typescript: {
+				tsconfigFile: './tsconfig.json',
+			},
+		}),
+	],
 };
 
 export default config;

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -1,5 +1,6 @@
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import { sveltePreprocess } from 'svelte-preprocess';
 import { defineConfig } from 'vitest/config';
@@ -7,6 +8,61 @@ import { defineConfig } from 'vitest/config';
 const systemJson = JSON.parse(readFileSync(path.resolve(__dirname, 'public/system.json'), 'utf8'));
 const systemRoot = `/systems/${systemJson.id}`;
 const systemBase = `${systemRoot}/`;
+
+// Rewrites `.system-nimble` → `.system-<id>` in every SCSS unit at sass
+// compile time, so source files keep the literal `.system-nimble` selector
+// without authors needing to know about a build-time substitution.
+//
+// Mechanism: register our importer as `sassOptions.importer` (singular). Sass
+// associates that importer with the entry source, and relative `@use` paths
+// inside it cascade through our canonicalize first — see
+// https://sass-lang.com/documentation/js-api/interfaces/importer/ ("Sass first
+// attempts to resolve the URL relative to ... the original importer").
+const NAMESPACE_PATTERN = /\.system-nimble\b(?!-)/g;
+const namespaceReplacement = `.system-${systemJson.id}`;
+const rewriteNamespace = (source: string) =>
+	source.replace(NAMESPACE_PATTERN, namespaceReplacement);
+
+const namespaceRewriteImporter = {
+	canonicalize(url: string) {
+		// Sass passes either a bare/relative path (e.g. `components/foo`) or an
+		// already-resolved `file://` URL (sass's implicit URL importer resolves
+		// the @use target against the parent's URL before delegating to us).
+		// Either way, we need to find a real file via sass's partial-resolution
+		// rules and return its canonical file:// URL.
+		let basePath: string;
+		if (url.startsWith('file:')) {
+			basePath = fileURLToPath(new URL(url));
+		} else if (path.isAbsolute(url)) {
+			basePath = url;
+		} else {
+			// Bare relative path with no containing URL — uncommon for entries.
+			basePath = path.resolve(url);
+		}
+		const dir = path.dirname(basePath);
+		const filename = path.basename(basePath);
+		const candidates = [
+			path.join(dir, `_${filename}.scss`),
+			path.join(dir, `${filename}.scss`),
+			path.join(dir, filename, '_index.scss'),
+			path.join(dir, filename, 'index.scss'),
+		];
+		const resolved = candidates.find(existsSync);
+		return resolved ? pathToFileURL(resolved) : null;
+	},
+	load(canonicalUrl: URL) {
+		return {
+			contents: rewriteNamespace(readFileSync(fileURLToPath(canonicalUrl), 'utf-8')),
+			syntax: 'scss' as const,
+			sourceMapUrl: canonicalUrl,
+		};
+	},
+};
+
+const scssRewriteOptions = {
+	additionalData: (source: string) => rewriteNamespace(source),
+	importer: namespaceRewriteImporter,
+};
 
 const config = defineConfig({
 	root: 'src/',
@@ -55,6 +111,11 @@ const config = defineConfig({
 	esbuild: {
 		keepNames: true,
 	},
+	css: {
+		preprocessorOptions: {
+			scss: scssRewriteOptions,
+		},
+	},
 	plugins: [
 		svelte({
 			configFile: path.resolve(__dirname, 'svelte.config.js'),
@@ -63,11 +124,23 @@ const config = defineConfig({
 					return { runes: false };
 				}
 			},
-			preprocess: sveltePreprocess({
-				typescript: {
-					tsconfigFile: './tsconfig.json',
+			preprocess: [
+				// Rewrites `.system-nimble` in component <style lang="scss"> blocks
+				// before they hit sass. Component blocks don't @use our partials,
+				// so a string-level rewrite covers them — no sass importer needed.
+				{
+					name: 'system-namespace-rewrite',
+					style({ content, attributes }) {
+						if (attributes.lang !== 'scss' && attributes.lang !== 'sass') return;
+						return { code: rewriteNamespace(content) };
+					},
 				},
-			}),
+				sveltePreprocess({
+					typescript: {
+						tsconfigFile: './tsconfig.json',
+					},
+				}),
+			],
 			onwarn: (warning, handler) => {
 				// Suppress `a11y-missing-attribute` for missing href in <a> links.
 				// Foundry doesn't follow accessibility rules.


### PR DESCRIPTION
## Summary

Makes the system id configurable from `public/system.json` so the rolling dev release (id `nimble-dev`) can install in Foundry side-by-side with the stable `nimble` system. Without this, the dev build's CSS namespacing, asset paths, and pack document references all bake `nimble` literally and break under the rebranded install.

## Changes

- **`src/utils/systemId.ts`** (new) exports `SYSTEM_ID` and `SYSTEM_PATH` derived from `public/system.json` at build time. `tsconfig.json` enables `resolveJsonModule`; `vite.config.mts` adds `server.fs.allow` for the cross-boundary import.
- **`vite.config.mts`** derives the dev-server `base` and proxy keys from the same JSON. Hardcoded `systems/nimble/` strings in `src/config.ts`, `src/config/registerConditionsConfig.ts`, and `src/macros/createHeroicActionMacro.ts` (34 sites — actor banners, class images, condition icons, fallback macro icon) now use `${SYSTEM_PATH}/...`.
- **`vite.config.mts`** registers a sass `Importer` (singular `importer` option) that intercepts every `@use` load and rewrites `.system-nimble` → `.system-${id}` in the file content before sass compiles. A small Svelte preprocessor does the same for component `<style lang="scss">` blocks. Source files keep the literal `.system-nimble` selector — no convention to learn.
- **`svelte.config.js`** mirrors the Svelte preprocessor for IDE/`svelte-check` parity.
- **`build/dev-rebrand.mjs`** rewrites `public/system.json` (`id`, `title`, `packs[*].system`, `background` prefix), `Compendium.nimble.<...>` UUIDs in pack JSON, and `systems/nimble/` asset paths in pack document `img`/`src` fields. CI dev-release workflow runs this before `pnpm build`.

## Test Plan

1. **Stable build unchanged.** With `public/system.json` untouched: `pnpm build` and confirm `dist/nimble.css` contains `.system-nimble` (583 occurrences) and `url(/systems/nimble/fonts/...)`. `dist/system.json` keeps `id: "nimble"`.
2. **Tests / type-check / lint clean.** `pnpm check` passes (1052 tests).
3. **Dev rebrand path.** `node ./build/dev-rebrand.mjs` then `pnpm build`. Confirm:
   - `dist/system.json` has `id: "nimble-dev"`, `title: "Nimble (Dev)"`, every `packs[*].system: "nimble-dev"`, and `background: "systems/nimble-dev/..."`.
   - `dist/nimble.css` contains 583 `.system-nimble-dev` (zero leftover `.system-nimble`) and `url(/systems/nimble-dev/fonts/...)`.
   - `dist/nimble.js` chunks bake in `iL = "nimble-dev"` so `SYSTEM_PATH` resolves to `systems/nimble-dev` at runtime.
   - `dist/packs/**/*.ldb` contain `systems/nimble-dev/...` asset references (zero `systems/nimble/` leftovers).
4. **Foundry side-by-side.** With both stable `nimble` and the dev build symlinked into `Data/systems/`, restart Foundry. Both systems list correctly. Open a world with the dev system: fonts render, condition icons appear on tokens, class images show in the character creation dialog, actor sheet banners load.
5. **Revert before committing.** `git checkout -- public/system.json packs/` after local rebrand testing.

## Checklist

- [ ] Added or updated unit tests
- [x] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [ ] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** yes
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues

Follow-up to #748 (rolling dev release workflow). Without the changes here, the `latest-dev` build produced by that workflow can be installed but its UI is broken: missing fonts, broken layouts (CSS namespace mismatch), and 404'd images for class banners, condition icons, and pack document portraits.