### PR TITLE
feat(dicePools): add dice pool tracking for Berserker, Commander, and Oathsworn

### DIFF
--- a/packs/classFeatures/core/berserker/berserker-progression/rage.json
+++ b/packs/classFeatures/core/berserker/berserker-progression/rage.json
@@ -1,58 +1,128 @@
 {
-	"folder": "d40bf36abe9f4b0a",
-	"name": "Rage",
-	"type": "feature",
-	"img": "icons/skills/social/intimidation-impressing.webp",
-	"system": {
-		"macro": "",
-		"identifier": "",
-		"rules": [],
-		"activation": {
-			"acquireTargetsFromTemplate": false,
-			"cost": {
-				"details": "",
-				"quantity": 1,
-				"type": "action",
-				"isReaction": false
-			},
-			"duration": {
-				"details": "Your Rage Ends... If you leave combat, drop to 0 HP, or go 1 round without attacking or Raging.",
-				"quantity": 1,
-				"type": "special"
-			},
-			"effects": [],
-			"showDescription": true,
-			"targets": {
-				"count": 1,
-				"restrictions": ""
-			},
-			"template": {
-				"length": 1,
-				"radius": 1,
-				"shape": "",
-				"width": 1
-			}
-		},
-		"description": "<p>(1/turn) Action: Roll a Fury Die [[/r 1d4]] and set it aside. Add it to every STR attack you make. You can have a max of KEY Fury Dice; they are lost when your Rage ends.</p><hr><p>Level 1: Gain 1 Fury Die</p><p>Level 5: Whenever you Rage, gain 2 Fury Dice instead.</p>",
-		"featureType": "class",
-		"class": "berserker",
-		"group": "berserker-progression",
-		"gainedAtLevel": 1,
-		"gainedAtLevels": [
-			1,
-			5
-		],
-		"subclass": false
-	},
-	"effects": [],
-	"flags": {},
-	"_stats": {
-		"coreVersion": "13.347",
-		"systemId": "nimble",
-		"systemVersion": "0.1.8",
-		"createdTime": 1759180745583,
-		"modifiedTime": 1761434416421,
-		"lastModifiedBy": "zvcmZ9cAKxekqF5X"
-	},
-	"_id": "GjPt8evcIoVuQ6zg"
+  "folder": "d40bf36abe9f4b0a",
+  "name": "Rage",
+  "type": "feature",
+  "img": "icons/skills/social/intimidation-impressing.webp",
+  "system": {
+    "macro": "",
+    "identifier": "",
+    "rules": [
+      {
+        "type": "dicePool",
+        "disabled": false,
+        "id": "BkRfX2mN8pLqY4sW",
+        "identifier": "fury-dice",
+        "label": "Fury Dice",
+        "predicate": {},
+        "priority": 1,
+        "faces": 4,
+        "quantity": "@key",
+        "poolMode": "individual",
+        "resetOnEncounterEnd": true,
+        "levels": {
+          "6": {
+            "faces": 6,
+            "quantity": ""
+          },
+          "9": {
+            "faces": 8,
+            "quantity": ""
+          },
+          "13": {
+            "faces": 10,
+            "quantity": ""
+          },
+          "17": {
+            "faces": 12,
+            "quantity": ""
+          }
+        },
+        "rollOnActivation": true
+      },
+      {
+        "type": "dicePool",
+        "disabled": false,
+        "id": "Lm7xQ4wR9pKv3sTn",
+        "identifier": "fury-dice",
+        "label": "Fury Dice",
+        "predicate": {
+          "level": {
+            "min": 5
+          }
+        },
+        "priority": 2,
+        "faces": 4,
+        "quantity": "@key",
+        "poolMode": "individual",
+        "resetOnEncounterEnd": true,
+        "fillOnInitiative": false,
+        "rollOnActivation": true,
+        "levels": {
+          "6": {
+            "faces": 6,
+            "quantity": ""
+          },
+          "9": {
+            "faces": 8,
+            "quantity": ""
+          },
+          "13": {
+            "faces": 10,
+            "quantity": ""
+          },
+          "17": {
+            "faces": 12,
+            "quantity": ""
+          }
+        }
+      }
+    ],
+    "activation": {
+      "acquireTargetsFromTemplate": false,
+      "cost": {
+        "details": "",
+        "quantity": 1,
+        "type": "action",
+        "isReaction": false
+      },
+      "duration": {
+        "details": "Your Rage Ends... If you leave combat, drop to 0 HP, or go 1 round without attacking or Raging.",
+        "quantity": 1,
+        "type": "special"
+      },
+      "effects": [],
+      "showDescription": true,
+      "targets": {
+        "count": 0,
+        "restrictions": ""
+      },
+      "template": {
+        "length": 1,
+        "radius": 1,
+        "shape": "",
+        "width": 1
+      }
+    },
+    "description": "<p>(1/turn) Action: Roll a Fury Die [[/r 1d4]] and set it aside. Add it to every STR attack you make. You can have a max of KEY Fury Dice; they are lost when your Rage ends.</p><hr><p>Level 1: Gain 1 Fury Die</p><p>Level 5: Whenever you Rage, gain 2 Fury Dice instead.</p>",
+    "featureType": "class",
+    "class": "berserker",
+    "group": "berserker-progression",
+    "gainedAtLevel": 1,
+    "gainedAtLevels": [
+      1,
+      5
+    ],
+    "subclass": false
+  },
+  "effects": [],
+  "flags": {},
+  "_stats": {
+    "coreVersion": "13.347",
+    "systemId": "nimble",
+    "systemVersion": "0.1.8",
+    "createdTime": 1759180745583,
+    "modifiedTime": 1761434416421,
+    "lastModifiedBy": "zvcmZ9cAKxekqF5X"
+  },
+  "_id": "GjPt8evcIoVuQ6zg"
 }

--- a/packs/classFeatures/core/commander/commander-progression/fit-for-any-battlefield.json
+++ b/packs/classFeatures/core/commander/commander-progression/fit-for-any-battlefield.json
@@ -7,6 +7,102 @@
 		"identifier": "",
 		"rules": [
 			{
+				"type": "dicePool",
+				"disabled": false,
+				"id": "FfAbCmbtDc8p2QwNx",
+				"identifier": "combat-dice",
+				"label": "Combat Dice",
+				"predicate": {},
+				"priority": 1,
+				"faces": 6,
+				"quantity": "@strength",
+				"poolMode": "resource",
+				"resetOnEncounterEnd": true,
+				"fillOnInitiative": true,
+				"levels": {
+					"1": {
+						"faces": 0,
+						"quantity": ""
+					},
+					"2": {
+						"faces": 0,
+						"quantity": ""
+					},
+					"3": {
+						"faces": 0,
+						"quantity": ""
+					},
+					"4": {
+						"faces": 0,
+						"quantity": ""
+					},
+					"5": {
+						"faces": 8,
+						"quantity": ""
+					},
+					"6": {
+						"faces": 0,
+						"quantity": ""
+					},
+					"7": {
+						"faces": 0,
+						"quantity": ""
+					},
+					"8": {
+						"faces": 0,
+						"quantity": ""
+					},
+					"9": {
+						"faces": 10,
+						"quantity": ""
+					},
+					"10": {
+						"faces": 0,
+						"quantity": ""
+					},
+					"11": {
+						"faces": 0,
+						"quantity": ""
+					},
+					"12": {
+						"faces": 0,
+						"quantity": ""
+					},
+					"13": {
+						"faces": 12,
+						"quantity": ""
+					},
+					"14": {
+						"faces": 0,
+						"quantity": ""
+					},
+					"15": {
+						"faces": 0,
+						"quantity": ""
+					},
+					"16": {
+						"faces": 0,
+						"quantity": ""
+					},
+					"17": {
+						"faces": 20,
+						"quantity": ""
+					},
+					"18": {
+						"faces": 0,
+						"quantity": ""
+					},
+					"19": {
+						"faces": 0,
+						"quantity": ""
+					},
+					"20": {
+						"faces": 0,
+						"quantity": ""
+					}
+				}
+			},
+			{
 				"type": "grantItem",
 				"disabled": false,
 				"id": "OCPNZWXtQjoVmJsW",

--- a/packs/classFeatures/core/oathsworn/oathsworn-progression/radiant-judgement.json
+++ b/packs/classFeatures/core/oathsworn/oathsworn-progression/radiant-judgement.json
@@ -6,7 +6,42 @@
 	"system": {
 		"macro": "",
 		"identifier": "",
-		"rules": [],
+		"rules": [
+			{
+				"type": "dicePool",
+				"disabled": false,
+				"id": "OsJdgRdnt6wP3mKz",
+				"identifier": "judgment-dice",
+				"label": "Judgement Dice",
+				"predicate": {},
+				"priority": 1,
+				"faces": 6,
+				"quantity": "2",
+				"poolMode": "store",
+				"levels": {
+					"3": {
+						"faces": 8,
+						"quantity": ""
+					},
+					"5": {
+						"faces": 10,
+						"quantity": ""
+					},
+					"8": {
+						"faces": 12,
+						"quantity": ""
+					},
+					"10": {
+						"faces": 20,
+						"quantity": ""
+					},
+					"14": {
+						"faces": 0,
+						"quantity": "3"
+					}
+				}
+			}
+		],
 		"activation": {
 			"acquireTargetsFromTemplate": false,
 			"cost": {

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -537,6 +537,7 @@
 		},
 		"ruleTypes": {
 			"abilityBonus": "Stat Bonus",
+			"dicePool": "Dice Pool",
 			"applyCondition": "Apply Condition",
 			"armorClass": "Armor Class",
 			"chargeConsumer": "Charge Consumer",

--- a/src/config/registerRulesConfig.ts
+++ b/src/config/registerRulesConfig.ts
@@ -6,6 +6,7 @@ import { ChargePoolRule } from '../models/rules/chargePool.js';
 import { CombatManaRule } from '../models/rules/combatMana.js';
 import { ConditionImmunityRule } from '../models/rules/conditionImmunity.js';
 import { DamageBonusRule } from '../models/rules/damageBonus.js';
+import { DicePoolRule } from '../models/rules/dicePool.js';
 import { ItemGrantRule } from '../models/rules/grantItem.js';
 import { GrantProficiencyRule } from '../models/rules/grantProficiencies.ts';
 import { GrantSpellsRule } from '../models/rules/grantSpells.js';
@@ -29,6 +30,7 @@ import { UnarmedDamageRule } from '../models/rules/unarmedDamage.js';
 export default function registerRulesConfig() {
 	const ruleTypes = {
 		abilityBonus: 'NIMBLE.ruleTypes.abilityBonus',
+		dicePool: 'NIMBLE.ruleTypes.dicePool',
 		applyCondition: 'NIMBLE.ruleTypes.applyCondition',
 		armorClass: 'NIMBLE.ruleTypes.armorClass',
 		chargeConsumer: 'NIMBLE.ruleTypes.chargeConsumer',
@@ -59,6 +61,7 @@ export default function registerRulesConfig() {
 
 	const ruleDataModels = {
 		abilityBonus: AbilityBonusRule,
+		dicePool: DicePoolRule,
 		applyCondition: ApplyConditionRule,
 		armorClass: ArmorClassRule,
 		chargeConsumer: ChargeConsumerRule,

--- a/src/documents/actor/base.svelte.ts
+++ b/src/documents/actor/base.svelte.ts
@@ -217,6 +217,7 @@ class NimbleBaseActor<ActorType extends SystemActorTypes = SystemActorTypes> ext
 		super.prepareBaseData();
 
 		// Resets
+		(this as any).dicePools = {};
 		this.tags = new Set();
 		this._populateBaseTags();
 	}

--- a/src/hooks/ruleEventDispatch.ts
+++ b/src/hooks/ruleEventDispatch.ts
@@ -1,6 +1,8 @@
 import type {
 	ActorHealthContext,
+	EncounterContext,
 	InitiativeRolledContext,
+	ItemActivatedContext,
 	ItemUsedContext,
 	NimbleBaseRule,
 	RestContext,
@@ -169,6 +171,51 @@ function handleInitiativeRolled(payload: NimbleInitiativePayload): void {
 	void dispatch(payload.actor, 'onInitiativeRolled', context);
 }
 
+async function handleUseItem(item: unknown, card: unknown, _options: unknown): Promise<void> {
+	if (!isAutoApplyEnabled()) return;
+	const typedItem = item as {
+		rules?: Map<string, NimbleBaseRule>;
+		actor?: unknown;
+	} | null;
+	if (!typedItem?.rules) return;
+	const context: ItemActivatedContext = {
+		item: typedItem as unknown as ItemActivatedContext['item'],
+		actor: typedItem.actor as unknown as ItemActivatedContext['actor'],
+		card: card as ChatMessage | null,
+	};
+	// Rules are awaited sequentially so each one sees the updated flag state
+	// written by the previous rule (e.g. two dicePool rules on the same pool).
+	for (const rule of typedItem.rules.values()) {
+		const method = (rule as unknown as Record<string, unknown>).onItemActivated as
+			| ((ctx: ItemActivatedContext) => Promise<void>)
+			| undefined;
+		if (typeof method !== 'function') continue;
+		try {
+			await method.call(rule, context);
+		} catch (error) {
+			// eslint-disable-next-line no-console
+			console.warn(`Nimble | ruleEventDispatch onItemActivated failed`, error);
+		}
+	}
+}
+
+const encounterEndDispatchedCombatIds = new Set<string>();
+
+function didEncounterEndTransition(changes: Record<string, unknown>): boolean {
+	if (!foundry.utils.hasProperty(changes, 'started')) return false;
+	return foundry.utils.getProperty(changes, 'started') === false;
+}
+
+function handleEncounterEnd(combat: Combat): void {
+	if (!isAutoApplyEnabled()) return;
+	const context: EncounterContext = { combat };
+	for (const combatant of combat.combatants.contents) {
+		const actor = combatant.actor as unknown as ActorWithRules | null;
+		if (!actor) continue;
+		void dispatch(actor, 'onEncounterEnd', context);
+	}
+}
+
 let didRegister = false;
 
 type HookFn = (...args: unknown[]) => void;
@@ -179,12 +226,47 @@ export default function registerRuleEventDispatch(): void {
 	if (didRegister) return;
 	didRegister = true;
 
+	onHook('nimble.useItem', handleUseItem as HookFn);
 	onHook('nimble.damageApplied', handleDamageApplied as HookFn);
 	onHook('combatTurn', handleCombatTurn as HookFn);
 	onHook('updateActor', handleActorUpdate as HookFn);
 	onHook('nimble.saveResolved', handleSaveResolved as HookFn);
 	onHook('nimble.rest', handleRest as HookFn);
 	onHook('nimble.initiativeRolled', handleInitiativeRolled as HookFn);
+
+	// Fire onInitiativeRolled for any path that sets combatant initiative
+	// (actor sheet, ActionTracker, CtTopTracker, manual GM entry all go through updateCombatant)
+	onHook('updateCombatant', ((combatant: Combatant, changes: Record<string, unknown>) => {
+		if (typeof changes.initiative !== 'number') return;
+		if (!isAutoApplyEnabled()) return;
+		const actor = combatant.actor as unknown as ActorWithRules | null;
+		if (!actor) return;
+		const context: InitiativeRolledContext = {
+			actor: actor as unknown as InitiativeRolledContext['actor'],
+			combatant: combatant as unknown as InitiativeRolledContext['combatant'],
+		};
+		void dispatch(actor, 'onInitiativeRolled', context);
+	}) as HookFn);
+
+	onHook('deleteCombat', ((combat: Combat) => {
+		const combatId = combat.id ?? null;
+		if (combatId && encounterEndDispatchedCombatIds.has(combatId)) {
+			encounterEndDispatchedCombatIds.delete(combatId);
+			return;
+		}
+		handleEncounterEnd(combat);
+		if (combatId) encounterEndDispatchedCombatIds.delete(combatId);
+	}) as HookFn);
+
+	onHook('updateCombat', ((combat: Combat, changes: Record<string, unknown>) => {
+		if (!didEncounterEndTransition(changes)) return;
+		if (combat.started !== false) return;
+		if (combat.combatants.size === 0) return;
+		const combatId = combat.id ?? null;
+		if (combatId && encounterEndDispatchedCombatIds.has(combatId)) return;
+		if (combatId) encounterEndDispatchedCombatIds.add(combatId);
+		handleEncounterEnd(combat);
+	}) as HookFn);
 }
 
 export {

--- a/src/migration/MigrationRunnerBase.ts
+++ b/src/migration/MigrationRunnerBase.ts
@@ -9,7 +9,7 @@ interface CollectionDiff<T = any> {
 class MigrationRunnerBase {
 	migrations: MigrationBase[];
 
-	static LATEST_SCHEMA_VERSION = 18;
+	static LATEST_SCHEMA_VERSION = 21;
 
 	static RECOMMENDED_SAFE_VERSION = 0;
 

--- a/src/migration/migrations/Migration019DicePoolFields.ts
+++ b/src/migration/migrations/Migration019DicePoolFields.ts
@@ -1,0 +1,72 @@
+import { MigrationBase } from '../MigrationBase.js';
+
+/**
+ * Backfills `poolMode`, `resetOnEncounterEnd`, and `fillOnInitiative` on
+ * existing `dicePool` rules that pre-date these fields.
+ *
+ * These fields were added in the dice-pools feature branch. Actors who already
+ * had Berserker, Commander, or Oathsworn features embedded will have `dicePool`
+ * rules in their stored items without these properties; Foundry's DataModel
+ * fills in schema defaults at runtime, but those defaults are wrong for rules
+ * that require non-default lifecycle behaviour.
+ *
+ * Pool mode semantics:
+ * - 'resource'   : count-based, spent one pip at a time (Commander Combat Dice)
+ * - 'accumulate' : roll one die, add value to running total (Berserker Fury Dice)
+ * - 'store'      : roll full pool, store total, expend to clear (Oathsworn Judgement Dice)
+ *
+ * Resolution per rule (by well-known identifier):
+ * - combat-dice   → poolMode: 'resource', resetOnEncounterEnd: true, fillOnInitiative: true
+ * - fury-dice     → poolMode: 'accumulate', resetOnEncounterEnd: true
+ * - judgment-dice → poolMode: 'store'
+ * - unknown       → poolMode: 'resource' (safe default)
+ *
+ * Also removes the legacy `rollable` field if present (superseded by poolMode).
+ */
+class Migration019DicePoolFields extends MigrationBase {
+	static override readonly version = 19;
+
+	override readonly version = Migration019DicePoolFields.version;
+
+	override async updateItem(source: any): Promise<void> {
+		const rules: any[] | undefined = source.system?.rules;
+		if (!Array.isArray(rules)) return;
+
+		for (const rule of rules) {
+			if (rule.type !== 'dicePool') continue;
+
+			const id: string = rule.identifier ?? '';
+			const _before = {
+				poolMode: rule.poolMode,
+				resetOnEncounterEnd: rule.resetOnEncounterEnd,
+				fillOnInitiative: rule.fillOnInitiative,
+				rollable: rule.rollable,
+			};
+
+			// Remove legacy rollable field (superseded by poolMode)
+			delete rule.rollable;
+
+			// For known identifiers always enforce the correct mode; for unknowns
+			// only backfill if missing (preserves any intentional value).
+			if (id === 'fury-dice') {
+				rule.poolMode = 'individual';
+				rule.resetOnEncounterEnd = true;
+				rule.fillOnInitiative ??= false;
+			} else if (id === 'judgment-dice') {
+				rule.poolMode = 'store';
+				rule.resetOnEncounterEnd ??= false;
+				rule.fillOnInitiative ??= false;
+			} else if (id === 'combat-dice') {
+				rule.poolMode = 'resource';
+				rule.resetOnEncounterEnd = true;
+				rule.fillOnInitiative = true;
+			} else {
+				rule.poolMode ??= 'resource';
+				rule.resetOnEncounterEnd ??= false;
+				rule.fillOnInitiative ??= false;
+			}
+		}
+	}
+}
+
+export { Migration019DicePoolFields };

--- a/src/migration/migrations/Migration020RollOnActivation.ts
+++ b/src/migration/migrations/Migration020RollOnActivation.ts
@@ -1,0 +1,45 @@
+import { MigrationBase } from '../MigrationBase.js';
+
+/**
+ * Fixes fury-dice pool rules on already-embedded items.
+ *
+ * Migration019 set poolMode='accumulate' for fury-dice, but the correct mode is
+ * 'resource' (individual spendable pips, not an aggregated running total).
+ *
+ * Additionally backfills rollOnActivation and corrects the die-face level
+ * overrides (d6 at 6, d8 at 9, d10 at 13, d12 at 17) which were only present
+ * in the compendium JSON and not in already-embedded items.
+ */
+class Migration020RollOnActivation extends MigrationBase {
+	static override readonly version = 20;
+
+	override readonly version = Migration020RollOnActivation.version;
+
+	override async updateItem(source: any): Promise<void> {
+		const rules: any[] | undefined = source.system?.rules;
+		if (!Array.isArray(rules)) return;
+
+		for (const rule of rules) {
+			if (rule.type !== 'dicePool') continue;
+			if (rule.identifier === 'fury-dice') {
+				rule.poolMode = 'individual';
+				rule.rollOnActivation = true;
+				// Fix die-size level overrides for the Intensifying Fury progression
+				if (rule.levels) {
+					rule.levels['6'] ??= {};
+					rule.levels['9'] ??= {};
+					rule.levels['13'] ??= {};
+					rule.levels['17'] ??= {};
+					rule.levels['6'].faces = 6;
+					rule.levels['9'].faces = 8;
+					rule.levels['13'].faces = 10;
+					rule.levels['17'].faces = 12;
+				}
+			} else {
+				rule.rollOnActivation ??= false;
+			}
+		}
+	}
+}
+
+export { Migration020RollOnActivation };

--- a/src/migration/migrations/Migration021IndividualFuryDice.ts
+++ b/src/migration/migrations/Migration021IndividualFuryDice.ts
@@ -1,0 +1,76 @@
+import { MigrationBase } from '../MigrationBase.js';
+
+const FURY_LEVEL_OVERRIDES: Record<string, { faces: number; quantity: string }> = {
+	'6': { faces: 6, quantity: '' },
+	'9': { faces: 8, quantity: '' },
+	'13': { faces: 10, quantity: '' },
+	'17': { faces: 12, quantity: '' },
+};
+
+const SECOND_FURY_RULE = {
+	type: 'dicePool',
+	disabled: false,
+	id: 'Lm7xQ4wR9pKv3sTn',
+	identifier: 'fury-dice',
+	label: 'Fury Dice',
+	predicate: { level: { min: 5 } },
+	priority: 2,
+	faces: 4,
+	quantity: '@key',
+	poolMode: 'individual',
+	resetOnEncounterEnd: true,
+	fillOnInitiative: false,
+	rollOnActivation: true,
+	levels: { ...FURY_LEVEL_OVERRIDES },
+};
+
+/**
+ * Upgrades embedded fury-dice pool rules to the `individual` pool mode.
+ *
+ * Earlier migrations left fury-dice as `resource` or `accumulate`. This
+ * migration corrects that to `individual`, backfills the die-face level
+ * overrides (d6 at 6, d8 at 9, d10 at 13, d12 at 17), and adds the second
+ * dicePool rule (level 5+ predicate) if it was never embedded.
+ */
+class Migration021IndividualFuryDice extends MigrationBase {
+	static override readonly version = 21;
+
+	override readonly version = Migration021IndividualFuryDice.version;
+
+	override async updateItem(source: any): Promise<void> {
+		const rules: any[] | undefined = source.system?.rules;
+		if (!Array.isArray(rules)) return;
+
+		const furyRules = rules.filter((r) => r.type === 'dicePool' && r.identifier === 'fury-dice');
+		if (furyRules.length === 0) return;
+
+		for (const rule of furyRules) {
+			rule.poolMode = 'individual';
+			rule.rollOnActivation = true;
+			rule.resetOnEncounterEnd = true;
+			rule.fillOnInitiative = false;
+			rule.quantity = '@key';
+
+			if (!rule.levels) rule.levels = {};
+			for (const [lvl, override] of Object.entries(FURY_LEVEL_OVERRIDES)) {
+				rule.levels[lvl] = override;
+			}
+			// Remove empty placeholders left by earlier migrations
+			for (const [lvl, override] of Object.entries(rule.levels)) {
+				if ((override as any).faces === 0 && (override as any).quantity === '') {
+					delete rule.levels[lvl];
+				}
+			}
+		}
+
+		// Add the level-5+ rule if missing
+		const hasSecondRule = furyRules.some(
+			(r) => r.predicate?.level?.min === 5 || r.id === SECOND_FURY_RULE.id,
+		);
+		if (!hasSecondRule) {
+			source.system.rules.push({ ...SECOND_FURY_RULE });
+		}
+	}
+}
+
+export { Migration021IndividualFuryDice };

--- a/src/migration/migrations/index.ts
+++ b/src/migration/migrations/index.ts
@@ -16,3 +16,6 @@ export { Migration015WeaponType } from './Migration015WeaponType.js';
 export { Migration016DamageBonus } from './Migration016DamageBonus.js';
 export { Migration017WeaponAttackType } from './Migration017WeaponAttackType.js';
 export { Migration018LastStandHp } from './Migration018LastStandHp.js';
+export { Migration019DicePoolFields } from './Migration019DicePoolFields.js';
+export { Migration020RollOnActivation } from './Migration020RollOnActivation.js';
+export { Migration021IndividualFuryDice } from './Migration021IndividualFuryDice.js';

--- a/src/models/rules/base.ts
+++ b/src/models/rules/base.ts
@@ -93,6 +93,16 @@ interface InitiativeRolledContext {
 	combatant: Combatant;
 }
 
+interface EncounterContext {
+	combat: Combat;
+}
+
+interface ItemActivatedContext {
+	item: NimbleBaseItem;
+	actor: NimbleBaseActor;
+	card: ChatMessage | null;
+}
+
 abstract class NimbleBaseRule<
 	Schema extends NimbleBaseRule.Schema = NimbleBaseRule.Schema,
 	Parent extends foundry.abstract.DataModel.Any = foundry.abstract.DataModel.Any,
@@ -278,6 +288,16 @@ abstract class NimbleBaseRule<
 		// Default implementation does nothing
 	}
 
+	/** Hook called when an encounter ends (combat deleted or started→false). */
+	async onEncounterEnd(_context: EncounterContext): Promise<void> {
+		// Default implementation does nothing
+	}
+
+	/** Hook called when this rule's parent item is activated. Fires on the item's own rules only. */
+	async onItemActivated(_context: ItemActivatedContext): Promise<void> {
+		// Default implementation does nothing
+	}
+
 	/**
 	 * Called by the chat card renderer when an activation card resolves, for every
 	 * rule on the speaker actor. Returns zero or more EffectNode entries to inject
@@ -299,10 +319,12 @@ export {
 	NimbleBaseRule,
 	type PreCreateArgs,
 	type ItemUsedContext,
+	type ItemActivatedContext,
 	type TurnContext,
 	type ActorHealthContext,
 	type SaveResolvedContext,
 	type RestContext,
 	type InitiativeRolledContext,
+	type EncounterContext,
 	type ActivationCardContext,
 };

--- a/src/models/rules/dicePool.test.ts
+++ b/src/models/rules/dicePool.test.ts
@@ -1,0 +1,264 @@
+import type { Mock } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { DicePoolEntry, PoolMode } from './dicePool.js';
+import { DicePoolRule } from './dicePool.js';
+
+interface MockActor {
+	dicePools?: Record<string, DicePoolEntry>;
+	getRollData: Mock<() => Record<string, unknown>>;
+}
+
+interface MockItem {
+	isEmbedded: boolean;
+	actor: MockActor;
+	name: string;
+	uuid: string;
+}
+
+interface RuleSourceData {
+	type: string;
+	id: string;
+	identifier: string;
+	label: string;
+	faces: number;
+	quantity: string;
+	poolMode: PoolMode;
+	levels: Record<string, { faces: number; quantity: string }>;
+	disabled: boolean;
+	priority: number;
+	predicate: Record<string, unknown>;
+}
+
+interface DicePoolRuleTestInstance extends DicePoolRule {
+	identifier: string;
+	label: string;
+	faces: number;
+	quantity: string;
+	poolMode: PoolMode;
+	levels: Record<string, { faces: number; quantity: string }>;
+	disabled: boolean;
+}
+
+function createMockActor(level = 1): MockActor {
+	return {
+		getRollData: vi.fn(() => ({ level })),
+	};
+}
+
+function createMockItem(actor: MockActor, isEmbedded = true): MockItem {
+	return { isEmbedded, actor, name: 'Test Feature', uuid: 'test-uuid' };
+}
+
+function createDicePoolRule(
+	config: {
+		identifier: string;
+		label?: string;
+		faces?: number;
+		quantity?: string;
+		poolMode?: PoolMode;
+		levels?: Record<string, { faces?: number; quantity?: string }>;
+		disabled?: boolean;
+	},
+	actor: MockActor,
+	options: { isEmbedded?: boolean } = {},
+): DicePoolRuleTestInstance {
+	const item = createMockItem(actor, options.isEmbedded ?? true);
+
+	const fullLevels: Record<string, { faces: number; quantity: string }> = {};
+	for (let i = 1; i <= 20; i++) {
+		const override = config.levels?.[i];
+		fullLevels[i] = { faces: override?.faces ?? 0, quantity: override?.quantity ?? '' };
+	}
+
+	const source: RuleSourceData = {
+		type: 'dicePool',
+		id: 'test-rule-id',
+		identifier: config.identifier,
+		label: config.label ?? config.identifier,
+		faces: config.faces ?? 6,
+		quantity: config.quantity ?? '1',
+		poolMode: config.poolMode ?? 'resource',
+		levels: fullLevels,
+		disabled: config.disabled ?? false,
+		priority: 1,
+		predicate: {},
+	};
+
+	const rule = new DicePoolRule(
+		source as foundry.data.fields.SchemaField.CreateData<DicePoolRule['schema']['fields']>,
+		{ parent: item as unknown as foundry.abstract.DataModel.Any, strict: false },
+	) as DicePoolRuleTestInstance;
+
+	rule.identifier = config.identifier;
+	rule.label = config.label ?? config.identifier;
+	rule.faces = config.faces ?? 6;
+	rule.quantity = config.quantity ?? '1';
+	rule.poolMode = config.poolMode ?? 'resource';
+	rule.levels = fullLevels;
+	rule.disabled = config.disabled ?? false;
+
+	Object.defineProperty(rule, 'item', { get: () => item, configurable: true });
+	Object.defineProperty(rule, '_predicate', {
+		get: () => ({ size: 0 }),
+		configurable: true,
+	});
+
+	return rule;
+}
+
+describe('DicePoolRule', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe('afterPrepareData', () => {
+		it('registers a pool on actor.dicePools', () => {
+			const actor = createMockActor(1);
+			const rule = createDicePoolRule(
+				{ identifier: 'fury-dice', label: 'Fury Dice', faces: 4, quantity: '1' },
+				actor,
+			);
+
+			rule.afterPrepareData();
+
+			expect(actor.dicePools).toBeDefined();
+			expect(actor.dicePools!['fury-dice']).toEqual({
+				identifier: 'fury-dice',
+				label: 'Fury Dice',
+				faces: 4,
+				max: 1,
+				poolMode: 'resource',
+			});
+		});
+
+		it('accumulates multiple pools from different rules', () => {
+			const actor = createMockActor(1);
+			const ruleA = createDicePoolRule({ identifier: 'fury-dice', faces: 4 }, actor);
+			const ruleB = createDicePoolRule({ identifier: 'combat-dice', faces: 8 }, actor);
+
+			ruleA.afterPrepareData();
+			ruleB.afterPrepareData();
+
+			expect(Object.keys(actor.dicePools!)).toHaveLength(2);
+			expect(actor.dicePools!['fury-dice'].faces).toBe(4);
+			expect(actor.dicePools!['combat-dice'].faces).toBe(8);
+		});
+
+		it('does nothing when item is not embedded', () => {
+			const actor = createMockActor(1);
+			const rule = createDicePoolRule({ identifier: 'fury-dice' }, actor, { isEmbedded: false });
+
+			rule.afterPrepareData();
+
+			expect(actor.dicePools).toBeUndefined();
+		});
+
+		it('does nothing when identifier is empty', () => {
+			const actor = createMockActor(1);
+			const rule = createDicePoolRule({ identifier: '' }, actor);
+
+			rule.afterPrepareData();
+
+			expect(actor.dicePools).toBeUndefined();
+		});
+	});
+
+	describe('level overrides', () => {
+		it('upgrades die faces at a threshold level', () => {
+			const actor = createMockActor(9);
+			const rule = createDicePoolRule(
+				{
+					identifier: 'combat-dice',
+					faces: 8,
+					quantity: '1',
+					levels: { '9': { faces: 10 } },
+				},
+				actor,
+			);
+
+			rule.afterPrepareData();
+
+			expect(actor.dicePools!['combat-dice'].faces).toBe(10);
+		});
+
+		it('keeps base faces when level is below threshold', () => {
+			const actor = createMockActor(5);
+			const rule = createDicePoolRule(
+				{
+					identifier: 'combat-dice',
+					faces: 8,
+					levels: { '9': { faces: 10 } },
+				},
+				actor,
+			);
+
+			rule.afterPrepareData();
+
+			expect(actor.dicePools!['combat-dice'].faces).toBe(8);
+		});
+
+		it('upgrades quantity at a threshold level', () => {
+			const actor = createMockActor(5);
+			const rule = createDicePoolRule(
+				{
+					identifier: 'fury-dice',
+					faces: 4,
+					quantity: '1',
+					levels: { '5': { quantity: '2' } },
+				},
+				actor,
+			);
+
+			rule.afterPrepareData();
+
+			expect(actor.dicePools!['fury-dice'].max).toBe(2);
+		});
+
+		it('applies the highest applicable level override', () => {
+			const actor = createMockActor(13);
+			const rule = createDicePoolRule(
+				{
+					identifier: 'combat-dice',
+					faces: 8,
+					levels: { '9': { faces: 10 }, '13': { faces: 12 }, '17': { faces: 20 } },
+				},
+				actor,
+			);
+
+			rule.afterPrepareData();
+
+			expect(actor.dicePools!['combat-dice'].faces).toBe(12);
+		});
+
+		it('applies multiple level overrides cumulatively', () => {
+			const actor = createMockActor(14);
+			const rule = createDicePoolRule(
+				{
+					identifier: 'judgment-dice',
+					faces: 6,
+					quantity: '2',
+					levels: { '3': { faces: 8 }, '14': { quantity: '3' } },
+				},
+				actor,
+			);
+
+			rule.afterPrepareData();
+
+			expect(actor.dicePools!['judgment-dice'].faces).toBe(8);
+			expect(actor.dicePools!['judgment-dice'].max).toBe(3);
+		});
+	});
+
+	describe('schema', () => {
+		it('defines the required schema fields', () => {
+			const schemaDef = DicePoolRule.defineSchema();
+
+			expect(schemaDef).toHaveProperty('identifier');
+			expect(schemaDef).toHaveProperty('label');
+			expect(schemaDef).toHaveProperty('faces');
+			expect(schemaDef).toHaveProperty('quantity');
+			expect(schemaDef).toHaveProperty('levels');
+			expect(schemaDef).toHaveProperty('type');
+		});
+	});
+});

--- a/src/models/rules/dicePool.ts
+++ b/src/models/rules/dicePool.ts
@@ -1,0 +1,235 @@
+import type { EncounterContext, InitiativeRolledContext, ItemActivatedContext } from './base.js';
+import { NimbleBaseRule } from './base.js';
+
+export type PoolMode = 'resource' | 'accumulate' | 'store' | 'individual';
+
+export interface DicePoolEntry {
+	identifier: string;
+	label: string;
+	faces: number;
+	max: number;
+	poolMode: PoolMode;
+}
+
+interface ActorWithPools {
+	dicePools?: Record<string, DicePoolEntry>;
+}
+
+function levelOverridesSchema() {
+	const { fields } = foundry.data;
+	return Array.from({ length: 20 }, (_, i) => i + 1).reduce(
+		(acc: Record<string, unknown>, level) => {
+			acc[level] = new fields.SchemaField({
+				faces: new fields.NumberField({
+					required: true,
+					nullable: false,
+					initial: 0,
+					integer: true,
+				}),
+				quantity: new fields.StringField({ required: true, nullable: false, initial: '' }),
+			});
+			return acc;
+		},
+		{},
+	);
+}
+
+function schema() {
+	const { fields } = foundry.data;
+
+	return {
+		faces: new fields.NumberField({ required: true, nullable: false, initial: 6, integer: true }),
+		quantity: new fields.StringField({ required: true, nullable: false, initial: '1' }),
+		levels: new fields.SchemaField(levelOverridesSchema() as any),
+		/**
+		 * Controls how the pool's value is tracked and updated:
+		 * - 'resource'   : count-based; filled by lifecycle hooks, spent one pip at a time
+		 * - 'accumulate' : roll one die at a time and add value to a running total
+		 * - 'store'      : roll the full pool at once, store the total; expend to clear
+		 */
+		poolMode: new fields.StringField({ required: true, nullable: false, initial: 'resource' }),
+		resetOnEncounterEnd: new fields.BooleanField({
+			required: true,
+			nullable: false,
+			initial: false,
+		}),
+		fillOnInitiative: new fields.BooleanField({ required: true, nullable: false, initial: false }),
+		rollOnActivation: new fields.BooleanField({ required: true, nullable: false, initial: false }),
+		type: new fields.StringField({ required: true, nullable: false, initial: 'dicePool' }),
+	};
+}
+
+declare namespace DicePoolRule {
+	type Schema = NimbleBaseRule.Schema & ReturnType<typeof schema>;
+}
+
+/**
+ * Rule that declares a named dice pool on the actor.
+ *
+ * Each rule instance registers one pool under a unique identifier. During data
+ * preparation the rule resolves the effective die size and maximum quantity for
+ * the character's current level (using optional per-level overrides) and writes
+ * them to `actor.system.dicePools[identifier]`. The live value (how much is
+ * currently stored or remaining) is kept in actor flags so it persists across
+ * sessions without a schema change.
+ *
+ * The rule's base `identifier` field (from NimbleBaseRule) serves as the pool
+ * key on the actor. The base `label` field provides the display name.
+ *
+ * Pool modes (see `poolMode` field above) control both how the UI presents
+ * the pool and what rolling the badge does.
+ */
+class DicePoolRule extends NimbleBaseRule<DicePoolRule.Schema> {
+	declare faces: number;
+	declare quantity: string;
+	declare poolMode: PoolMode;
+	declare resetOnEncounterEnd: boolean;
+	declare fillOnInitiative: boolean;
+	declare rollOnActivation: boolean;
+
+	static override defineSchema(): DicePoolRule.Schema {
+		return {
+			...NimbleBaseRule.defineSchema(),
+			...schema(),
+		};
+	}
+
+	override tooltipInfo(): string {
+		return super.tooltipInfo(
+			new Map([
+				['faces', 'number'],
+				['quantity', 'string'],
+				['poolMode', "'resource' | 'accumulate' | 'store'"],
+				['resetOnEncounterEnd', 'boolean'],
+				['fillOnInitiative', 'boolean'],
+				['rollOnActivation', 'boolean'],
+			]),
+		);
+	}
+
+	private resolveEffectiveConfig(): { faces: number; quantity: string } {
+		const characterLevel = Math.round(this.resolveFormula('@level') ?? 1);
+		let effectiveFaces = this.faces;
+		let effectiveQuantity = this.quantity;
+		const levels = this.levels as unknown as Record<number, { faces: number; quantity: string }>;
+		for (let lvl = 1; lvl <= characterLevel; lvl++) {
+			const override = levels[lvl];
+			if (override?.faces > 0) effectiveFaces = override.faces;
+			if (override?.quantity) effectiveQuantity = override.quantity;
+		}
+		return { faces: effectiveFaces, quantity: effectiveQuantity };
+	}
+
+	override afterPrepareData(): void {
+		if (!this.item.isEmbedded) return;
+		if (!this.test()) return;
+
+		const identifier = this.identifier;
+		if (!identifier) return;
+
+		const actor = this.item.actor as unknown as ActorWithPools;
+		const { faces, quantity } = this.resolveEffectiveConfig();
+		const resolvedMax = Math.max(1, Math.round(this.resolveFormula(quantity) ?? 1));
+
+		if (!actor.dicePools) {
+			actor.dicePools = {};
+		}
+
+		const existing = actor.dicePools[identifier];
+		if (existing && this.poolMode === 'resource') {
+			// Multiple rules can contribute to the same resource pool (e.g. a base
+			// pool plus a player-selected "Additional Combat Die" choice item).
+			existing.max += resolvedMax;
+		} else {
+			actor.dicePools[identifier] = {
+				identifier,
+				label: this.label || identifier,
+				faces,
+				max: resolvedMax,
+				poolMode: this.poolMode,
+			} satisfies DicePoolEntry;
+		}
+	}
+
+	override async onEncounterEnd(_context: EncounterContext): Promise<void> {
+		if (!this.item.isEmbedded) return;
+		if (!this.test()) return;
+		if (!this.resetOnEncounterEnd) return;
+		const update: Record<string, unknown> = {};
+		if (this.poolMode === 'individual') {
+			foundry.utils.setProperty(update, `flags.nimble.dicePools.${this.identifier}.dice`, []);
+		} else {
+			foundry.utils.setProperty(update, `flags.nimble.dicePools.${this.identifier}.current`, 0);
+		}
+		await this.item.actor?.update(update);
+	}
+
+	override async onInitiativeRolled(_context: InitiativeRolledContext): Promise<void> {
+		if (!this.item.isEmbedded) return;
+		if (!this.test()) return;
+		if (!this.fillOnInitiative) return;
+		const { quantity } = this.resolveEffectiveConfig();
+		const max = Math.max(1, Math.round(this.resolveFormula(quantity) ?? 1));
+		const update: Record<string, unknown> = {};
+		foundry.utils.setProperty(update, `flags.nimble.dicePools.${this.identifier}.current`, max);
+		await this.item.actor?.update(update);
+	}
+
+	override async onItemActivated(_context: ItemActivatedContext): Promise<void> {
+		if (!this.item.isEmbedded) return;
+		if (!this.test()) return;
+		if (!this.rollOnActivation) return;
+
+		const { faces, quantity } = this.resolveEffectiveConfig();
+		const max = Math.max(1, Math.round(this.resolveFormula(quantity) ?? 1));
+		const actor = this.item.actor as unknown as Record<string, unknown>;
+
+		if (this.poolMode === 'individual') {
+			const currentDice =
+				((actor as any).flags?.nimble?.dicePools?.[this.identifier]?.dice as number[]) ?? [];
+			if (currentDice.length >= max) return;
+			const roll = new Roll(`1d${faces}`);
+			await roll.evaluate();
+			await roll.toMessage({
+				speaker: ChatMessage.getSpeaker({ actor: this.item.actor }),
+				flavor: this.label,
+			});
+			const update: Record<string, unknown> = {};
+			foundry.utils.setProperty(update, `flags.nimble.dicePools.${this.identifier}.dice`, [
+				...currentDice,
+				roll.total ?? 1,
+			]);
+			await this.item.actor?.update(update);
+			return;
+		}
+
+		const roll = new Roll(`1d${faces}`);
+		await roll.evaluate();
+		await roll.toMessage({
+			speaker: ChatMessage.getSpeaker({ actor: this.item.actor }),
+			flavor: this.label,
+		});
+
+		const current =
+			((actor as any).flags?.nimble?.dicePools?.[this.identifier]?.current as number) ?? 0;
+		const update: Record<string, unknown> = {};
+
+		if (this.poolMode === 'resource') {
+			foundry.utils.setProperty(
+				update,
+				`flags.nimble.dicePools.${this.identifier}.current`,
+				Math.min(max, current + 1),
+			);
+		} else if (this.poolMode === 'accumulate') {
+			foundry.utils.setProperty(
+				update,
+				`flags.nimble.dicePools.${this.identifier}.current`,
+				current + (roll.total ?? 0),
+			);
+		}
+
+		await this.item.actor?.update(update);
+	}
+}
+
+export { DicePoolRule };

--- a/src/view/sheets/PlayerCharacterSheet.svelte
+++ b/src/view/sheets/PlayerCharacterSheet.svelte
@@ -5,6 +5,7 @@
 	import PrimaryNavigation from '../components/PrimaryNavigation.svelte';
 	import updateDocumentImage from '#view/handlers/updateDocumentImage.js';
 	import ActionTracker from './components/ActionTracker.svelte';
+	import DicePoolTracker from './components/DicePoolTracker.svelte';
 	import HitDiceBar from './components/HitDiceBar.svelte';
 	import HitPointBar from './components/HitPointBar.svelte';
 	import ManaBar from './components/ManaBar.svelte';
@@ -433,12 +434,25 @@
 	>
 		<i class="fa-solid fa-moon"></i>
 	</button>
-	<ActionTracker {actor} />
+
+	<div class="nimble-sheet__left-trackers">
+		<ActionTracker {actor} />
+		<DicePoolTracker {actor} />
+	</div>
 </section>
 
 <style lang="scss">
 	.nimble-sheet__header {
 		position: relative;
+	}
+
+	.nimble-sheet__left-trackers {
+		position: absolute;
+		top: 15rem;
+		left: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
 	}
 
 	.nimble-edit-toggle__track {

--- a/src/view/sheets/components/ActionTracker.svelte
+++ b/src/view/sheets/components/ActionTracker.svelte
@@ -96,10 +96,6 @@
 
 <style lang="scss">
 	.action-tracker {
-		position: absolute;
-		top: 15rem;
-		left: 0;
-
 		&__panel {
 			display: flex;
 			flex-direction: column;

--- a/src/view/sheets/components/DicePoolTracker.svelte
+++ b/src/view/sheets/components/DicePoolTracker.svelte
@@ -1,0 +1,476 @@
+<script>
+	import { createDicePoolTrackerState, getDieFaceIcon } from './DicePoolTracker.svelte.ts';
+
+	// ============================================================================
+	// Props
+	// ============================================================================
+
+	let { actor } = $props();
+
+	// ============================================================================
+	// State
+	// ============================================================================
+
+	const state = createDicePoolTrackerState(() => actor);
+</script>
+
+{#if state.hasDicePools}
+	<div class="dice-pool-tracker">
+		<div class="dice-pool-tracker__panel">
+			{#each state.dicePools as pool (pool.identifier)}
+				{#if pool.poolMode === 'resource'}
+					<!-- Static badge shows die type; pips are individual die-face icons -->
+					<div
+						class="dice-pool-tracker__badge dice-pool-tracker__badge--static"
+						data-tooltip="{pool.label} ({pool.current}/{pool.max})"
+						data-tooltip-direction="RIGHT"
+					>
+						<i class="fa-solid {getDieFaceIcon(pool.faces)}"></i>
+					</div>
+
+					{#each { length: pool.max }, i}
+						{@const isAvailable = i < pool.current}
+						<button
+							class="dice-pool-tracker__pip"
+							class:dice-pool-tracker__pip--available={isAvailable}
+							class:dice-pool-tracker__pip--spent={!isAvailable}
+							type="button"
+							aria-label={isAvailable ? `Spend 1 ${pool.label}` : `Restore 1 ${pool.label}`}
+							data-tooltip={isAvailable ? 'Click to spend' : 'Click to restore'}
+							data-tooltip-direction="RIGHT"
+							onclick={() => state.handlePoolPipClick(pool.identifier, i, isAvailable)}
+						>
+							<i class="fa-solid {getDieFaceIcon(pool.faces)}"></i>
+						</button>
+					{/each}
+				{:else if pool.poolMode === 'individual'}
+					<!-- Individual die mode: static badge + one chip per rolled die value -->
+					<div
+						class="dice-pool-tracker__badge dice-pool-tracker__badge--static"
+						data-tooltip={pool.dice.length > 0
+							? `${pool.label} (${pool.dice.length}/${pool.max}) – Total: ${pool.current}`
+							: `${pool.label} (0/${pool.max})`}
+						data-tooltip-direction="RIGHT"
+					>
+						<i class="fa-solid {getDieFaceIcon(pool.faces)}"></i>
+					</div>
+
+					{#each pool.dice as value, i (i)}
+						<button
+							class="dice-pool-tracker__die-chip"
+							type="button"
+							aria-label="Spend {pool.label} die (value: {value})"
+							data-tooltip="Rolled {value} – Click to spend"
+							data-tooltip-direction="RIGHT"
+							onclick={() => state.spendDie(pool.identifier, i)}
+						>
+							{value}
+						</button>
+					{/each}
+
+					{#if pool.dice.length > 1}
+						<div
+							class="dice-pool-tracker__die-total"
+							data-tooltip="{pool.label} total: {pool.current}"
+							data-tooltip-direction="RIGHT"
+						>
+							{pool.current}
+						</div>
+					{/if}
+				{:else}
+					<!-- Clickable badge rolls the pool; value chip shows stored total -->
+					<button
+						class="dice-pool-tracker__badge dice-pool-tracker__badge--roll"
+						type="button"
+						aria-label="{pool.label} – Click to roll"
+						data-tooltip={pool.poolMode === 'accumulate'
+							? `${pool.label} – Click to roll 1 die (max ${pool.max})`
+							: `${pool.label} – Click to roll`}
+						data-tooltip-direction="RIGHT"
+						onclick={() => state.rollPool(pool)}
+					>
+						<i class="fa-solid {getDieFaceIcon(pool.faces)}"></i>
+					</button>
+
+					<button
+						class="dice-pool-tracker__value-chip"
+						class:dice-pool-tracker__value-chip--empty={pool.current <= 0}
+						type="button"
+						aria-label="Expend {pool.label} (current: {pool.current})"
+						data-tooltip={pool.current > 0
+							? `Stored: ${pool.current} – Click to expend`
+							: `${pool.label} – nothing stored`}
+						data-tooltip-direction="RIGHT"
+						onclick={() => state.expendPool(pool.identifier)}
+					>
+						{pool.current > 0 ? pool.current : '–'}
+					</button>
+				{/if}
+			{/each}
+		</div>
+	</div>
+{/if}
+
+<style lang="scss">
+	.dice-pool-tracker {
+		// Color tokens — override per theme so a single var(--dp-*) works everywhere.
+		// Light: hsl(210,65%,46%) ~3.5:1 on white (WCAG AA for non-text UI elements)
+		// Dark:  hsl(210,80%,63%) ~5:1 on hsl(220,15%,16%)
+		--dp-available: hsl(210, 65%, 46%);
+		--dp-spent: hsl(220, 10%, 58%);
+		--dp-expend-hover: hsl(0, 65%, 58%);
+		&__panel {
+			display: flex;
+			flex-direction: column;
+			align-items: center;
+			gap: 0.125rem;
+			padding: 0.25rem;
+			background: color-mix(in srgb, var(--nimble-sheet-background) 85%, transparent);
+			border: 1px solid hsl(220, 10%, 70%);
+			border-left: none;
+			border-radius: 0 6px 6px 0;
+			box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+		}
+
+		// Badge: the die-face icon cell.
+		// Static variant (resource mode) = display only. Non-static = clickable roll button.
+		&__badge {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			width: 1.625rem;
+			height: 1.625rem;
+			padding: 0;
+			background: #fff;
+			border: 2px solid var(--dp-available);
+			border-radius: 4px;
+			cursor: pointer;
+			transition:
+				background 0.15s ease,
+				box-shadow 0.15s ease;
+
+			i {
+				font-size: 1rem;
+				color: var(--dp-available);
+				transition: filter 0.15s ease;
+			}
+
+			&--static {
+				border-width: 1px;
+				border-color: var(--nimble-dark-text-color);
+				cursor: default;
+
+				i {
+					color: var(--nimble-dark-text-color);
+				}
+			}
+
+			// Roll badge (store/accumulate): neutral header look but still clickable
+			&--roll {
+				border-width: 1px;
+				border-color: var(--nimble-dark-text-color);
+
+				i {
+					color: var(--nimble-dark-text-color);
+				}
+
+				&:hover {
+					background: hsl(220, 10%, 94%);
+
+					i {
+						filter: none;
+					}
+				}
+			}
+
+			&:not(&--static):not(&--roll):hover {
+				background: hsl(210, 75%, 92%);
+
+				i {
+					filter: drop-shadow(0 0 4px var(--dp-available));
+				}
+			}
+		}
+
+		// Pips: one per die in a resource pool (e.g. Commander Combat Dice).
+		&__pip {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			width: 1.625rem;
+			height: 1.625rem;
+			padding: 0;
+			background: #fff;
+			border: 1px solid hsl(220, 10%, 78%);
+			border-radius: 4px;
+			cursor: pointer;
+			transition:
+				border-color 0.15s ease,
+				background 0.15s ease;
+
+			i {
+				font-size: 0.875rem;
+				transition:
+					color 0.15s ease,
+					filter 0.15s ease;
+			}
+
+			&--available {
+				border-color: var(--dp-available);
+
+				i {
+					color: var(--dp-available);
+				}
+
+				&:hover {
+					background: hsl(210, 75%, 92%);
+
+					i {
+						filter: drop-shadow(0 0 4px var(--dp-available));
+					}
+				}
+			}
+
+			&--spent {
+				i {
+					color: var(--dp-spent);
+				}
+
+				&:hover {
+					border-color: var(--dp-available);
+
+					i {
+						color: var(--dp-available);
+					}
+				}
+			}
+		}
+
+		// Individual die chips: one per rolled die in 'individual' mode.
+		&__die-chip {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			width: 1.625rem;
+			height: 1.625rem;
+			padding: 0;
+			background: #fff;
+			border: 2px solid var(--dp-available);
+			border-radius: 4px;
+			cursor: pointer;
+			font-size: 0.75rem;
+			font-weight: 700;
+			color: var(--dp-available);
+			transition:
+				border-color 0.15s ease,
+				color 0.15s ease,
+				background 0.15s ease;
+
+			&:hover {
+				border-color: var(--dp-expend-hover);
+				color: var(--dp-expend-hover);
+				background: hsl(0, 65%, 96%);
+			}
+		}
+
+		// Running total shown below the individual die chips.
+		&__die-total {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			width: 1.625rem;
+			padding: 0.1rem 0;
+			font-size: 0.75rem;
+			font-weight: 600;
+			color: var(--dp-spent);
+			border-top: 1px solid hsl(220, 10%, 78%);
+		}
+
+		// Value chip: shows the accumulated/stored total for non-resource pools.
+		// Click to expend (clear to zero).
+		&__value-chip {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			width: 1.625rem;
+			min-height: 1.625rem;
+			padding: 0.125rem 0;
+			background: #fff;
+			border: 2px solid var(--dp-available);
+			border-radius: 4px;
+			cursor: pointer;
+			font-size: 0.875rem;
+			font-weight: 600;
+			color: var(--dp-available);
+			transition:
+				border-color 0.15s ease,
+				color 0.15s ease;
+
+			&:hover {
+				border-color: var(--dp-expend-hover);
+				color: var(--dp-expend-hover);
+			}
+
+			&--empty {
+				border-width: 1px;
+				border-color: hsl(220, 10%, 78%);
+				color: var(--dp-spent);
+				cursor: default;
+
+				&:hover {
+					border-color: hsl(220, 10%, 78%);
+					color: var(--dp-spent);
+				}
+			}
+		}
+	}
+
+	// ── Dark theme ──────────────────────────────────────────────────────────────
+	// All dark overrides use explicit, contrast-checked values.
+
+	:global(.theme-dark) .dice-pool-tracker {
+		--dp-available: hsl(210, 80%, 63%);
+		--dp-spent: hsl(220, 10%, 50%);
+	}
+
+	:global(.theme-dark) .dice-pool-tracker__panel {
+		background: hsla(220, 15%, 13%, 0.97);
+		border-color: hsl(220, 10%, 28%);
+	}
+
+	:global(.theme-dark) .dice-pool-tracker__badge {
+		background: hsl(220, 15%, 20%);
+		border-color: var(--dp-available);
+
+		i {
+			color: var(--dp-available);
+		}
+
+		&:not(.dice-pool-tracker__badge--static):not(.dice-pool-tracker__badge--roll) {
+			background: hsl(220, 18%, 24%);
+			box-shadow: 0 0 8px color-mix(in srgb, var(--dp-available) 45%, transparent);
+
+			i {
+				filter: drop-shadow(0 0 5px var(--dp-available));
+			}
+
+			&:hover {
+				background: hsl(220, 18%, 30%);
+				box-shadow: 0 0 14px color-mix(in srgb, var(--dp-available) 65%, transparent);
+
+				i {
+					filter: drop-shadow(0 0 8px var(--dp-available));
+				}
+			}
+		}
+
+		&.dice-pool-tracker__badge--static {
+			border-color: var(--nimble-dark-text-color);
+			box-shadow: none;
+
+			i {
+				color: var(--nimble-dark-text-color);
+				filter: none;
+			}
+		}
+
+		&.dice-pool-tracker__badge--roll {
+			border-color: var(--nimble-dark-text-color);
+			box-shadow: none;
+
+			i {
+				color: var(--nimble-dark-text-color);
+				filter: none;
+			}
+
+			&:hover {
+				background: hsl(220, 15%, 26%);
+			}
+		}
+	}
+
+	:global(.theme-dark) .dice-pool-tracker__pip {
+		background: hsl(220, 15%, 18%);
+		border-color: hsl(220, 10%, 30%);
+
+		&:hover {
+			background: hsl(220, 15%, 24%);
+		}
+
+		&.dice-pool-tracker__pip--available {
+			border-color: hsl(210, 85%, 55%);
+
+			i {
+				color: var(--dp-available);
+			}
+
+			&:hover {
+				background: hsl(220, 18%, 26%);
+
+				i {
+					filter: drop-shadow(0 0 5px var(--dp-available));
+				}
+			}
+		}
+
+		&.dice-pool-tracker__pip--spent {
+			i {
+				color: var(--dp-spent);
+			}
+
+			&:hover {
+				border-color: hsl(210, 50%, 55%);
+
+				i {
+					color: hsl(210, 70%, 65%);
+					filter: none;
+				}
+			}
+		}
+	}
+
+	:global(.theme-dark) .dice-pool-tracker__value-chip {
+		background: hsl(220, 18%, 24%);
+		border-color: var(--dp-available);
+		color: var(--dp-available);
+		box-shadow: 0 0 6px color-mix(in srgb, var(--dp-available) 35%, transparent);
+
+		&:hover {
+			background: hsl(220, 18%, 30%);
+			border-color: var(--dp-expend-hover);
+			color: var(--dp-expend-hover);
+			box-shadow: none;
+		}
+
+		&.dice-pool-tracker__value-chip--empty {
+			background: hsl(220, 15%, 18%);
+			border-color: hsl(220, 10%, 30%);
+			color: var(--dp-spent);
+			box-shadow: none;
+
+			&:hover {
+				border-color: hsl(220, 10%, 30%);
+				color: var(--dp-spent);
+			}
+		}
+	}
+
+	:global(.theme-dark) .dice-pool-tracker__die-chip {
+		background: hsl(220, 18%, 24%);
+		border-color: var(--dp-available);
+		color: var(--dp-available);
+		box-shadow: 0 0 6px color-mix(in srgb, var(--dp-available) 35%, transparent);
+
+		&:hover {
+			background: hsl(220, 18%, 30%);
+			border-color: var(--dp-expend-hover);
+			color: var(--dp-expend-hover);
+			box-shadow: none;
+		}
+	}
+
+	:global(.theme-dark) .dice-pool-tracker__die-total {
+		color: var(--dp-spent);
+		border-top-color: hsl(220, 10%, 30%);
+	}
+</style>

--- a/src/view/sheets/components/DicePoolTracker.svelte.ts
+++ b/src/view/sheets/components/DicePoolTracker.svelte.ts
@@ -1,0 +1,173 @@
+import type { NimbleCharacter } from '#documents/actor/character.js';
+import type { DicePoolEntry } from '../../../models/rules/dicePool.js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface LiveDicePool extends DicePoolEntry {
+	current: number;
+	/** Populated only for poolMode === 'individual': the individual rolled die values. */
+	dice: number[];
+}
+
+// ============================================================================
+// Die Face Icons
+// ============================================================================
+
+const DIE_FACE_ICONS: Record<number, string> = {
+	4: 'fa-dice-d4',
+	6: 'fa-dice-d6',
+	8: 'fa-dice-d8',
+	10: 'fa-dice-d10',
+	12: 'fa-dice-d12',
+	20: 'fa-dice-d20',
+};
+
+export function getDieFaceIcon(faces: number): string {
+	return DIE_FACE_ICONS[faces] ?? 'fa-dice-d6';
+}
+
+// ============================================================================
+// State Factory
+// ============================================================================
+
+export function createDicePoolTrackerState(getActor: () => NimbleCharacter) {
+	// ============================================================================
+	// Dice Pool State
+	// ============================================================================
+
+	const dicePools = $derived.by((): LiveDicePool[] => {
+		const actor = getActor();
+		const actorPools = ((actor.reactive as any)?.dicePools ?? {}) as Record<string, DicePoolEntry>;
+		const flagPools = ((actor.reactive?.flags as any)?.nimble?.dicePools ?? {}) as Record<
+			string,
+			{ current?: number; dice?: number[] }
+		>;
+
+		return Object.values(actorPools).map((pool) => {
+			const flagPool = flagPools[pool.identifier] ?? {};
+			if (pool.poolMode === 'individual') {
+				const dice = (flagPool.dice as number[] | undefined) ?? [];
+				return {
+					...pool,
+					current: dice.reduce((sum, v) => sum + v, 0),
+					dice,
+				};
+			}
+			return {
+				...pool,
+				current: flagPool.current ?? 0,
+				dice: [],
+			};
+		});
+	});
+
+	// Individual pools hide when no dice are rolled (nothing to show).
+	// Resource pools show while in combat (empty pips stay visible) or when pips remain.
+	// Accumulate/store always expose the roll badge.
+	const hasDicePools = $derived(
+		dicePools.some((p) => {
+			if (p.poolMode === 'individual') return p.dice.length > 0;
+			if (p.poolMode === 'resource') {
+				return p.current > 0 || Boolean((getActor() as any).inCombat);
+			}
+			return true;
+		}),
+	);
+
+	// ============================================================================
+	// Actions
+	// ============================================================================
+
+	async function setPoolCurrent(identifier: string, newValue: number): Promise<void> {
+		const actor = getActor();
+		const update: Record<string, unknown> = {};
+		foundry.utils.setProperty(update, `flags.nimble.dicePools.${identifier}.current`, newValue);
+		await actor.update(update);
+	}
+
+	async function handlePoolPipClick(
+		identifier: string,
+		_index: number,
+		isAvailable: boolean,
+	): Promise<void> {
+		const pool = dicePools.find((p) => p.identifier === identifier);
+		if (!pool) return;
+
+		if (isAvailable) {
+			const actor = getActor();
+			const roll = new Roll(`1d${pool.faces}`);
+			await roll.evaluate();
+			await roll.toMessage({
+				speaker: ChatMessage.getSpeaker({ actor }),
+				flavor: pool.label,
+			});
+			await setPoolCurrent(identifier, Math.max(0, pool.current - 1));
+		} else {
+			await setPoolCurrent(identifier, Math.min(pool.max, pool.current + 1));
+		}
+	}
+
+	async function rollPool(pool: LiveDicePool): Promise<void> {
+		const actor = getActor();
+
+		if (pool.poolMode === 'accumulate') {
+			// Roll one die and add the result to the running total.
+			const roll = new Roll(`1d${pool.faces}`);
+			await roll.evaluate();
+			await roll.toMessage({
+				speaker: ChatMessage.getSpeaker({ actor }),
+				flavor: pool.label,
+			});
+			const newTotal = pool.current + (roll.total ?? 0);
+			await setPoolCurrent(pool.identifier, newTotal);
+			return;
+		}
+
+		if (pool.poolMode === 'store') {
+			// Roll the full pool and store the total, replacing any existing value.
+			const roll = new Roll(`${pool.max}d${pool.faces}`);
+			await roll.evaluate();
+			await roll.toMessage({
+				speaker: ChatMessage.getSpeaker({ actor }),
+				flavor: pool.label,
+			});
+			await setPoolCurrent(pool.identifier, roll.total ?? 0);
+			return;
+		}
+	}
+
+	async function expendPool(identifier: string): Promise<void> {
+		await setPoolCurrent(identifier, 0);
+	}
+
+	/** Spend one individual die by index, removing it from the pool. */
+	async function spendDie(identifier: string, dieIndex: number): Promise<void> {
+		const pool = dicePools.find((p) => p.identifier === identifier);
+		if (!pool || pool.poolMode !== 'individual') return;
+		const newDice = [...pool.dice];
+		newDice.splice(dieIndex, 1);
+		const actor = getActor();
+		const update: Record<string, unknown> = {};
+		foundry.utils.setProperty(update, `flags.nimble.dicePools.${identifier}.dice`, newDice);
+		await actor.update(update);
+	}
+
+	// ============================================================================
+	// Return Public Interface
+	// ============================================================================
+
+	return {
+		get dicePools() {
+			return dicePools;
+		},
+		get hasDicePools() {
+			return hasDicePools;
+		},
+		handlePoolPipClick,
+		rollPool,
+		expendPool,
+		spendDie,
+	};
+}


### PR DESCRIPTION
## Summary

- Adds `DicePoolRule` rule type supporting four modes: `resource` (pips), `individual` (per-die chips), `accumulate`, and `store`
- Adds `DicePoolTracker` Svelte component rendered on the character sheet sidebar with full light/dark theme support
- Wires up Berserker Fury Dice (`individual`, rolls on Rage activation, resets on encounter end, max = `@key`), Commander Combat Dice (`resource`, fills on initiative, stays visible in combat), and Oathsworn Judgment Dice (`store`, roll full pool and expend)
- Fury dice die size and quantity scale with level via per-level overrides (d4→d12, up to `@key` dice)
- Migrations 019–021 upgrade embedded items to correct pool mode, level overrides, and add missing second Fury Dice rule for level 5+
- Clicking a Combat Dice pip rolls the die before spending it
- Pool badges use neutral header color (matching section headings); blue reserved for interactive value elements

## Test plan

- [ ] Berserker: rage → fury dice roll and appear as chips; spending a chip removes it; encounter end clears all dice; level 5+ gives 2 dice per rage; max respects `@key` modifier
- [ ] Commander: initiative fill → pips appear; clicking pip rolls die and decrements; pips stay visible in combat when empty; player-choice additional combat die stacks additive max
- [ ] Oathsworn: clicking badge rolls pool and stores total in value chip; clicking chip expends (clears to zero)
- [ ] Dark theme: all three trackers show correct neutral header badge + blue value elements
- [ ] Migration: existing embedded actors upgrade poolMode and level overrides correctly