### PR TITLE
fix(character-creation): deduplicate world-item spells against compendium source in spell index

### DIFF
--- a/src/utils/getSpells.ts
+++ b/src/utils/getSpells.ts
@@ -51,8 +51,11 @@ interface SpellPackIndexEntry {
 export async function buildSpellIndex(): Promise<SpellIndex> {
 	const index: SpellIndex = new Map();
 
-	// Track seen UUIDs to avoid duplicates
+	// Track seen UUIDs to avoid duplicates.
+	// Also track compendium source UUIDs covered by world items so we can skip
+	// the original compendium entry when a world-item copy already exists.
 	const seen = new Set<string>();
+	const seenCompendiumSources = new Set<string>();
 
 	/**
 	 * Adds a spell entry to the index for a specific school and tier.
@@ -95,7 +98,7 @@ export async function buildSpellIndex(): Promise<SpellIndex> {
 
 		const isUtility = selectedProperties.includes('utilitySpell');
 
-		addToIndex({
+		const added = addToIndex({
 			uuid: item.uuid,
 			name: item.name ?? 'Unknown Spell',
 			img: item.img ?? 'icons/svg/item-bag.svg',
@@ -104,6 +107,15 @@ export async function buildSpellIndex(): Promise<SpellIndex> {
 			isUtility,
 			classes: system.classes ?? [],
 		});
+
+		// If this world item was imported from a compendium, mark that source UUID as
+		// covered so the compendium's own entry is skipped below (prevents duplicates
+		// when a player has world-item copies of compendium spells).
+		if (added) {
+			const compendiumSource = (item._stats as { compendiumSource?: string } | undefined)
+				?.compendiumSource;
+			if (compendiumSource) seenCompendiumSources.add(compendiumSource);
+		}
 	}
 
 	// Process compendium packs
@@ -122,6 +134,9 @@ export async function buildSpellIndex(): Promise<SpellIndex> {
 		for (const indexEntry of packIndex) {
 			const packEntry = indexEntry as SpellPackIndexEntry;
 			if (packEntry.type !== 'spell') continue;
+
+			// Skip if a world item imported from this compendium entry is already indexed
+			if (seenCompendiumSources.has(packEntry.uuid)) continue;
 
 			const system = packEntry.system;
 			if (!system?.school) continue;


### PR DESCRIPTION
## Summary

- `buildSpellIndex()` only deduplicated by UUID, so a world item imported from a compendium (different UUID, same spell) and its original compendium entry both landed in the index
- `getSpellsFromIndex` returned both copies; `seenSpellUuids` in `CharacterCreationDialog` could not deduplicate them (different UUIDs), resulting in duplicate cantrips on the character sheet after creation
- Fix: track a `seenCompendiumSources` set alongside the existing `seen` set; when a world item has `_stats.compendiumSource`, mark that compendium UUID as covered so the compendium entry is skipped during pack processing

## Test plan

- [ ] Create a character with a spell-granting class (Mage, Shepherd, Stormshifter, Shadowmancer, Songweaver) in a world that has compendium spells imported as world items — confirm no duplicate cantrips on the sheet
- [ ] Same scenario without world-item spells — confirm normal spell granting still works
- [ ] All 1082 existing tests pass