### PR TITLE
feat(combat-ui): highlight canvas token on hover (#487)

### DIFF
--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -1470,6 +1470,7 @@ export const myStore = writable<MyStoreState>(initialState);
 | `spell/*` | `src/utils/spell/` | Spell-related utilities |
 | `treeManipulation/*` | `src/utils/treeManipulation/` | Tree data structure utilities |
 | `countAdjacentEnemies()`, `ADJACENCY_QUALIFIER` | `src/utils/tokenAdjacency.ts` | Count enemy tokens adjacent to a given token; respects the `adjacencyIncludesDiagonals` world setting; accepts position overrides for pre-commit token moves |
+| `tokenHoverIn()`, `tokenGroupHoverIn()`, `tokenHoverOut()` | `src/utils/tokenHoverHighlight.ts` | Draw/remove a PIXI ring on canvas tokens on hover; `tokenGroupHoverIn` highlights multiple tokens simultaneously (used for monster stacks) |
 
 ### Shared Stores
 

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -2038,6 +2038,10 @@
 				"name": "Debug Mode",
 				"hint": "Enables developer tools like the dice testbench. Changes take effect immediately.",
 				"openTestbench": "Open Dice Testbench"
+			},
+			"combatTrackerHoverColor": {
+				"name": "Combat Tracker Hover Color",
+				"hint": "Choose your personal token hover highlight color"
 			}
 		},
 		"diceTestbench": {

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -1144,6 +1144,7 @@
 				"colorsSection": "Colors",
 				"actionColor": "Action Color",
 				"reactionColor": "Reaction Color",
+				"hoverColor": "Hover Color",
 				"colorWhite": "White",
 				"colorGreen": "Green",
 				"colorRed": "Red",

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -2042,6 +2042,91 @@
 			"combatTrackerHoverColor": {
 				"name": "Combat Tracker Hover Color",
 				"hint": "Choose your personal token hover highlight color"
+			},
+			"combatTrackerPlayersCanExpandMonsterCards": {
+				"name": "Combat Tracker Monster Card Visibility",
+				"hint": "Allow players to view individual monster and minion cards when the GM expands them"
+			},
+			"combatTrackerResourceDrawerHover": {
+				"name": "Combat Tracker Resource Drawer Hover",
+				"hint": "When enabled, player resource drawers open only on hover"
+			},
+			"combatTrackerPlayerHpBarTextMode": {
+				"name": "Combat Tracker Player HP Bar Center Text",
+				"hint": "Choose whether player HP bars show nothing, health state, or HP percentage"
+			},
+			"combatTrackerNonPlayerHpBarEnabled": {
+				"name": "Combat Tracker Non-Player HP Bar",
+				"hint": "Show a hit point bar below individual non-player combatant cards"
+			},
+			"combatTrackerNonPlayerHpBarTextMode": {
+				"name": "Combat Tracker Non-Player HP Bar Center Text",
+				"hint": "Choose whether centered text in the non-player HP bar shows nothing, health state, or HP percentage"
+			},
+			"hpBarTextMode": {
+				"none": "None",
+				"hpState": "Health State",
+				"percentage": "HP %"
+			},
+			"combatTrackerEnabled": {
+				"name": "Enable Combat Tracker",
+				"hint": "Show the Combat Tracker at the top of the screen"
+			},
+			"combatTrackerWidthLevel": {
+				"name": "Combat Tracker Width Level",
+				"hint": "Controls how wide Combat Tracker can be in the top tracker"
+			},
+			"combatTrackerCardSizeLevel": {
+				"name": "Combat Tracker Card Size Level",
+				"hint": "Controls how large Combat Tracker combatant cards appear"
+			},
+			"combatTrackerActionDiceColor": {
+				"name": "Combat Tracker Action Color",
+				"hint": "Choose your personal action color for Combat Tracker"
+			},
+			"combatTrackerReactionColor": {
+				"name": "Combat Tracker Reaction Color",
+				"hint": "Choose your personal reaction color for Combat Tracker"
+			},
+			"combatTrackerLeftToRightOrdering": {
+				"name": "Combat Tracker Left-to-Right Ordering",
+				"hint": "Display combatants in fixed left-to-right order instead of centering the active combatant"
+			},
+			"combatTrackerCurrentTurnColorLegacy": {
+				"name": "Combat Tracker Current Turn Color (Legacy)",
+				"hint": "Legacy current turn color setting used before per-animation colors"
+			},
+			"combatTrackerCurrentTurnPulseAnimation": {
+				"name": "Combat Tracker Current Turn Pulse Animation",
+				"hint": "Enable pulse animation for the active combatant card"
+			},
+			"combatTrackerCurrentTurnPulseSpeed": {
+				"name": "Combat Tracker Current Turn Pulse Speed",
+				"hint": "Adjust pulse animation speed for the active combatant card"
+			},
+			"combatTrackerCurrentTurnBorderGlow": {
+				"name": "Combat Tracker Current Turn Border Glow",
+				"hint": "Enable border glow for the active combatant card"
+			},
+			"combatTrackerCurrentTurnBorderGlowColor": {
+				"name": "Combat Tracker Border Glow Color",
+				"hint": "Color used by the border glow for the active combatant card"
+			},
+			"combatTrackerCurrentTurnBorderGlowSize": {
+				"name": "Combat Tracker Border Glow Size",
+				"hint": "Adjust the glow size for the active combatant card border"
+			},
+			"combatTrackerCurrentTurnEdgeCrawler": {
+				"name": "Combat Tracker Current Turn Edge Crawler",
+				"hint": "Enable edge crawler effect for the active combatant card"
+			},
+			"combatTrackerCurrentTurnEdgeCrawlerColor": {
+				"name": "Combat Tracker Edge Crawler Color",
+				"hint": "Color used by the edge crawler for the active combatant card"
+			},
+			"combatTrackerCurrentTurnEdgeCrawlerSize": {
+				"name": "Combat Tracker Edge Crawler Size",
+				"hint": "Adjust capsule size for the active combatant edge crawler effect"
 			}
 		},
 		"diceTestbench": {

--- a/src/hooks/minionGroupTokenActions.ts
+++ b/src/hooks/minionGroupTokenActions.ts
@@ -1729,13 +1729,11 @@ function renderGroupAttackNonMinionSection(panel: HTMLDivElement, hasAnyTarget: 
 			row.classList.add('nimble-minion-group-attack-panel__row--inactive');
 		}
 
-		const getNonMinionToken = () => {
-			const combat = getCombatForCurrentScene();
-			const combatant = combat?.combatants.get(member.combatantId) ?? null;
-			return (combatant?.token?.object as unknown) ?? null;
-		};
-		row.addEventListener('mouseenter', () => tokenHoverIn(getNonMinionToken()));
-		row.addEventListener('mouseleave', () => tokenHoverOut(getNonMinionToken()));
+		const combat = getCombatForCurrentScene();
+		const nonMinionToken =
+			(combat?.combatants.get(member.combatantId)?.token?.object as unknown) ?? null;
+		row.addEventListener('mouseenter', () => tokenHoverIn(nonMinionToken));
+		row.addEventListener('mouseleave', () => tokenHoverOut(nonMinionToken));
 
 		const memberCell = createGroupAttackMemberCell(member);
 
@@ -1801,8 +1799,8 @@ function renderGroupAttackNonMinionSection(panel: HTMLDivElement, hasAnyTarget: 
 		if (hasNoActionsRemaining) {
 			controlsRow.classList.add('nimble-minion-group-attack-panel__row--inactive');
 		}
-		controlsRow.addEventListener('mouseenter', () => tokenHoverIn(getNonMinionToken()));
-		controlsRow.addEventListener('mouseleave', () => tokenHoverOut(getNonMinionToken()));
+		controlsRow.addEventListener('mouseenter', () => tokenHoverIn(nonMinionToken));
+		controlsRow.addEventListener('mouseleave', () => tokenHoverOut(nonMinionToken));
 
 		const controlsCell = document.createElement('td');
 		controlsCell.className = 'nimble-minion-group-attack-panel__monster-controls-cell';
@@ -1830,13 +1828,11 @@ function renderGroupAttackMinionSection(panel: HTMLDivElement): void {
 			row.classList.add('nimble-minion-group-attack-panel__row--inactive');
 		}
 
-		const getMinionToken = () => {
-			const combat = getCombatForCurrentScene();
-			const combatant = combat?.combatants.get(member.combatantId) ?? null;
-			return (combatant?.token?.object as unknown) ?? null;
-		};
-		row.addEventListener('mouseenter', () => tokenHoverIn(getMinionToken()));
-		row.addEventListener('mouseleave', () => tokenHoverOut(getMinionToken()));
+		const minionToken =
+			(getCombatForCurrentScene()?.combatants.get(member.combatantId)?.token?.object as unknown) ??
+			null;
+		row.addEventListener('mouseenter', () => tokenHoverIn(minionToken));
+		row.addEventListener('mouseleave', () => tokenHoverOut(minionToken));
 
 		const memberCell = createGroupAttackMemberCell(member);
 

--- a/src/hooks/minionGroupTokenActions.ts
+++ b/src/hooks/minionGroupTokenActions.ts
@@ -80,6 +80,7 @@ let groupAttackTargetPopoverElement: HTMLDivElement | null = null;
 let groupAttackTargetPopoverRefreshInterval: ReturnType<typeof setInterval> | null = null;
 let groupAttackActionDescriptionPopoverElement: HTMLDivElement | null = null;
 let groupAttackImagePopoverElement: HTMLDivElement | null = null;
+let panelHoverAbortController: AbortController | null = null;
 let sceneControlsRefreshHandle: ReturnType<typeof setTimeout> | null = null;
 let ncswSidebarViewMode: NcswSidebarViewMode = 'ncs';
 let hasInitializedNcswSidebarViewMode = false;
@@ -1244,6 +1245,8 @@ function handleGroupAttackPanelDragStart(event: PointerEvent): void {
 }
 
 function hideGroupAttackPanel(options: { clearTargets?: boolean } = {}): void {
+	panelHoverAbortController?.abort();
+	panelHoverAbortController = null;
 	if (minionGroupAttackPanelElement) {
 		minionGroupAttackPanelElement.hidden = true;
 		minionGroupAttackPanelElement.replaceChildren();
@@ -1489,6 +1492,8 @@ function buildSelectionWarnings(result: {
 }
 
 function resetGroupAttackPanelForRender(panel: HTMLDivElement): void {
+	panelHoverAbortController?.abort();
+	panelHoverAbortController = new AbortController();
 	panel.hidden = false;
 	hideGroupAttackTargetPopover();
 	hideGroupAttackActionDescriptionPopover();
@@ -1582,14 +1587,23 @@ function renderGroupAttackTargetSection(params: {
 			image.alt = targetToken.name;
 			targetButton.append(image);
 
-			targetButton.addEventListener('mouseenter', () => {
-				showGroupAttackTargetPopover(targetButton, targetToken);
-				tokenHoverIn(targetToken.token);
-			});
-			targetButton.addEventListener('mouseleave', () => {
-				hideGroupAttackTargetPopover();
-				tokenHoverOut(targetToken.token);
-			});
+			const { signal } = panelHoverAbortController!;
+			targetButton.addEventListener(
+				'mouseenter',
+				() => {
+					showGroupAttackTargetPopover(targetButton, targetToken);
+					tokenHoverIn(targetToken.token);
+				},
+				{ signal },
+			);
+			targetButton.addEventListener(
+				'mouseleave',
+				() => {
+					hideGroupAttackTargetPopover();
+					tokenHoverOut(targetToken.token);
+				},
+				{ signal },
+			);
 			targetButton.addEventListener('focus', () => {
 				showGroupAttackTargetPopover(targetButton, targetToken);
 			});
@@ -1732,8 +1746,13 @@ function renderGroupAttackNonMinionSection(panel: HTMLDivElement, hasAnyTarget: 
 		const combat = getCombatForCurrentScene();
 		const nonMinionToken =
 			(combat?.combatants.get(member.combatantId)?.token?.object as unknown) ?? null;
-		row.addEventListener('mouseenter', () => tokenHoverIn(nonMinionToken));
-		row.addEventListener('mouseleave', () => tokenHoverOut(nonMinionToken));
+		const { signal: nonMinionSignal } = panelHoverAbortController!;
+		row.addEventListener('mouseenter', () => tokenHoverIn(nonMinionToken), {
+			signal: nonMinionSignal,
+		});
+		row.addEventListener('mouseleave', () => tokenHoverOut(nonMinionToken), {
+			signal: nonMinionSignal,
+		});
 
 		const memberCell = createGroupAttackMemberCell(member);
 
@@ -1799,8 +1818,12 @@ function renderGroupAttackNonMinionSection(panel: HTMLDivElement, hasAnyTarget: 
 		if (hasNoActionsRemaining) {
 			controlsRow.classList.add('nimble-minion-group-attack-panel__row--inactive');
 		}
-		controlsRow.addEventListener('mouseenter', () => tokenHoverIn(nonMinionToken));
-		controlsRow.addEventListener('mouseleave', () => tokenHoverOut(nonMinionToken));
+		controlsRow.addEventListener('mouseenter', () => tokenHoverIn(nonMinionToken), {
+			signal: nonMinionSignal,
+		});
+		controlsRow.addEventListener('mouseleave', () => tokenHoverOut(nonMinionToken), {
+			signal: nonMinionSignal,
+		});
 
 		const controlsCell = document.createElement('td');
 		controlsCell.className = 'nimble-minion-group-attack-panel__monster-controls-cell';
@@ -1831,8 +1854,9 @@ function renderGroupAttackMinionSection(panel: HTMLDivElement): void {
 		const minionToken =
 			(getCombatForCurrentScene()?.combatants.get(member.combatantId)?.token?.object as unknown) ??
 			null;
-		row.addEventListener('mouseenter', () => tokenHoverIn(minionToken));
-		row.addEventListener('mouseleave', () => tokenHoverOut(minionToken));
+		const { signal: minionSignal } = panelHoverAbortController!;
+		row.addEventListener('mouseenter', () => tokenHoverIn(minionToken), { signal: minionSignal });
+		row.addEventListener('mouseleave', () => tokenHoverOut(minionToken), { signal: minionSignal });
 
 		const memberCell = createGroupAttackMemberCell(member);
 

--- a/src/hooks/minionGroupTokenActions.ts
+++ b/src/hooks/minionGroupTokenActions.ts
@@ -1582,13 +1582,13 @@ function renderGroupAttackTargetSection(params: {
 			image.alt = targetToken.name;
 			targetButton.append(image);
 
-			targetButton.addEventListener('mouseenter', (event) => {
+			targetButton.addEventListener('mouseenter', () => {
 				showGroupAttackTargetPopover(targetButton, targetToken);
-				tokenHoverIn(targetToken.token, event);
+				tokenHoverIn(targetToken.token);
 			});
-			targetButton.addEventListener('mouseleave', (event) => {
+			targetButton.addEventListener('mouseleave', () => {
 				hideGroupAttackTargetPopover();
-				tokenHoverOut(targetToken.token, event);
+				tokenHoverOut(targetToken.token);
 			});
 			targetButton.addEventListener('focus', () => {
 				showGroupAttackTargetPopover(targetButton, targetToken);
@@ -1734,8 +1734,8 @@ function renderGroupAttackNonMinionSection(panel: HTMLDivElement, hasAnyTarget: 
 			const combatant = combat?.combatants.get(member.combatantId) ?? null;
 			return (combatant?.token?.object as unknown) ?? null;
 		};
-		row.addEventListener('mouseenter', (event) => tokenHoverIn(getNonMinionToken(), event));
-		row.addEventListener('mouseleave', (event) => tokenHoverOut(getNonMinionToken(), event));
+		row.addEventListener('mouseenter', () => tokenHoverIn(getNonMinionToken()));
+		row.addEventListener('mouseleave', () => tokenHoverOut(getNonMinionToken()));
 
 		const memberCell = createGroupAttackMemberCell(member);
 
@@ -1801,10 +1801,8 @@ function renderGroupAttackNonMinionSection(panel: HTMLDivElement, hasAnyTarget: 
 		if (hasNoActionsRemaining) {
 			controlsRow.classList.add('nimble-minion-group-attack-panel__row--inactive');
 		}
-		controlsRow.addEventListener('mouseenter', (event) => tokenHoverIn(getNonMinionToken(), event));
-		controlsRow.addEventListener('mouseleave', (event) =>
-			tokenHoverOut(getNonMinionToken(), event),
-		);
+		controlsRow.addEventListener('mouseenter', () => tokenHoverIn(getNonMinionToken()));
+		controlsRow.addEventListener('mouseleave', () => tokenHoverOut(getNonMinionToken()));
 
 		const controlsCell = document.createElement('td');
 		controlsCell.className = 'nimble-minion-group-attack-panel__monster-controls-cell';
@@ -1837,8 +1835,8 @@ function renderGroupAttackMinionSection(panel: HTMLDivElement): void {
 			const combatant = combat?.combatants.get(member.combatantId) ?? null;
 			return (combatant?.token?.object as unknown) ?? null;
 		};
-		row.addEventListener('mouseenter', (event) => tokenHoverIn(getMinionToken(), event));
-		row.addEventListener('mouseleave', (event) => tokenHoverOut(getMinionToken(), event));
+		row.addEventListener('mouseenter', () => tokenHoverIn(getMinionToken()));
+		row.addEventListener('mouseleave', () => tokenHoverOut(getMinionToken()));
 
 		const memberCell = createGroupAttackMemberCell(member);
 

--- a/src/hooks/minionGroupTokenActions.ts
+++ b/src/hooks/minionGroupTokenActions.ts
@@ -27,6 +27,7 @@ import {
 } from '../utils/minionGroupAttackSession.js';
 import { isMinionCombatant } from '../utils/minionGrouping.js';
 import resolveItemActionCost from '../utils/resolveItemActionCost.js';
+import { tokenHoverIn, tokenHoverOut } from '../utils/tokenHoverHighlight.js';
 
 const NCSW_PANEL_ID = 'nimble-minion-group-attack-panel';
 const MINION_GROUP_TOKEN_UI_DEBUG_ENABLED_KEY = 'NIMBLE_ENABLE_GROUP_TOKEN_UI_LOGS';
@@ -1581,11 +1582,13 @@ function renderGroupAttackTargetSection(params: {
 			image.alt = targetToken.name;
 			targetButton.append(image);
 
-			targetButton.addEventListener('mouseenter', () => {
+			targetButton.addEventListener('mouseenter', (event) => {
 				showGroupAttackTargetPopover(targetButton, targetToken);
+				tokenHoverIn(targetToken.token, event);
 			});
-			targetButton.addEventListener('mouseleave', () => {
+			targetButton.addEventListener('mouseleave', (event) => {
 				hideGroupAttackTargetPopover();
+				tokenHoverOut(targetToken.token, event);
 			});
 			targetButton.addEventListener('focus', () => {
 				showGroupAttackTargetPopover(targetButton, targetToken);
@@ -1726,6 +1729,14 @@ function renderGroupAttackNonMinionSection(panel: HTMLDivElement, hasAnyTarget: 
 			row.classList.add('nimble-minion-group-attack-panel__row--inactive');
 		}
 
+		const getNonMinionToken = () => {
+			const combat = getCombatForCurrentScene();
+			const combatant = combat?.combatants.get(member.combatantId) ?? null;
+			return (combatant?.token?.object as unknown) ?? null;
+		};
+		row.addEventListener('mouseenter', (event) => tokenHoverIn(getNonMinionToken(), event));
+		row.addEventListener('mouseleave', (event) => tokenHoverOut(getNonMinionToken(), event));
+
 		const memberCell = createGroupAttackMemberCell(member);
 
 		const actionCell = document.createElement('td');
@@ -1790,6 +1801,10 @@ function renderGroupAttackNonMinionSection(panel: HTMLDivElement, hasAnyTarget: 
 		if (hasNoActionsRemaining) {
 			controlsRow.classList.add('nimble-minion-group-attack-panel__row--inactive');
 		}
+		controlsRow.addEventListener('mouseenter', (event) => tokenHoverIn(getNonMinionToken(), event));
+		controlsRow.addEventListener('mouseleave', (event) =>
+			tokenHoverOut(getNonMinionToken(), event),
+		);
 
 		const controlsCell = document.createElement('td');
 		controlsCell.className = 'nimble-minion-group-attack-panel__monster-controls-cell';
@@ -1816,6 +1831,14 @@ function renderGroupAttackMinionSection(panel: HTMLDivElement): void {
 		if (member.actionsRemaining < 1) {
 			row.classList.add('nimble-minion-group-attack-panel__row--inactive');
 		}
+
+		const getMinionToken = () => {
+			const combat = getCombatForCurrentScene();
+			const combatant = combat?.combatants.get(member.combatantId) ?? null;
+			return (combatant?.token?.object as unknown) ?? null;
+		};
+		row.addEventListener('mouseenter', (event) => tokenHoverIn(getMinionToken(), event));
+		row.addEventListener('mouseleave', (event) => tokenHoverOut(getMinionToken(), event));
 
 		const memberCell = createGroupAttackMemberCell(member);
 

--- a/src/settings/combatTrackerSettings.ts
+++ b/src/settings/combatTrackerSettings.ts
@@ -76,7 +76,6 @@ const ANIMATION_SLIDER_MIN = 0;
 const ANIMATION_SLIDER_MAX = 100;
 const CT_ACTION_DICE_COLOR_CSS_VAR = '--nimble-ct-action-die-color';
 const CT_REACTION_COLOR_CSS_VAR = '--nimble-ct-reaction-color';
-const CT_HOVER_COLOR_CSS_VAR = '--nimble-ct-hover-color';
 type CurrentTurnAnimationSettingKey =
 	(typeof CURRENT_TURN_ANIMATION_SETTING_KEYS)[keyof typeof CURRENT_TURN_ANIMATION_SETTING_KEYS];
 const CURRENT_TURN_ANIMATION_SETTING_KEY_SET = new Set<CurrentTurnAnimationSettingKey>(
@@ -172,12 +171,6 @@ function applyCtReactionColorCssVariable(value: unknown): void {
 	if (typeof document === 'undefined') return;
 	const normalizedColor = normalizeHexColor(value);
 	document.documentElement.style.setProperty(CT_REACTION_COLOR_CSS_VAR, normalizedColor);
-}
-
-function applyCtHoverColorCssVariable(value: unknown): void {
-	if (typeof document === 'undefined') return;
-	const normalizedColor = normalizeHexColor(value);
-	document.documentElement.style.setProperty(CT_HOVER_COLOR_CSS_VAR, normalizedColor);
 }
 
 function dispatchCtClientSettingUpdated(settingKey: string): void {
@@ -320,8 +313,7 @@ export function registerCombatTrackerSettings(): void {
 		config: false,
 		type: String,
 		default: DEFAULT_CT_HOVER_COLOR_SETTING,
-		onChange: (value) => {
-			applyCtHoverColorCssVariable(value);
+		onChange: () => {
 			dispatchCtClientSettingUpdated(COMBAT_TRACKER_HOVER_COLOR_SETTING_KEY);
 		},
 	});
@@ -414,7 +406,6 @@ export function registerCombatTrackerSettings(): void {
 
 	applyCtActionDiceColorCssVariable(getCombatTrackerActionDiceColor());
 	applyCtReactionColorCssVariable(getCombatTrackerReactionColor());
-	applyCtHoverColorCssVariable(getCombatTrackerHoverColor());
 }
 
 export function getCombatTrackerPlayersCanExpandMonsterCards(): boolean {
@@ -749,12 +740,10 @@ export async function setCombatTrackerReactionColor(value: string): Promise<void
 }
 
 export async function setCombatTrackerHoverColor(value: string): Promise<void> {
-	const normalizedColor = normalizeHexColor(value);
-	applyCtHoverColorCssVariable(normalizedColor);
 	await game.settings.set(
 		'nimble' as 'core',
 		COMBAT_TRACKER_HOVER_COLOR_SETTING_KEY as 'rollMode',
-		normalizedColor as never,
+		normalizeHexColor(value) as never,
 	);
 }
 

--- a/src/settings/combatTrackerSettings.ts
+++ b/src/settings/combatTrackerSettings.ts
@@ -420,7 +420,7 @@ export function getCombatTrackerPlayersCanExpandMonsterCards(): boolean {
 export function isCombatTrackerPlayerMonsterExpansionSettingKey(settingKey: unknown): boolean {
 	if (typeof settingKey !== 'string') return false;
 	if (settingKey === COMBAT_TRACKER_PLAYER_MONSTER_EXPANSION_SETTING_KEY) return true;
-	return settingKey === `nimble.${COMBAT_TRACKER_PLAYER_MONSTER_EXPANSION_SETTING_KEY}`;
+	return settingKey === `${SYSTEM_ID}.${COMBAT_TRACKER_PLAYER_MONSTER_EXPANSION_SETTING_KEY}`;
 }
 
 export function getCombatTrackerResourceDrawerHoverEnabled(): boolean {
@@ -507,73 +507,73 @@ export function getCombatTrackerReactionColor(): string {
 export function isCombatTrackerResourceDrawerHoverSettingKey(settingKey: unknown): boolean {
 	if (typeof settingKey !== 'string') return false;
 	if (settingKey === COMBAT_TRACKER_RESOURCE_DRAWER_HOVER_SETTING_KEY) return true;
-	return settingKey === `nimble.${COMBAT_TRACKER_RESOURCE_DRAWER_HOVER_SETTING_KEY}`;
+	return settingKey === `${SYSTEM_ID}.${COMBAT_TRACKER_RESOURCE_DRAWER_HOVER_SETTING_KEY}`;
 }
 
 export function isCombatTrackerPlayerHpBarTextModeSettingKey(settingKey: unknown): boolean {
 	if (typeof settingKey !== 'string') return false;
 	if (settingKey === COMBAT_TRACKER_PLAYER_HP_BAR_TEXT_MODE_SETTING_KEY) return true;
-	return settingKey === `nimble.${COMBAT_TRACKER_PLAYER_HP_BAR_TEXT_MODE_SETTING_KEY}`;
+	return settingKey === `${SYSTEM_ID}.${COMBAT_TRACKER_PLAYER_HP_BAR_TEXT_MODE_SETTING_KEY}`;
 }
 
 export function isCombatTrackerNonPlayerHpBarEnabledSettingKey(settingKey: unknown): boolean {
 	if (typeof settingKey !== 'string') return false;
 	if (settingKey === COMBAT_TRACKER_NON_PLAYER_HP_BAR_ENABLED_SETTING_KEY) return true;
-	return settingKey === `nimble.${COMBAT_TRACKER_NON_PLAYER_HP_BAR_ENABLED_SETTING_KEY}`;
+	return settingKey === `${SYSTEM_ID}.${COMBAT_TRACKER_NON_PLAYER_HP_BAR_ENABLED_SETTING_KEY}`;
 }
 
 export function isCombatTrackerNonPlayerHpBarTextModeSettingKey(settingKey: unknown): boolean {
 	if (typeof settingKey !== 'string') return false;
 	if (settingKey === COMBAT_TRACKER_NON_PLAYER_HP_BAR_TEXT_MODE_SETTING_KEY) return true;
-	return settingKey === `nimble.${COMBAT_TRACKER_NON_PLAYER_HP_BAR_TEXT_MODE_SETTING_KEY}`;
+	return settingKey === `${SYSTEM_ID}.${COMBAT_TRACKER_NON_PLAYER_HP_BAR_TEXT_MODE_SETTING_KEY}`;
 }
 
 export function isCombatTrackerEnabledSettingKey(settingKey: unknown): boolean {
 	if (typeof settingKey !== 'string') return false;
 	if (settingKey === COMBAT_TRACKER_ENABLED_SETTING_KEY) return true;
-	return settingKey === `nimble.${COMBAT_TRACKER_ENABLED_SETTING_KEY}`;
+	return settingKey === `${SYSTEM_ID}.${COMBAT_TRACKER_ENABLED_SETTING_KEY}`;
 }
 
 export function isCombatTrackerWidthLevelSettingKey(settingKey: unknown): boolean {
 	if (typeof settingKey !== 'string') return false;
 	if (settingKey === COMBAT_TRACKER_WIDTH_LEVEL_SETTING_KEY) return true;
-	return settingKey === `nimble.${COMBAT_TRACKER_WIDTH_LEVEL_SETTING_KEY}`;
+	return settingKey === `${SYSTEM_ID}.${COMBAT_TRACKER_WIDTH_LEVEL_SETTING_KEY}`;
 }
 
 export function isCombatTrackerCardSizeLevelSettingKey(settingKey: unknown): boolean {
 	if (typeof settingKey !== 'string') return false;
 	if (settingKey === COMBAT_TRACKER_CARD_SIZE_LEVEL_SETTING_KEY) return true;
-	return settingKey === `nimble.${COMBAT_TRACKER_CARD_SIZE_LEVEL_SETTING_KEY}`;
+	return settingKey === `${SYSTEM_ID}.${COMBAT_TRACKER_CARD_SIZE_LEVEL_SETTING_KEY}`;
 }
 
 export function isCombatTrackerLeftToRightOrderingSettingKey(settingKey: unknown): boolean {
 	if (typeof settingKey !== 'string') return false;
 	if (settingKey === COMBAT_TRACKER_LEFT_TO_RIGHT_ORDERING_SETTING_KEY) return true;
-	return settingKey === `nimble.${COMBAT_TRACKER_LEFT_TO_RIGHT_ORDERING_SETTING_KEY}`;
+	return settingKey === `${SYSTEM_ID}.${COMBAT_TRACKER_LEFT_TO_RIGHT_ORDERING_SETTING_KEY}`;
 }
 
 export function isCombatTrackerActionDiceColorSettingKey(settingKey: unknown): boolean {
 	if (typeof settingKey !== 'string') return false;
 	if (settingKey === COMBAT_TRACKER_ACTION_DICE_COLOR_SETTING_KEY) return true;
-	return settingKey === `nimble.${COMBAT_TRACKER_ACTION_DICE_COLOR_SETTING_KEY}`;
+	return settingKey === `${SYSTEM_ID}.${COMBAT_TRACKER_ACTION_DICE_COLOR_SETTING_KEY}`;
 }
 
 export function isCombatTrackerReactionColorSettingKey(settingKey: unknown): boolean {
 	if (typeof settingKey !== 'string') return false;
 	if (settingKey === COMBAT_TRACKER_REACTION_COLOR_SETTING_KEY) return true;
-	return settingKey === `nimble.${COMBAT_TRACKER_REACTION_COLOR_SETTING_KEY}`;
+	return settingKey === `${SYSTEM_ID}.${COMBAT_TRACKER_REACTION_COLOR_SETTING_KEY}`;
 }
 
 export function getCombatTrackerHoverColor(): string {
 	return normalizeHexColor(
-		game.settings.get('nimble' as 'core', COMBAT_TRACKER_HOVER_COLOR_SETTING_KEY as 'rollMode'),
+		game.settings.get(SYSTEM_ID as 'core', COMBAT_TRACKER_HOVER_COLOR_SETTING_KEY as 'rollMode'),
 	);
 }
 
 export function isCombatTrackerHoverColorSettingKey(settingKey: unknown): boolean {
 	if (typeof settingKey !== 'string') return false;
 	if (settingKey === COMBAT_TRACKER_HOVER_COLOR_SETTING_KEY) return true;
-	return settingKey === `nimble.${COMBAT_TRACKER_HOVER_COLOR_SETTING_KEY}`;
+	return settingKey === `${SYSTEM_ID}.${COMBAT_TRACKER_HOVER_COLOR_SETTING_KEY}`;
 }
 
 export function getCurrentTurnAnimationSettings(): CurrentTurnAnimationSettings {
@@ -637,9 +637,9 @@ export function isCurrentTurnAnimationSettingKey(settingKey: unknown): boolean {
 	if (CURRENT_TURN_ANIMATION_SETTING_KEY_SET.has(settingKey as CurrentTurnAnimationSettingKey)) {
 		return true;
 	}
-	if (!settingKey.startsWith('nimble.')) return false;
+	if (!settingKey.startsWith(`${SYSTEM_ID}.`)) return false;
 	return CURRENT_TURN_ANIMATION_SETTING_KEY_SET.has(
-		settingKey.slice('nimble.'.length) as CurrentTurnAnimationSettingKey,
+		settingKey.slice(`${SYSTEM_ID}.`.length) as CurrentTurnAnimationSettingKey,
 	);
 }
 
@@ -741,7 +741,7 @@ export async function setCombatTrackerReactionColor(value: string): Promise<void
 
 export async function setCombatTrackerHoverColor(value: string): Promise<void> {
 	await game.settings.set(
-		'nimble' as 'core',
+		SYSTEM_ID as 'core',
 		COMBAT_TRACKER_HOVER_COLOR_SETTING_KEY as 'rollMode',
 		normalizeHexColor(value) as never,
 	);

--- a/src/settings/combatTrackerSettings.ts
+++ b/src/settings/combatTrackerSettings.ts
@@ -184,8 +184,8 @@ function dispatchCtClientSettingUpdated(settingKey: string): void {
 
 export function registerCombatTrackerSettings(): void {
 	registerWorldSetting(COMBAT_TRACKER_PLAYER_MONSTER_EXPANSION_SETTING_KEY, {
-		name: 'Combat Tracker Player Expanded Monster Visibility',
-		hint: 'Allow players to view individual monster and minion cards when the GM expands them',
+		name: 'NIMBLE.settings.combatTrackerPlayersCanExpandMonsterCards.name',
+		hint: 'NIMBLE.settings.combatTrackerPlayersCanExpandMonsterCards.hint',
 		scope: 'world',
 		config: false,
 		type: Boolean,
@@ -193,8 +193,8 @@ export function registerCombatTrackerSettings(): void {
 	});
 
 	registerWorldSetting(COMBAT_TRACKER_RESOURCE_DRAWER_HOVER_SETTING_KEY, {
-		name: 'Combat Tracker Resource Drawer Hover',
-		hint: 'When enabled, player resource drawers open only on hover',
+		name: 'NIMBLE.settings.combatTrackerResourceDrawerHover.name',
+		hint: 'NIMBLE.settings.combatTrackerResourceDrawerHover.hint',
 		scope: 'client',
 		config: false,
 		type: Boolean,
@@ -205,15 +205,15 @@ export function registerCombatTrackerSettings(): void {
 	});
 
 	registerWorldSetting(COMBAT_TRACKER_PLAYER_HP_BAR_TEXT_MODE_SETTING_KEY, {
-		name: 'Combat Tracker Player HP Bar Center Text',
-		hint: 'Choose whether player HP bars show nothing, health state, or HP percentage',
+		name: 'NIMBLE.settings.combatTrackerPlayerHpBarTextMode.name',
+		hint: 'NIMBLE.settings.combatTrackerPlayerHpBarTextMode.hint',
 		scope: 'client',
 		config: false,
 		type: String,
 		choices: {
-			none: 'None',
-			hpState: 'Health State',
-			percentage: 'HP %',
+			none: 'NIMBLE.settings.hpBarTextMode.none',
+			hpState: 'NIMBLE.settings.hpBarTextMode.hpState',
+			percentage: 'NIMBLE.settings.hpBarTextMode.percentage',
 		},
 		default: DEFAULT_CT_PLAYER_HP_BAR_TEXT_MODE_SETTING,
 		onChange: () => {
@@ -222,8 +222,8 @@ export function registerCombatTrackerSettings(): void {
 	});
 
 	registerWorldSetting(COMBAT_TRACKER_NON_PLAYER_HP_BAR_ENABLED_SETTING_KEY, {
-		name: 'Combat Tracker Non-player HP Bar',
-		hint: 'Show a hit point bar below individual non-player combatant cards',
+		name: 'NIMBLE.settings.combatTrackerNonPlayerHpBarEnabled.name',
+		hint: 'NIMBLE.settings.combatTrackerNonPlayerHpBarEnabled.hint',
 		scope: 'world',
 		config: false,
 		type: Boolean,
@@ -231,22 +231,22 @@ export function registerCombatTrackerSettings(): void {
 	});
 
 	registerWorldSetting(COMBAT_TRACKER_NON_PLAYER_HP_BAR_TEXT_MODE_SETTING_KEY, {
-		name: 'Combat Tracker Non-player HP Bar Center Text',
-		hint: 'Choose whether centered text in the non-player HP bar shows nothing, health state, or HP percentage',
+		name: 'NIMBLE.settings.combatTrackerNonPlayerHpBarTextMode.name',
+		hint: 'NIMBLE.settings.combatTrackerNonPlayerHpBarTextMode.hint',
 		scope: 'world',
 		config: false,
 		type: String,
 		choices: {
-			none: 'None',
-			hpState: 'Health State',
-			percentage: 'HP %',
+			none: 'NIMBLE.settings.hpBarTextMode.none',
+			hpState: 'NIMBLE.settings.hpBarTextMode.hpState',
+			percentage: 'NIMBLE.settings.hpBarTextMode.percentage',
 		},
 		default: DEFAULT_CT_NON_PLAYER_HP_BAR_TEXT_MODE_SETTING,
 	});
 
 	registerWorldSetting(COMBAT_TRACKER_ENABLED_SETTING_KEY, {
-		name: 'Enable Combat Tracker',
-		hint: 'Show the Combat Tracker at the top of the screen',
+		name: 'NIMBLE.settings.combatTrackerEnabled.name',
+		hint: 'NIMBLE.settings.combatTrackerEnabled.hint',
 		scope: 'client',
 		config: true,
 		type: Boolean,
@@ -257,8 +257,8 @@ export function registerCombatTrackerSettings(): void {
 	});
 
 	registerWorldSetting(COMBAT_TRACKER_WIDTH_LEVEL_SETTING_KEY, {
-		name: 'Combat Tracker Width Level',
-		hint: 'Controls how wide Combat Tracker can be in the top tracker',
+		name: 'NIMBLE.settings.combatTrackerWidthLevel.name',
+		hint: 'NIMBLE.settings.combatTrackerWidthLevel.hint',
 		scope: 'client',
 		config: false,
 		type: Number,
@@ -269,8 +269,8 @@ export function registerCombatTrackerSettings(): void {
 	});
 
 	registerWorldSetting(COMBAT_TRACKER_CARD_SIZE_LEVEL_SETTING_KEY, {
-		name: 'Combat Tracker Card Size Level',
-		hint: 'Controls how large Combat Tracker combatant cards appear',
+		name: 'NIMBLE.settings.combatTrackerCardSizeLevel.name',
+		hint: 'NIMBLE.settings.combatTrackerCardSizeLevel.hint',
 		scope: 'client',
 		config: false,
 		type: Number,
@@ -281,8 +281,8 @@ export function registerCombatTrackerSettings(): void {
 	});
 
 	registerWorldSetting(COMBAT_TRACKER_ACTION_DICE_COLOR_SETTING_KEY, {
-		name: 'Combat Tracker Action Color',
-		hint: 'Choose your personal action color for Combat Tracker',
+		name: 'NIMBLE.settings.combatTrackerActionDiceColor.name',
+		hint: 'NIMBLE.settings.combatTrackerActionDiceColor.hint',
 		scope: 'client',
 		config: false,
 		type: String,
@@ -294,8 +294,8 @@ export function registerCombatTrackerSettings(): void {
 	});
 
 	registerWorldSetting(COMBAT_TRACKER_REACTION_COLOR_SETTING_KEY, {
-		name: 'Combat Tracker Reaction Color',
-		hint: 'Choose your personal reaction color for Combat Tracker',
+		name: 'NIMBLE.settings.combatTrackerReactionColor.name',
+		hint: 'NIMBLE.settings.combatTrackerReactionColor.hint',
 		scope: 'client',
 		config: false,
 		type: String,
@@ -319,8 +319,8 @@ export function registerCombatTrackerSettings(): void {
 	});
 
 	registerWorldSetting(COMBAT_TRACKER_LEFT_TO_RIGHT_ORDERING_SETTING_KEY, {
-		name: 'Combat Tracker Left-to-Right Ordering',
-		hint: 'Display combatants in fixed left-to-right order instead of centering the active combatant',
+		name: 'NIMBLE.settings.combatTrackerLeftToRightOrdering.name',
+		hint: 'NIMBLE.settings.combatTrackerLeftToRightOrdering.hint',
 		scope: 'world',
 		config: false,
 		type: Boolean,
@@ -329,8 +329,8 @@ export function registerCombatTrackerSettings(): void {
 
 	// Legacy settings retained as hidden registrations so existing worlds keep their values.
 	registerWorldSetting(LEGACY_CURRENT_TURN_COLOR_SETTING_KEY, {
-		name: 'Combat Tracker Current Turn Color (Legacy)',
-		hint: 'Legacy current turn color setting used before per-animation colors',
+		name: 'NIMBLE.settings.combatTrackerCurrentTurnColorLegacy.name',
+		hint: 'NIMBLE.settings.combatTrackerCurrentTurnColorLegacy.hint',
 		scope: 'world',
 		config: false,
 		type: String,
@@ -340,64 +340,64 @@ export function registerCombatTrackerSettings(): void {
 		game.settings.get(SYSTEM_ID as 'core', LEGACY_CURRENT_TURN_COLOR_SETTING_KEY as 'rollMode'),
 	);
 	registerWorldSetting(CURRENT_TURN_ANIMATION_SETTING_KEYS.pulseAnimation, {
-		name: 'Combat Tracker Current Turn Pulse Animation',
-		hint: 'Enable pulse animation for the active combatant card',
+		name: 'NIMBLE.settings.combatTrackerCurrentTurnPulseAnimation.name',
+		hint: 'NIMBLE.settings.combatTrackerCurrentTurnPulseAnimation.hint',
 		scope: 'world',
 		config: false,
 		type: Boolean,
 		default: DEFAULT_CURRENT_TURN_ANIMATION_SETTINGS.pulseAnimation,
 	});
 	registerWorldSetting(CURRENT_TURN_ANIMATION_SETTING_KEYS.pulseSpeed, {
-		name: 'Combat Tracker Current Turn Pulse Speed',
-		hint: 'Adjust pulse animation speed for the active combatant card',
+		name: 'NIMBLE.settings.combatTrackerCurrentTurnPulseSpeed.name',
+		hint: 'NIMBLE.settings.combatTrackerCurrentTurnPulseSpeed.hint',
 		scope: 'world',
 		config: false,
 		type: Number,
 		default: DEFAULT_CURRENT_TURN_ANIMATION_SETTINGS.pulseSpeed,
 	});
 	registerWorldSetting(CURRENT_TURN_ANIMATION_SETTING_KEYS.borderGlow, {
-		name: 'Combat Tracker Current Turn Border Glow',
-		hint: 'Enable border glow for the active combatant card',
+		name: 'NIMBLE.settings.combatTrackerCurrentTurnBorderGlow.name',
+		hint: 'NIMBLE.settings.combatTrackerCurrentTurnBorderGlow.hint',
 		scope: 'world',
 		config: false,
 		type: Boolean,
 		default: DEFAULT_CURRENT_TURN_ANIMATION_SETTINGS.borderGlow,
 	});
 	registerWorldSetting(CURRENT_TURN_ANIMATION_SETTING_KEYS.borderGlowColor, {
-		name: 'Combat Tracker Border Glow Color',
-		hint: 'Color used by the border glow for the active combatant card',
+		name: 'NIMBLE.settings.combatTrackerCurrentTurnBorderGlowColor.name',
+		hint: 'NIMBLE.settings.combatTrackerCurrentTurnBorderGlowColor.hint',
 		scope: 'world',
 		config: false,
 		type: String,
 		default: legacyColorDefault,
 	});
 	registerWorldSetting(CURRENT_TURN_ANIMATION_SETTING_KEYS.borderGlowSize, {
-		name: 'Combat Tracker Border Glow Size',
-		hint: 'Adjust the glow size for the active combatant card border',
+		name: 'NIMBLE.settings.combatTrackerCurrentTurnBorderGlowSize.name',
+		hint: 'NIMBLE.settings.combatTrackerCurrentTurnBorderGlowSize.hint',
 		scope: 'world',
 		config: false,
 		type: Number,
 		default: DEFAULT_CURRENT_TURN_ANIMATION_SETTINGS.borderGlowSize,
 	});
 	registerWorldSetting(CURRENT_TURN_ANIMATION_SETTING_KEYS.edgeCrawler, {
-		name: 'Combat Tracker Current Turn Edge Crawler',
-		hint: 'Enable edge crawler effect for the active combatant card',
+		name: 'NIMBLE.settings.combatTrackerCurrentTurnEdgeCrawler.name',
+		hint: 'NIMBLE.settings.combatTrackerCurrentTurnEdgeCrawler.hint',
 		scope: 'world',
 		config: false,
 		type: Boolean,
 		default: DEFAULT_CURRENT_TURN_ANIMATION_SETTINGS.edgeCrawler,
 	});
 	registerWorldSetting(CURRENT_TURN_ANIMATION_SETTING_KEYS.edgeCrawlerColor, {
-		name: 'Combat Tracker Edge Crawler Color',
-		hint: 'Color used by the edge crawler for the active combatant card',
+		name: 'NIMBLE.settings.combatTrackerCurrentTurnEdgeCrawlerColor.name',
+		hint: 'NIMBLE.settings.combatTrackerCurrentTurnEdgeCrawlerColor.hint',
 		scope: 'world',
 		config: false,
 		type: String,
 		default: legacyColorDefault,
 	});
 	registerWorldSetting(CURRENT_TURN_ANIMATION_SETTING_KEYS.edgeCrawlerSize, {
-		name: 'Combat Tracker Edge Crawler Size',
-		hint: 'Adjust capsule size for the active combatant edge crawler effect',
+		name: 'NIMBLE.settings.combatTrackerCurrentTurnEdgeCrawlerSize.name',
+		hint: 'NIMBLE.settings.combatTrackerCurrentTurnEdgeCrawlerSize.hint',
 		scope: 'world',
 		config: false,
 		type: Number,

--- a/src/settings/combatTrackerSettings.ts
+++ b/src/settings/combatTrackerSettings.ts
@@ -15,6 +15,7 @@ export const COMBAT_TRACKER_WIDTH_LEVEL_SETTING_KEY = 'combatTrackerCtWidthLevel
 export const COMBAT_TRACKER_CARD_SIZE_LEVEL_SETTING_KEY = 'combatTrackerCtCardSizeLevel';
 export const COMBAT_TRACKER_ACTION_DICE_COLOR_SETTING_KEY = 'combatTrackerCtActionDiceColor';
 export const COMBAT_TRACKER_REACTION_COLOR_SETTING_KEY = 'combatTrackerCtReactionColor';
+export const COMBAT_TRACKER_HOVER_COLOR_SETTING_KEY = 'combatTrackerCtHoverColor';
 export const COMBAT_TRACKER_LEFT_TO_RIGHT_ORDERING_SETTING_KEY =
 	'combatTrackerCtLeftToRightOrdering';
 export const COMBAT_TRACKER_CLIENT_SETTING_UPDATED_EVENT_NAME = 'nimble:ct-client-setting-updated';
@@ -53,6 +54,7 @@ const DEFAULT_CT_WIDTH_LEVEL_SETTING = 5;
 const DEFAULT_CT_CARD_SIZE_LEVEL_SETTING = 5;
 const DEFAULT_CT_ACTION_DICE_COLOR_SETTING = '#ffffff';
 const DEFAULT_CT_REACTION_COLOR_SETTING = '#4fc3f7';
+const DEFAULT_CT_HOVER_COLOR_SETTING = '#33bc4e';
 const DEFAULT_CT_LEFT_TO_RIGHT_ORDERING_SETTING = false;
 const DEFAULT_CURRENT_TURN_ANIMATION_SETTINGS: CurrentTurnAnimationSettings = {
 	pulseAnimation: true,
@@ -74,6 +76,7 @@ const ANIMATION_SLIDER_MIN = 0;
 const ANIMATION_SLIDER_MAX = 100;
 const CT_ACTION_DICE_COLOR_CSS_VAR = '--nimble-ct-action-die-color';
 const CT_REACTION_COLOR_CSS_VAR = '--nimble-ct-reaction-color';
+const CT_HOVER_COLOR_CSS_VAR = '--nimble-ct-hover-color';
 type CurrentTurnAnimationSettingKey =
 	(typeof CURRENT_TURN_ANIMATION_SETTING_KEYS)[keyof typeof CURRENT_TURN_ANIMATION_SETTING_KEYS];
 const CURRENT_TURN_ANIMATION_SETTING_KEY_SET = new Set<CurrentTurnAnimationSettingKey>(
@@ -169,6 +172,12 @@ function applyCtReactionColorCssVariable(value: unknown): void {
 	if (typeof document === 'undefined') return;
 	const normalizedColor = normalizeHexColor(value);
 	document.documentElement.style.setProperty(CT_REACTION_COLOR_CSS_VAR, normalizedColor);
+}
+
+function applyCtHoverColorCssVariable(value: unknown): void {
+	if (typeof document === 'undefined') return;
+	const normalizedColor = normalizeHexColor(value);
+	document.documentElement.style.setProperty(CT_HOVER_COLOR_CSS_VAR, normalizedColor);
 }
 
 function dispatchCtClientSettingUpdated(settingKey: string): void {
@@ -304,6 +313,19 @@ export function registerCombatTrackerSettings(): void {
 		},
 	});
 
+	registerWorldSetting(COMBAT_TRACKER_HOVER_COLOR_SETTING_KEY, {
+		name: 'Combat Tracker Hover Color',
+		hint: 'Choose your personal token hover highlight color',
+		scope: 'client',
+		config: false,
+		type: String,
+		default: DEFAULT_CT_HOVER_COLOR_SETTING,
+		onChange: (value) => {
+			applyCtHoverColorCssVariable(value);
+			dispatchCtClientSettingUpdated(COMBAT_TRACKER_HOVER_COLOR_SETTING_KEY);
+		},
+	});
+
 	registerWorldSetting(COMBAT_TRACKER_LEFT_TO_RIGHT_ORDERING_SETTING_KEY, {
 		name: 'Combat Tracker Left-to-Right Ordering',
 		hint: 'Display combatants in fixed left-to-right order instead of centering the active combatant',
@@ -392,6 +414,7 @@ export function registerCombatTrackerSettings(): void {
 
 	applyCtActionDiceColorCssVariable(getCombatTrackerActionDiceColor());
 	applyCtReactionColorCssVariable(getCombatTrackerReactionColor());
+	applyCtHoverColorCssVariable(getCombatTrackerHoverColor());
 }
 
 export function getCombatTrackerPlayersCanExpandMonsterCards(): boolean {
@@ -548,6 +571,18 @@ export function isCombatTrackerReactionColorSettingKey(settingKey: unknown): boo
 	if (typeof settingKey !== 'string') return false;
 	if (settingKey === COMBAT_TRACKER_REACTION_COLOR_SETTING_KEY) return true;
 	return settingKey === `nimble.${COMBAT_TRACKER_REACTION_COLOR_SETTING_KEY}`;
+}
+
+export function getCombatTrackerHoverColor(): string {
+	return normalizeHexColor(
+		game.settings.get('nimble' as 'core', COMBAT_TRACKER_HOVER_COLOR_SETTING_KEY as 'rollMode'),
+	);
+}
+
+export function isCombatTrackerHoverColorSettingKey(settingKey: unknown): boolean {
+	if (typeof settingKey !== 'string') return false;
+	if (settingKey === COMBAT_TRACKER_HOVER_COLOR_SETTING_KEY) return true;
+	return settingKey === `nimble.${COMBAT_TRACKER_HOVER_COLOR_SETTING_KEY}`;
 }
 
 export function getCurrentTurnAnimationSettings(): CurrentTurnAnimationSettings {
@@ -709,6 +744,16 @@ export async function setCombatTrackerReactionColor(value: string): Promise<void
 	await game.settings.set(
 		SYSTEM_ID as 'core',
 		COMBAT_TRACKER_REACTION_COLOR_SETTING_KEY as 'rollMode',
+		normalizedColor as never,
+	);
+}
+
+export async function setCombatTrackerHoverColor(value: string): Promise<void> {
+	const normalizedColor = normalizeHexColor(value);
+	applyCtHoverColorCssVariable(normalizedColor);
+	await game.settings.set(
+		'nimble' as 'core',
+		COMBAT_TRACKER_HOVER_COLOR_SETTING_KEY as 'rollMode',
 		normalizedColor as never,
 	);
 }

--- a/src/settings/combatTrackerSettings.ts
+++ b/src/settings/combatTrackerSettings.ts
@@ -314,8 +314,8 @@ export function registerCombatTrackerSettings(): void {
 	});
 
 	registerWorldSetting(COMBAT_TRACKER_HOVER_COLOR_SETTING_KEY, {
-		name: 'Combat Tracker Hover Color',
-		hint: 'Choose your personal token hover highlight color',
+		name: 'NIMBLE.settings.combatTrackerHoverColor.name',
+		hint: 'NIMBLE.settings.combatTrackerHoverColor.hint',
 		scope: 'client',
 		config: false,
 		type: String,

--- a/src/utils/tokenHoverHighlight.ts
+++ b/src/utils/tokenHoverHighlight.ts
@@ -1,0 +1,83 @@
+import { getCombatTrackerHoverColor } from '../settings/combatTrackerSettings.js';
+
+const HOVER_RING_NAME = 'nimble-token-hover-ring';
+const DEFAULT_HOVER_RING_COLOR = 0x33bc4e;
+
+function getHoverRingColor(): number {
+	try {
+		const hex = getCombatTrackerHoverColor().replace('#', '');
+		const parsed = parseInt(hex, 16);
+		return Number.isFinite(parsed) ? parsed : DEFAULT_HOVER_RING_COLOR;
+	} catch {
+		return DEFAULT_HOVER_RING_COLOR;
+	}
+}
+
+let ringToken: unknown = null;
+
+type TokenWithHover = {
+	isVisible?: boolean;
+	controlled?: boolean;
+	w?: number;
+	h?: number;
+	addChild(child: unknown): unknown;
+	removeChild(child: unknown): void;
+	children?: Array<{ name?: string }>;
+	_onHoverIn?(event: MouseEvent, options?: { hoverOutOthers?: boolean }): void;
+	_onHoverOut?(event: MouseEvent): void;
+};
+
+function removeRing(): void {
+	if (!ringToken) return;
+	const t = ringToken as TokenWithHover;
+	ringToken = null;
+	if (!Array.isArray(t.children)) return;
+	const ring = t.children.find((c) => c.name === HOVER_RING_NAME);
+	if (ring) t.removeChild(ring);
+}
+
+function addRing(token: TokenWithHover): void {
+	removeRing();
+	if (typeof token.addChild !== 'function') return;
+	const PIXI = (
+		globalThis as unknown as {
+			PIXI?: {
+				Graphics: new () => {
+					name: string;
+					lineStyle(width: number, color: number, alpha: number): void;
+					drawCircle(x: number, y: number, radius: number): void;
+				};
+			};
+		}
+	).PIXI;
+	if (!PIXI?.Graphics) return;
+	const g = new PIXI.Graphics();
+	g.name = HOVER_RING_NAME;
+	const w = (token.w as number | undefined) ?? 100;
+	const h = (token.h as number | undefined) ?? 100;
+	g.lineStyle(4, getHoverRingColor(), 1);
+	g.drawCircle(w / 2, h / 2, Math.max(w, h) / 2 + 8);
+	token.addChild(g);
+	ringToken = token;
+}
+
+export function tokenHoverIn(token: unknown, event: MouseEvent): void {
+	const t = token as TokenWithHover;
+	if (!t || t.isVisible === false) return;
+	if (t.controlled) {
+		addRing(t);
+	} else {
+		removeRing();
+		t._onHoverIn?.(event, { hoverOutOthers: true });
+	}
+}
+
+export function tokenHoverOut(token: unknown, event: MouseEvent): void {
+	const t = token as TokenWithHover;
+	if (!t || t.isVisible === false) return;
+	if (t.controlled) {
+		removeRing();
+	} else {
+		t._onHoverOut?.(event);
+	}
+}

--- a/src/utils/tokenHoverHighlight.ts
+++ b/src/utils/tokenHoverHighlight.ts
@@ -17,14 +17,11 @@ let ringToken: unknown = null;
 
 type TokenWithHover = {
 	isVisible?: boolean;
-	controlled?: boolean;
 	w?: number;
 	h?: number;
 	addChild(child: unknown): unknown;
 	removeChild(child: unknown): void;
 	children?: Array<{ name?: string }>;
-	_onHoverIn?(event: MouseEvent, options?: { hoverOutOthers?: boolean }): void;
-	_onHoverOut?(event: MouseEvent): void;
 };
 
 function removeRing(): void {
@@ -61,23 +58,14 @@ function addRing(token: TokenWithHover): void {
 	ringToken = token;
 }
 
-export function tokenHoverIn(token: unknown, event: MouseEvent): void {
+export function tokenHoverIn(token: unknown, _event: MouseEvent): void {
 	const t = token as TokenWithHover;
 	if (!t || t.isVisible === false) return;
-	if (t.controlled) {
-		addRing(t);
-	} else {
-		removeRing();
-		t._onHoverIn?.(event, { hoverOutOthers: true });
-	}
+	addRing(t);
 }
 
-export function tokenHoverOut(token: unknown, event: MouseEvent): void {
+export function tokenHoverOut(token: unknown, _event: MouseEvent): void {
 	const t = token as TokenWithHover;
 	if (!t || t.isVisible === false) return;
-	if (t.controlled) {
-		removeRing();
-	} else {
-		t._onHoverOut?.(event);
-	}
+	removeRing();
 }

--- a/src/utils/tokenHoverHighlight.ts
+++ b/src/utils/tokenHoverHighlight.ts
@@ -36,18 +36,6 @@ function removeAllRings(): void {
 
 function addRingToToken(token: TokenWithHover): void {
 	if (typeof token.addChild !== 'function') return;
-	const PIXI = (
-		globalThis as unknown as {
-			PIXI?: {
-				Graphics: new () => {
-					name: string;
-					lineStyle(width: number, color: number, alpha: number): void;
-					drawCircle(x: number, y: number, radius: number): void;
-				};
-			};
-		}
-	).PIXI;
-	if (!PIXI?.Graphics) return;
 	const g = new PIXI.Graphics();
 	g.name = HOVER_RING_NAME;
 	const w = (token.w as number | undefined) ?? 100;

--- a/src/utils/tokenHoverHighlight.ts
+++ b/src/utils/tokenHoverHighlight.ts
@@ -13,7 +13,7 @@ function getHoverRingColor(): number {
 	}
 }
 
-let ringToken: unknown = null;
+let ringTokens: unknown[] = [];
 
 type TokenWithHover = {
 	isVisible?: boolean;
@@ -24,17 +24,17 @@ type TokenWithHover = {
 	children?: Array<{ name?: string }>;
 };
 
-function removeRing(): void {
-	if (!ringToken) return;
-	const t = ringToken as TokenWithHover;
-	ringToken = null;
-	if (!Array.isArray(t.children)) return;
-	const ring = t.children.find((c) => c.name === HOVER_RING_NAME);
-	if (ring) t.removeChild(ring);
+function removeAllRings(): void {
+	for (const raw of ringTokens) {
+		const t = raw as TokenWithHover;
+		if (!Array.isArray(t.children)) continue;
+		const ring = t.children.find((c) => c.name === HOVER_RING_NAME);
+		if (ring) t.removeChild(ring);
+	}
+	ringTokens = [];
 }
 
-function addRing(token: TokenWithHover): void {
-	removeRing();
+function addRingToToken(token: TokenWithHover): void {
 	if (typeof token.addChild !== 'function') return;
 	const PIXI = (
 		globalThis as unknown as {
@@ -55,17 +55,25 @@ function addRing(token: TokenWithHover): void {
 	g.lineStyle(4, getHoverRingColor(), 1);
 	g.drawCircle(w / 2, h / 2, Math.max(w, h) / 2 + 8);
 	token.addChild(g);
-	ringToken = token;
+	ringTokens.push(token);
 }
 
 export function tokenHoverIn(token: unknown, _event: MouseEvent): void {
+	removeAllRings();
 	const t = token as TokenWithHover;
 	if (!t || t.isVisible === false) return;
-	addRing(t);
+	addRingToToken(t);
 }
 
-export function tokenHoverOut(token: unknown, _event: MouseEvent): void {
-	const t = token as TokenWithHover;
-	if (!t || t.isVisible === false) return;
-	removeRing();
+export function tokenGroupHoverIn(tokens: unknown[], _event: MouseEvent): void {
+	removeAllRings();
+	for (const token of tokens) {
+		const t = token as TokenWithHover;
+		if (!t || t.isVisible === false) continue;
+		addRingToToken(t);
+	}
+}
+
+export function tokenHoverOut(_token: unknown, _event: MouseEvent): void {
+	removeAllRings();
 }

--- a/src/utils/tokenHoverHighlight.ts
+++ b/src/utils/tokenHoverHighlight.ts
@@ -4,35 +4,35 @@ const HOVER_RING_NAME = 'nimble-token-hover-ring';
 const DEFAULT_HOVER_RING_COLOR = 0x33bc4e;
 
 function getHoverRingColor(): number {
-	try {
-		const hex = getCombatTrackerHoverColor().replace('#', '');
-		const parsed = parseInt(hex, 16);
-		return Number.isFinite(parsed) ? parsed : DEFAULT_HOVER_RING_COLOR;
-	} catch {
-		return DEFAULT_HOVER_RING_COLOR;
-	}
+	const hex = getCombatTrackerHoverColor().replace('#', '');
+	const parsed = parseInt(hex, 16);
+	return Number.isFinite(parsed) ? parsed : DEFAULT_HOVER_RING_COLOR;
 }
 
 let ringTokens: unknown[] = [];
 
 type TokenWithHover = {
+	destroyed?: boolean;
 	isVisible?: boolean;
 	w?: number;
 	h?: number;
 	addChild(child: unknown): unknown;
 	removeChild(child: unknown): void;
-	children?: Array<{ name?: string }>;
+	children?: Array<{ name?: string; destroyed?: boolean }>;
 };
 
 function removeAllRings(): void {
 	for (const raw of ringTokens) {
 		const t = raw as TokenWithHover;
+		if (t.destroyed) continue;
 		if (!Array.isArray(t.children)) continue;
 		const ring = t.children.find((c) => c.name === HOVER_RING_NAME);
-		if (ring) t.removeChild(ring);
+		if (ring && !ring.destroyed) t.removeChild(ring);
 	}
 	ringTokens = [];
 }
+
+Hooks.on('canvasTearDown', removeAllRings);
 
 function addRingToToken(token: TokenWithHover): void {
 	if (typeof token.addChild !== 'function') return;
@@ -46,14 +46,14 @@ function addRingToToken(token: TokenWithHover): void {
 	ringTokens.push(token);
 }
 
-export function tokenHoverIn(token: unknown, _event: MouseEvent): void {
+export function tokenHoverIn(token: unknown): void {
 	removeAllRings();
 	const t = token as TokenWithHover;
 	if (!t || t.isVisible === false) return;
 	addRingToToken(t);
 }
 
-export function tokenGroupHoverIn(tokens: unknown[], _event: MouseEvent): void {
+export function tokenGroupHoverIn(tokens: unknown[]): void {
 	removeAllRings();
 	for (const token of tokens) {
 		const t = token as TokenWithHover;
@@ -62,6 +62,6 @@ export function tokenGroupHoverIn(tokens: unknown[], _event: MouseEvent): void {
 	}
 }
 
-export function tokenHoverOut(_token: unknown, _event: MouseEvent): void {
+export function tokenHoverOut(_token: unknown): void {
 	removeAllRings();
 }

--- a/src/view/chat/components/Targets.svelte
+++ b/src/view/chat/components/Targets.svelte
@@ -11,7 +11,7 @@
 		messageDocument.addTargetedTokensAsTargets();
 	}
 
-	function getArmorIcon(token) {
+	function getArmorIcon(token: TokenDocument.Implementation) {
 		const armor = token.actor?.system?.attributes.armor;
 		const armorIcon = npcArmorIcons[armor];
 
@@ -27,7 +27,7 @@
 	`;
 	}
 
-	function getArmorTooltip(armor) {
+	function getArmorTooltip(armor: string) {
 		const armorEffect = npcArmorEffects[armor];
 		const armorIcon = npcArmorIcons[armor];
 		const armorLabel = npcArmorTypes[armor];
@@ -44,13 +44,12 @@
     `;
 	}
 
-	async function prepareTargets(targetIDs) {
+	async function prepareTargets(targetIDs: string[]) {
 		const tokenDocuments = await Promise.all(targetIDs.map((id) => fromUuid(id)));
 		return tokenDocuments.filter(Boolean);
 	}
 
-	function removeTarget(targetId) {
-		console.log('CLICKED!');
+	function removeTarget(targetId: string) {
 		messageDocument.removeTarget(targetId);
 	}
 

--- a/src/view/chat/components/Targets.svelte
+++ b/src/view/chat/components/Targets.svelte
@@ -1,6 +1,7 @@
 <script>
 	import { getContext } from 'svelte';
 	import localize from '../../../utils/localize.js';
+	import { tokenHoverIn, tokenHoverOut } from '../../../utils/tokenHoverHighlight.js';
 
 	function addSelectedTokensAsTargets() {
 		messageDocument.addSelectedTokensAsTargets();
@@ -41,20 +42,6 @@
 
         ${armorEffect}
     `;
-	}
-
-	async function handleTokenHighlight(event, tokenDocument, mode) {
-		event.preventDefault();
-
-		const token = tokenDocument.object;
-
-		if (!token || !token.isVisible || token.controlled) return;
-
-		if (mode === 'enter') {
-			token._onHoverIn(event, { hoverOutOthers: true });
-		} else {
-			token._onHoverOut(event);
-		}
 	}
 
 	async function prepareTargets(targetIDs) {
@@ -107,8 +94,8 @@
 			{#each tokens as token}
 				<li
 					class="nimble-card"
-					onmouseenter={(event) => handleTokenHighlight(event, token, 'enter')}
-					onmouseleave={(event) => handleTokenHighlight(event, token, 'leave')}
+					onmouseenter={(event) => tokenHoverIn(token.object, event)}
+					onmouseleave={(event) => tokenHoverOut(token.object, event)}
 				>
 					<img
 						class="nimble-card__img"

--- a/src/view/chat/components/Targets.svelte
+++ b/src/view/chat/components/Targets.svelte
@@ -94,8 +94,8 @@
 			{#each tokens as token}
 				<li
 					class="nimble-card"
-					onmouseenter={(event) => tokenHoverIn(token.object, event)}
-					onmouseleave={(event) => tokenHoverOut(token.object, event)}
+					onmouseenter={() => tokenHoverIn(token.object)}
+					onmouseleave={() => tokenHoverOut(token.object)}
 				>
 					<img
 						class="nimble-card__img"

--- a/src/view/chat/components/Targets.svelte
+++ b/src/view/chat/components/Targets.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import { getContext } from 'svelte';
 	import localize from '../../../utils/localize.js';
 	import { tokenHoverIn, tokenHoverOut } from '../../../utils/tokenHoverHighlight.js';

--- a/src/view/dialogs/CtSettingsDialog.svelte
+++ b/src/view/dialogs/CtSettingsDialog.svelte
@@ -246,6 +246,36 @@
 					/>
 				</div>
 			</div>
+			<div class="nimble-ct-settings__color-row">
+				<div class="nimble-ct-settings__color-head">
+					<label class="nimble-ct-settings__label" for="nimble-ct-hover-color"
+						>{localize('NIMBLE.ui.ctSettings.hoverColor')}</label
+					>
+				</div>
+				<div class="nimble-ct-settings__color-controls">
+					{#each COLOR_PRESETS as preset}
+						<button
+							type="button"
+							class="nimble-ct-settings__color-swatch"
+							class:nimble-ct-settings__color-swatch--active={state.hoverColor === preset.color}
+							style={`--nimble-ct-color: ${preset.color};`}
+							aria-label={localize(preset.labelKey)}
+							data-tooltip={localize(preset.labelKey)}
+							onclick={() => state.applyHoverColor(preset.color)}
+						></button>
+					{/each}
+					<input
+						id="nimble-ct-hover-color"
+						type="color"
+						class="nimble-ct-settings__color-picker"
+						value={state.hoverColor}
+						oninput={(event) =>
+							state.applyHoverColor((event.currentTarget as HTMLInputElement).value)}
+						onchange={(event) =>
+							state.applyHoverColor((event.currentTarget as HTMLInputElement).value)}
+					/>
+				</div>
+			</div>
 		</div>
 	</fieldset>
 </section>

--- a/src/view/dialogs/ctSettingsDialog/state.svelte.ts
+++ b/src/view/dialogs/ctSettingsDialog/state.svelte.ts
@@ -5,6 +5,7 @@ import {
 	getCombatTrackerCtCardSizeLevel,
 	getCombatTrackerCtLeftToRightOrdering,
 	getCombatTrackerCtWidthLevel,
+	getCombatTrackerHoverColor,
 	getCombatTrackerNonPlayerHpBarEnabled,
 	getCombatTrackerNonPlayerHpBarTextMode,
 	getCombatTrackerPlayerHpBarTextMode,
@@ -12,6 +13,7 @@ import {
 	getCombatTrackerResourceDrawerHoverEnabled,
 	isCombatTrackerActionDiceColorSettingKey,
 	isCombatTrackerCardSizeLevelSettingKey,
+	isCombatTrackerHoverColorSettingKey,
 	isCombatTrackerLeftToRightOrderingSettingKey,
 	isCombatTrackerNonPlayerHpBarEnabledSettingKey,
 	isCombatTrackerNonPlayerHpBarTextModeSettingKey,
@@ -24,6 +26,7 @@ import {
 	setCombatTrackerCtCardSizeLevel,
 	setCombatTrackerCtLeftToRightOrdering,
 	setCombatTrackerCtWidthLevel,
+	setCombatTrackerHoverColor,
 	setCombatTrackerNonPlayerHpBarEnabled,
 	setCombatTrackerNonPlayerHpBarTextMode,
 	setCombatTrackerPlayerHpBarTextMode,
@@ -92,6 +95,8 @@ export class CtSettingsDialogState {
 	actionColor = $state(getCombatTrackerActionDiceColor());
 
 	reactionColor = $state(getCombatTrackerReactionColor());
+
+	hoverColor = $state(getCombatTrackerHoverColor());
 
 	leftToRightOrdering = $state(getCombatTrackerCtLeftToRightOrdering());
 
@@ -262,6 +267,12 @@ export class CtSettingsDialogState {
 		this.persistCtSetting('reaction color', setCombatTrackerReactionColor(normalizedColor));
 	};
 
+	applyHoverColor = (color: string): void => {
+		const normalizedColor = normalizeHexColor(color);
+		this.hoverColor = normalizedColor;
+		this.persistCtSetting('hover color', setCombatTrackerHoverColor(normalizedColor));
+	};
+
 	mount(): void {
 		this.refreshCombatPermissionState();
 		this.sliderPreviewGlobalPointerUpListener = () => {
@@ -318,6 +329,9 @@ export class CtSettingsDialogState {
 			}
 			if (isCombatTrackerReactionColorSettingKey(settingKey)) {
 				this.reactionColor = getCombatTrackerReactionColor();
+			}
+			if (isCombatTrackerHoverColorSettingKey(settingKey)) {
+				this.hoverColor = getCombatTrackerHoverColor();
 			}
 			if (isCombatTrackerLeftToRightOrderingSettingKey(settingKey)) {
 				this.leftToRightOrdering = getCombatTrackerCtLeftToRightOrdering();

--- a/src/view/ui/CtTopTracker.state.svelte.ts
+++ b/src/view/ui/CtTopTracker.state.svelte.ts
@@ -14,7 +14,7 @@ import { isCombatantDead } from '#utils/isCombatantDead.js';
 import { isCombatStarted } from '#utils/isCombatStarted.js';
 import localize from '#utils/localize.js';
 import { queueCombatantMutationWithFreshDocument } from '#utils/queueCombatantMutationWithFreshDocument.js';
-import { tokenHoverIn, tokenHoverOut } from '#utils/tokenHoverHighlight.js';
+import { tokenGroupHoverIn, tokenHoverIn, tokenHoverOut } from '#utils/tokenHoverHighlight.js';
 import CtSettingsDialogComponent from '#view/dialogs/CtSettingsDialog.svelte';
 import { COMBAT_TRACKER_CLIENT_SETTING_UPDATED_EVENT_NAME } from '../../settings/combatTrackerSettings.js';
 import {
@@ -528,6 +528,17 @@ export function createCtTopTrackerState() {
 	): void {
 		if (!canvas?.ready) return;
 		tokenHoverOut(getCombatantToken(combatant), event);
+	}
+
+	function handleMonsterStackMouseEnter(event: MouseEvent, entry: MonsterStackTrackEntry): void {
+		if (!canvas?.ready) return;
+		const tokens = entry.combatants.map(getCombatantToken).filter((t) => t !== null);
+		tokenGroupHoverIn(tokens, event);
+	}
+
+	function handleMonsterStackMouseLeave(event: MouseEvent, _entry: MonsterStackTrackEntry): void {
+		if (!canvas?.ready) return;
+		tokenHoverOut(null, event);
 	}
 
 	function canRemoveCombatant(): boolean {
@@ -1613,6 +1624,8 @@ export function createCtTopTrackerState() {
 		handleMonsterStackClick,
 		handleMonsterStackContextMenu,
 		handleMonsterStackKeyDown,
+		handleMonsterStackMouseEnter,
+		handleMonsterStackMouseLeave,
 		handleTrackDragOver,
 		handleTrackDrop,
 		handleTrackScroll,

--- a/src/view/ui/CtTopTracker.state.svelte.ts
+++ b/src/view/ui/CtTopTracker.state.svelte.ts
@@ -14,6 +14,7 @@ import { isCombatantDead } from '#utils/isCombatantDead.js';
 import { isCombatStarted } from '#utils/isCombatStarted.js';
 import localize from '#utils/localize.js';
 import { queueCombatantMutationWithFreshDocument } from '#utils/queueCombatantMutationWithFreshDocument.js';
+import { tokenHoverIn, tokenHoverOut } from '#utils/tokenHoverHighlight.js';
 import CtSettingsDialogComponent from '#view/dialogs/CtSettingsDialog.svelte';
 import { COMBAT_TRACKER_CLIENT_SETTING_UPDATED_EVENT_NAME } from '../../settings/combatTrackerSettings.js';
 import {
@@ -517,41 +518,16 @@ export function createCtTopTrackerState() {
 		event: MouseEvent,
 		combatant: Combatant.Implementation,
 	): void {
-		console.log('[Nimble][CT] mouseenter', {
-			combatantId: getCombatantId(combatant),
-			canvasReady: canvas?.ready,
-		});
-		if (!canvas?.ready) {
-			console.log('[Nimble][CT] mouseenter: canvas not ready');
-			return;
-		}
-		const token = getCombatantToken(combatant);
-		console.log('[Nimble][CT] mouseenter token', {
-			token,
-			isVisible: token?.isVisible,
-			controlled: token?.controlled,
-			hasHoverIn: typeof (token as unknown as { _onHoverIn?: unknown })._onHoverIn,
-		});
-		if (!token || token.isVisible === false || token.controlled) {
-			console.log('[Nimble][CT] mouseenter: skipped (no token / not visible / controlled)');
-			return;
-		}
-		(
-			token as unknown as {
-				_onHoverIn?: (e: MouseEvent, opts?: { hoverOutOthers?: boolean }) => void;
-			}
-		)._onHoverIn?.(event, { hoverOutOthers: true });
+		if (!canvas?.ready) return;
+		tokenHoverIn(getCombatantToken(combatant), event);
 	}
 
 	function handleCombatantCardMouseLeave(
 		event: MouseEvent,
 		combatant: Combatant.Implementation,
 	): void {
-		console.log('[Nimble][CT] mouseleave', { combatantId: getCombatantId(combatant) });
 		if (!canvas?.ready) return;
-		const token = getCombatantToken(combatant);
-		if (!token || token.isVisible === false || token.controlled) return;
-		(token as unknown as { _onHoverOut?: (e: MouseEvent) => void })._onHoverOut?.(event);
+		tokenHoverOut(getCombatantToken(combatant), event);
 	}
 
 	function canRemoveCombatant(): boolean {

--- a/src/view/ui/CtTopTracker.state.svelte.ts
+++ b/src/view/ui/CtTopTracker.state.svelte.ts
@@ -513,6 +513,47 @@ export function createCtTopTrackerState() {
 		void pingCombatantToken(combatant);
 	}
 
+	function handleCombatantCardMouseEnter(
+		event: MouseEvent,
+		combatant: Combatant.Implementation,
+	): void {
+		console.log('[Nimble][CT] mouseenter', {
+			combatantId: getCombatantId(combatant),
+			canvasReady: canvas?.ready,
+		});
+		if (!canvas?.ready) {
+			console.log('[Nimble][CT] mouseenter: canvas not ready');
+			return;
+		}
+		const token = getCombatantToken(combatant);
+		console.log('[Nimble][CT] mouseenter token', {
+			token,
+			isVisible: token?.isVisible,
+			controlled: token?.controlled,
+			hasHoverIn: typeof (token as unknown as { _onHoverIn?: unknown })._onHoverIn,
+		});
+		if (!token || token.isVisible === false || token.controlled) {
+			console.log('[Nimble][CT] mouseenter: skipped (no token / not visible / controlled)');
+			return;
+		}
+		(
+			token as unknown as {
+				_onHoverIn?: (e: MouseEvent, opts?: { hoverOutOthers?: boolean }) => void;
+			}
+		)._onHoverIn?.(event, { hoverOutOthers: true });
+	}
+
+	function handleCombatantCardMouseLeave(
+		event: MouseEvent,
+		combatant: Combatant.Implementation,
+	): void {
+		console.log('[Nimble][CT] mouseleave', { combatantId: getCombatantId(combatant) });
+		if (!canvas?.ready) return;
+		const token = getCombatantToken(combatant);
+		if (!token || token.isVisible === false || token.controlled) return;
+		(token as unknown as { _onHoverOut?: (e: MouseEvent) => void })._onHoverOut?.(event);
+	}
+
 	function canRemoveCombatant(): boolean {
 		return Boolean(game.user?.isGM);
 	}
@@ -1589,6 +1630,8 @@ export function createCtTopTrackerState() {
 		handleCombatantCardClick,
 		handleCombatantCardContextMenu,
 		handleCombatantCardKeyDown,
+		handleCombatantCardMouseEnter,
+		handleCombatantCardMouseLeave,
 		canRemoveCombatant,
 		handleRemoveCombatant,
 		handleMonsterStackClick,

--- a/src/view/ui/CtTopTracker.state.svelte.ts
+++ b/src/view/ui/CtTopTracker.state.svelte.ts
@@ -515,7 +515,7 @@ export function createCtTopTrackerState() {
 	}
 
 	function handleCombatantCardMouseEnter(
-		event: MouseEvent,
+		_event: MouseEvent,
 		combatant: Combatant.Implementation,
 	): void {
 		if (!canvas?.ready) return;
@@ -523,20 +523,20 @@ export function createCtTopTrackerState() {
 	}
 
 	function handleCombatantCardMouseLeave(
-		event: MouseEvent,
+		_event: MouseEvent,
 		combatant: Combatant.Implementation,
 	): void {
 		if (!canvas?.ready) return;
 		tokenHoverOut(getCombatantToken(combatant));
 	}
 
-	function handleMonsterStackMouseEnter(event: MouseEvent, entry: MonsterStackTrackEntry): void {
+	function handleMonsterStackMouseEnter(_event: MouseEvent, entry: MonsterStackTrackEntry): void {
 		if (!canvas?.ready) return;
 		const tokens = entry.combatants.map(getCombatantToken).filter((t) => t !== null);
 		tokenGroupHoverIn(tokens);
 	}
 
-	function handleMonsterStackMouseLeave(event: MouseEvent, _entry: MonsterStackTrackEntry): void {
+	function handleMonsterStackMouseLeave(_event: MouseEvent, _entry: MonsterStackTrackEntry): void {
 		if (!canvas?.ready) return;
 		tokenHoverOut(null);
 	}

--- a/src/view/ui/CtTopTracker.state.svelte.ts
+++ b/src/view/ui/CtTopTracker.state.svelte.ts
@@ -519,7 +519,7 @@ export function createCtTopTrackerState() {
 		combatant: Combatant.Implementation,
 	): void {
 		if (!canvas?.ready) return;
-		tokenHoverIn(getCombatantToken(combatant), event);
+		tokenHoverIn(getCombatantToken(combatant));
 	}
 
 	function handleCombatantCardMouseLeave(
@@ -527,18 +527,18 @@ export function createCtTopTrackerState() {
 		combatant: Combatant.Implementation,
 	): void {
 		if (!canvas?.ready) return;
-		tokenHoverOut(getCombatantToken(combatant), event);
+		tokenHoverOut(getCombatantToken(combatant));
 	}
 
 	function handleMonsterStackMouseEnter(event: MouseEvent, entry: MonsterStackTrackEntry): void {
 		if (!canvas?.ready) return;
 		const tokens = entry.combatants.map(getCombatantToken).filter((t) => t !== null);
-		tokenGroupHoverIn(tokens, event);
+		tokenGroupHoverIn(tokens);
 	}
 
 	function handleMonsterStackMouseLeave(event: MouseEvent, _entry: MonsterStackTrackEntry): void {
 		if (!canvas?.ready) return;
-		tokenHoverOut(null, event);
+		tokenHoverOut(null);
 	}
 
 	function canRemoveCombatant(): boolean {

--- a/src/view/ui/CtTopTracker.svelte
+++ b/src/view/ui/CtTopTracker.svelte
@@ -83,6 +83,8 @@
 	const handleMonsterStackClick = trackerViewState.handleMonsterStackClick;
 	const handleMonsterStackContextMenu = trackerViewState.handleMonsterStackContextMenu;
 	const handleMonsterStackKeyDown = trackerViewState.handleMonsterStackKeyDown;
+	const handleMonsterStackMouseEnter = trackerViewState.handleMonsterStackMouseEnter;
+	const handleMonsterStackMouseLeave = trackerViewState.handleMonsterStackMouseLeave;
 	const handleTrackDragOver = trackerViewState.handleTrackDragOver;
 	const handleTrackDrop = trackerViewState.handleTrackDrop;
 	const handleTrackScroll = trackerViewState.handleTrackScroll;
@@ -546,6 +548,8 @@
 									onclick={(event) => handleMonsterStackClick(event, entry)}
 									oncontextmenu={(event) => handleMonsterStackContextMenu(event, entry)}
 									onkeydown={(event) => handleMonsterStackKeyDown(event, entry)}
+									onmouseenter={(event) => handleMonsterStackMouseEnter(event, entry)}
+									onmouseleave={(event) => handleMonsterStackMouseLeave(event, entry)}
 								>
 									{#if canDragEntry}
 										<div

--- a/src/view/ui/CtTopTracker.svelte
+++ b/src/view/ui/CtTopTracker.svelte
@@ -76,6 +76,8 @@
 	const handleCombatantCardClick = trackerViewState.handleCombatantCardClick;
 	const handleCombatantCardContextMenu = trackerViewState.handleCombatantCardContextMenu;
 	const handleCombatantCardKeyDown = trackerViewState.handleCombatantCardKeyDown;
+	const handleCombatantCardMouseEnter = trackerViewState.handleCombatantCardMouseEnter;
+	const handleCombatantCardMouseLeave = trackerViewState.handleCombatantCardMouseLeave;
 	const canRemoveCombatant = trackerViewState.canRemoveCombatant;
 	const handleRemoveCombatant = trackerViewState.handleRemoveCombatant;
 	const handleMonsterStackClick = trackerViewState.handleMonsterStackClick;
@@ -384,6 +386,8 @@
 									onclick={(event) => handleCombatantCardClick(event, entry.combatant)}
 									oncontextmenu={(event) => handleCombatantCardContextMenu(event, entry.combatant)}
 									onkeydown={(event) => handleCombatantCardKeyDown(event, entry.combatant)}
+									onmouseenter={(event) => handleCombatantCardMouseEnter(event, entry.combatant)}
+									onmouseleave={(event) => handleCombatantCardMouseLeave(event, entry.combatant)}
 								>
 									<img
 										class="nimble-ct__image"

--- a/src/view/ui/ctTopTracker/types.ts
+++ b/src/view/ui/ctTopTracker/types.ts
@@ -47,6 +47,8 @@ export interface CtWidthPreviewEventDetail {
 export interface CanvasTokenLike {
 	center?: { x: number; y: number } | null;
 	document?: { id?: string | null } | null;
+	isVisible?: boolean;
+	controlled?: boolean;
 }
 
 export type CombatWithDrop = Combat & {


### PR DESCRIPTION
## Summary

- Adds a PIXI ring highlight on canvas tokens when hovering over combatant entries across the Combat Tracker (CT), the Nimble Combat System Window (NCSW), and the Targets panel
- All hover rows in the NCSW (roll row, roll-and-end-turn row, member cells) highlight the corresponding canvas token
- Monster stack cards in the CT highlight **all** tokens in the group simultaneously
- Adds a configurable **Hover Color** swatch to CT Settings alongside the existing Action/Reaction colors
- Hover color is applied at hover-time so changes take effect immediately without reload
- Works for both controlled and uncontrolled tokens (uses PIXI ring, not Foundry native highlight)

## Implementation

- New shared utility `src/utils/tokenHoverHighlight.ts` exports `tokenHoverIn`, `tokenGroupHoverIn`, and `tokenHoverOut`
- `tokenGroupHoverIn` draws rings on multiple tokens simultaneously (used for monster stacks)
- Hover color read from `combatTrackerSettings` at call-time via `getCombatTrackerHoverColor()`
- `combatTrackerSettings.ts` extended with `combatTrackerCtHoverColor` setting (client-scoped)
- CT Settings dialog updated with hover color row (presets + color picker)

## Closes

Closes #487

## Test Plan

- [x] Hover over a combatant card in the CT — ring appears on canvas token
- [x] Hover over a monster stack card in the CT — rings appear on all tokens in the group
- [x] Hover over rows in the NCSW (roll row, roll-and-end-turn row) — ring appears
- [x] Hover over target entries in the Targets panel — ring appears
- [x] Change Hover Color in CT Settings — new color reflected on next hover
- [x] Uncontrolled tokens highlight correctly (no token selected)
- [x] Ring disappears on mouse leave