### PR TITLE
fix(actors): place new actors in the selected folder (#721)

### DIFF
--- a/src/documents/actor/base.svelte.ts
+++ b/src/documents/actor/base.svelte.ts
@@ -149,12 +149,19 @@ class NimbleBaseActor<ActorType extends SystemActorTypes = SystemActorTypes> ext
 	): Promise<Actor.Stored | null | undefined> {
 		const { parent, pack, types } = context ?? {};
 
+		// Use folder from Foundry data if provided, otherwise fall back to the active folder in the sidebar
+		const folderId =
+			(data?.folder as string | null | undefined) ??
+			(ui.actors as unknown as { folder?: { id?: string } | null })?.folder?.id ??
+			null;
+
 		const { default: ActorCreationDialog } = await import(
 			'../dialogs/ActorCreationDialog.svelte.js'
 		);
 		const dialog = new ActorCreationDialog(
 			{
 				...data,
+				folder: folderId,
 				parent,
 				pack,
 				types,

--- a/src/documents/dialogs/ActorCreationDialog.svelte.ts
+++ b/src/documents/dialogs/ActorCreationDialog.svelte.ts
@@ -1,9 +1,8 @@
 import type { DeepPartial } from 'fvtt-types/utils';
 import { SvelteApplicationMixin } from '#lib/SvelteApplicationMixin.svelte.js';
-
+import NimbleNexusImportDialog from '../../import/nimbleNexus/NimbleNexusImportDialog.svelte.js';
 import ActorCreationDialogComponent from '../../view/dialogs/ActorCreationDialog.svelte';
 import CharacterCreationDialog from './CharacterCreationDialog.svelte.js';
-import NimbleNexusImportDialog from '../../import/nimbleNexus/NimbleNexusImportDialog.svelte.js';
 
 const { ApplicationV2 } = foundry.applications.api;
 
@@ -62,7 +61,8 @@ export default class ActorCreationDialog extends SvelteApplicationMixin(Applicat
 		const { documentClasses } = CONFIG.NIMBLE.Actor;
 
 		if (actorType === 'character') {
-			const characterCreationDialog = new CharacterCreationDialog();
+			const folder = (this.data.folder as string | null | undefined) ?? null;
+			const characterCreationDialog = new CharacterCreationDialog({}, { folder });
 			characterCreationDialog.render(true);
 		} else {
 			(documentClasses as Record<string, typeof Actor>)[actorType].create(

--- a/src/documents/dialogs/CharacterCreationDialog.svelte.ts
+++ b/src/documents/dialogs/CharacterCreationDialog.svelte.ts
@@ -103,12 +103,16 @@ export default class CharacterCreationDialog extends SvelteApplicationMixin(Appl
 	data: Record<string, any>;
 	parent: any;
 	pack: any;
+	folder: string | null;
 	classFeatureIndex: Promise<ClassFeatureIndex> | null = null;
 	spellIndex: Promise<SpellIndex> | null = null;
 
 	protected root;
 
-	constructor(data = {}, { parent = null, pack = null, ...options } = {}) {
+	constructor(
+		data = {},
+		{ parent = null, pack = null, folder = null as string | null, ...options } = {},
+	) {
 		const width = 608;
 		super(
 			foundry.utils.mergeObject(options, {
@@ -125,6 +129,7 @@ export default class CharacterCreationDialog extends SvelteApplicationMixin(Appl
 		this.data = data;
 		this.parent = parent;
 		this.pack = pack;
+		this.folder = folder;
 	}
 
 	static override DEFAULT_OPTIONS = {
@@ -196,7 +201,7 @@ export default class CharacterCreationDialog extends SvelteApplicationMixin(Appl
 		};
 	}) {
 		const actor = await Actor.create(
-			{ name: results.name || 'New Character', type: 'character' },
+			{ name: results.name || 'New Character', type: 'character', folder: this.folder },
 			{ renderSheet: true },
 		);
 


### PR DESCRIPTION
## Summary

- When the Actors sidebar has an active folder, `createDialog` now detects that folder (from either Foundry's `data.folder` context or `ui.actors.folder`) and pre-populates it on the new actor
- Non-character types (NPC, minion, solo monster) already propagated `this.data` to `Actor.create`, so they pick up the folder automatically once it is set in `createDialog`
- Character creation via `CharacterCreationDialog` was silently dropping the folder; the wizard now receives the folder ID and passes it to `Actor.create`

## How it works

1. `NimbleBaseActor.createDialog` resolves the target folder: `data.folder` (from Foundry's own folder-context button) → `ui.actors.folder.id` (active/browsed folder in the sidebar) → `null` (root)
2. The resolved folder ID is passed explicitly into `ActorCreationDialog`
3. Non-character paths spread `this.data` (unchanged behavior, now includes folder)
4. Character paths receive `folder` in the `CharacterCreationDialog` constructor and forward it to `Actor.create`

## Test plan

- [ ] Create a folder in the Actors directory, navigate into it (or select it), click "Create Actor" → confirm the actor appears inside the folder for all actor types
- [ ] Create an actor from root level (no folder selected) → confirm it lands at root
- [ ] Create an actor via the folder-specific create button in the tree → confirm it lands in that folder
- [ ] All of the above for character type (goes through CharacterCreationDialog wizard)

Closes #721