### PR TITLE
feat(character-creation): auto-equip starting equipment items on character creation

### DIFF
--- a/src/documents/dialogs/CharacterCreationDialog.svelte.ts
+++ b/src/documents/dialogs/CharacterCreationDialog.svelte.ts
@@ -1,5 +1,6 @@
 import type { DeepPartial } from 'fvtt-types/utils';
 import type { NimbleFeatureItem } from '#documents/item/feature.js';
+import type { NimbleObjectItem } from '#documents/item/object.js';
 import { SvelteApplicationMixin } from '#lib/SvelteApplicationMixin.svelte.js';
 import { buildSpellIndex, type SpellIndex } from '#utils/getSpells.js';
 import { getSpellsFromIndex } from '#utils/getSpellsFromIndex.js';
@@ -323,6 +324,14 @@ export default class CharacterCreationDialog extends SvelteApplicationMixin(Appl
 		// If equipment was chosen, items will be granted automatically
 		// If gold was chosen, grantItem rules were disabled above so no items are granted
 		await actor?.createEmbeddedDocuments('Item', originDocumentSources);
+
+		// Auto-equip all object items granted as starting equipment
+		if (startingEquipmentChoice === 'equipment' && actor) {
+			const objectItems = actor.items.filter((i) => i.type === 'object');
+			for (const item of objectItems) {
+				await (item as unknown as NimbleObjectItem).toggleEquipment();
+			}
+		}
 
 		// Create class feature documents
 		const featureDocumentSources: Item.CreateData[] = [];


### PR DESCRIPTION
## Summary

- After origin documents (ancestry, background, class) are created during character creation, all granted `object`-type items are now automatically equipped
- Auto-equip only runs when the player chose the starting equipment path (not gold)
- Calls `toggleEquipment()` on each item, which enables all associated rules in addition to setting `system.equipped = true`

## Test plan

- [ ] Create a new character and choose starting equipment — verify all granted items show as equipped in the inventory
- [ ] Create a new character and choose starting gold — verify no items are created and no equip logic runs
- [ ] Confirm equipped items have their rules active (e.g. armor AC bonus applies)