### PR TITLE
fix(rules-builder): theme-token cleanup and JSON editor fixes

### DIFF
--- a/src/scss/base/_theme.scss
+++ b/src/scss/base/_theme.scss
@@ -27,6 +27,7 @@
 
 	/** OTHER COLORS **/
 	--nimble-box-background-color: hsl(293, 10%, 17%);
+	--nimble-card-background-color: hsl(293, 10%, 17%);
 	--nimble-sheet-background-color: unset;
 	--nimble-accent-color: hsl(278, 10%, 42%);
 	--nimble-range-slider-handle-color: var(--nimble-dark-text-color);

--- a/src/scss/base/_variables.scss
+++ b/src/scss/base/_variables.scss
@@ -97,6 +97,7 @@
 
 	// Use Foundry's background color to match system dialogs
 	--nimble-sheet-background: var(--color-bg, hsl(40, 20%, 94%));
+	--nimble-card-background-color: hsl(48, 17%, 97%);
 	--nimble-card-border-color: hsla(41, 18%, 54%, 25%);
 	--nimble-card-box-shadow: hsla(0, 0%, 0%, 0.24) 0 3px 8px;
 

--- a/src/view/rulesBuilder/RulesBuilderWindow.svelte
+++ b/src/view/rulesBuilder/RulesBuilderWindow.svelte
@@ -118,7 +118,7 @@
 		align-items: center;
 		justify-content: space-between;
 		padding: 0.5rem;
-		border-bottom: 1px solid hsla(41, 18%, 54%, 25%);
+		border-bottom: 1px solid var(--nimble-card-border-color);
 	}
 
 	.nimble-rules-builder-window__header-left,

--- a/src/view/rulesBuilder/components/RichTextEditor.svelte
+++ b/src/view/rulesBuilder/components/RichTextEditor.svelte
@@ -56,8 +56,8 @@
 		position: relative;
 		min-height: 6rem;
 		padding: 0.25rem;
-		background: var(--nimble-box-background-color);
-		border: 1px solid var(--nimble-accent-color);
+		background: var(--nimble-input-background-color);
+		border: 1px solid var(--nimble-input-border-color);
 		border-radius: 4px;
 
 		&--disabled {

--- a/src/view/rulesBuilder/components/RuleCard.svelte
+++ b/src/view/rulesBuilder/components/RuleCard.svelte
@@ -239,9 +239,10 @@
 		flex-direction: column;
 		gap: 0.5rem;
 		padding: 0.625rem;
-		background: var(--nimble-sheet-background);
-		border: 1px solid var(--nimble-accent-color);
-		border-radius: 6px;
+		background: var(--nimble-card-background-color);
+		border: 1px solid var(--nimble-card-border-color);
+		border-radius: 4px;
+		box-shadow: var(--nimble-box-shadow);
 
 		&--disabled {
 			opacity: 0.6;
@@ -284,8 +285,8 @@
 			padding: 0 0.25rem;
 			font-size: var(--nimble-xs-text);
 			text-align: center;
-			background: var(--nimble-sheet-background, transparent);
-			border: 1px solid var(--nimble-accent-color);
+			background: var(--nimble-input-background-color);
+			border: 1px solid var(--nimble-input-border-color);
 			border-radius: 3px;
 		}
 

--- a/src/view/rulesBuilder/components/RuleCard.svelte
+++ b/src/view/rulesBuilder/components/RuleCard.svelte
@@ -149,7 +149,7 @@
 		{#if state.showJson}
 			<div class="nimble-rule-card__json">
 				<textarea
-					class="nimble-code-block__text-area"
+					class="nimble-rule-card__json-textarea"
 					value={state.jsonDraft}
 					oninput={(e) => state.setJsonDraft((e.target as HTMLTextAreaElement).value)}
 					rows="11"
@@ -356,6 +356,17 @@
 			display: flex;
 			flex-direction: column;
 			gap: 0.375rem;
+		}
+
+		&__json-textarea {
+			padding: 0.5rem;
+			font-family: var(--nimble-mono-font);
+			font-size: var(--nimble-sm-text);
+			color: var(--nimble-code-editor-text-color);
+			background: var(--nimble-code-editor-background-color);
+			border: 1px solid var(--nimble-card-border-color);
+			border-radius: 4px;
+			resize: vertical;
 		}
 
 		&__json-controls {

--- a/src/view/rulesBuilder/components/RuleTypePicker.svelte
+++ b/src/view/rulesBuilder/components/RuleTypePicker.svelte
@@ -58,7 +58,7 @@
 			gap: 0.25rem;
 			padding: 0.375rem 0.5rem 0.5rem;
 			background: var(--nimble-box-background-color);
-			border: 1px solid hsla(41, 18%, 54%, 25%);
+			border: 1px solid var(--nimble-card-border-color);
 			border-radius: 6px;
 		}
 
@@ -72,7 +72,7 @@
 			text-transform: uppercase;
 			letter-spacing: 0.05em;
 			color: var(--color-text-dark-secondary);
-			border-bottom: 1px solid hsla(41, 18%, 54%, 15%);
+			border-bottom: 1px solid var(--nimble-card-border-color);
 
 			i {
 				color: var(--nimble-accent-color);
@@ -84,7 +84,7 @@
 			padding: 0 0.375rem;
 			font-size: var(--nimble-xs-text);
 			color: var(--color-text-dark-secondary);
-			background: var(--nimble-sheet-background, transparent);
+			background: var(--nimble-input-background-color);
 			border-radius: 999px;
 		}
 
@@ -100,10 +100,10 @@
 			align-items: center;
 			padding: 0.25rem 0.5rem;
 			min-height: 1.75rem;
-			background: var(--nimble-sheet-background);
+			background: var(--nimble-card-background-color);
 			color: inherit;
 			text-align: left;
-			border: 1px solid var(--nimble-accent-color);
+			border: 1px solid var(--nimble-card-border-color);
 			border-radius: 4px;
 			cursor: pointer;
 			overflow: hidden;
@@ -113,8 +113,12 @@
 
 			&:hover,
 			&:focus {
-				background: var(--nimble-selected-tag-background-color);
-				color: var(--nimble-selected-tag-text-color, var(--nimble-light-text-color));
+				background: color-mix(
+					in srgb,
+					var(--nimble-card-background-color) 80%,
+					var(--nimble-accent-color)
+				);
+				border-color: var(--nimble-accent-color);
 				outline: none;
 			}
 

--- a/src/view/rulesBuilder/components/SchemaFieldRenderer.svelte
+++ b/src/view/rulesBuilder/components/SchemaFieldRenderer.svelte
@@ -281,10 +281,13 @@
 				</button>
 			</div>
 		{:else}
-			<div class="nimble-renderer-error">
-				Field <code>{name}</code> uses an unsupported ArrayField element type. The renderer's closed
-				widget catalog needs an extension to handle it — see
-				<code>SchemaFieldRenderer.svelte</code>.
+			<div class="nimble-hint nimble-hint--warning nimble-renderer-error">
+				<i class="nimble-hint__icon fa-solid fa-circle-exclamation"></i>
+				<span>
+					Field <code>{name}</code> uses an unsupported ArrayField element type. The renderer's
+					closed widget catalog needs an extension to handle it — see
+					<code>SchemaFieldRenderer.svelte</code>.
+				</span>
 			</div>
 			{(() => {
 				console.warn(
@@ -315,12 +318,15 @@
 			{/each}
 		</fieldset>
 	{:else}
-		<div class="nimble-renderer-error">
-			Field <code>{name}</code> of type
-			<code>
-				{(field as { constructor?: { name?: string } })?.constructor?.name ?? 'unknown'}
-			</code>
-			has no widget. Add one to <code>SchemaFieldRenderer.svelte</code>.
+		<div class="nimble-hint nimble-hint--warning nimble-renderer-error">
+			<i class="nimble-hint__icon fa-solid fa-circle-exclamation"></i>
+			<span>
+				Field <code>{name}</code> of type
+				<code>
+					{(field as { constructor?: { name?: string } })?.constructor?.name ?? 'unknown'}
+				</code>
+				has no widget. Add one to <code>SchemaFieldRenderer.svelte</code>.
+			</span>
 		</div>
 		{(() => {
 			console.warn(
@@ -407,17 +413,5 @@
 			font-weight: 600;
 			color: var(--color-text-dark-secondary);
 		}
-	}
-
-	.nimble-renderer-error {
-		display: flex;
-		flex-direction: column;
-		gap: 0.25rem;
-		padding: 0.5rem;
-		background: var(--nimble-warning-background, rgba(200, 60, 60, 0.12));
-		color: var(--nimble-warning-text, darkred);
-		border: 1px solid var(--color-level-error, crimson);
-		border-radius: 4px;
-		font-size: var(--nimble-sm-text);
 	}
 </style>

--- a/src/view/sheets/pages/ItemRulesTab.svelte
+++ b/src/view/sheets/pages/ItemRulesTab.svelte
@@ -56,8 +56,8 @@
 					class="nimble-rules-tab__row"
 					class:nimble-rules-tab__row--disabled={rule.disabled}
 					data-reorder-id={rule.id}
-					draggable="true"
-					data-tooltip={localize('NIMBLE.rulesBuilder.dragToCopy')}
+					draggable={!jsonOpen}
+					data-tooltip={jsonOpen ? undefined : localize('NIMBLE.rulesBuilder.dragToCopy')}
 				>
 					<div class="nimble-rules-tab__row-main">
 						<span
@@ -101,7 +101,7 @@
 					{#if jsonOpen}
 						<div class="nimble-rules-tab__json">
 							<textarea
-								class="nimble-code-block__text-area"
+								class="nimble-rules-tab__json-textarea"
 								bind:value={state.jsonDrafts[rule.id]}
 								rows="11"
 								autocapitalize="off"
@@ -205,6 +205,17 @@
 		flex-direction: column;
 		gap: 0.375rem;
 		cursor: default;
+	}
+
+	.nimble-rules-tab__json-textarea {
+		padding: 0.5rem;
+		font-family: var(--nimble-mono-font);
+		font-size: var(--nimble-sm-text);
+		color: var(--nimble-code-editor-text-color);
+		background: var(--nimble-code-editor-background-color);
+		border: 1px solid var(--nimble-card-border-color);
+		border-radius: 4px;
+		resize: vertical;
 	}
 
 	.nimble-rules-tab__json-controls {


### PR DESCRIPTION
## Summary

Make the Rules Builder visually cohesive with the rest of the Nimble theme in both light and dark Foundry color schemes, and fix the JSON editor in the rules tab summary view.

## Changes

- Replace hardcoded colors (`hsla(41, 18%, 54%, …)`, `rgba(200, 60, 60, …)`, `darkred`, `crimson`) in the Rules Builder with Nimble theme tokens
- Define `--nimble-card-background-color` in both `:root` and `.theme-dark` — it was referenced by 20+ components but never set, leaving card surfaces transparent in light mode
- Renderer error blocks now reuse `.nimble-hint--warning` instead of rolling their own warning styles
- Rule-type picker hover uses a subtle accent-tinted lift instead of a harsh dark-purple swap
- Give both JSON textareas (rule card + rules-tab summary view) their own scoped style so they render as proper code editors (dark bg + light text) in both color schemes — the shared `.nimble-code-block__text-area` rule only set text color and left the textarea on white in light mode
- Disable `draggable` on rules-tab rows while the JSON editor is open so text selection in the textarea doesn't start a drag

## Test Plan

1. Open an item sheet with the Rules tab
2. Switch Foundry to **Configure Settings → Core → Color Scheme → Light**
3. Add a rule, expand its body — card surface, borders, and inputs should look like other Nimble panels (subtle lift from the window background, theme-aware borders)
4. Click the `</>` icon on a rule to toggle the JSON editor — text should be readable in both modes
5. In the rules tab (item sheet), click the `</>` toggle to expand the summary JSON view — same readability expected, and you should be able to select / edit text without the row starting to drag
6. Force a renderer error (e.g. open a rule with an unsupported schema field) — error box uses the standard Nimble warning callout
7. Switch back to **Dark** color scheme and confirm nothing regressed
8. Hover the rule-type picker buttons — subtle accent-tinted hover, no jarring color swap

## Checklist

- [x] Added or updated unit tests *(no new logic; existing 1227 tests pass)*
- [x] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [x] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** yes
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues

<!-- none -->