### PR TITLE
fix(combat): skip end-turn confirmation for monsters and NPCs

### DIFF
--- a/src/view/ui/CtTopTracker.state.svelte.ts
+++ b/src/view/ui/CtTopTracker.state.svelte.ts
@@ -301,7 +301,8 @@ export function createCtTopTrackerState() {
 		event.stopPropagation();
 		if (!canCurrentUserEndTurn) return;
 
-		if (!activeAllActionsUsed) {
+		const activeCombatant = trackerStore.activeCombatant;
+		if (!activeAllActionsUsed && activeCombatant && isPlayerCombatant(activeCombatant)) {
 			const confirmed = await confirmEndTurnEarly();
 			if (!confirmed) return;
 		}


### PR DESCRIPTION
## Summary

- The end-turn confirmation dialog ("You haven't used all your actions yet") now only appears for player characters (heroes)
- Monsters and NPCs skip the dialog and end their turn immediately when the GM clicks End Turn
- No change to player character behavior

## Test plan

- [ ] End a hero's turn with unused actions — confirmation dialog should appear
- [ ] End a monster/NPC's turn with unused actions — no dialog, turn ends immediately
- [ ] End a hero's turn with all actions used — no dialog (existing behavior)