### PR TITLE
fix(tests): add String.prototype.slugify polyfill to test setup

### DIFF
--- a/src/view/dialogs/CharacterLevelUpDialog.test.ts
+++ b/src/view/dialogs/CharacterLevelUpDialog.test.ts
@@ -25,7 +25,7 @@ vi.mock('#utils/getSubclassFeatures.ts', () => ({
 }));
 
 // Mock getSubclassChoices to return empty array (avoid SubclassSelection rendering issues in tests)
-vi.mock('../../utils/getSubclassChoices.ts', () => ({
+vi.mock('#utils/getSubclassChoices.ts', () => ({
 	default: vi.fn(() => Promise.resolve([])),
 }));
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -13,6 +13,22 @@ import {
 	uiMock,
 } from './mocks/foundry.js';
 
+// Mock Foundry's String.prototype.slugify extension.
+// Foundry VTT adds this to String.prototype at runtime; the test environment
+// does not load Foundry, so any source code that calls .slugify() will throw
+// without this polyfill.
+(String.prototype as unknown as { slugify(opts?: { strict?: boolean }): string }).slugify =
+	function slugify(this: string, { strict = false }: { strict?: boolean } = {}): string {
+		const clean = this.normalize('NFD')
+			.replace(/\p{M}/gu, '')
+			.toLowerCase()
+			.replace(/'/g, '')
+			.replace(/[^a-zA-Z0-9\s-]/g, ' ')
+			.trim()
+			.replace(/[\s-]+/g, '-');
+		return strict ? clean.replace(/[^a-zA-Z0-9-]/g, '') : clean;
+	};
+
 // Mock Foundry global object required setup before importing config
 // CRITICAL: These document classes must be mocked BEFORE any code tries to extend them
 // They are global Foundry classes, not part of the foundry object


### PR DESCRIPTION
## Summary

- Foundry VTT extends `String.prototype` with `.slugify()` at runtime, but the test environment never loads Foundry
- Any source code calling `.slugify()` (e.g. `getSubclassChoices.ts`) threw `TypeError: item.name.slugify is not a function` during the level-3 subclass selection test, producing spurious `stderr` noise even though the test still passed
- Added a matching polyfill to `tests/setup.ts` so the extension is available in all tests

## Test plan

- [ ] `pnpm test` passes with no `stderr` output about `slugify`
- [ ] `pnpm type-check` passes clean