### PR TITLE
feat(spells): deduplicate spell index by signature, prefer default Nimble compendium

### DIFF
--- a/src/documents/dialogs/CharacterCreationDialog.test.ts
+++ b/src/documents/dialogs/CharacterCreationDialog.test.ts
@@ -25,6 +25,7 @@ function createSpellEntry({
 		school,
 		tier,
 		isUtility,
+		identifier: '',
 		classes,
 	};
 }

--- a/src/utils/getSpells.test.ts
+++ b/src/utils/getSpells.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { SpellIndex, SpellIndexEntry } from './getSpells.js';
-import { buildSpellIndex } from './getSpells.js';
+import { buildSpellIndex, spellSignature } from './getSpells.js';
 import { getSpellsFromIndex } from './getSpellsFromIndex.js';
 
 interface TestSpellSource {
@@ -25,6 +25,7 @@ function createIndexedSpell({
 	school = 'fire',
 	tier = 0,
 	isUtility = false,
+	identifier = '',
 	classes = [],
 }: {
 	uuid: string;
@@ -32,6 +33,7 @@ function createIndexedSpell({
 	school?: string;
 	tier?: number;
 	isUtility?: boolean;
+	identifier?: string;
 	classes?: string[];
 }): SpellIndexEntry {
 	return {
@@ -41,6 +43,7 @@ function createIndexedSpell({
 		school,
 		tier,
 		isUtility,
+		identifier,
 		classes,
 	};
 }
@@ -170,7 +173,13 @@ describe('buildSpellIndex', () => {
 		const fireCantrips = index.get('fire')?.get(0) ?? [];
 
 		expect(itemPack.getIndex).toHaveBeenCalledWith({
-			fields: ['system.school', 'system.tier', 'system.classes', 'system.properties.selected'],
+			fields: [
+				'system.school',
+				'system.tier',
+				'system.identifier',
+				'system.classes',
+				'system.properties.selected',
+			],
 		});
 		expect(fireCantrips.map((spell) => spell.name)).toEqual([
 			'Class Bolt',
@@ -189,6 +198,76 @@ describe('buildSpellIndex', () => {
 			)?.classes,
 		).toEqual(['mage']);
 		expect(fireCantrips.some((spell) => spell.uuid === secretSpell.uuid)).toBe(false);
+	});
+
+	it('deduplicates spells across packs using identifier+tier+school signature', async () => {
+		const nimbleSpell = createSpellSource({
+			uuid: 'Compendium.nimble.nimble-spells.Item.original',
+			name: 'Flame Dart',
+			system: { school: 'fire', tier: 0, properties: { selected: [] } },
+		});
+		const copySpell = createSpellSource({
+			uuid: 'Compendium.world-copy.nimble-spells-copy.Item.copy',
+			name: 'Flame Dart',
+			system: { school: 'fire', tier: 0, properties: { selected: [] } },
+		});
+
+		const nimblePack = {
+			documentName: 'Item',
+			collection: 'nimble.nimble-spells',
+			getIndex: vi.fn().mockResolvedValue([nimbleSpell]),
+		};
+		const copyPack = {
+			documentName: 'Item',
+			collection: 'world-copy.nimble-spells-copy',
+			getIndex: vi.fn().mockResolvedValue([copySpell]),
+		};
+
+		// Copy pack listed first — nimble should still win because of sorting
+		(game as unknown as { packs: unknown[] }).packs = [copyPack, nimblePack];
+
+		const index = await buildSpellIndex();
+		const fireCantrips = index.get('fire')?.get(0) ?? [];
+
+		expect(fireCantrips).toHaveLength(1);
+		expect(fireCantrips[0].uuid).toBe(nimbleSpell.uuid);
+	});
+
+	it('stores identifier in index entries', async () => {
+		const spellWithId = createSpellSource({
+			uuid: 'Compendium.nimble.nimble-spells.Item.frost-bolt',
+			name: 'Frost Bolt',
+			system: { school: 'ice', tier: 1, properties: { selected: [] } },
+		});
+		(spellWithId as any).system!.identifier = 'frost-bolt';
+
+		const pack = {
+			documentName: 'Item',
+			collection: 'nimble.nimble-spells',
+			getIndex: vi.fn().mockResolvedValue([spellWithId]),
+		};
+		(game as unknown as { packs: unknown[] }).packs = [pack];
+
+		const index = await buildSpellIndex();
+		const iceT1 = index.get('ice')?.get(1) ?? [];
+
+		expect(iceT1).toHaveLength(1);
+		expect(iceT1[0].identifier).toBe('frost-bolt');
+	});
+});
+
+describe('spellSignature', () => {
+	it('uses identifier when set', () => {
+		expect(spellSignature('frost-bolt', 'Frost Bolt', 1, 'ice')).toBe('frost-bolt:1:ice');
+	});
+
+	it('falls back to lowercased name when identifier is empty', () => {
+		expect(spellSignature('', 'Frost Bolt', 1, 'ice')).toBe('frost bolt:1:ice');
+	});
+
+	it('trims whitespace from both identifier and name', () => {
+		expect(spellSignature('  frost-bolt  ', 'Frost Bolt', 1, 'ice')).toBe('frost-bolt:1:ice');
+		expect(spellSignature('', '  Frost Bolt  ', 1, 'ice')).toBe('frost bolt:1:ice');
 	});
 });
 

--- a/src/utils/getSpells.ts
+++ b/src/utils/getSpells.ts
@@ -3,6 +3,8 @@
  * Used during character creation to quickly find spells by school and tier.
  */
 
+const DEFAULT_NIMBLE_SPELL_PACK = 'nimble.nimble-spells';
+
 /**
  * Lightweight entry stored in the spell index.
  * Contains only the data needed for display and granting.
@@ -14,8 +16,25 @@ export interface SpellIndexEntry {
 	school: string;
 	tier: number;
 	isUtility: boolean;
+	/** Semantic slug identifier from system.identifier, or empty string if unset */
+	identifier: string;
 	/** Class restrictions - empty array means available to all classes */
 	classes: string[];
+}
+
+/**
+ * Produces a stable deduplication key for a spell using its identifier (or name
+ * as fallback), tier, and school.  Two spells with the same key are treated as
+ * the same spell regardless of which pack they come from.
+ */
+export function spellSignature(
+	identifier: string,
+	name: string,
+	tier: number,
+	school: string,
+): string {
+	const key = identifier.trim() || name.toLowerCase().trim();
+	return `${key}:${tier}:${school}`;
 }
 
 /**
@@ -36,6 +55,7 @@ interface SpellPackIndexEntry {
 	system?: {
 		school?: string;
 		tier?: number;
+		identifier?: string;
 		classes?: string[];
 		properties?: {
 			selected?: string[];
@@ -54,8 +74,11 @@ export async function buildSpellIndex(): Promise<SpellIndex> {
 	// Track seen UUIDs to avoid duplicates.
 	// Also track compendium source UUIDs covered by world items so we can skip
 	// the original compendium entry when a world-item copy already exists.
+	// Finally, track spell signatures (identifier+tier+school) so that copy packs
+	// don't produce duplicate entries when the default Nimble pack is indexed first.
 	const seen = new Set<string>();
 	const seenCompendiumSources = new Set<string>();
+	const seenSignatures = new Set<string>();
 
 	/**
 	 * Adds a spell entry to the index for a specific school and tier.
@@ -86,6 +109,7 @@ export async function buildSpellIndex(): Promise<SpellIndex> {
 		const system = item.system as {
 			school?: string;
 			tier?: number;
+			identifier?: string;
 			classes?: string[];
 			properties?: { selected?: string[] };
 		};
@@ -97,14 +121,18 @@ export async function buildSpellIndex(): Promise<SpellIndex> {
 		if (selectedProperties.includes('secretSpell')) continue;
 
 		const isUtility = selectedProperties.includes('utilitySpell');
+		const identifier = system.identifier ?? '';
+		const name = item.name ?? 'Unknown Spell';
+		const tier = system.tier ?? 0;
 
 		const added = addToIndex({
 			uuid: item.uuid,
-			name: item.name ?? 'Unknown Spell',
+			name,
 			img: item.img ?? 'icons/svg/item-bag.svg',
 			school: system.school,
-			tier: system.tier ?? 0,
+			tier,
 			isUtility,
+			identifier,
 			classes: system.classes ?? [],
 		});
 
@@ -112,21 +140,30 @@ export async function buildSpellIndex(): Promise<SpellIndex> {
 		// covered so the compendium's own entry is skipped below (prevents duplicates
 		// when a player has world-item copies of compendium spells).
 		if (added) {
+			seenSignatures.add(spellSignature(identifier, name, tier, system.school));
 			const compendiumSource = (item._stats as { compendiumSource?: string } | undefined)
 				?.compendiumSource;
 			if (compendiumSource) seenCompendiumSources.add(compendiumSource);
 		}
 	}
 
-	// Process compendium packs
+	// Process compendium packs — default Nimble pack first so its entries win over
+	// any copy packs a GM may have created with different UUIDs.
 	const indexFields = [
 		'system.school',
 		'system.tier',
+		'system.identifier',
 		'system.classes',
 		'system.properties.selected',
 	] as string[];
 
-	for (const pack of game.packs) {
+	const sortedPacks = [...game.packs].sort((a, b) => {
+		if (a.collection === DEFAULT_NIMBLE_SPELL_PACK) return -1;
+		if (b.collection === DEFAULT_NIMBLE_SPELL_PACK) return 1;
+		return 0;
+	});
+
+	for (const pack of sortedPacks) {
 		if (pack.documentName !== 'Item') continue;
 
 		// @ts-expect-error - Foundry types don't include custom index fields, but the API accepts them
@@ -146,17 +183,29 @@ export async function buildSpellIndex(): Promise<SpellIndex> {
 			// Skip secret spells - they should never be granted during character creation
 			if (selectedProperties.includes('secretSpell')) continue;
 
+			const identifier = system.identifier ?? '';
+			const name = packEntry.name ?? 'Unknown Spell';
+			const tier = system.tier ?? 0;
+			const sig = spellSignature(identifier, name, tier, system.school);
+
+			// Skip if another pack (or a world item) already contributed a spell with this
+			// identifier+tier+school combination.  Processing the default Nimble pack first
+			// guarantees its entries take priority over any copy packs.
+			if (seenSignatures.has(sig)) continue;
+
 			const isUtility = selectedProperties.includes('utilitySpell');
 
-			addToIndex({
+			const added = addToIndex({
 				uuid: packEntry.uuid,
-				name: packEntry.name ?? 'Unknown Spell',
+				name,
 				img: packEntry.img ?? 'icons/svg/item-bag.svg',
 				school: system.school,
-				tier: system.tier ?? 0,
+				tier,
 				isUtility,
+				identifier,
 				classes: system.classes ?? [],
 			});
+			if (added) seenSignatures.add(sig);
 		}
 	}
 

--- a/src/view/dialogs/CharacterLevelUpDialogState.svelte.ts
+++ b/src/view/dialogs/CharacterLevelUpDialogState.svelte.ts
@@ -8,7 +8,7 @@ import getChoicesFromCompendium from '#utils/getChoicesFromCompendium.ts';
 import getClassFeaturesFromIndex, { buildClassFeatureIndex } from '#utils/getClassFeatures.ts';
 import getEpicBoons from '#utils/getEpicBoons.ts';
 import type { SpellIndex, SpellIndexEntry } from '#utils/getSpells.js';
-import { buildSpellIndex } from '#utils/getSpells.ts';
+import { buildSpellIndex, spellSignature } from '#utils/getSpells.ts';
 import { getSpellsFromIndex } from '#utils/getSpellsFromIndex.ts';
 import getSubclassChoices from '#utils/getSubclassChoices.ts';
 import getSubclassFeaturesFromIndex from '#utils/getSubclassFeatures.ts';
@@ -33,6 +33,8 @@ interface LevelUpDocument {
 		system?: {
 			rules?: Array<{ type: string; [key: string]: unknown }>;
 			school?: string;
+			tier?: number;
+			identifier?: string;
 			parentClass?: string;
 		};
 		_stats?: { compendiumSource?: string };
@@ -222,12 +224,22 @@ export function createLevelUpState(
 		const classIdentifier = characterClass?.identifier ?? '';
 		const items = getDocument().items ?? [];
 
-		// Get already-owned spell UUIDs
+		// Get already-owned spell UUIDs and signatures.
+		// Signatures (identifier+tier+school) catch spells that were granted from a copy
+		// pack — their compendiumSource won't match the canonical Nimble UUID now in the
+		// index, so the UUID check alone would re-grant them.
 		const ownedSpellUuids = new Set<string>();
+		const ownedSpellSignatures = new Set<string>();
 		for (const item of items) {
 			if (item.type !== 'spell') continue;
 			const source = item._stats?.compendiumSource;
 			if (source) ownedSpellUuids.add(source);
+			const sys = item.system;
+			if (sys?.school && sys.tier !== undefined) {
+				ownedSpellSignatures.add(
+					spellSignature(sys.identifier ?? '', item.name ?? '', sys.tier, sys.school),
+				);
+			}
 		}
 
 		// Derive known schools from auto-mode grantSpells rules on class features,
@@ -267,6 +279,7 @@ export function createLevelUpState(
 			levelingTo,
 			ownedSpellUuids,
 			knownSchools,
+			ownedSpellSignatures,
 		);
 
 		autoGrantedSpells = result.autoGrant;

--- a/src/view/dialogs/characterCreation/state.svelte.test.ts
+++ b/src/view/dialogs/characterCreation/state.svelte.test.ts
@@ -38,6 +38,7 @@ function createSpellEntry({
 		school,
 		tier,
 		isUtility,
+		identifier: '',
 		classes,
 	};
 }

--- a/src/view/dialogs/components/characterCreator/SchoolSelection.svelte.test.ts
+++ b/src/view/dialogs/components/characterCreator/SchoolSelection.svelte.test.ts
@@ -25,6 +25,7 @@ function createSpellEntry({
 		school,
 		tier: 0,
 		isUtility,
+		identifier: '',
 		classes,
 	};
 }

--- a/src/view/dialogs/components/characterCreator/SpellSelection.svelte.test.ts
+++ b/src/view/dialogs/components/characterCreator/SpellSelection.svelte.test.ts
@@ -21,6 +21,7 @@ function createSpellEntry({
 		school,
 		tier: 0,
 		isUtility: false,
+		identifier: '',
 		classes: [],
 	};
 }

--- a/src/view/dialogs/spellGrantUtils.test.ts
+++ b/src/view/dialogs/spellGrantUtils.test.ts
@@ -18,6 +18,7 @@ function createSpellEntry(
 		school: 'fire',
 		tier: 0,
 		isUtility: false,
+		identifier: '',
 		classes: [],
 		...overrides,
 	};
@@ -240,6 +241,33 @@ describe('collectSpellGrants', () => {
 
 		const owned = new Set(['fire-cantrip-1']);
 		const result = collectSpellGrants([rules], index, 'mage', 2, owned, new Set());
+
+		expect(result.autoGrant.map((s) => s.uuid)).toEqual(['fire-cantrip-2']);
+	});
+
+	it('skips spells whose signature matches an owned spell from a different pack', () => {
+		const index = buildTestIndex();
+		const rules: RulesArray = [
+			{
+				type: 'grantSpells',
+				schools: ['fire'],
+				tiers: [0],
+				mode: 'auto',
+				predicate: { level: { min: 2 } },
+			},
+		];
+
+		// fire-cantrip-1 was granted from a copy pack; its signature matches the index entry
+		const ownedSignatures = new Set(['ember:0:fire']);
+		const result = collectSpellGrants(
+			[rules],
+			index,
+			'mage',
+			2,
+			new Set(),
+			new Set(),
+			ownedSignatures,
+		);
 
 		expect(result.autoGrant.map((s) => s.uuid)).toEqual(['fire-cantrip-2']);
 	});

--- a/src/view/dialogs/spellGrantUtils.ts
+++ b/src/view/dialogs/spellGrantUtils.ts
@@ -1,4 +1,5 @@
 import type { SpellIndex, SpellIndexEntry } from '#utils/getSpells.js';
+import { spellSignature } from '#utils/getSpells.ts';
 import { getSpellsFromIndex } from '#utils/getSpellsFromIndex.ts';
 import localize from '#utils/localize.ts';
 
@@ -90,6 +91,10 @@ function buildUuidLookup(spellIndex: SpellIndex): Map<string, SpellIndexEntry> {
 /**
  * Collects spell grants from grantSpells rules, filtered by level predicate.
  * Returns auto-granted spells (filtered by ownership) and school selection groups.
+ *
+ * Pass `ownedSpellSignatures` to also filter by identifier+tier+school, which
+ * handles actors that received spells from a copy pack whose UUIDs differ from
+ * the canonical Nimble compendium UUIDs now stored in the index.
  */
 export function collectSpellGrants(
 	rulesArrays: RulesArray[],
@@ -98,12 +103,22 @@ export function collectSpellGrants(
 	targetLevel: number,
 	ownedSpellUuids: Set<string>,
 	knownSchools: Set<string>,
+	ownedSpellSignatures: Set<string> = new Set(),
 ): SpellGrantResult {
 	const autoGrant: SpellIndexEntry[] = [];
 	const schoolSelections: SchoolSelectionGroup[] = [];
 	const spellSelections: SpellSelectionGroup[] = [];
 	const seenUuids = new Set<string>();
 	const uuidLookup = buildUuidLookup(spellIndex);
+
+	function isOwned(spell: SpellIndexEntry): boolean {
+		return (
+			ownedSpellUuids.has(spell.uuid) ||
+			ownedSpellSignatures.has(
+				spellSignature(spell.identifier, spell.name, spell.tier, spell.school),
+			)
+		);
+	}
 
 	for (const rules of rulesArrays) {
 		for (const rule of rules) {
@@ -122,7 +137,14 @@ export function collectSpellGrants(
 						if (seenUuids.has(uuid) || ownedSpellUuids.has(uuid)) continue;
 						seenUuids.add(uuid);
 						const spell = uuidLookup.get(uuid);
-						if (spell) autoGrant.push(spell);
+						if (!spell) continue;
+						if (
+							ownedSpellSignatures.has(
+								spellSignature(spell.identifier, spell.name, spell.tier, spell.school),
+							)
+						)
+							continue;
+						autoGrant.push(spell);
 					}
 				} else if (resolvedSchools.length > 0) {
 					const spells = getSpellsFromIndex(spellIndex, resolvedSchools, tiers, {
@@ -130,7 +152,7 @@ export function collectSpellGrants(
 						forClass: classIdentifier,
 					});
 					for (const spell of spells) {
-						if (seenUuids.has(spell.uuid) || ownedSpellUuids.has(spell.uuid)) continue;
+						if (seenUuids.has(spell.uuid) || isOwned(spell)) continue;
 						seenUuids.add(spell.uuid);
 						autoGrant.push(spell);
 					}
@@ -143,7 +165,7 @@ export function collectSpellGrants(
 						utilityOnly,
 						forClass: classIdentifier,
 					});
-					return schoolSpells.some((s) => !ownedSpellUuids.has(s.uuid));
+					return schoolSpells.some((s) => !isOwned(s));
 				});
 
 				if (availableSchools.length > 0) {
@@ -168,7 +190,7 @@ export function collectSpellGrants(
 					const availableSpells = getSpellsFromIndex(spellIndex, [school], tiers, {
 						utilityOnly,
 						forClass: classIdentifier,
-					}).filter((s) => !ownedSpellUuids.has(s.uuid));
+					}).filter((s) => !isOwned(s));
 
 					if (availableSpells.length > 0) {
 						spellSelections.push({


### PR DESCRIPTION
## Summary

- `buildSpellIndex` now sorts packs so `nimble.nimble-spells` is processed first; copy packs with different UUIDs but identical spells are skipped via an `identifier+tier+school` signature check
- World item signatures are also tracked so compendium entries do not re-appear alongside a world spell with the same characteristics
- `collectSpellGrants` gains an optional `ownedSpellSignatures` parameter; the level-up dialog builds and passes this set so actors that received spells from a copy pack are not re-granted those spells at level-up
- `SpellIndexEntry` gains an `identifier` field (carries `system.identifier` when set, otherwise empty string)

## Test plan

- [ ] All 1097 existing tests pass
- [ ] New `buildSpellIndex` tests: signature dedup across packs, nimble-wins-over-copy, identifier stored in entry
- [ ] New `spellSignature` unit tests: identifier vs name fallback, whitespace trimming
- [ ] New `collectSpellGrants` test: `ownedSpellSignatures` prevents re-grant of copy-pack spells
- [ ] Manual: create a character with a copy of the Nimble spell compendium present — each spell should appear only once in the grant list