### PR TITLE
ci(dev-release): list merged PRs in rolling dev release body

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -17,8 +17,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+      pull-requests: read
+
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - name: Use Node.js ${{ env.node_version }}
       uses: actions/setup-node@v4
@@ -69,6 +75,15 @@ jobs:
       working-directory: ./dist
       run: zip -r ./nimble-dev.zip ./*
 
+    - name: Generate dev changelog
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        VERSION: ${{ steps.dev_version.outputs.version }}
+        SHORT_SHA: ${{ steps.dev_version.outputs.short_sha }}
+        TIMESTAMP: ${{ github.event.head_commit.timestamp }}
+        MANIFEST_URL: https://github.com/${{ github.repository }}/releases/download/${{ env.dev_tag }}/system.json
+      run: node ./build/generate-dev-changelog.mjs
+
     - name: Update Rolling Dev Release
       uses: ncipollo/release-action@v1
       with:
@@ -81,14 +96,4 @@ jobs:
         makeLatest: false
         token: ${{ secrets.GITHUB_TOKEN }}
         artifacts: './dist/system.json,./dist/nimble-dev.zip'
-        body: |
-          Rolling development build from the `dev` branch. **Unstable — for testing only.**
-
-          - Version: `${{ steps.dev_version.outputs.version }}`
-          - Commit: [`${{ steps.dev_version.outputs.short_sha }}`](https://github.com/${{ github.repository }}/commit/${{ github.sha }})
-          - Built: ${{ github.event.head_commit.timestamp }}
-
-          Install in Foundry via Manifest URL:
-          ```
-          https://github.com/${{ github.repository }}/releases/download/${{ env.dev_tag }}/system.json
-          ```
+        bodyFile: ./release-body.md

--- a/build/generate-dev-changelog.mjs
+++ b/build/generate-dev-changelog.mjs
@@ -1,0 +1,213 @@
+/* eslint-disable no-console */
+/**
+ * Generates the release body for the rolling `latest-dev` release, including
+ * a list of PRs merged since the previous dev build. CI-only: invoked by
+ * .github/workflows/dev-release.yml.
+ *
+ *   - Looks up the previous dev-build SHA via `gh release view latest-dev`.
+ *   - Lists PRs (and any direct commits) in the range prev..HEAD.
+ *   - Writes release-body.md ready for ncipollo/release-action `bodyFile:`.
+ *
+ * Failure modes:
+ *   - No prior `latest-dev` release → skip changelog section entirely.
+ *   - Empty SHA range → skip changelog section entirely.
+ *   - Prev SHA not in history (force-push) → skip changelog section.
+ *   - `gh pr view` fails for a PR → include PR with title from commit subject.
+ *   - More than 50 PRs → cap at 50, note "and N earlier PRs not shown".
+ */
+
+import { execFileSync } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
+
+const PREV_TAG = 'latest-dev';
+const MAX_PRS = 50;
+
+const REPO = process.env.GITHUB_REPOSITORY ?? '';
+const REPO_URL = `https://github.com/${REPO}`;
+
+function sh(cmd, args, { allowFailure = false } = {}) {
+	try {
+		return execFileSync(cmd, args, {
+			encoding: 'utf8',
+			stdio: ['ignore', 'pipe', 'pipe'],
+		}).trimEnd();
+	} catch (err) {
+		if (allowFailure) return null;
+		throw err;
+	}
+}
+
+function getPreviousSha() {
+	const json = sh('gh', ['release', 'view', PREV_TAG, '--json', 'targetCommitish'], {
+		allowFailure: true,
+	});
+	if (!json) return null;
+	try {
+		const parsed = JSON.parse(json);
+		const sha = parsed.targetCommitish;
+		if (!sha || typeof sha !== 'string') return null;
+		const exists = sh('git', ['cat-file', '-e', sha], { allowFailure: true });
+		if (exists === null) {
+			console.log(
+				`[changelog] Previous SHA ${sha} not in local history (force-push?); skipping changelog.`,
+			);
+			return null;
+		}
+		return sha;
+	} catch {
+		return null;
+	}
+}
+
+function getCommitsInRange(prevSha, currentSha) {
+	const out = sh(
+		'git',
+		['log', '--no-merges', '--pretty=format:%H%x09%s', `${prevSha}..${currentSha}`],
+		{ allowFailure: true },
+	);
+	if (out === null || out === '') return [];
+	return out
+		.split('\n')
+		.map((line) => {
+			const [sha, ...rest] = line.split('\t');
+			return { sha, subject: rest.join('\t') };
+		})
+		.filter((c) => c.sha);
+}
+
+function parsePrNumber(subject) {
+	const match = subject.match(/\(#(\d+)\)\s*$/);
+	return match ? Number(match[1]) : null;
+}
+
+function fetchPr(number) {
+	const json = sh('gh', ['pr', 'view', String(number), '--json', 'number,title,url'], {
+		allowFailure: true,
+	});
+	if (!json) return null;
+	try {
+		return JSON.parse(json);
+	} catch {
+		return null;
+	}
+}
+
+function buildEntries(commits) {
+	const entries = [];
+	for (const commit of commits) {
+		const prNumber = parsePrNumber(commit.subject);
+		if (prNumber) {
+			const pr = fetchPr(prNumber);
+			if (pr) {
+				entries.push({ kind: 'pr', number: pr.number, title: pr.title, url: pr.url });
+			} else {
+				const titleOnly = commit.subject.replace(/\s*\(#\d+\)\s*$/, '');
+				entries.push({
+					kind: 'pr',
+					number: prNumber,
+					title: titleOnly,
+					url: `${REPO_URL}/pull/${prNumber}`,
+				});
+			}
+		} else {
+			entries.push({
+				kind: 'commit',
+				sha: commit.sha,
+				shortSha: commit.sha.slice(0, 7),
+				title: commit.subject,
+				url: `${REPO_URL}/commit/${commit.sha}`,
+			});
+		}
+	}
+	return entries;
+}
+
+function escapeLinkText(text) {
+	return text.replace(/\[/g, '\\[').replace(/\]/g, '\\]');
+}
+
+function renderPrList(entries, truncatedCount) {
+	const lines = ['**Changes**'];
+	for (const entry of entries) {
+		const safeTitle = escapeLinkText(entry.title);
+		if (entry.kind === 'pr') {
+			lines.push(`- ${safeTitle} ([#${entry.number}](${entry.url}))`);
+		} else {
+			lines.push(`- ${safeTitle} ([\`${entry.shortSha}\`](${entry.url}))`);
+		}
+	}
+	if (truncatedCount > 0) {
+		lines.push(`- _…and ${truncatedCount} earlier PR${truncatedCount === 1 ? '' : 's'} not shown_`);
+	}
+	return lines.join('\n');
+}
+
+function buildBody({ version, shortSha, sha, timestamp, manifestUrl, hasChanges, prListMarkdown }) {
+	const header = [
+		'Rolling development build from the `dev` branch. **Unstable — for testing only.**',
+		'',
+		`- Version: \`${version}\``,
+		`- Commit: [\`${shortSha}\`](${REPO_URL}/commit/${sha})`,
+		`- Built: ${timestamp}`,
+		'',
+	];
+
+	const install = ['Install in Foundry via Manifest URL:', '```', manifestUrl, '```'];
+
+	if (!hasChanges) {
+		return [...header, ...install].join('\n');
+	}
+
+	return [...header, prListMarkdown, '', ...install].join('\n');
+}
+
+function readEnv(name, { required = false } = {}) {
+	const value = process.env[name];
+	if (required && !value) {
+		console.error(`[changelog] Missing required env var: ${name}`);
+		process.exit(1);
+	}
+	return value ?? '';
+}
+
+function run() {
+	const currentSha = readEnv('GITHUB_SHA', { required: true });
+	const version = readEnv('VERSION', { required: true });
+	const shortSha = readEnv('SHORT_SHA', { required: true });
+	const timestamp = readEnv('TIMESTAMP');
+	const manifestUrl = readEnv('MANIFEST_URL', { required: true });
+
+	const prevSha = getPreviousSha();
+	let entries = [];
+	let truncatedCount = 0;
+
+	if (prevSha && prevSha !== currentSha) {
+		const commits = getCommitsInRange(prevSha, currentSha);
+		if (commits.length > MAX_PRS) {
+			truncatedCount = commits.length - MAX_PRS;
+			entries = buildEntries(commits.slice(0, MAX_PRS));
+		} else {
+			entries = buildEntries(commits);
+		}
+	}
+
+	const hasChanges = entries.length > 0;
+	const prListMarkdown = hasChanges ? renderPrList(entries, truncatedCount) : '';
+
+	const body = buildBody({
+		version,
+		shortSha,
+		sha: currentSha,
+		timestamp,
+		manifestUrl,
+		hasChanges,
+		prListMarkdown,
+	});
+
+	writeFileSync('release-body.md', body);
+	console.log(
+		`[changelog] hasChanges=${hasChanges}, entries=${entries.length}, truncated=${truncatedCount}`,
+	);
+}
+
+run();


### PR DESCRIPTION
## Summary

Adds a list of merged PRs to the rolling `latest-dev` release body so users visiting the release page can see what changed since the previous dev build.

## Changes

- New script `build/generate-dev-changelog.mjs` that diffs HEAD against the SHA of the previous `latest-dev` release, resolves PR titles/links via `gh pr view`, and writes `release-body.md`.
- `.github/workflows/dev-release.yml`:
  - Added `permissions: contents: write` + `pull-requests: read` to the job.
  - `actions/checkout` now uses `fetch-depth: 0` so the script can `git log` across the full range.
  - New "Generate dev changelog" step runs the script before the release step.
  - Release step now uses `bodyFile: ./release-body.md` instead of an inline `body:` block; the script owns the full body shape (header + changelog + install instructions).
- Falls back gracefully: no prior release, empty SHA range, force-pushed history, or a failed `gh pr view` all degrade safely (no changelog section, or PR entry rendered with title-from-commit-subject only). Caps at 50 PRs and notes the truncation.

## Test Plan

The workflow only runs on push to `dev` and `workflow_dispatch`, so end-to-end verification happens after merge. Local sanity checks already performed:

- Ran the script with `GH_TOKEN=invalid` to simulate "no prior release available" — produces today's release body shape unchanged (no changelog section). Verified `release-body.md` matches expected output byte-for-byte except for the new metadata.
- Syntax-checked the script with `node --check`.
- Parsed the workflow YAML with `js-yaml` to confirm it's valid.

To verify post-merge:

1. Merge to `dev`. The next push to `dev` will trigger the workflow.
2. Visit the `latest-dev` release page and confirm the body now includes a `**Changes**` section listing the merged PRs since the previous build, each linked to its PR.
3. Subsequent pushes should produce diffs from the *previous* build SHA, not from `main`, so the list naturally shrinks once you've installed a recent dev build.

## Checklist

- [ ] Added or updated unit tests
- [x] PR targets the `dev` branch
- [ ] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [ ] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** yes
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues

<!-- None -->