### PR TITLE
fix(heroicActions): remove long-cast spells from heroic action panel and show class features in attack panel

### DIFF
--- a/src/view/sheets/components/AttackActionPanel.svelte.ts
+++ b/src/view/sheets/components/AttackActionPanel.svelte.ts
@@ -31,7 +31,6 @@ interface WeaponSystemData {
 				public?: string;
 		  }
 		| string;
-	actionType?: string;
 }
 
 export function createAttackPanelState(
@@ -87,7 +86,7 @@ export function createAttackPanelState(
 			const activation = system.activation;
 			if (!activation) return false;
 
-			return activation.cost?.type === 'action' && Boolean(system.actionType?.includes('attack'));
+			return activation.cost?.type === 'action';
 		});
 
 		if (!searchTerm) return features;

--- a/src/view/sheets/components/CastSpellActionPanel.svelte.ts
+++ b/src/view/sheets/components/CastSpellActionPanel.svelte.ts
@@ -60,7 +60,12 @@ export function createSpellPanelState(
 	// Spell Data
 	// ============================================================================
 
-	const spells = $derived(filterItems(getActor().reactive, ['spell'], searchTerm));
+	const spells = $derived(
+		filterItems(getActor().reactive, ['spell'], searchTerm).filter((spell) => {
+			const costType = getSystemData(spell).activation?.cost?.type;
+			return costType !== 'minute' && costType !== 'hour';
+		}),
+	);
 
 	function getSpellEffect(spell: Item): SpellEffect | null {
 		const effects = getSystemData(spell).activation?.effects;

--- a/src/view/sheets/pages/PlayerCharacterHeroicActionsTab.svelte.ts
+++ b/src/view/sheets/pages/PlayerCharacterHeroicActionsTab.svelte.ts
@@ -312,7 +312,13 @@ export function createHeroicActionsTabState(getActor: () => NimbleCharacter) {
 	// Spell Data (for hasSpells check)
 	// ============================================================================
 
-	const allSpells = $derived(filterItems(getActor().reactive, ['spell'], ''));
+	const allSpells = $derived(
+		filterItems(getActor().reactive, ['spell'], '').filter((spell) => {
+			const costType = (spell.system as unknown as { activation?: { cost?: { type?: string } } })
+				.activation?.cost?.type;
+			return costType !== 'minute' && costType !== 'hour';
+		}),
+	);
 	const hasSpells = $derived(allSpells.length > 0);
 
 	// ============================================================================


### PR DESCRIPTION
## Summary

- **Utility spells with 1-minute (or longer) casting time** were appearing in Heroic Actions → Spells. Filter them out of both the spell list and the `hasSpells` gate so the Spell button is correctly disabled when only long-cast spells exist.
- **Class features with `activation.cost.type === 'action'`** (e.g. Searing Light) were never surfacing in the Attack panel. The `attackFeatures` filter checked `system.actionType` which is not defined in `NimbleFeatureData`'s schema and was always `undefined`. Removed the dead check so all action-cost features appear.

## Changes

- `CastSpellActionPanel.svelte.ts` — filter out `'minute'`/`'hour'` cost-type spells from the displayed list
- `PlayerCharacterHeroicActionsTab.svelte.ts` — apply same filter to `allSpells` so `hasSpells` reflects only combat-eligible spells
- `AttackActionPanel.svelte.ts` — remove broken `system.actionType?.includes('attack')` check; drop unused `actionType` from `WeaponSystemData` interface

## Test plan

- [ ] Character with a 1-minute utility spell: spell should not appear in Heroic Actions → Spells; Spell button should be disabled if no other spells exist
- [ ] Character with only instant-cast spells: spells appear as normal
- [ ] Character with a class feature action (e.g. Searing Light): feature appears in the Attack panel
- [ ] `pnpm check` passes (73/73 tests, no type errors)