### PR TITLE
chore: adjust aoe targeting string

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -1499,7 +1499,7 @@
 			"targets": "Targets",
 			"target": "Target",
 			"duration": "Duration",
-			"acquireTargetsFromTemplate": "Acquire targets from template",
+			"acquireTargetsFromTemplate": "AoE targeting (can't miss or crit)",
 			"targetCount": "Target Count",
 			"targetRestrictions": "Target Restrictions",
 			"attackType": "Attack Type",


### PR DESCRIPTION
## Summary

Clarifies "Acquire targets from template" to "AoE targeting" to make it clearer that the item/spell is now AoE and it can't crit or miss anymore.