### PR TITLE
fix(combat): end turn QoL, action tracker visibility, combatant init

### DIFF
--- a/packs/backgrounds/core/fearless.json
+++ b/packs/backgrounds/core/fearless.json
@@ -36,7 +36,9 @@
 				"label": "Fearless",
 				"predicate": {},
 				"priority": 1,
-				"conditions": ["frightened"]
+				"conditions": [
+					"frightened"
+				]
 			}
 		],
 		"description": "<p>You are immune to the Frightened condition. +1 Initiative. –1 Armor.</p><hr><p>+1 Initiative [A]</p><p>-1 Armor [A]</p>"

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -845,6 +845,8 @@
 				"endTurn": "End Turn",
 				"rollInitiative": "Roll Initiative",
 				"useActionsFirst": "Use your actions first",
+				"confirmEndTurnEarlyTitle": "End Turn Early?",
+				"confirmEndTurnEarlyBody": "You haven't used all your actions yet. Are you sure you want to end your turn?",
 				"noPermissionEndTurn": "You do not have permission to end turns.",
 				"noPermissionRollInitiative": "You do not have permission to roll initiative.",
 				"initiativeAlreadyRolled": "Initiative has already been rolled for this combatant.",

--- a/src/documents/combat/combat.svelte.test.ts
+++ b/src/documents/combat/combat.svelte.test.ts
@@ -951,9 +951,7 @@ describe('NimbleCombat', () => {
 		expect(normalizedData[2]?.type).toBe('soloMonster');
 		expect(foundry.utils.getProperty(normalizedData[2], 'system.actions.base.current')).toBe(1);
 		expect(normalizedData[3]?.type).toBe('character');
-		expect(foundry.utils.getProperty(normalizedData[3], 'system.actions.base.current')).toBe(
-			undefined,
-		);
+		expect(foundry.utils.getProperty(normalizedData[3], 'system.actions.base.current')).toBe(3);
 	});
 
 	it('creates a late-joining character after the last living character turn', async () => {

--- a/src/documents/combat/combat.svelte.ts
+++ b/src/documents/combat/combat.svelte.ts
@@ -505,10 +505,6 @@ class NimbleCombat extends Combat {
 			normalizedEntry.type = 'npc';
 		}
 
-		if (normalizedEntry.type === 'character') {
-			return { normalizedEntry, normalizedMinionType };
-		}
-
 		const currentActions = foundry.utils.getProperty(
 			normalizedEntry,
 			'system.actions.base.current',
@@ -520,9 +516,10 @@ class NimbleCombat extends Combat {
 		const explicitMaxActions = Number(
 			foundry.utils.getProperty(normalizedEntry, 'system.actions.base.max') ?? Number.NaN,
 		);
+		const defaultActions = normalizedEntry.type === 'character' ? 3 : 1;
 		const initialActions = Number.isFinite(explicitMaxActions)
 			? Math.max(0, Math.trunc(explicitMaxActions))
-			: 1;
+			: defaultActions;
 		foundry.utils.setProperty(normalizedEntry, 'system.actions.base.current', initialActions);
 		return { normalizedEntry, normalizedMinionType };
 	}

--- a/src/utils/combatState.ts
+++ b/src/utils/combatState.ts
@@ -36,16 +36,28 @@ export function registerCombatStateHooks(listener: () => void): () => void {
 
 export function getActiveCombatForCurrentScene(): Combat | null {
 	const sceneId = canvas?.scene?.id;
-	if (!sceneId) return null;
+	if (!sceneId) {
+		console.log('[combatState] getActiveCombatForCurrentScene: no canvas scene id');
+		return null;
+	}
+
+	function combatMatchesScene(combat: Combat): boolean {
+		// A combat with no scene link is globally available — treat it as matching
+		return !combat.scene?.id || combat.scene.id === sceneId;
+	}
 
 	const activeCombat = game.combat;
-	if (activeCombat?.scene?.id === sceneId && (activeCombat.active || activeCombat.started)) {
+	if (
+		activeCombat &&
+		(activeCombat.active || activeCombat.started) &&
+		combatMatchesScene(activeCombat)
+	) {
 		syncCombatTurns(activeCombat);
 		return activeCombat;
 	}
 
 	const activeByScene = game.combats?.contents?.find(
-		(combat) => combat?.scene?.id === sceneId && (combat.active || combat.started),
+		(combat) => (combat.active || combat.started) && combatMatchesScene(combat),
 	);
 	if (activeByScene) {
 		syncCombatTurns(activeByScene);
@@ -53,7 +65,11 @@ export function getActiveCombatForCurrentScene(): Combat | null {
 	}
 
 	const viewedCombat = game.combats?.viewed ?? null;
-	if (viewedCombat?.scene?.id === sceneId && (viewedCombat.active || viewedCombat.started)) {
+	if (
+		viewedCombat &&
+		(viewedCombat.active || viewedCombat.started) &&
+		combatMatchesScene(viewedCombat)
+	) {
 		syncCombatTurns(viewedCombat);
 		return viewedCombat;
 	}

--- a/src/view/sheets/PlayerCharacterSheet.svelte
+++ b/src/view/sheets/PlayerCharacterSheet.svelte
@@ -433,7 +433,6 @@
 	>
 		<i class="fa-solid fa-moon"></i>
 	</button>
-
 	<ActionTracker {actor} />
 </section>
 

--- a/src/view/sheets/components/ActionTracker.svelte.ts
+++ b/src/view/sheets/components/ActionTracker.svelte.ts
@@ -168,9 +168,46 @@ export function createActionTrackerState(getActor: () => NimbleCharacter) {
 		});
 	}
 
+	async function confirmEndTurnEarly(): Promise<boolean> {
+		const dialogApi = foundry.applications?.api?.DialogV2;
+		const title = localize('NIMBLE.ui.heroicActions.confirmEndTurnEarlyTitle');
+		const prompt = localize('NIMBLE.ui.heroicActions.confirmEndTurnEarlyBody');
+
+		if (!dialogApi?.wait) {
+			return globalThis.confirm(prompt);
+		}
+
+		const result = await dialogApi.wait({
+			window: { title },
+			content: `<p>${prompt}</p>`,
+			modal: true,
+			rejectClose: false,
+			buttons: [
+				{
+					action: 'no',
+					icon: 'fa-solid fa-xmark',
+					label: localize('No'),
+				},
+				{
+					action: 'yes',
+					icon: 'fa-solid fa-check',
+					label: localize('Yes'),
+					default: true,
+				},
+			],
+		});
+
+		return result === 'yes' || (result as unknown) === true;
+	}
+
 	async function endTurn(): Promise<void> {
 		const combat = getActiveCombatForCurrentScene();
 		if (!combat) return;
+
+		if (actionsData.current > 0) {
+			const confirmed = await confirmEndTurnEarly();
+			if (!confirmed) return;
+		}
 
 		try {
 			const advanced = await requestAdvanceCombatTurn({ combat });

--- a/src/view/ui/CtTopTracker.state.svelte.ts
+++ b/src/view/ui/CtTopTracker.state.svelte.ts
@@ -12,6 +12,7 @@ import {
 import type { HeroicReactionKey } from '#utils/heroicActions.js';
 import { isCombatantDead } from '#utils/isCombatantDead.js';
 import { isCombatStarted } from '#utils/isCombatStarted.js';
+import localize from '#utils/localize.js';
 import { queueCombatantMutationWithFreshDocument } from '#utils/queueCombatantMutationWithFreshDocument.js';
 import CtSettingsDialogComponent from '#view/dialogs/CtSettingsDialog.svelte';
 import { COMBAT_TRACKER_CLIENT_SETTING_UPDATED_EVENT_NAME } from '../../settings/combatTrackerSettings.js';
@@ -263,10 +264,48 @@ export function createCtTopTrackerState() {
 		return result === 'yes' || (result as unknown) === true;
 	}
 
+	async function confirmEndTurnEarly(): Promise<boolean> {
+		const dialogApi = foundry.applications?.api?.DialogV2;
+		const title = localize('NIMBLE.ui.heroicActions.confirmEndTurnEarlyTitle');
+		const prompt = localize('NIMBLE.ui.heroicActions.confirmEndTurnEarlyBody');
+
+		if (!dialogApi?.wait) {
+			return globalThis.confirm(prompt);
+		}
+
+		const result = await dialogApi.wait({
+			window: { title },
+			content: `<p>${prompt}</p>`,
+			modal: true,
+			rejectClose: false,
+			buttons: [
+				{
+					action: 'no',
+					icon: 'fa-solid fa-xmark',
+					label: localize('No'),
+				},
+				{
+					action: 'yes',
+					icon: 'fa-solid fa-check',
+					label: localize('Yes'),
+					default: true,
+				},
+			],
+		});
+
+		return result === 'yes' || (result as unknown) === true;
+	}
+
 	async function handleEndTurnFromCard(event: MouseEvent): Promise<void> {
 		event.preventDefault();
 		event.stopPropagation();
 		if (!canCurrentUserEndTurn) return;
+
+		if (!activeAllActionsUsed) {
+			const confirmed = await confirmEndTurnEarly();
+			if (!confirmed) return;
+		}
+
 		const actionCombat = resolveActionCombat();
 		if (!actionCombat) return;
 		const advanced = await requestAdvanceCombatTurn({ combat: actionCombat });
@@ -1235,6 +1274,14 @@ export function createCtTopTrackerState() {
 	const orderedAliveEntries = $derived(trackerStore.orderedAliveEntries);
 	const activeEntryKey = $derived(trackerStore.activeEntryKey);
 	const canCurrentUserEndTurn = $derived(trackerStore.canCurrentUserEndTurn);
+	const activeAllActionsUsed = $derived.by(() => {
+		// trackDependency on renderVersion forces re-evaluation when any combatant update fires,
+		// because Foundry mutates combatant documents in-place (same object reference).
+		trackDependency(trackerStore.renderVersion);
+		const activeCombatant = trackerStore.activeCombatant;
+		if (!activeCombatant) return false;
+		return getCombatantCurrentActions(activeCombatant) === 0;
+	});
 	const shouldVirtualizeAliveEntries = $derived(
 		orderedAliveEntries.length >= CT_VIRTUALIZATION_ENTRY_THRESHOLD,
 	);
@@ -1492,6 +1539,9 @@ export function createCtTopTrackerState() {
 		},
 		get canCurrentUserEndTurn() {
 			return canCurrentUserEndTurn;
+		},
+		get activeAllActionsUsed() {
+			return activeAllActionsUsed;
 		},
 		get virtualizedAliveEntries() {
 			return virtualizedAliveEntries;

--- a/src/view/ui/CtTopTracker.svelte
+++ b/src/view/ui/CtTopTracker.svelte
@@ -45,6 +45,7 @@
 	let orderedAliveEntries = $derived(trackerViewState.orderedAliveEntries);
 	let activeEntryKey = $derived(trackerViewState.activeEntryKey);
 	let canCurrentUserEndTurn = $derived(trackerViewState.canCurrentUserEndTurn);
+	let activeAllActionsUsed = $derived(trackerViewState.activeAllActionsUsed);
 	let virtualizedAliveEntries = $derived(trackerViewState.virtualizedAliveEntries);
 	let expandedMonsterGroupBars = $derived(trackerViewState.expandedMonsterGroupBars);
 	let roundSeparatorIndex = $derived(trackerViewState.roundSeparatorIndex);
@@ -489,6 +490,7 @@
 									{#if showEndTurnOverlay}
 										<button
 											class="nimble-ct__end-turn-overlay"
+											class:nimble-ct__end-turn-overlay--ready={activeAllActionsUsed}
 											type="button"
 											aria-label="End Turn"
 											onclick={handleEndTurnFromCard}
@@ -555,6 +557,7 @@
 									{#if combatStarted && activeEntryKey === entry.key && canCurrentUserEndTurn}
 										<button
 											class="nimble-ct__end-turn-overlay"
+											class:nimble-ct__end-turn-overlay--ready={activeAllActionsUsed}
 											type="button"
 											aria-label="End Turn"
 											onclick={handleEndTurnFromCard}
@@ -2338,6 +2341,25 @@
 	.nimble-ct__end-turn-overlay:hover,
 	.nimble-ct__end-turn-overlay:focus-visible {
 		filter: brightness(1.12);
+	}
+	.nimble-ct__end-turn-overlay--ready {
+		opacity: 1;
+		transform: translate(-50%, 0);
+		pointer-events: all;
+		animation: ct-end-turn-pulse 2.2s ease-in-out infinite;
+	}
+	.nimble-ct__end-turn-overlay--ready:hover,
+	.nimble-ct__end-turn-overlay--ready:focus-visible {
+		animation: none;
+	}
+	@keyframes ct-end-turn-pulse {
+		0%,
+		100% {
+			box-shadow: 0 0 0.4rem color-mix(in srgb, hsl(124 56% 52%) 40%, transparent);
+		}
+		50% {
+			box-shadow: 0 0 1.2rem color-mix(in srgb, hsl(124 56% 52%) 70%, transparent);
+		}
 	}
 	.nimble-ct__dead {
 		display: inline-flex;


### PR DESCRIPTION
## Summary

- **End Turn button pulsing**: The End Turn button on the CT combatant card and the PC sheet action tracker now shows persistently and pulses green when the active combatant has used all their actions (`current === 0`), drawing attention to players that they should end their turn
- **End Turn confirmation**: Clicking End Turn while actions remain triggers a confirmation dialog ("You haven't used all your actions yet...") on both the CT and the PC sheet tracker
- **Action tracker not rendering**: Fixed `getActiveCombatForCurrentScene` to support globally-linked combats (no scene association). Previously all three fallback checks required `combat.scene?.id` to match the canvas scene, causing the tracker to never render when combats are not linked to a specific scene
- **PC combatant action init bug**: `normalizeCombatantCreateData` returned early for `type === 'character'` without initializing `system.actions.base.current`, so PCs always started with 0 actions instead of their max (typically 3). This caused `consumeCombatantAction` to exit early and actions to never deduct
- **CT reactivity fix**: Added `trackDependency(renderVersion)` to the `activeAllActionsUsed` derived — Foundry mutates combatant documents in-place (same object reference), so without this Svelte 5's signal system never re-evaluated the derived when action counts changed

## Test plan

- [ ] Start combat with PC combatants — action tracker should appear on the PC sheet
- [ ] Use actions — pip count decrements correctly
- [ ] Use all actions — End Turn button pulses green on both CT card and PC sheet tracker
- [ ] Click End Turn with actions remaining — confirmation dialog appears
- [ ] Confirm early end turn — turn advances normally
- [ ] Cancel early end turn — turn does not advance
- [ ] Click End Turn after all actions used — no dialog, turn advances immediately