### PR TITLE
fix(reactions): opp attack deducts 1 action, detect scene-agnostic combats

### DIFF
--- a/src/documents/actor/character.ts
+++ b/src/documents/actor/character.ts
@@ -1608,7 +1608,7 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 		const item = this.items.get(id);
 		const result = await super.activateItem(id, options);
 
-		if (result && item) {
+		if (result && item && !options.skipActionDeduction) {
 			const activation = (
 				item.system as { activation?: { cost?: { type: string; quantity: number } } }
 			).activation;

--- a/src/documents/combat/combat.svelte.ts
+++ b/src/documents/combat/combat.svelte.ts
@@ -733,7 +733,7 @@ class NimbleCombat extends Combat {
 	async useHeroicReactions(
 		combatantId: string,
 		reactionKeys: HeroicReactionKey[],
-		options?: { force?: boolean; skipActionDeduction?: boolean },
+		options?: { force?: boolean },
 	): Promise<boolean> {
 		if (!combatantId || reactionKeys.length < 1) return false;
 
@@ -754,18 +754,17 @@ class NimbleCombat extends Combat {
 					const canForceUsage =
 						options?.force === true && isSoftBlockedReason(usageState.blockedReason);
 
-					if (!usageState.canUse && !canForceUsage) return false;
+					if (!usageState.canUse && !canForceUsage) {
+						return false;
+					}
 
 					const reactionAvailabilityUpdate = {
 						_id: combatantId,
-					} as Record<string, unknown>;
-
-					if (!options?.skipActionDeduction) {
-						reactionAvailabilityUpdate['system.actions.base.current'] = Math.max(
+						'system.actions.base.current': Math.max(
 							0,
 							usageState.currentActions - usageState.requiredActions,
-						);
-					}
+						),
+					} as Record<string, unknown>;
 
 					for (const reactionKey of usageState.reactionKeys) {
 						Object.assign(

--- a/src/macros/activateHeroicActionMacro.ts
+++ b/src/macros/activateHeroicActionMacro.ts
@@ -23,7 +23,7 @@ type CombatWithHeroicReactionUse = Combat & {
 	useHeroicReactions?: (
 		combatantId: string,
 		reactionKeys: HeroicReactionKey[],
-		options?: { force?: boolean; skipActionDeduction?: boolean },
+		options?: { force?: boolean },
 	) => Promise<boolean>;
 };
 

--- a/src/utils/combatState.ts
+++ b/src/utils/combatState.ts
@@ -34,6 +34,14 @@ export function registerCombatStateHooks(listener: () => void): () => void {
 	};
 }
 
+function isCombatActiveOrStarted(combat: Combat): boolean {
+	return combat.active === true || combat.started === true;
+}
+
+function getCombatSceneId(combat: Combat): string | null {
+	return combat.scene?.id ?? null;
+}
+
 export function getActiveCombatForCurrentScene(): Combat | null {
 	const sceneId = canvas?.scene?.id;
 	if (!sceneId) {
@@ -47,8 +55,10 @@ export function getActiveCombatForCurrentScene(): Combat | null {
 	}
 
 	const activeCombat = game.combat;
+	// Prefer an exact scene ID match from game.combat, then the full collection, then viewed.
 	if (
 		activeCombat &&
+		isCombatActiveOrStarted(activeCombat) &&
 		(activeCombat.active || activeCombat.started) &&
 		combatMatchesScene(activeCombat)
 	) {
@@ -72,6 +82,26 @@ export function getActiveCombatForCurrentScene(): Combat | null {
 	) {
 		syncCombatTurns(viewedCombat);
 		return viewedCombat;
+	}
+
+	// Fallback: accept an active/started combat with no linked scene (theater-of-the-mind).
+	// Foundry does not always populate combat.scene when a combat has no scene association,
+	// so scene?.id comes back undefined. Treat these as valid for any canvas scene.
+	if (
+		activeCombat &&
+		isCombatActiveOrStarted(activeCombat) &&
+		getCombatSceneId(activeCombat) === null
+	) {
+		syncCombatTurns(activeCombat);
+		return activeCombat;
+	}
+
+	const sceneAgnostic = game.combats?.contents?.find(
+		(combat) => combat && isCombatActiveOrStarted(combat) && getCombatSceneId(combat) === null,
+	);
+	if (sceneAgnostic) {
+		syncCombatTurns(sceneAgnostic);
+		return sceneAgnostic;
 	}
 
 	return null;

--- a/src/view/sheets/components/HelpReactionPanel.svelte.ts
+++ b/src/view/sheets/components/HelpReactionPanel.svelte.ts
@@ -9,10 +9,7 @@ export function createHelpPanelState(
 	getHelpSpent: () => boolean,
 	getNoActions: () => boolean,
 	getIsActiveTurn: () => boolean,
-	getOnUseReaction: () => (options?: {
-		force?: boolean;
-		skipActionDeduction?: boolean;
-	}) => Promise<boolean>,
+	getOnUseReaction: () => (options?: { force?: boolean }) => Promise<boolean>,
 ) {
 	// Targeting state
 	let targetingVersion = $state(0);

--- a/src/view/sheets/components/OpportunityAttackPanel.svelte.ts
+++ b/src/view/sheets/components/OpportunityAttackPanel.svelte.ts
@@ -29,10 +29,7 @@ export function createOpportunityAttackPanelState(
 	getOpportunitySpent: () => boolean,
 	getNoActions: () => boolean,
 	getIsActiveTurn: () => boolean,
-	getOnUseReaction: () => (options?: {
-		force?: boolean;
-		skipActionDeduction?: boolean;
-	}) => Promise<boolean>,
+	getOnUseReaction: () => (options?: { force?: boolean }) => Promise<boolean>,
 	getForceNextReactionUse: () => boolean,
 	getOnConsumeForcedReactionUse: () => () => void,
 ) {
@@ -286,11 +283,14 @@ export function createOpportunityAttackPanelState(
 		if (!confirmed) return null;
 
 		const item = getActor().items.get(itemId);
-		const result = await getActor().activateItem(itemId, { rollMode: -1 }); // Disadvantage
+		const result = await getActor().activateItem(itemId, {
+			rollMode: -1,
+			skipActionDeduction: true,
+		});
 
 		if (result && item) {
-			// activateItem already deducted the action; only mark the reaction spent.
-			const reactionUsed = await getOnUseReaction()({ force, skipActionDeduction: true });
+			const reactionOptions = force ? { force: true } : undefined;
+			const reactionUsed = await getOnUseReaction()(reactionOptions);
 			if (!reactionUsed) return null;
 
 			if (force) {

--- a/src/view/sheets/components/ReactionPanels.test.ts
+++ b/src/view/sheets/components/ReactionPanels.test.ts
@@ -296,9 +296,35 @@ describe('reaction panel confirmation wrappers', () => {
 
 		await fireEvent.click(screen.getByRole('button', { name: /spear/i }));
 
-		expect(actor.activateItem).toHaveBeenCalledWith('weapon-opportunity', { rollMode: -1 });
-		await waitFor(() =>
-			expect(onUseReaction).toHaveBeenCalledWith({ force: true, skipActionDeduction: true }),
-		);
+		expect(actor.activateItem).toHaveBeenCalledWith('weapon-opportunity', {
+			rollMode: -1,
+			skipActionDeduction: true,
+		});
+		await waitFor(() => expect(onUseReaction).toHaveBeenCalledWith({ force: true }));
+	});
+
+	it('deducts action via useHeroicReactions, not activateItem, when reaction is available', async () => {
+		const actor = createOpportunityActor();
+		const onUseReaction = vi.fn().mockResolvedValue(true);
+
+		render(OpportunityAttackPanel.default, {
+			props: {
+				actor,
+				reactionDisabled: false,
+				opportunitySpent: false,
+				noActions: false,
+				onUseReaction,
+				showEmbeddedDocumentImages: false,
+			},
+		});
+
+		await fireEvent.click(screen.getByRole('button', { name: /spear/i }));
+
+		expect(confirmDialog()).not.toHaveBeenCalled();
+		expect(actor.activateItem).toHaveBeenCalledWith('weapon-opportunity', {
+			rollMode: -1,
+			skipActionDeduction: true,
+		});
+		await waitFor(() => expect(onUseReaction).toHaveBeenCalledWith(undefined));
 	});
 });

--- a/src/view/sheets/pages/PlayerCharacterHeroicActionsTab.svelte.ts
+++ b/src/view/sheets/pages/PlayerCharacterHeroicActionsTab.svelte.ts
@@ -146,7 +146,8 @@ export function createHeroicActionsTabState(getActor: () => NimbleCharacter) {
 	function getCombatant(): Combatant | null {
 		const combat = getCombat();
 		if (!combat) return null;
-		return combat.combatants.find((entry) => entry.actorId === getActor().id) ?? null;
+		const actorId = getActor().id;
+		return combat.combatants.find((entry) => entry.actorId === actorId) ?? null;
 	}
 
 	function isInActiveCombat(): boolean {

--- a/src/view/sheets/pages/PlayerCharacterHeroicActionsTab.test.ts
+++ b/src/view/sheets/pages/PlayerCharacterHeroicActionsTab.test.ts
@@ -195,15 +195,15 @@ describe('PlayerCharacterHeroicActionsTab opportunity macro handoff', () => {
 		await waitFor(() => expect(screen.getByRole('button', { name: /spear/i })).toBeInTheDocument());
 		await fireEvent.click(screen.getByRole('button', { name: /spear/i }));
 
-		expect(actor.activateItem).toHaveBeenCalledWith('weapon-opportunity', { rollMode: -1 });
+		expect(actor.activateItem).toHaveBeenCalledWith('weapon-opportunity', {
+			rollMode: -1,
+			skipActionDeduction: true,
+		});
 		await waitFor(() =>
 			expect(useHeroicReactions).toHaveBeenCalledWith(
 				'combatant-opportunity',
 				['opportunityAttack'],
-				{
-					force: true,
-					skipActionDeduction: true,
-				},
+				{ force: true },
 			),
 		);
 		expect(globals().foundry.applications.api.DialogV2.confirm).toHaveBeenCalledTimes(1);

--- a/types/components/ReactionPanel.d.ts
+++ b/types/components/ReactionPanel.d.ts
@@ -8,15 +8,9 @@ export interface ReactionPanelStateOptions {
 	getNoActions: () => boolean;
 	getIsActiveTurn: () => boolean;
 	getCombinedIsActiveTurn: () => boolean;
-	getOnUseReaction: () => (options?: {
-		force?: boolean;
-		skipActionDeduction?: boolean;
-	}) => Promise<boolean>;
+	getOnUseReaction: () => (options?: { force?: boolean }) => Promise<boolean>;
 	getCombinedReactionDisabled: () => boolean;
-	getOnUseCombinedReaction: () => (options?: {
-		force?: boolean;
-		skipActionDeduction?: boolean;
-	}) => Promise<boolean>;
+	getOnUseCombinedReaction: () => (options?: { force?: boolean }) => Promise<boolean>;
 }
 
 export interface ReactionPanelProps {
@@ -30,14 +24,8 @@ export interface ReactionPanelProps {
 	noActions?: boolean;
 	isActiveTurn?: boolean;
 	combinedIsActiveTurn?: boolean;
-	onUseReaction?: (options?: {
-		force?: boolean;
-		skipActionDeduction?: boolean;
-	}) => Promise<boolean>;
-	onUseCombinedReaction?: (options?: {
-		force?: boolean;
-		skipActionDeduction?: boolean;
-	}) => Promise<boolean>;
+	onUseReaction?: (options?: { force?: boolean }) => Promise<boolean>;
+	onUseCombinedReaction?: (options?: { force?: boolean }) => Promise<boolean>;
 }
 
 export interface OpportunityAttackPanelProps extends ReactionPanelProps {


### PR DESCRIPTION
## Summary

- **Bug fix:** `getActiveCombatForCurrentScene` now accepts combats with no linked scene (theater-of-the-mind). Foundry returns `undefined` for `combat.scene?.id` when no scene is associated, so all three original lookup paths silently returned `null` — leaving characters undetected as in-combat and their actions untracked.
- **Bug fix:** Opportunity attacks no longer deduct 2 actions. `useHeroicReactions` is now the single point of action deduction; `activateItem` is called with `skipActionDeduction: true` from the opportunity attack panel so the weapon activation does not also deduct an action.
- Removed `skipActionDeduction` option from `useHeroicReactions` and related types — it was the mechanism enabling the double-deduction.

## Test plan

- [ ] Start combat with characters in a scene-agnostic (no linked scene) encounter — verify `inCombat` is detected and actions are tracked correctly
- [ ] Perform an opportunity attack — verify exactly 1 action is deducted (not 2)
- [ ] Verify forced opportunity attacks (forceNextReactionUse path) still work and deduct 1 action
- [ ] Confirm all 69 test files / 1019 tests pass (`pnpm check`)