### PR TITLE
feat(inventory): improve equip toggle button with contextual icons and tooltip

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -435,6 +435,8 @@
 			"configureSkills": "Configure Skills",
 			"configureWeaponProficiencies": "Configure Weapon Proficiencies",
 			"toggleEquipment": "Toggle Equipped State of {name}",
+			"equippedTooltip": "Equipped",
+			"unequippedTooltip": "Not Equipped",
 			"editRoll": "Edit Roll",
 			"levelUp": "Level Up",
 			"safeRest": "Safe Rest",

--- a/src/view/sheets/pages/PlayerCharacterInventoryTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterInventoryTab.svelte
@@ -273,6 +273,9 @@
 									aria-label={localize('NIMBLE.prompts.toggleEquipment', {
 										name: item.reactive.name,
 									})}
+									data-tooltip={item.reactive.system.equipped
+										? localize('NIMBLE.prompts.equippedTooltip')
+										: localize('NIMBLE.prompts.unequippedTooltip')}
 									onclick={async (event) => {
 										event.stopPropagation();
 										const newEquippedState = !item.reactive.system.equipped;
@@ -295,10 +298,16 @@
 										}
 									}}
 								>
-									{#if item.reactive.system.equipped}
-										<i class="fa-solid fa-circle"></i>
+									{#if ['armor', 'shield'].includes(item.reactive.system.objectType)}
+										{#if item.reactive.system.equipped}
+											<i class="fa-solid fa-shield"></i>
+										{:else}
+											<i class="fa-regular fa-shield"></i>
+										{/if}
+									{:else if item.reactive.system.equipped}
+										<i class="fa-solid fa-hand"></i>
 									{:else}
-										<i class="fa-regular fa-circle"></i>
+										<i class="fa-regular fa-hand"></i>
 									{/if}
 								</button>
 							{:else}


### PR DESCRIPTION
## Summary

- Shield icon (solid/outline) for armor and shield items
- Hand icon (solid/outline) for weapons, consumables, and misc items
- Solid = equipped, outline = not equipped
- Adds `data-tooltip` showing "Equipped" / "Not Equipped" on hover

## Test plan

- [ ] Equip/unequip an armor item — should show solid/outline shield
- [ ] Equip/unequip a non-armor item — should show solid/outline hand
- [ ] Hover the button — tooltip should show current equipped state