### PR TITLE
fix(combat): prevent runaway round counter with legendary turn expansion

### DIFF
--- a/src/documents/combat/combat.svelte.test.ts
+++ b/src/documents/combat/combat.svelte.test.ts
@@ -142,6 +142,68 @@ describe('NimbleCombat', () => {
 		expect(turns.map((combatant) => combatant.id)).toEqual(['alive-character']);
 	});
 
+	it('does not let super.setupTurns bump round when turn exceeds combatant count', () => {
+		// Reproduces the legendary-expansion round-spike: Foundry's super.setupTurns does `this.round++`
+		// when `this.turn >= combatants.size`, which fires legitimately for the 2nd+ occurrence of a
+		// solo monster in the expanded order. The override must snapshot/restore round around super.
+		const combatId = 'combat-setup-turns-round-stability';
+		const playerOne = createMockCombatant({
+			id: 'player-one',
+			type: 'character',
+			sort: 1,
+			isOwner: true,
+			initiative: 16,
+			actor: createCombatActorFixture({ hp: 8, woundsValue: 0, woundsMax: 6 }),
+			combatId,
+		});
+		const playerTwo = createMockCombatant({
+			id: 'player-two',
+			type: 'character',
+			sort: 2,
+			isOwner: true,
+			initiative: 14,
+			actor: createCombatActorFixture({ hp: 8, woundsValue: 0, woundsMax: 6 }),
+			combatId,
+		});
+		const legendary = createMockCombatant({
+			id: 'legendary-one',
+			type: 'soloMonster',
+			sort: 3,
+			isOwner: false,
+			initiative: 12,
+			actor: createCombatActorFixture({ hp: 40 }),
+			combatId,
+		});
+
+		// Replicate Foundry core's setupTurns side effect so the regression has something to defend against.
+		globals().Combat.prototype.setupTurns = vi.fn(function (this: {
+			combatants?: { contents?: Combatant.Implementation[]; size?: number };
+			turn: number | null;
+			round: number;
+		}) {
+			const contents = this.combatants?.contents ?? [];
+			const size = this.combatants?.size ?? contents.length;
+			if (this.turn !== null && this.turn >= size) {
+				this.turn = 0;
+				this.round += 1;
+			}
+			return contents;
+		});
+
+		const combat = new NimbleCombat({
+			id: combatId,
+			combatants: createCombatantsCollectionFixture([playerOne, playerTwo, legendary]),
+		} as unknown as Combat.CreateData);
+		combat.round = 5;
+		// Expanded order is [PC1, SOLO, PC2, SOLO]; index 3 (last SOLO) sits beyond combatants.size of 3.
+		combat.turn = 3;
+
+		combat.setupTurns();
+
+		expect(combat.round).toBe(5);
+		expect(combat.turn).toBe(3);
+	});
+
 	it('collapses grouped minions into a single shared turn entry', () => {
 		const combatId = 'combat-minion-groups';
 		const minionActorLeader = {

--- a/src/documents/combat/combat.svelte.ts
+++ b/src/documents/combat/combat.svelte.ts
@@ -1066,7 +1066,13 @@ class NimbleCombat extends Combat {
 	}
 
 	override setupTurns(): Combatant.Implementation[] {
+		// super.setupTurns() does `this.round++` when this.turn exceeds combatants.size, which fires
+		// spuriously once expandLegendaryTurns produces a turn list longer than the combatant count.
+		const savedRound = this.round;
+		const savedTurn = this.turn;
 		const aliveTurns = super.setupTurns().filter((combatant) => !isCombatantDead(combatant));
+		if (this.round !== savedRound) this.round = savedRound;
+		if (this.turn !== savedTurn) this.turn = savedTurn;
 		const minionNormalizedTurns = normalizeMinionTurns(aliveTurns);
 		return expandLegendaryTurns(minionNormalizedTurns);
 	}


### PR DESCRIPTION
## Summary

Fixes a bug where the combat round counter spiraled (a user reported it hitting 293 after a few rounds) when a solo monster shared the initiative with multiple PCs. Foundry's `Combat.setupTurns` silently increments `this.round` when `this.turn >= combatants.size`, and `expandLegendaryTurns` legitimately produces a turn list longer than the combatant count, so every `super.setupTurns` call ratcheted the round upward.

## Changes

- `setupTurns` override now snapshots `this.round` / `this.turn` before calling `super.setupTurns()` and restores them if Foundry mutated them.
- Added a regression test that mocks Foundry's buggy side effect and asserts `combat.round` stays put when `combat.turn` exceeds `combatants.size`.

## Test Plan

1. Start a combat with 3 PCs + 1 solo monster — turn order interleaves to `[PC1, SOLO, PC2, SOLO, PC3, SOLO]`.
2. Cycle through the round by clicking end-turn on each combatant.
3. After the last SOLO's turn ends, the round counter should advance from 1 → 2 (not 1 → 5+ as before).
4. Repeat several times — round should advance by exactly 1 per full cycle.
5. Verify a non-legendary combat (no `soloMonster` combatants) still behaves correctly.

## Checklist

- [x] Added or updated unit tests
- [x] PR targets the \`dev\` branch
- [ ] \`pnpm check\` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used \`localize()\`)
- [x] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** yes
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues

<!-- Link related issues if applicable -->