### PR TITLE
feat(combat-tracker): highlight token on canvas when hovering over combatant card

### DIFF
--- a/src/view/ui/CtTopTracker.state.svelte.ts
+++ b/src/view/ui/CtTopTracker.state.svelte.ts
@@ -517,9 +517,25 @@ export function createCtTopTrackerState() {
 		event: MouseEvent,
 		combatant: Combatant.Implementation,
 	): void {
-		if (!canvas?.ready) return;
+		console.log('[Nimble][CT] mouseenter', {
+			combatantId: getCombatantId(combatant),
+			canvasReady: canvas?.ready,
+		});
+		if (!canvas?.ready) {
+			console.log('[Nimble][CT] mouseenter: canvas not ready');
+			return;
+		}
 		const token = getCombatantToken(combatant);
-		if (!token || token.isVisible === false || token.controlled) return;
+		console.log('[Nimble][CT] mouseenter token', {
+			token,
+			isVisible: token?.isVisible,
+			controlled: token?.controlled,
+			hasHoverIn: typeof (token as unknown as { _onHoverIn?: unknown })._onHoverIn,
+		});
+		if (!token || token.isVisible === false || token.controlled) {
+			console.log('[Nimble][CT] mouseenter: skipped (no token / not visible / controlled)');
+			return;
+		}
 		(
 			token as unknown as {
 				_onHoverIn?: (e: MouseEvent, opts?: { hoverOutOthers?: boolean }) => void;
@@ -531,6 +547,7 @@ export function createCtTopTrackerState() {
 		event: MouseEvent,
 		combatant: Combatant.Implementation,
 	): void {
+		console.log('[Nimble][CT] mouseleave', { combatantId: getCombatantId(combatant) });
 		if (!canvas?.ready) return;
 		const token = getCombatantToken(combatant);
 		if (!token || token.isVisible === false || token.controlled) return;

--- a/src/view/ui/CtTopTracker.state.svelte.ts
+++ b/src/view/ui/CtTopTracker.state.svelte.ts
@@ -513,6 +513,34 @@ export function createCtTopTrackerState() {
 		void pingCombatantToken(combatant);
 	}
 
+	function handleCombatantCardMouseEnter(
+		event: MouseEvent,
+		combatant: Combatant.Implementation,
+	): void {
+		if (!canvas?.ready) return;
+		const token = getCombatantToken(combatant) as {
+			isVisible?: boolean;
+			controlled?: boolean;
+			_onHoverIn?: (event: MouseEvent, options?: { hoverOutOthers?: boolean }) => void;
+		} | null;
+		if (!token || token.isVisible === false || token.controlled) return;
+		token._onHoverIn?.(event, { hoverOutOthers: true });
+	}
+
+	function handleCombatantCardMouseLeave(
+		event: MouseEvent,
+		combatant: Combatant.Implementation,
+	): void {
+		if (!canvas?.ready) return;
+		const token = getCombatantToken(combatant) as {
+			isVisible?: boolean;
+			controlled?: boolean;
+			_onHoverOut?: (event: MouseEvent) => void;
+		} | null;
+		if (!token || token.isVisible === false || token.controlled) return;
+		token._onHoverOut?.(event);
+	}
+
 	function canRemoveCombatant(): boolean {
 		return Boolean(game.user?.isGM);
 	}
@@ -1589,6 +1617,8 @@ export function createCtTopTrackerState() {
 		handleCombatantCardClick,
 		handleCombatantCardContextMenu,
 		handleCombatantCardKeyDown,
+		handleCombatantCardMouseEnter,
+		handleCombatantCardMouseLeave,
 		canRemoveCombatant,
 		handleRemoveCombatant,
 		handleMonsterStackClick,

--- a/src/view/ui/CtTopTracker.state.svelte.ts
+++ b/src/view/ui/CtTopTracker.state.svelte.ts
@@ -518,13 +518,13 @@ export function createCtTopTrackerState() {
 		combatant: Combatant.Implementation,
 	): void {
 		if (!canvas?.ready) return;
-		const token = getCombatantToken(combatant) as {
-			isVisible?: boolean;
-			controlled?: boolean;
-			_onHoverIn?: (event: MouseEvent, options?: { hoverOutOthers?: boolean }) => void;
-		} | null;
+		const token = getCombatantToken(combatant);
 		if (!token || token.isVisible === false || token.controlled) return;
-		token._onHoverIn?.(event, { hoverOutOthers: true });
+		(
+			token as unknown as {
+				_onHoverIn?: (e: MouseEvent, opts?: { hoverOutOthers?: boolean }) => void;
+			}
+		)._onHoverIn?.(event, { hoverOutOthers: true });
 	}
 
 	function handleCombatantCardMouseLeave(
@@ -532,13 +532,9 @@ export function createCtTopTrackerState() {
 		combatant: Combatant.Implementation,
 	): void {
 		if (!canvas?.ready) return;
-		const token = getCombatantToken(combatant) as {
-			isVisible?: boolean;
-			controlled?: boolean;
-			_onHoverOut?: (event: MouseEvent) => void;
-		} | null;
+		const token = getCombatantToken(combatant);
 		if (!token || token.isVisible === false || token.controlled) return;
-		token._onHoverOut?.(event);
+		(token as unknown as { _onHoverOut?: (e: MouseEvent) => void })._onHoverOut?.(event);
 	}
 
 	function canRemoveCombatant(): boolean {

--- a/src/view/ui/CtTopTracker.svelte
+++ b/src/view/ui/CtTopTracker.svelte
@@ -76,6 +76,8 @@
 	const handleCombatantCardClick = trackerViewState.handleCombatantCardClick;
 	const handleCombatantCardContextMenu = trackerViewState.handleCombatantCardContextMenu;
 	const handleCombatantCardKeyDown = trackerViewState.handleCombatantCardKeyDown;
+	const handleCombatantCardMouseEnter = trackerViewState.handleCombatantCardMouseEnter;
+	const handleCombatantCardMouseLeave = trackerViewState.handleCombatantCardMouseLeave;
 	const canRemoveCombatant = trackerViewState.canRemoveCombatant;
 	const handleRemoveCombatant = trackerViewState.handleRemoveCombatant;
 	const handleMonsterStackClick = trackerViewState.handleMonsterStackClick;
@@ -384,6 +386,8 @@
 									onclick={(event) => handleCombatantCardClick(event, entry.combatant)}
 									oncontextmenu={(event) => handleCombatantCardContextMenu(event, entry.combatant)}
 									onkeydown={(event) => handleCombatantCardKeyDown(event, entry.combatant)}
+									onmouseenter={(event) => handleCombatantCardMouseEnter(event, entry.combatant)}
+									onmouseleave={(event) => handleCombatantCardMouseLeave(event, entry.combatant)}
 								>
 									<img
 										class="nimble-ct__image"

--- a/src/view/ui/ctTopTracker/types.ts
+++ b/src/view/ui/ctTopTracker/types.ts
@@ -47,6 +47,8 @@ export interface CtWidthPreviewEventDetail {
 export interface CanvasTokenLike {
 	center?: { x: number; y: number } | null;
 	document?: { id?: string | null } | null;
+	isVisible?: boolean;
+	controlled?: boolean;
 }
 
 export type CombatWithDrop = Combat & {


### PR DESCRIPTION
## Summary

- Hovering over a combatant card in the Nimble combat tracker now highlights the corresponding token on the canvas using Foundry's built-in `_onHoverIn`/`_onHoverOut` hover mechanism
- Hovering out removes the highlight
- Guards against invisible or already-controlled tokens (matching the same pattern used in `Targets.svelte`)

## Related Issue

Closes #487

## Test Plan

- [ ] Start combat with multiple combatants on the canvas
- [ ] Hover over a combatant card in the tracker — the corresponding token should highlight on the map
- [ ] Mouse out — highlight should clear
- [ ] Verify tokens that are already controlled or not visible are skipped without error