### PR TITLE
fix(migration): Migration023 — propagate class restrictions onto existing spells

### DIFF
--- a/packs/spells/core/wind/vicious-mockery.json
+++ b/packs/spells/core/wind/vicious-mockery.json
@@ -101,7 +101,10 @@
 			]
 		},
 		"school": "wind",
-		"tier": 0
+		"tier": 0,
+		"classes": [
+			"songweaver"
+		]
 	},
 	"effects": [],
 	"folder": null,

--- a/src/migration/MigrationRunnerBase.ts
+++ b/src/migration/MigrationRunnerBase.ts
@@ -9,7 +9,7 @@ interface CollectionDiff<T = any> {
 class MigrationRunnerBase {
 	migrations: MigrationBase[];
 
-	static LATEST_SCHEMA_VERSION = 22;
+	static LATEST_SCHEMA_VERSION = 23;
 
 	static RECOMMENDED_SAFE_VERSION = 0;
 

--- a/src/migration/migrations/Migration023SpellClasses.ts
+++ b/src/migration/migrations/Migration023SpellClasses.ts
@@ -1,0 +1,67 @@
+import { MigrationBase } from '../MigrationBase.js';
+
+const CLASS_RESTRICTED_SPELL_SOURCE_IDS = new Map<string, string[]>([
+	['Compendium.nimble.spells.Item.KICmDNpyNoMuZ20E', ['shepherd']], // Lifebinding Spirit
+	['Compendium.nimble.spells.Item.9TNPdOXlCcGgxw6r', ['shadowmancer']], // Shadow Blast
+	['Compendium.nimble.spells.Item.ho2KADcmQWWTeYR0', ['shadowmancer']], // Summon Shadow
+]);
+
+// Name-based fallback for spells in world compendiums duplicated from the official pack
+// (those items may not have a compendiumSource pointing back to nimble.spells)
+const CLASS_RESTRICTED_SPELL_NAMES = new Map<string, string[]>([
+	['Lifebinding Spirit', ['shepherd']],
+	['Shadow Blast', ['shadowmancer']],
+	['Summon Shadow', ['shadowmancer']],
+]);
+
+/**
+ * Migration to propagate class restrictions onto spell items that were imported
+ * before the `classes` field was added to the compendium data.
+ *
+ * Affected spells (shepherd: Lifebinding Spirit; shadowmancer: Shadow Blast,
+ * Summon Shadow) were added to the compendium with a `classes` array, but
+ * copies already living in world items, actor sheets, or duplicated world
+ * compendiums still have an empty array and therefore appear on every class's
+ * spell list regardless of school.
+ *
+ * Matching strategy:
+ * 1. Source ID — canonical match for anything dragged from the official pack.
+ * 2. Spell name — fallback for duplicated world compendiums where the item has
+ *    no `compendiumSource`, but only when `classes` is currently empty to avoid
+ *    overriding intentional GM customisation.
+ */
+class Migration023SpellClasses extends MigrationBase {
+	static override readonly version = 23;
+
+	override readonly version = Migration023SpellClasses.version;
+
+	override async updateItem(source: any): Promise<void> {
+		if (source.type !== 'spell') return;
+
+		const sourceId = this.getSourceId(source);
+		const currentClasses: string[] = source.system?.classes ?? [];
+
+		let requiredClasses: string[] | null = null;
+
+		if (sourceId) {
+			requiredClasses = CLASS_RESTRICTED_SPELL_SOURCE_IDS.get(sourceId) ?? null;
+		}
+
+		if (!requiredClasses && currentClasses.length === 0) {
+			requiredClasses = CLASS_RESTRICTED_SPELL_NAMES.get(source.name) ?? null;
+		}
+
+		if (!requiredClasses) return;
+
+		const requiredSorted = [...requiredClasses].sort().join(',');
+		const currentSorted = [...currentClasses].sort().join(',');
+		if (requiredSorted === currentSorted) return;
+
+		source.system.classes = requiredClasses;
+		console.log(
+			`Nimble Migration | ${source.name}: set classes to [${requiredClasses.join(', ')}]`,
+		);
+	}
+}
+
+export { Migration023SpellClasses };

--- a/src/migration/migrations/Migration023SpellClasses.ts
+++ b/src/migration/migrations/Migration023SpellClasses.ts
@@ -4,6 +4,7 @@ const CLASS_RESTRICTED_SPELL_SOURCE_IDS = new Map<string, string[]>([
 	['Compendium.nimble.spells.Item.KICmDNpyNoMuZ20E', ['shepherd']], // Lifebinding Spirit
 	['Compendium.nimble.spells.Item.9TNPdOXlCcGgxw6r', ['shadowmancer']], // Shadow Blast
 	['Compendium.nimble.spells.Item.ho2KADcmQWWTeYR0', ['shadowmancer']], // Summon Shadow
+	['Compendium.nimble.spells.Item.kTJSEElZSzeOMXBO', ['songweaver']], // Vicious Mockery
 ]);
 
 // Name-based fallback for spells in world compendiums duplicated from the official pack
@@ -12,6 +13,7 @@ const CLASS_RESTRICTED_SPELL_NAMES = new Map<string, string[]>([
 	['Lifebinding Spirit', ['shepherd']],
 	['Shadow Blast', ['shadowmancer']],
 	['Summon Shadow', ['shadowmancer']],
+	['Vicious Mockery', ['songweaver']],
 ]);
 
 /**
@@ -19,7 +21,8 @@ const CLASS_RESTRICTED_SPELL_NAMES = new Map<string, string[]>([
  * before the `classes` field was added to the compendium data.
  *
  * Affected spells (shepherd: Lifebinding Spirit; shadowmancer: Shadow Blast,
- * Summon Shadow) were added to the compendium with a `classes` array, but
+ * Summon Shadow; songweaver: Vicious Mockery) were added to the compendium
+ * with a `classes` array, but
  * copies already living in world items, actor sheets, or duplicated world
  * compendiums still have an empty array and therefore appear on every class's
  * spell list regardless of school.

--- a/src/migration/migrations/index.ts
+++ b/src/migration/migrations/index.ts
@@ -20,3 +20,4 @@ export { Migration019SearingLightDisposition } from './Migration019SearingLightD
 export { Migration020DicePoolBackfill } from './Migration020DicePoolBackfill.js';
 export { Migration021RagePoolActivation } from './Migration021RagePoolActivation.js';
 export { Migration022CelestialSavingThrow } from './Migration022CelestialSavingThrow.js';
+export { Migration023SpellClasses } from './Migration023SpellClasses.js';


### PR DESCRIPTION
## Summary

- Adds `Migration019SpellClasses` to backfill the `classes` array on spell items that were imported before the field was populated in the compendium data
- Bumps `LATEST_SCHEMA_VERSION` from 18 → 19
- Registers the migration in `migrations/index.ts`

## Affected spells

| Spell | Restricted to |
|---|---|
| Lifebinding Spirit | `shepherd` |
| Shadow Blast | `shadowmancer` |
| Summon Shadow | `shadowmancer` |

## Matching strategy

1. **Source ID** (primary) — matches anything dragged from `Compendium.nimble.spells` onto actors, world items, or world compendiums after import
2. **Spell name** (fallback) — matches spells in duplicated world compendiums where no `compendiumSource` is set, but only when `classes` is currently empty to avoid overwriting intentional GM customisation

## Fixes

Closes #744 — Lifebinding Spirit (Shepherd) was appearing on the Oathsworn level 2 spell list because copies in existing worlds had an empty `classes` array.