### PR TITLE
refactor(dev-build): route system id through SYSTEM_ID constant

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,13 @@ This file provides guidance for AI assistants working on this codebase.
 - **Don't modify test infrastructure**: `tests/setup.ts` and `tests/mocks/foundry.js` are stable shared infrastructure — fix your test, not the setup
 - **English localization only**: Agents may add or modify English source strings in `en.json` but must flag all changes for human review. Never generate, modify, or translate locale files for any other language.
 - **Base branch is `dev`**: When comparing against remote, creating PRs, or referencing the base branch, always use `dev` — never `main`.
+- **Never hardcode `'nimble'` as the system id**: Always import `SYSTEM_ID` from `#system` (or `SYSTEM_PATH` for `systems/<id>/...` asset paths). The dev rolling release rebuilds under a different system id (`nimble-dev`), and hardcoded `'nimble'` literals silently break flags, settings, sheet registration, and pack UUIDs in that build. This applies to:
+  - **Flag scope:** `actor.setFlag(SYSTEM_ID, ...)`, `getFlag`, `unsetFlag`
+  - **Flag paths:** `` `flags.${SYSTEM_ID}.X` `` (or use the existing `*RuleConfig.flagPath`/`flagScope` constants when applicable)
+  - **Property access:** `actor.flags[SYSTEM_ID]`, not `actor.flags.nimble`
+  - **Settings:** `game.settings.get/set/register(SYSTEM_ID as 'core', ...)`
+  - **Sheet/keybinding registration:** `Actors.registerSheet(SYSTEM_ID, ...)`, `game.keybindings.register(SYSTEM_ID, ...)`
+  - **Asset paths:** `` `${SYSTEM_PATH}/icons/foo.svg` `` instead of `'systems/nimble/icons/foo.svg'`
 
 ## References
 
@@ -38,7 +45,7 @@ System internals (read before touching the area):
 - **Props types**: Define in separate `types/components/*.d.ts` files, not inline
 - **Naming**: PascalCase for components/classes, camelCase for functions/directories
 - **Localization**: Use `localize()` from `src/utils/localize.ts` for all user-facing strings
-- **Path aliases**: Use `#documents/*`, `#lib/*`, `#managers/*`, `#stores/*`, `#types/*`, `#utils/*`, `#view/*`
+- **Path aliases**: Use `#documents/*`, `#lib/*`, `#managers/*`, `#stores/*`, `#system`, `#types/*`, `#utils/*`, `#view/*`
 
 ### Engineering Principles
 These are mandatory implementation constraints, not slogans.

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -1445,6 +1445,7 @@ export const myStore = writable<MyStoreState>(initialState);
 
 | Utility | Location | Purpose |
 |---------|----------|---------|
+| `SYSTEM_ID`, `SYSTEM_PATH` | `src/utils/systemId.ts` (alias: `#system`) | Build-time-baked system id from `public/system.json` and `systems/<id>` path prefix. Use for every flag scope, settings namespace, sheet/keybinding registration, and asset path — never hardcode `'nimble'`. The dev rolling release rebuilds under a different id |
 | `localize()` | `src/utils/localize.ts` | Format i18n strings with optional interpolation |
 | `isCombatStarted()` | `src/utils/isCombatStarted.ts` | Determine whether a combat encounter has started |
 | `isCombatantDead()` | `src/utils/isCombatantDead.ts` | Check if a combatant is dead based on HP/wounds |

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
 		"#lib/*": "./lib/*",
 		"#managers/*": "./src/managers/*",
 		"#stores/*": "./src/stores/*",
+		"#system": "./src/utils/systemId.ts",
 		"#types/*": "./types/*",
 		"#utils/*": "./src/utils/*",
 		"#view/*": "./src/view/*"

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -2228,6 +2228,21 @@
 				"finished": "Finished migrating compendium: {packName}."
 			}
 		},
+		"devRebrand": {
+			"dialog": {
+				"title": "Nimble (Dev) — One-time Migration",
+				"intro": "This world was originally created under the stable Nimble system. The Dev build installs under a separate system id (\"nimble-dev\"), so Foundry stores its flags and settings in a different namespace from the stable install.",
+				"body": "Click <strong>Continue</strong> to copy all existing Nimble flags and settings on this world into the Dev namespace so your characters, items, and settings work in the Dev build. This runs once per world.",
+				"warning": "After this runs, the original Nimble data is removed from this world. If you want to keep using the stable Nimble system with this world, cancel now and use a separate world for the Dev build instead.",
+				"confirm": "Continue",
+				"cancel": "Cancel"
+			},
+			"notifications": {
+				"starting": "Nimble (Dev): rebranding world data from nimble → nimble-dev...",
+				"completed": "Nimble (Dev): world data rebrand complete.",
+				"failed": "Nimble (Dev): world data rebrand failed. Check the browser console (F12) for details."
+			}
+		},
 		"actorImport": {
 			"buttonLabel": "Import Actor",
 			"dialogTitle": "Import from Nimble Nexus",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,7 @@
+import { SYSTEM_PATH } from '#system';
 import type { AbilityKeyType } from '#types/abilityKey.js';
 import type { SaveKeyType } from '#types/saveKey.js';
 import type { SkillKeyType } from '#types/skillKey.js';
-import { SYSTEM_PATH } from '#utils/systemId.ts';
 import registerConditionsConfig from './config/registerConditionsConfig.js';
 import registerDocumentConfig from './config/registerDocumentConfig.js';
 import registerPredicateConfig from './config/registerPredicateConfig.js';

--- a/src/config/registerConditionsConfig.ts
+++ b/src/config/registerConditionsConfig.ts
@@ -1,4 +1,4 @@
-import { SYSTEM_PATH } from '#utils/systemId.ts';
+import { SYSTEM_PATH } from '#system';
 
 /**
  * Canonical status-effect IDs for system-managed conditions. The keys here are the

--- a/src/documents/actor/base.svelte.ts
+++ b/src/documents/actor/base.svelte.ts
@@ -1,5 +1,6 @@
 import type { DeepPartial, InexactPartial } from 'fvtt-types/utils';
 import { createSubscriber } from 'svelte/reactivity';
+import { SYSTEM_ID } from '#system';
 import type { AbilityKeyType } from '#types/abilityKey.d.ts';
 import type { SaveKeyType } from '#types/saveKey.d.ts';
 import { NimbleRoll } from '../../dice/NimbleRoll.js';
@@ -277,7 +278,7 @@ class NimbleBaseActor<ActorType extends SystemActorTypes = SystemActorTypes> ext
 
 	_populateDerivedTags(): void {
 		if (getAdjacencySyncEnabled()) {
-			const adjacency = this.getFlag('nimble', 'adjacency') as
+			const adjacency = this.getFlag(SYSTEM_ID, 'adjacency') as
 				| { enemiesAdjacentCount?: number; hasMostAdjacentEnemies?: boolean }
 				| undefined;
 
@@ -556,7 +557,7 @@ class NimbleBaseActor<ActorType extends SystemActorTypes = SystemActorTypes> ext
 		}
 
 		const autoExecMacros =
-			(this as Actor).getFlag('nimble', 'automaticallyExecuteAvailableMacros') ?? true;
+			(this as Actor).getFlag(SYSTEM_ID, 'automaticallyExecuteAvailableMacros') ?? true;
 		if (autoExecMacros) {
 			options.executeMacro ??= item?.hasMacro;
 		}

--- a/src/documents/actor/character.ts
+++ b/src/documents/actor/character.ts
@@ -4,6 +4,7 @@ import type { NimbleBoonItem } from '#documents/item/boon.js';
 import type { NimbleClassItem } from '#documents/item/class.js';
 import type { NimbleFeatureItem } from '#documents/item/feature.js';
 import type { NimbleSubclassItem } from '#documents/item/subclass.js';
+import { SYSTEM_ID } from '#system';
 import type { SkillKeyType } from '#types/skillKey.js';
 import { getHighestSpellTier } from '#utils/spell/getHighestSpellTier.ts';
 import CharacterMetaConfigDialog from '#view/dialogs/CharacterMetaConfigDialog.svelte';
@@ -330,7 +331,7 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 		// add one slots for all small stuff
 		if (smallObjectsCarried) slotsRequiredSum += 1;
 		// account for coinage
-		if (this.getFlag('nimble', 'includeCurrencyBulk') ?? true) {
+		if (this.getFlag(SYSTEM_ID, 'includeCurrencyBulk') ?? true) {
 			const totalCoinage = Object.values(this.system.currency).reduce(
 				(totalCurrencyBulk, { value }) => totalCurrencyBulk + value,
 				0,

--- a/src/documents/combat/expandedTurnIdentityStore.ts
+++ b/src/documents/combat/expandedTurnIdentityStore.ts
@@ -1,7 +1,8 @@
+import { SYSTEM_ID } from '#system';
 import type { TurnIdentity } from './combatTypes.js';
 
 const expandedTurnIdentityByCombatId = new Map<string, TurnIdentity>();
-export const EXPANDED_TURN_IDENTITY_FLAG_PATH = 'flags.nimble.expandedTurnIdentity';
+export const EXPANDED_TURN_IDENTITY_FLAG_PATH = `flags.${SYSTEM_ID}.expandedTurnIdentity`;
 
 function normalizeTurnIdentity(value: unknown): TurnIdentity | null {
 	if (!value || typeof value !== 'object') return null;

--- a/src/documents/combat/handlers/combatManaHandler.ts
+++ b/src/documents/combat/handlers/combatManaHandler.ts
@@ -1,3 +1,4 @@
+import { SYSTEM_ID } from '#system';
 import {
 	getCombatManaGrantForCombat,
 	getCombatManaGrantMap,
@@ -39,7 +40,7 @@ export default async function combatManaHandler({
 		combatant.actor.update({
 			'system.resources.mana.baseMax': combatMana,
 			'system.resources.mana.current': combatMana,
-			'flags.nimble.combatManaGrants': grants,
+			[`flags.${SYSTEM_ID}.combatManaGrants`]: grants,
 		} as Record<string, unknown>),
 	);
 }

--- a/src/hooks/chargeSystem.ts
+++ b/src/hooks/chargeSystem.ts
@@ -1,3 +1,4 @@
+import { SYSTEM_ID } from '#system';
 import {
 	consumeOnResolvedItemUse,
 	validateItemChargeConsumption,
@@ -141,7 +142,7 @@ function registerItemUseHooks(): void {
 		void consumeOnResolvedItemUse(characterItem, itemUseContext).then(async (validation) => {
 			if (validation.consumption && validation.consumption.length > 0 && typedChatMessage?.update) {
 				await typedChatMessage.update({
-					'flags.nimble.chargeConsumption': validation.consumption,
+					[`flags.${SYSTEM_ID}.chargeConsumption`]: validation.consumption,
 				} as Record<string, unknown>);
 			}
 

--- a/src/hooks/combatantHooks/adjacencySync.ts
+++ b/src/hooks/combatantHooks/adjacencySync.ts
@@ -1,7 +1,8 @@
+import { SYSTEM_ID } from '#system';
 import { getAdjacencyIncludesDiagonals } from '../../settings/adjacencySettings.js';
 import { countAdjacentEnemies, type PositionOverrides } from '../../utils/tokenAdjacency.js';
 
-const ADJACENCY_FLAG_PATH = 'flags.nimble.adjacency';
+const ADJACENCY_FLAG_PATH = `flags.${SYSTEM_ID}.adjacency`;
 
 interface AdjacencyFlagData {
 	enemiesAdjacentCount: number;
@@ -42,7 +43,7 @@ async function syncAdjacency(overrides?: PositionOverrides): Promise<void> {
 			const count = counts[i];
 			const hasMost = count > 0 && count === maxCount;
 
-			const currentFlag = actor.getFlag('nimble', 'adjacency') as AdjacencyFlagData | undefined;
+			const currentFlag = actor.getFlag(SYSTEM_ID, 'adjacency') as AdjacencyFlagData | undefined;
 			if (
 				currentFlag?.enemiesAdjacentCount === count &&
 				currentFlag?.hasMostAdjacentEnemies === hasMost
@@ -75,7 +76,7 @@ async function clearAdjacencyForCombat(combat: Combat.Implementation): Promise<v
 		.map((c) => c.actor)
 		.filter((actor): actor is Actor.Implementation => {
 			if (!actor) return false;
-			const flag = actor.getFlag('nimble', 'adjacency') as AdjacencyFlagData | undefined;
+			const flag = actor.getFlag(SYSTEM_ID, 'adjacency') as AdjacencyFlagData | undefined;
 			return (flag?.enemiesAdjacentCount ?? 0) > 0 || (flag?.hasMostAdjacentEnemies ?? false);
 		});
 

--- a/src/hooks/init.ts
+++ b/src/hooks/init.ts
@@ -1,3 +1,4 @@
+import { SYSTEM_ID } from '#system';
 import { NimbleTemplateLayer } from '../canvas/layers/templateLayer.js';
 import { NIMBLE } from '../config.js';
 import { DamageRoll } from '../dice/DamageRoll.js';
@@ -104,7 +105,7 @@ export default function init() {
 	foundry.documents.collections.Actors.unregisterSheet('core', foundry.appv1.sheets.ActorSheet);
 
 	foundry.documents.collections.Actors.registerSheet(
-		'nimble',
+		SYSTEM_ID,
 		NPCSheet as unknown as ActorSheetConstructor,
 		{
 			types: ['npc'],
@@ -114,7 +115,7 @@ export default function init() {
 	);
 
 	foundry.documents.collections.Actors.registerSheet(
-		'nimble',
+		SYSTEM_ID,
 		PlayerCharacterSheet as unknown as ActorSheetConstructor,
 		{
 			types: ['character'],
@@ -124,7 +125,7 @@ export default function init() {
 	);
 
 	foundry.documents.collections.Actors.registerSheet(
-		'nimble',
+		SYSTEM_ID,
 		NPCSheet as unknown as ActorSheetConstructor,
 		{
 			types: ['soloMonster'],
@@ -134,7 +135,7 @@ export default function init() {
 	);
 
 	foundry.documents.collections.Actors.registerSheet(
-		'nimble',
+		SYSTEM_ID,
 		NPCSheet as unknown as ActorSheetConstructor,
 		{
 			types: ['minion'],
@@ -146,7 +147,7 @@ export default function init() {
 	foundry.documents.collections.Items.unregisterSheet('core', foundry.appv1.sheets.ItemSheet);
 
 	foundry.documents.collections.Items.registerSheet(
-		'nimble',
+		SYSTEM_ID,
 		BackgroundSheet as unknown as ItemSheetConstructor,
 		{
 			types: ['background'],
@@ -156,7 +157,7 @@ export default function init() {
 	);
 
 	foundry.documents.collections.Items.registerSheet(
-		'nimble',
+		SYSTEM_ID,
 		BoonSheet as unknown as ItemSheetConstructor,
 		{
 			types: ['boon'],
@@ -165,7 +166,7 @@ export default function init() {
 		},
 	);
 	foundry.documents.collections.Items.registerSheet(
-		'nimble',
+		SYSTEM_ID,
 		ClassSheet as unknown as ItemSheetConstructor,
 		{
 			types: ['class'],
@@ -175,7 +176,7 @@ export default function init() {
 	);
 
 	foundry.documents.collections.Items.registerSheet(
-		'nimble',
+		SYSTEM_ID,
 		FeatureSheet as unknown as ItemSheetConstructor,
 		{
 			types: ['feature'],
@@ -185,7 +186,7 @@ export default function init() {
 	);
 
 	foundry.documents.collections.Items.registerSheet(
-		'nimble',
+		SYSTEM_ID,
 		MonsterFeatureSheet as unknown as ItemSheetConstructor,
 		{
 			types: ['monsterFeature'],
@@ -195,7 +196,7 @@ export default function init() {
 	);
 
 	foundry.documents.collections.Items.registerSheet(
-		'nimble',
+		SYSTEM_ID,
 		ObjectSheet as unknown as ItemSheetConstructor,
 		{
 			types: ['object'],
@@ -205,7 +206,7 @@ export default function init() {
 	);
 
 	foundry.documents.collections.Items.registerSheet(
-		'nimble',
+		SYSTEM_ID,
 		AncestrySheet as unknown as ItemSheetConstructor,
 		{
 			types: ['ancestry'],
@@ -215,7 +216,7 @@ export default function init() {
 	);
 
 	foundry.documents.collections.Items.registerSheet(
-		'nimble',
+		SYSTEM_ID,
 		SpellSheet as unknown as ItemSheetConstructor,
 		{
 			types: ['spell'],
@@ -225,7 +226,7 @@ export default function init() {
 	);
 
 	foundry.documents.collections.Items.registerSheet(
-		'nimble',
+		SYSTEM_ID,
 		SubclassSheet as unknown as ItemSheetConstructor,
 		{
 			types: ['subclass'],

--- a/src/hooks/ready.ts
+++ b/src/hooks/ready.ts
@@ -1,5 +1,5 @@
 import { mount, unmount } from 'svelte';
-
+import { SYSTEM_ID } from '#system';
 import { MigrationList } from '../migration/MigrationList.js';
 import { MigrationRunner } from '../migration/MigrationRunner.js';
 import { MigrationRunnerBase } from '../migration/MigrationRunnerBase.js';
@@ -18,7 +18,7 @@ export default async function ready() {
 	// Only the GM should run migrations (requires world-level write permissions)
 	if (game.user?.isGM) {
 		const worldSchemaVersion = game.settings.get(
-			'nimble' as 'core',
+			SYSTEM_ID as 'core',
 			'worldSchemaVersion' as 'rollMode',
 		) as unknown as number;
 		const latestSchemaVersion = MigrationRunnerBase.LATEST_SCHEMA_VERSION;

--- a/src/hooks/ready.ts
+++ b/src/hooks/ready.ts
@@ -1,5 +1,6 @@
 import { mount, unmount } from 'svelte';
 import { SYSTEM_ID } from '#system';
+import { runDevFlagRebrandPersist } from '../migration/devFlagRebrand.js';
 import { MigrationList } from '../migration/MigrationList.js';
 import { MigrationRunner } from '../migration/MigrationRunner.js';
 import { MigrationRunnerBase } from '../migration/MigrationRunnerBase.js';
@@ -17,6 +18,11 @@ let canvasConditionsPanelComponent: object | null = null;
 export default async function ready() {
 	// Only the GM should run migrations (requires world-level write permissions)
 	if (game.user?.isGM) {
+		// Dev-build-only phase 2: persist the in-memory rebrand (from
+		// preInitGame) to the database. No-op on the stable install, on
+		// non-GM clients, and on already-clean dev worlds.
+		await runDevFlagRebrandPersist();
+
 		const worldSchemaVersion = game.settings.get(
 			SYSTEM_ID as 'core',
 			'worldSchemaVersion' as 'rollMode',

--- a/src/hooks/ruleEventDispatch.ts
+++ b/src/hooks/ruleEventDispatch.ts
@@ -1,3 +1,4 @@
+import { SYSTEM_ID } from '#system';
 import type {
 	ActorHealthContext,
 	InitiativeRolledContext,
@@ -44,7 +45,7 @@ interface NimbleInitiativePayload {
 function isAutoApplyEnabled(): boolean {
 	try {
 		return Boolean(
-			game.settings?.get('nimble' as 'core', AUTO_APPLY_CONDITIONS_SETTING as 'rollMode'),
+			game.settings?.get(SYSTEM_ID as 'core', AUTO_APPLY_CONDITIONS_SETTING as 'rollMode'),
 		);
 	} catch {
 		return false;

--- a/src/macros/createHeroicActionMacro.ts
+++ b/src/macros/createHeroicActionMacro.ts
@@ -1,4 +1,4 @@
-import { SYSTEM_PATH } from '#utils/systemId.ts';
+import { SYSTEM_PATH } from '#system';
 
 interface HeroicActionMacroData {
 	actionId: string;

--- a/src/managers/ItemActivationManager.ts
+++ b/src/managers/ItemActivationManager.ts
@@ -13,7 +13,9 @@ import {
 	hasWeaponProficiency,
 } from '../utils/attackUtils.js';
 import { adjustPool } from '../utils/chargePool/chargePoolRecover.js';
+import { ChargePoolRuleConfig } from '../utils/chargePoolRuleConfig.js';
 import { rollDieIntoPool, rollPoolFresh, setPoolFaces } from '../utils/dicePool/dicePoolRefill.js';
+import { DicePoolRuleConfig } from '../utils/dicePool/dicePoolRuleConfig.js';
 import getRollFormula from '../utils/getRollFormula.js';
 import { normalizeDamageRollFormula } from '../utils/normalizeDamageRollFormula.js';
 import { applyUpcastDeltas } from '../utils/spell/applyUpcastDeltas.js';
@@ -400,14 +402,14 @@ class ItemActivationManager {
 			// items here since the dispatcher does the same elsewhere.
 			let currentFaces: number[] | null = null;
 			if (poolId.startsWith('actor:')) {
-				const map = foundry.utils.getProperty(actor, 'flags.nimble.dicePools') as
+				const map = foundry.utils.getProperty(actor, DicePoolRuleConfig.flagPath) as
 					| Record<string, { faces?: number[] }>
 					| undefined;
 				const entry = map?.[poolId];
 				currentFaces = Array.isArray(entry?.faces) ? [...entry.faces] : null;
 			} else {
 				for (const item of actor.items.contents) {
-					const map = foundry.utils.getProperty(item, 'flags.nimble.dicePools') as
+					const map = foundry.utils.getProperty(item, DicePoolRuleConfig.flagPath) as
 						| Record<string, { faces?: number[] }>
 						| undefined;
 					const entry = map?.[poolId];
@@ -451,7 +453,7 @@ class ItemActivationManager {
 			// values, so read current and 'set' to current - count.
 			let currentValue = 0;
 			for (const item of actor.items.contents) {
-				const map = foundry.utils.getProperty(item, 'flags.nimble.chargePools') as
+				const map = foundry.utils.getProperty(item, ChargePoolRuleConfig.flagPath) as
 					| Record<string, { current?: number }>
 					| undefined;
 				const poolEntry = map?.[entry.poolId];
@@ -514,18 +516,18 @@ class ItemActivationManager {
 
 		if (node.poolType === 'dice') {
 			const readPool = (): { label?: string; faces: number[] } => {
-				// Item-scoped pools live on item.flags.nimble.dicePools[identifier];
-				// actor-scoped pools (id "actor:identifier") live on actor.flags.nimble.dicePools.
+				// Item-scoped pools live on item flags under DicePoolRuleConfig.flagPath[identifier];
+				// actor-scoped pools (id "actor:identifier") live on the actor under the same path.
 				if (poolId.startsWith('actor:')) {
 					const actorMap =
-						(foundry.utils.getProperty(actor, 'flags.nimble.dicePools') as
+						(foundry.utils.getProperty(actor, DicePoolRuleConfig.flagPath) as
 							| Record<string, { label?: string; faces?: number[] }>
 							| undefined) ?? {};
 					const entry = actorMap[poolId];
 					return { label: entry?.label, faces: Array.isArray(entry?.faces) ? entry.faces : [] };
 				}
 				for (const item of actor.items.contents) {
-					const itemMap = foundry.utils.getProperty(item, 'flags.nimble.dicePools') as
+					const itemMap = foundry.utils.getProperty(item, DicePoolRuleConfig.flagPath) as
 						| Record<string, { label?: string; faces?: number[] }>
 						| undefined;
 					if (!itemMap) continue;
@@ -585,7 +587,7 @@ class ItemActivationManager {
 		if (node.poolType === 'charge') {
 			const readChargePool = (): { label?: string; current: number } => {
 				for (const item of actor.items.contents) {
-					const map = foundry.utils.getProperty(item, 'flags.nimble.chargePools') as
+					const map = foundry.utils.getProperty(item, ChargePoolRuleConfig.flagPath) as
 						| Record<string, { label?: string; current?: number; identifier?: string }>
 						| undefined;
 					if (!map) continue;

--- a/src/migration/MigrationRunner.ts
+++ b/src/migration/MigrationRunner.ts
@@ -1,3 +1,4 @@
+import { SYSTEM_ID } from '#system';
 import localize from '../utils/localize.js';
 import type { MigrationBase } from './MigrationBase.js';
 import { MigrationRunnerBase } from './MigrationRunnerBase.js';
@@ -19,7 +20,7 @@ class MigrationRunner extends MigrationRunnerBase {
 	override needsMigration(): boolean {
 		return super.needsMigration(
 			game.settings.get(
-				'nimble' as 'core',
+				SYSTEM_ID as 'core',
 				'worldSchemaVersion' as 'rollMode',
 			) as unknown as number,
 		);
@@ -452,7 +453,7 @@ class MigrationRunner extends MigrationRunnerBase {
 		const migrationVersion = {
 			latest: MigrationRunner.LATEST_SCHEMA_VERSION,
 			current: game.settings.get(
-				'nimble' as 'core',
+				SYSTEM_ID as 'core',
 				'worldSchemaVersion' as 'rollMode',
 			) as unknown as number,
 		};
@@ -479,7 +480,7 @@ class MigrationRunner extends MigrationRunnerBase {
 				await this.runMigrations(phase);
 				const lastVersion = phase[phase.length - 1].version;
 				await game.settings.set(
-					'nimble' as 'core',
+					SYSTEM_ID as 'core',
 					'worldSchemaVersion' as 'rollMode',
 					lastVersion as unknown as foundry.CONST.DICE_ROLL_MODES,
 				);

--- a/src/migration/devFlagRebrand.ts
+++ b/src/migration/devFlagRebrand.ts
@@ -1,0 +1,630 @@
+import { SYSTEM_ID } from '#system';
+import localize from '../utils/localize.js';
+
+/**
+ * The dev rolling release installs as system id `nimble-dev` (see
+ * `build/dev-rebrand.mjs`). Foundry namespaces flags and settings by the
+ * installed system id at write time, so any world or document that was created
+ * (or whose flags were written) under the stable `nimble` system has its data
+ * keyed under `flags.nimble.*` and `nimble.*` settings keys — invisible to code
+ * that reads via `SYSTEM_ID` after the dev install takes over.
+ *
+ * **Why init, not ready:** running on `ready` is too late. Foundry calls
+ * `prepareData` on every document during `Game.initializeDocuments` (which
+ * happens between `init` and `setup`). Any code path in `prepareDerivedData`
+ * that calls `this.getFlag(SYSTEM_ID, ...)` throws on a document whose
+ * persisted flags still have a stale `flags.nimble.*` key, because Foundry's
+ * `getFlag` validates the document's own flag scopes against installed
+ * packages and rejects unknown scopes (the legacy `'nimble'` package is not
+ * installed under the dev build).
+ *
+ * Two phases:
+ *
+ *   1. `init` (registered before the main init handler) — runs before document
+ *      instantiation. Walks the raw `game.data.*` arrays and rewrites
+ *      `flags.nimble.*` → `flags.nimble-dev.*` in memory. After this, when
+ *      Foundry constructs documents from the data, they see only the
+ *      dev-keyed flags. Settings storage is rebranded here too. This makes
+ *      the *current session* work without `getFlag` throws.
+ *
+ *      Confirmation dialog runs here too: world initialization is paused on
+ *      the modal until the user accepts. If they cancel, the rebrand is
+ *      skipped for this session (legacy keys remain in memory, which means
+ *      `getFlag` will throw — there's nothing we can do about that, but the
+ *      user explicitly chose this path).
+ *
+ *   2. `ready` — once documents exist as full instances, persist the rebrand
+ *      to the database via `Document#update`. This phase is asynchronous and
+ *      doesn't block the user from interacting; toasts notify when done.
+ *
+ * Per project decision the originals are *deleted* after the copy (the dev
+ * install is the source of truth from that point onward; the stable install
+ * cannot read the rebranded data without its own migration).
+ *
+ * No-op on the stable install (early-return on SYSTEM_ID check). No-op on
+ * already-rebranded worlds (legacy data detection short-circuits as soon as
+ * nothing remains under `flags.nimble.*` or `nimble.*` settings).
+ */
+
+const STABLE_SYSTEM_ID = 'nimble';
+const DEV_SYSTEM_ID = 'nimble-dev';
+
+interface RebrandStats {
+	actors: number;
+	items: number;
+	scenes: number;
+	tokens: number;
+	tokenActorDeltas: number;
+	journals: number;
+	macros: number;
+	tables: number;
+	combats: number;
+	combatants: number;
+	users: number;
+	chatMessages: number;
+	embeddedItems: number;
+	embeddedEffects: number;
+	settings: number;
+}
+
+function emptyStats(): RebrandStats {
+	return {
+		actors: 0,
+		items: 0,
+		scenes: 0,
+		tokens: 0,
+		tokenActorDeltas: 0,
+		journals: 0,
+		macros: 0,
+		tables: 0,
+		combats: 0,
+		combatants: 0,
+		users: 0,
+		chatMessages: 0,
+		embeddedItems: 0,
+		embeddedEffects: 0,
+		settings: 0,
+	};
+}
+
+function statsSummary(stats: RebrandStats): string {
+	const counted = Object.entries(stats)
+		.filter(([, count]) => count > 0)
+		.map(([label, count]) => `${label}=${count}`)
+		.join(', ');
+	return counted || 'no documents had legacy flags';
+}
+
+interface FlagBearing {
+	flags?: Record<string, unknown> | null;
+}
+
+function hasLegacyFlags(source: FlagBearing | null | undefined): boolean {
+	if (!source?.flags || typeof source.flags !== 'object') return false;
+	const legacy = (source.flags as Record<string, unknown>)[STABLE_SYSTEM_ID];
+	return legacy != null && typeof legacy === 'object' && !Array.isArray(legacy);
+}
+
+/**
+ * Mutate a raw source object in place: copy `flags.nimble` into
+ * `flags.nimble-dev` (merging with anything already there, dev side wins), and
+ * delete the `flags.nimble` key. Returns true if something changed.
+ */
+function rebrandSourceInPlace(source: FlagBearing): boolean {
+	if (!hasLegacyFlags(source)) return false;
+
+	const flags = source.flags as Record<string, unknown>;
+	const legacyData = flags[STABLE_SYSTEM_ID] as Record<string, unknown>;
+	const existingDevData = flags[DEV_SYSTEM_ID];
+	const merged =
+		existingDevData != null &&
+		typeof existingDevData === 'object' &&
+		!Array.isArray(existingDevData)
+			? foundry.utils.mergeObject(
+					foundry.utils.deepClone(legacyData),
+					foundry.utils.deepClone(existingDevData as Record<string, unknown>),
+					{ inplace: false, overwrite: true },
+				)
+			: foundry.utils.deepClone(legacyData);
+
+	flags[DEV_SYSTEM_ID] = merged;
+	delete flags[STABLE_SYSTEM_ID];
+	return true;
+}
+
+function rebrandIfNeeded(
+	source: FlagBearing | null | undefined,
+	stats: RebrandStats,
+	statKey: keyof RebrandStats,
+): boolean {
+	if (!source) return false;
+	if (!rebrandSourceInPlace(source)) return false;
+	stats[statKey] += 1;
+	return true;
+}
+
+// ---------------------------------------------------------------------------
+// Phase 1: in-memory rebrand on preInitGame.
+// ---------------------------------------------------------------------------
+
+interface RawWorldData {
+	actors?: RawActor[];
+	items?: RawItem[];
+	scenes?: RawScene[];
+	journal?: FlagBearing[];
+	macros?: FlagBearing[];
+	tables?: FlagBearing[];
+	combats?: RawCombat[];
+	users?: FlagBearing[];
+	messages?: FlagBearing[];
+}
+
+interface RawActor extends FlagBearing {
+	items?: FlagBearing[];
+	effects?: FlagBearing[];
+}
+
+interface RawItem extends FlagBearing {
+	effects?: FlagBearing[];
+}
+
+interface RawScene extends FlagBearing {
+	tokens?: RawToken[];
+}
+
+interface RawToken extends FlagBearing {
+	delta?: FlagBearing | null;
+}
+
+interface RawCombat extends FlagBearing {
+	combatants?: FlagBearing[];
+}
+
+function rebrandInMemory(stats: RebrandStats): void {
+	const data = (game as unknown as { data?: RawWorldData }).data;
+	if (!data) return;
+
+	for (const actor of data.actors ?? []) {
+		rebrandIfNeeded(actor, stats, 'actors');
+		for (const item of actor.items ?? []) {
+			rebrandIfNeeded(item, stats, 'embeddedItems');
+		}
+		for (const effect of actor.effects ?? []) {
+			rebrandIfNeeded(effect, stats, 'embeddedEffects');
+		}
+	}
+
+	for (const item of data.items ?? []) {
+		rebrandIfNeeded(item, stats, 'items');
+		for (const effect of item.effects ?? []) {
+			rebrandIfNeeded(effect, stats, 'embeddedEffects');
+		}
+	}
+
+	for (const scene of data.scenes ?? []) {
+		rebrandIfNeeded(scene, stats, 'scenes');
+		for (const token of scene.tokens ?? []) {
+			rebrandIfNeeded(token, stats, 'tokens');
+			if (token.delta) {
+				rebrandIfNeeded(token.delta, stats, 'tokenActorDeltas');
+			}
+		}
+	}
+
+	for (const journal of data.journal ?? []) rebrandIfNeeded(journal, stats, 'journals');
+	for (const macro of data.macros ?? []) rebrandIfNeeded(macro, stats, 'macros');
+	for (const table of data.tables ?? []) rebrandIfNeeded(table, stats, 'tables');
+	for (const combat of data.combats ?? []) {
+		rebrandIfNeeded(combat, stats, 'combats');
+		for (const combatant of combat.combatants ?? []) {
+			rebrandIfNeeded(combatant, stats, 'combatants');
+		}
+	}
+	for (const user of data.users ?? []) rebrandIfNeeded(user, stats, 'users');
+	for (const message of data.messages ?? []) rebrandIfNeeded(message, stats, 'chatMessages');
+}
+
+// ---------------------------------------------------------------------------
+// Settings rebrand.
+// ---------------------------------------------------------------------------
+
+interface RawSetting {
+	_id?: string;
+	key?: string;
+	value?: unknown;
+}
+
+/**
+ * Settings live in `game.settings.storage.get('world')`. At preInitGame the
+ * settings collection is already populated from the server payload. We rewrite
+ * keys here so any subsequent `game.settings.get(SYSTEM_ID as 'core', ...)`
+ * call during `init` or later sees the dev-keyed value.
+ *
+ * The persistent DB write happens in phase 2.
+ */
+function rebrandSettingsInMemory(stats: RebrandStats): RawSetting[] {
+	const storage = game.settings?.storage?.get('world') as { contents?: RawSetting[] } | undefined;
+	if (!storage?.contents) return [];
+
+	const legacy: RawSetting[] = [];
+	for (const setting of [...storage.contents]) {
+		const key = setting.key;
+		if (typeof key !== 'string' || !key.startsWith(`${STABLE_SYSTEM_ID}.`)) continue;
+		legacy.push(setting);
+
+		const settingName = key.slice(STABLE_SYSTEM_ID.length + 1);
+		const devKey = `${DEV_SYSTEM_ID}.${settingName}`;
+
+		// In-memory rewrite: mutate the key on the existing doc. The doc instance
+		// stays in the collection so settings reads still find it; only the key
+		// changes. Skip if a doc already exists at the dev key (user already
+		// configured it under the dev install).
+		const existingDev = storage.contents.find((s) => s.key === devKey);
+		if (!existingDev) {
+			setting.key = devKey;
+		}
+		stats.settings += 1;
+	}
+	return legacy;
+}
+
+// ---------------------------------------------------------------------------
+// Phase 2: persistent rebrand on ready.
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the update payload that copies `flags.nimble` → `flags.nimble-dev`
+ * (merging) and deletes `flags.nimble` from the persisted document. We use
+ * the document's CURRENT (already in-memory rebranded) flags as the source of
+ * truth for the dev-side data, and only target the `-=nimble` deletion plus
+ * the dev-side reinforcement. Returns null if nothing to persist.
+ */
+function buildPersistentUpdate(
+	source: FlagBearing,
+	legacyKeyPresent: boolean,
+): Record<string, unknown> | null {
+	if (!legacyKeyPresent) return null;
+	const flags = (source.flags ?? {}) as Record<string, unknown>;
+	const devData = flags[DEV_SYSTEM_ID];
+	return {
+		[`flags.${DEV_SYSTEM_ID}`]: devData ?? {},
+		[`flags.-=${STABLE_SYSTEM_ID}`]: null,
+	};
+}
+
+interface DocumentLike {
+	uuid?: string;
+	flags?: Record<string, unknown> | null;
+	update(data: object, options?: object): Promise<unknown>;
+}
+
+async function persistDocument(
+	doc: DocumentLike | null | undefined,
+	rawSourceHadLegacy: boolean,
+): Promise<void> {
+	if (!doc || !rawSourceHadLegacy) return;
+	const update = buildPersistentUpdate(doc as FlagBearing, true);
+	if (!update) return;
+	await doc.update(update, { noHook: true }).catch((err: unknown) => {
+		console.error(`Nimble | dev-rebrand: failed to persist update on ${doc.uuid}:`, err);
+	});
+}
+
+/**
+ * Map of `<documentName>:<id>` → true for each raw source that had a legacy
+ * key before phase 1 rewrote it. Phase 2 reads this to know which documents
+ * actually need a DB write. Built during phase 1 (before mutation).
+ */
+type LegacyRegistry = Set<string>;
+
+function recordLegacy(
+	registry: LegacyRegistry,
+	documentName: string,
+	source: { _id?: string } & FlagBearing,
+): void {
+	if (hasLegacyFlags(source) && source._id) {
+		registry.add(`${documentName}:${source._id}`);
+	}
+}
+
+function buildLegacyRegistry(): LegacyRegistry {
+	const registry: LegacyRegistry = new Set();
+	const data = (game as unknown as { data?: RawWorldData }).data;
+	if (!data) return registry;
+
+	for (const actor of data.actors ?? []) {
+		recordLegacy(registry, 'Actor', actor as { _id?: string } & FlagBearing);
+		for (const item of actor.items ?? []) {
+			recordLegacy(registry, 'Item', item as { _id?: string } & FlagBearing);
+		}
+		for (const effect of actor.effects ?? []) {
+			recordLegacy(registry, 'ActiveEffect', effect as { _id?: string } & FlagBearing);
+		}
+	}
+	for (const item of data.items ?? []) {
+		recordLegacy(registry, 'Item', item as { _id?: string } & FlagBearing);
+		for (const effect of item.effects ?? []) {
+			recordLegacy(registry, 'ActiveEffect', effect as { _id?: string } & FlagBearing);
+		}
+	}
+	for (const scene of data.scenes ?? []) {
+		recordLegacy(registry, 'Scene', scene as { _id?: string } & FlagBearing);
+		for (const token of scene.tokens ?? []) {
+			recordLegacy(registry, 'Token', token as { _id?: string } & FlagBearing);
+		}
+	}
+	for (const journal of data.journal ?? []) {
+		recordLegacy(registry, 'JournalEntry', journal as { _id?: string } & FlagBearing);
+	}
+	for (const macro of data.macros ?? []) {
+		recordLegacy(registry, 'Macro', macro as { _id?: string } & FlagBearing);
+	}
+	for (const table of data.tables ?? []) {
+		recordLegacy(registry, 'RollTable', table as { _id?: string } & FlagBearing);
+	}
+	for (const combat of data.combats ?? []) {
+		recordLegacy(registry, 'Combat', combat as { _id?: string } & FlagBearing);
+		for (const combatant of combat.combatants ?? []) {
+			recordLegacy(registry, 'Combatant', combatant as { _id?: string } & FlagBearing);
+		}
+	}
+	for (const user of data.users ?? []) {
+		recordLegacy(registry, 'User', user as { _id?: string } & FlagBearing);
+	}
+	for (const message of data.messages ?? []) {
+		recordLegacy(registry, 'ChatMessage', message as { _id?: string } & FlagBearing);
+	}
+	return registry;
+}
+
+async function persistRebrand(
+	legacyRegistry: LegacyRegistry,
+	legacySettings: RawSetting[],
+): Promise<void> {
+	if (!game.user?.isGM) return;
+
+	const had = (documentName: string, id: string | null | undefined): boolean =>
+		!!id && legacyRegistry.has(`${documentName}:${id}`);
+
+	for (const actor of game.actors ?? []) {
+		await persistDocument(actor as unknown as DocumentLike, had('Actor', actor.id));
+		for (const item of actor.items) {
+			await persistDocument(item as unknown as DocumentLike, had('Item', item.id));
+		}
+		for (const effect of actor.effects) {
+			await persistDocument(effect as unknown as DocumentLike, had('ActiveEffect', effect.id));
+		}
+	}
+
+	for (const item of game.items ?? []) {
+		await persistDocument(item as unknown as DocumentLike, had('Item', item.id));
+		for (const effect of item.effects) {
+			await persistDocument(effect as unknown as DocumentLike, had('ActiveEffect', effect.id));
+		}
+	}
+
+	for (const scene of game.scenes ?? []) {
+		await persistDocument(scene as unknown as DocumentLike, had('Scene', scene.id));
+		for (const token of scene.tokens) {
+			await persistDocument(token as unknown as DocumentLike, had('Token', token.id));
+		}
+	}
+
+	for (const journal of game.journal ?? []) {
+		await persistDocument(journal as unknown as DocumentLike, had('JournalEntry', journal.id));
+	}
+	for (const macro of game.macros ?? []) {
+		await persistDocument(macro as unknown as DocumentLike, had('Macro', macro.id));
+	}
+	for (const table of game.tables ?? []) {
+		await persistDocument(table as unknown as DocumentLike, had('RollTable', table.id));
+	}
+	for (const combat of game.combats ?? []) {
+		await persistDocument(combat as unknown as DocumentLike, had('Combat', combat.id));
+		for (const combatant of combat.combatants) {
+			await persistDocument(combatant as unknown as DocumentLike, had('Combatant', combatant.id));
+		}
+	}
+	for (const user of game.users ?? []) {
+		await persistDocument(user as unknown as DocumentLike, had('User', user.id));
+	}
+	for (const message of game.messages ?? []) {
+		await persistDocument(message as unknown as DocumentLike, had('ChatMessage', message.id));
+	}
+
+	// Persist setting rebrand: create new dev-keyed Setting docs and delete the
+	// legacy ones. We can't go through `game.settings.set` because the dev id
+	// hasn't registered the foreign keys. Use the Setting document class
+	// directly.
+	const SettingDoc = (globalThis as unknown as { Setting?: typeof foundry.documents.BaseSetting })
+		.Setting;
+	for (const legacy of legacySettings) {
+		if (!legacy.key || legacy._id == null) continue;
+
+		const settingName = legacy.key.startsWith(`${STABLE_SYSTEM_ID}.`)
+			? legacy.key.slice(STABLE_SYSTEM_ID.length + 1)
+			: legacy.key.startsWith(`${DEV_SYSTEM_ID}.`)
+				? legacy.key.slice(DEV_SYSTEM_ID.length + 1)
+				: null;
+		if (!settingName) continue;
+
+		const devKey = `${DEV_SYSTEM_ID}.${settingName}`;
+		try {
+			if (SettingDoc?.create) {
+				await (
+					SettingDoc.create as unknown as (
+						data: { key: string; value: string },
+						options?: object,
+					) => Promise<unknown>
+				)({ key: devKey, value: JSON.stringify(legacy.value) }, { noHook: true }).catch(
+					(err: unknown) => {
+						console.error(`Nimble | dev-rebrand: failed to create setting ${devKey}:`, err);
+					},
+				);
+			}
+
+			// Delete the legacy doc by id, looked up from the live storage.
+			const storage = game.settings?.storage?.get('world') as
+				| {
+						contents?: RawSetting[];
+						get?(id: string): { delete(options?: object): Promise<unknown> } | undefined;
+				  }
+				| undefined;
+			const legacyDoc = storage?.get?.(legacy._id);
+			await legacyDoc?.delete({ noHook: true }).catch((err: unknown) => {
+				console.error(`Nimble | dev-rebrand: failed to delete legacy setting ${legacy.key}:`, err);
+			});
+		} catch (err) {
+			console.error(`Nimble | dev-rebrand: error persisting setting ${legacy.key}:`, err);
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Detection & confirmation.
+// ---------------------------------------------------------------------------
+
+function detectLegacyDataInRaw(): boolean {
+	const data = (game as unknown as { data?: RawWorldData }).data;
+	if (!data) return false;
+
+	const sources: FlagBearing[][] = [
+		(data.actors ?? []) as FlagBearing[],
+		(data.items ?? []) as FlagBearing[],
+		(data.scenes ?? []) as FlagBearing[],
+		(data.journal ?? []) as FlagBearing[],
+		(data.macros ?? []) as FlagBearing[],
+		(data.tables ?? []) as FlagBearing[],
+		(data.combats ?? []) as FlagBearing[],
+		(data.users ?? []) as FlagBearing[],
+		(data.messages ?? []) as FlagBearing[],
+	];
+
+	for (const collection of sources) {
+		for (const src of collection) {
+			if (hasLegacyFlags(src)) return true;
+		}
+	}
+	// Embedded.
+	for (const actor of data.actors ?? []) {
+		for (const item of actor.items ?? []) if (hasLegacyFlags(item)) return true;
+		for (const effect of actor.effects ?? []) if (hasLegacyFlags(effect)) return true;
+	}
+	for (const item of data.items ?? []) {
+		for (const effect of item.effects ?? []) if (hasLegacyFlags(effect)) return true;
+	}
+	for (const scene of data.scenes ?? []) {
+		for (const token of scene.tokens ?? []) {
+			if (hasLegacyFlags(token)) return true;
+			if (token.delta && hasLegacyFlags(token.delta)) return true;
+		}
+	}
+	for (const combat of data.combats ?? []) {
+		for (const combatant of combat.combatants ?? []) {
+			if (hasLegacyFlags(combatant)) return true;
+		}
+	}
+
+	const storage = game.settings?.storage?.get('world') as { contents?: RawSetting[] } | undefined;
+	for (const setting of storage?.contents ?? []) {
+		if (typeof setting.key === 'string' && setting.key.startsWith(`${STABLE_SYSTEM_ID}.`)) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+async function confirmRebrand(): Promise<boolean> {
+	const dialogApi = (foundry as unknown as { applications?: { api?: { DialogV2?: any } } })
+		.applications?.api?.DialogV2;
+	if (!dialogApi?.confirm) {
+		console.warn(
+			'Nimble | dev-rebrand: DialogV2 not yet available at preInitGame; proceeding without confirmation.',
+		);
+		return true;
+	}
+
+	return (
+		(await dialogApi.confirm({
+			window: { title: localize('NIMBLE.devRebrand.dialog.title') },
+			content: `
+				<p>${localize('NIMBLE.devRebrand.dialog.intro')}</p>
+				<p>${localize('NIMBLE.devRebrand.dialog.body')}</p>
+				<p><strong>${localize('NIMBLE.devRebrand.dialog.warning')}</strong></p>
+			`,
+			yes: { label: localize('NIMBLE.devRebrand.dialog.confirm') },
+			no: { label: localize('NIMBLE.devRebrand.dialog.cancel') },
+			rejectClose: false,
+		})) === true
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Entry points (called from hooks/init.ts).
+// ---------------------------------------------------------------------------
+
+interface PendingPersistence {
+	registry: LegacyRegistry;
+	legacySettings: RawSetting[];
+	stats: RebrandStats;
+}
+
+let pendingPersistence: PendingPersistence | null = null;
+
+/**
+ * Phase 1: in-memory rebrand. Register on the `init` hook BEFORE any other
+ * init handler that might trigger document interaction.
+ *
+ * Rewrites `game.data.*` source arrays so document construction (which happens
+ * later, between `init` and `setup`) sees only dev-keyed flags. If legacy data
+ * is found, prompts the GM to confirm before mutating. Caches the rebrand
+ * intent for phase 2 to persist to the DB on `ready`.
+ */
+export async function runDevFlagRebrandPreInit(): Promise<void> {
+	if (SYSTEM_ID !== DEV_SYSTEM_ID) return;
+	if (!game.user?.isGM) return;
+	if (!detectLegacyDataInRaw()) return;
+
+	const confirmed = await confirmRebrand();
+	if (!confirmed) {
+		console.info(
+			'Nimble | dev-rebrand: user cancelled at preInitGame. Skipping rebrand for this session.',
+		);
+		return;
+	}
+
+	// Build the legacy registry BEFORE we mutate, so phase 2 knows which
+	// documents need a DB write.
+	const registry = buildLegacyRegistry();
+	const stats = emptyStats();
+
+	rebrandInMemory(stats);
+	const legacySettings = rebrandSettingsInMemory(stats);
+
+	console.info(
+		`Nimble | dev-rebrand: in-memory rebrand complete (${statsSummary(stats)}). Persisting on ready.`,
+	);
+
+	pendingPersistence = { registry, legacySettings, stats };
+}
+
+/**
+ * Phase 2: persist the rebrand to the database. Call from a `ready` hook
+ * handler. No-op if phase 1 didn't run or didn't find anything to do.
+ */
+export async function runDevFlagRebrandPersist(): Promise<void> {
+	if (!pendingPersistence) return;
+	const { registry, legacySettings, stats } = pendingPersistence;
+	pendingPersistence = null;
+
+	ui.notifications?.info(localize('NIMBLE.devRebrand.notifications.starting'));
+	try {
+		await persistRebrand(registry, legacySettings);
+		console.info(`Nimble | dev-rebrand: persistent rebrand complete (${statsSummary(stats)}).`);
+		ui.notifications?.info(localize('NIMBLE.devRebrand.notifications.completed'));
+	} catch (err) {
+		console.error('Nimble | dev-rebrand: persistent rebrand failed:', err);
+		ui.notifications?.error(localize('NIMBLE.devRebrand.notifications.failed'));
+	}
+}

--- a/src/migration/migrations/Migration004SpellbladeCombatMana.ts
+++ b/src/migration/migrations/Migration004SpellbladeCombatMana.ts
@@ -1,3 +1,4 @@
+import { SYSTEM_ID } from '#system';
 import {
 	getCombatManaGrantForCombat,
 	getCombatManaGrantMap,
@@ -171,7 +172,7 @@ class Migration004SpellbladeCombatMana extends MigrationBase {
 			await actor.update({
 				'system.resources.mana.baseMax': combatMana,
 				'system.resources.mana.current': combatMana,
-				'flags.nimble.combatManaGrants': grants,
+				[`flags.${SYSTEM_ID}.combatManaGrants`]: grants,
 			} as Record<string, unknown>);
 		}
 	}

--- a/src/nimble.ts
+++ b/src/nimble.ts
@@ -23,6 +23,7 @@ import renderCompendium from './hooks/renderCompendium.js';
 import renderNimbleTokenHUD from './hooks/renderNimbleTokenHUD.js';
 import registerRuleEventDispatch from './hooks/ruleEventDispatch.js';
 import setup from './hooks/setup.js';
+import { runDevFlagRebrandPreInit } from './migration/devFlagRebrand.js';
 import './scss/main.scss';
 import { SYSTEM_ID } from '#system';
 import { getCombatManaGrantForCombat, getCombatManaGrantMap } from '#utils/combatManaRules.js';
@@ -64,6 +65,10 @@ injectViteHmrClient();
 /** ----------------------------------- */
 //                Hooks
 /** ----------------------------------- */
+// Dev-build-only: rebrand legacy stable-id flags on world load. See
+// src/migration/devFlagRebrand.ts for details. Must be registered before
+// the main `init` handler so it fires first.
+Hooks.once('init', runDevFlagRebrandPreInit);
 Hooks.once('init', init);
 Hooks.once('setup', setup);
 Hooks.once('ready', ready);

--- a/src/nimble.ts
+++ b/src/nimble.ts
@@ -24,6 +24,7 @@ import renderNimbleTokenHUD from './hooks/renderNimbleTokenHUD.js';
 import registerRuleEventDispatch from './hooks/ruleEventDispatch.js';
 import setup from './hooks/setup.js';
 import './scss/main.scss';
+import { SYSTEM_ID } from '#system';
 import { getCombatManaGrantForCombat, getCombatManaGrantMap } from '#utils/combatManaRules.js';
 import { injectViteHmrClient } from '#utils/viteHmr.js';
 
@@ -46,7 +47,7 @@ async function clearCombatManaFromCombat(combat: Combat): Promise<void> {
 			actor.update({
 				'system.resources.mana.baseMax': 0,
 				'system.resources.mana.current': 0,
-				'flags.nimble.combatManaGrants': grants,
+				[`flags.${SYSTEM_ID}.combatManaGrants`]: grants,
 			} as Record<string, unknown>),
 		);
 		return acc;

--- a/src/registerKeyBindings.ts
+++ b/src/registerKeyBindings.ts
@@ -1,5 +1,7 @@
+import { SYSTEM_ID } from '#system';
+
 export default function registerKeybindings() {
-	game.keybindings.register('nimble', 'system-settings-open-close', {
+	game.keybindings.register(SYSTEM_ID, 'system-settings-open-close', {
 		name: 'Open/Close System Settings',
 		editable: [{ key: 'KeyS', modifiers: ['ALT'] }],
 		onDown: () => {

--- a/src/settings/adjacencySettings.ts
+++ b/src/settings/adjacencySettings.ts
@@ -1,9 +1,11 @@
+import { SYSTEM_ID } from '#system';
+
 export const ADJACENCY_SYNC_SETTING_KEY = 'autoTrackTokenAdjacency';
 export const ADJACENCY_INCLUDES_DIAGONALS_SETTING_KEY = 'adjacencyIncludesDiagonals';
 
 export function registerAdjacencySettings(): void {
 	game.settings.register(
-		'nimble' as 'core',
+		SYSTEM_ID as 'core',
 		ADJACENCY_SYNC_SETTING_KEY as 'rollMode',
 		{
 			name: 'NIMBLE.settings.autoTrackTokenAdjacency.name',
@@ -18,8 +20,8 @@ export function registerAdjacencySettings(): void {
 					// Tracking disabled — clear adjacency flags on all actors so stale
 					// data doesn't persist across the required reload.
 					game.actors?.forEach((actor) => {
-						if (actor.getFlag('nimble', 'adjacency')) {
-							actor.unsetFlag('nimble', 'adjacency');
+						if (actor.getFlag(SYSTEM_ID, 'adjacency')) {
+							actor.unsetFlag(SYSTEM_ID, 'adjacency');
 						}
 					});
 				}
@@ -31,14 +33,14 @@ export function registerAdjacencySettings(): void {
 }
 
 export function getAdjacencySyncEnabled(): boolean {
-	if (!game.settings.settings.has(`nimble.${ADJACENCY_SYNC_SETTING_KEY}` as 'core.rollMode'))
+	if (!game.settings.settings.has(`${SYSTEM_ID}.${ADJACENCY_SYNC_SETTING_KEY}` as 'core.rollMode'))
 		return false;
-	return Boolean(game.settings.get('nimble' as 'core', ADJACENCY_SYNC_SETTING_KEY as 'rollMode'));
+	return Boolean(game.settings.get(SYSTEM_ID as 'core', ADJACENCY_SYNC_SETTING_KEY as 'rollMode'));
 }
 
 function registerAdjacencyIncludesDiagonalsSetting(): void {
 	game.settings.register(
-		'nimble' as 'core',
+		SYSTEM_ID as 'core',
 		ADJACENCY_INCLUDES_DIAGONALS_SETTING_KEY as 'rollMode',
 		{
 			name: 'NIMBLE.settings.adjacencyIncludesDiagonals.name',
@@ -54,6 +56,6 @@ function registerAdjacencyIncludesDiagonalsSetting(): void {
 
 export function getAdjacencyIncludesDiagonals(): boolean {
 	return Boolean(
-		game.settings.get('nimble' as 'core', ADJACENCY_INCLUDES_DIAGONALS_SETTING_KEY as 'rollMode'),
+		game.settings.get(SYSTEM_ID as 'core', ADJACENCY_INCLUDES_DIAGONALS_SETTING_KEY as 'rollMode'),
 	);
 }

--- a/src/settings/combatTrackerSettings.ts
+++ b/src/settings/combatTrackerSettings.ts
@@ -1,3 +1,5 @@
+import { SYSTEM_ID } from '#system';
+
 export const COMBAT_TRACKER_PLAYER_MONSTER_EXPANSION_SETTING_KEY =
 	'combatTrackerPlayersCanExpandMonsterCards';
 export const COMBAT_TRACKER_RESOURCE_DRAWER_HOVER_SETTING_KEY =
@@ -92,7 +94,7 @@ function registerWorldSetting(
 	options: Parameters<typeof game.settings.register>[2],
 ): void {
 	game.settings.register(
-		'nimble' as 'core',
+		SYSTEM_ID as 'core',
 		key as 'rollMode',
 		options as unknown as Parameters<typeof game.settings.register>[2],
 	);
@@ -321,7 +323,7 @@ export function registerCombatTrackerSettings(): void {
 		default: DEFAULT_CURRENT_TURN_ANIMATION_SETTINGS.borderGlowColor,
 	});
 	const legacyColorDefault = normalizeCombatTrackerAnimationColor(
-		game.settings.get('nimble' as 'core', LEGACY_CURRENT_TURN_COLOR_SETTING_KEY as 'rollMode'),
+		game.settings.get(SYSTEM_ID as 'core', LEGACY_CURRENT_TURN_COLOR_SETTING_KEY as 'rollMode'),
 	);
 	registerWorldSetting(CURRENT_TURN_ANIMATION_SETTING_KEYS.pulseAnimation, {
 		name: 'Combat Tracker Current Turn Pulse Animation',
@@ -395,7 +397,7 @@ export function registerCombatTrackerSettings(): void {
 export function getCombatTrackerPlayersCanExpandMonsterCards(): boolean {
 	return Boolean(
 		game.settings.get(
-			'nimble' as 'core',
+			SYSTEM_ID as 'core',
 			COMBAT_TRACKER_PLAYER_MONSTER_EXPANSION_SETTING_KEY as 'rollMode',
 		),
 	);
@@ -410,7 +412,7 @@ export function isCombatTrackerPlayerMonsterExpansionSettingKey(settingKey: unkn
 export function getCombatTrackerResourceDrawerHoverEnabled(): boolean {
 	return Boolean(
 		game.settings.get(
-			'nimble' as 'core',
+			SYSTEM_ID as 'core',
 			COMBAT_TRACKER_RESOURCE_DRAWER_HOVER_SETTING_KEY as 'rollMode',
 		),
 	);
@@ -419,7 +421,7 @@ export function getCombatTrackerResourceDrawerHoverEnabled(): boolean {
 export function getCombatTrackerPlayerHpBarTextMode(): CombatTrackerPlayerHpBarTextMode {
 	return normalizeHpBarTextMode(
 		game.settings.get(
-			'nimble' as 'core',
+			SYSTEM_ID as 'core',
 			COMBAT_TRACKER_PLAYER_HP_BAR_TEXT_MODE_SETTING_KEY as 'rollMode',
 		),
 	);
@@ -428,7 +430,7 @@ export function getCombatTrackerPlayerHpBarTextMode(): CombatTrackerPlayerHpBarT
 export function getCombatTrackerNonPlayerHpBarEnabled(): boolean {
 	return Boolean(
 		game.settings.get(
-			'nimble' as 'core',
+			SYSTEM_ID as 'core',
 			COMBAT_TRACKER_NON_PLAYER_HP_BAR_ENABLED_SETTING_KEY as 'rollMode',
 		),
 	);
@@ -437,7 +439,7 @@ export function getCombatTrackerNonPlayerHpBarEnabled(): boolean {
 export function getCombatTrackerNonPlayerHpBarTextMode(): CombatTrackerNonPlayerHpBarTextMode {
 	return normalizeHpBarTextMode(
 		game.settings.get(
-			'nimble' as 'core',
+			SYSTEM_ID as 'core',
 			COMBAT_TRACKER_NON_PLAYER_HP_BAR_TEXT_MODE_SETTING_KEY as 'rollMode',
 		),
 	);
@@ -445,26 +447,29 @@ export function getCombatTrackerNonPlayerHpBarTextMode(): CombatTrackerNonPlayer
 
 export function getCombatTrackerCtEnabled(): boolean {
 	return Boolean(
-		game.settings.get('nimble' as 'core', COMBAT_TRACKER_ENABLED_SETTING_KEY as 'rollMode'),
+		game.settings.get(SYSTEM_ID as 'core', COMBAT_TRACKER_ENABLED_SETTING_KEY as 'rollMode'),
 	);
 }
 
 export function getCombatTrackerCtWidthLevel(): number {
 	return normalizeCtWidthLevel(
-		game.settings.get('nimble' as 'core', COMBAT_TRACKER_WIDTH_LEVEL_SETTING_KEY as 'rollMode'),
+		game.settings.get(SYSTEM_ID as 'core', COMBAT_TRACKER_WIDTH_LEVEL_SETTING_KEY as 'rollMode'),
 	);
 }
 
 export function getCombatTrackerCtCardSizeLevel(): number {
 	return normalizeCtCardSizeLevel(
-		game.settings.get('nimble' as 'core', COMBAT_TRACKER_CARD_SIZE_LEVEL_SETTING_KEY as 'rollMode'),
+		game.settings.get(
+			SYSTEM_ID as 'core',
+			COMBAT_TRACKER_CARD_SIZE_LEVEL_SETTING_KEY as 'rollMode',
+		),
 	);
 }
 
 export function getCombatTrackerCtLeftToRightOrdering(): boolean {
 	return Boolean(
 		game.settings.get(
-			'nimble' as 'core',
+			SYSTEM_ID as 'core',
 			COMBAT_TRACKER_LEFT_TO_RIGHT_ORDERING_SETTING_KEY as 'rollMode',
 		),
 	);
@@ -473,7 +478,7 @@ export function getCombatTrackerCtLeftToRightOrdering(): boolean {
 export function getCombatTrackerActionDiceColor(): string {
 	return normalizeHexColor(
 		game.settings.get(
-			'nimble' as 'core',
+			SYSTEM_ID as 'core',
 			COMBAT_TRACKER_ACTION_DICE_COLOR_SETTING_KEY as 'rollMode',
 		),
 	);
@@ -481,7 +486,7 @@ export function getCombatTrackerActionDiceColor(): string {
 
 export function getCombatTrackerReactionColor(): string {
 	return normalizeHexColor(
-		game.settings.get('nimble' as 'core', COMBAT_TRACKER_REACTION_COLOR_SETTING_KEY as 'rollMode'),
+		game.settings.get(SYSTEM_ID as 'core', COMBAT_TRACKER_REACTION_COLOR_SETTING_KEY as 'rollMode'),
 	);
 }
 
@@ -549,51 +554,51 @@ export function getCurrentTurnAnimationSettings(): CurrentTurnAnimationSettings 
 	return {
 		pulseAnimation: Boolean(
 			game.settings.get(
-				'nimble' as 'core',
+				SYSTEM_ID as 'core',
 				CURRENT_TURN_ANIMATION_SETTING_KEYS.pulseAnimation as 'rollMode',
 			),
 		),
 		pulseSpeed: normalizeCurrentTurnAnimationSliderValue(
 			game.settings.get(
-				'nimble' as 'core',
+				SYSTEM_ID as 'core',
 				CURRENT_TURN_ANIMATION_SETTING_KEYS.pulseSpeed as 'rollMode',
 			),
 			DEFAULT_CURRENT_TURN_ANIMATION_SETTINGS.pulseSpeed,
 		),
 		borderGlow: Boolean(
 			game.settings.get(
-				'nimble' as 'core',
+				SYSTEM_ID as 'core',
 				CURRENT_TURN_ANIMATION_SETTING_KEYS.borderGlow as 'rollMode',
 			),
 		),
 		borderGlowColor: normalizeCombatTrackerAnimationColor(
 			game.settings.get(
-				'nimble' as 'core',
+				SYSTEM_ID as 'core',
 				CURRENT_TURN_ANIMATION_SETTING_KEYS.borderGlowColor as 'rollMode',
 			),
 		),
 		borderGlowSize: normalizeCurrentTurnAnimationSliderValue(
 			game.settings.get(
-				'nimble' as 'core',
+				SYSTEM_ID as 'core',
 				CURRENT_TURN_ANIMATION_SETTING_KEYS.borderGlowSize as 'rollMode',
 			),
 			DEFAULT_CURRENT_TURN_ANIMATION_SETTINGS.borderGlowSize,
 		),
 		edgeCrawler: Boolean(
 			game.settings.get(
-				'nimble' as 'core',
+				SYSTEM_ID as 'core',
 				CURRENT_TURN_ANIMATION_SETTING_KEYS.edgeCrawler as 'rollMode',
 			),
 		),
 		edgeCrawlerColor: normalizeCombatTrackerAnimationColor(
 			game.settings.get(
-				'nimble' as 'core',
+				SYSTEM_ID as 'core',
 				CURRENT_TURN_ANIMATION_SETTING_KEYS.edgeCrawlerColor as 'rollMode',
 			),
 		),
 		edgeCrawlerSize: normalizeCurrentTurnAnimationSliderValue(
 			game.settings.get(
-				'nimble' as 'core',
+				SYSTEM_ID as 'core',
 				CURRENT_TURN_ANIMATION_SETTING_KEYS.edgeCrawlerSize as 'rollMode',
 			),
 			DEFAULT_CURRENT_TURN_ANIMATION_SETTINGS.edgeCrawlerSize,
@@ -614,7 +619,7 @@ export function isCurrentTurnAnimationSettingKey(settingKey: unknown): boolean {
 
 export async function setCombatTrackerPlayersCanExpandMonsterCards(value: boolean): Promise<void> {
 	await game.settings.set(
-		'nimble' as 'core',
+		SYSTEM_ID as 'core',
 		COMBAT_TRACKER_PLAYER_MONSTER_EXPANSION_SETTING_KEY as 'rollMode',
 		Boolean(value) as never,
 	);
@@ -622,7 +627,7 @@ export async function setCombatTrackerPlayersCanExpandMonsterCards(value: boolea
 
 export async function setCombatTrackerResourceDrawerHoverEnabled(value: boolean): Promise<void> {
 	await game.settings.set(
-		'nimble' as 'core',
+		SYSTEM_ID as 'core',
 		COMBAT_TRACKER_RESOURCE_DRAWER_HOVER_SETTING_KEY as 'rollMode',
 		Boolean(value) as never,
 	);
@@ -632,7 +637,7 @@ export async function setCombatTrackerPlayerHpBarTextMode(
 	value: CombatTrackerPlayerHpBarTextMode,
 ): Promise<void> {
 	await game.settings.set(
-		'nimble' as 'core',
+		SYSTEM_ID as 'core',
 		COMBAT_TRACKER_PLAYER_HP_BAR_TEXT_MODE_SETTING_KEY as 'rollMode',
 		normalizeHpBarTextMode(value) as never,
 	);
@@ -640,7 +645,7 @@ export async function setCombatTrackerPlayerHpBarTextMode(
 
 export async function setCombatTrackerNonPlayerHpBarEnabled(value: boolean): Promise<void> {
 	await game.settings.set(
-		'nimble' as 'core',
+		SYSTEM_ID as 'core',
 		COMBAT_TRACKER_NON_PLAYER_HP_BAR_ENABLED_SETTING_KEY as 'rollMode',
 		Boolean(value) as never,
 	);
@@ -650,7 +655,7 @@ export async function setCombatTrackerNonPlayerHpBarTextMode(
 	value: CombatTrackerNonPlayerHpBarTextMode,
 ): Promise<void> {
 	await game.settings.set(
-		'nimble' as 'core',
+		SYSTEM_ID as 'core',
 		COMBAT_TRACKER_NON_PLAYER_HP_BAR_TEXT_MODE_SETTING_KEY as 'rollMode',
 		normalizeHpBarTextMode(value) as never,
 	);
@@ -658,7 +663,7 @@ export async function setCombatTrackerNonPlayerHpBarTextMode(
 
 export async function setCombatTrackerCtEnabled(value: boolean): Promise<void> {
 	await game.settings.set(
-		'nimble' as 'core',
+		SYSTEM_ID as 'core',
 		COMBAT_TRACKER_ENABLED_SETTING_KEY as 'rollMode',
 		Boolean(value) as never,
 	);
@@ -666,7 +671,7 @@ export async function setCombatTrackerCtEnabled(value: boolean): Promise<void> {
 
 export async function setCombatTrackerCtWidthLevel(value: number): Promise<void> {
 	await game.settings.set(
-		'nimble' as 'core',
+		SYSTEM_ID as 'core',
 		COMBAT_TRACKER_WIDTH_LEVEL_SETTING_KEY as 'rollMode',
 		normalizeCtWidthLevel(value) as never,
 	);
@@ -674,7 +679,7 @@ export async function setCombatTrackerCtWidthLevel(value: number): Promise<void>
 
 export async function setCombatTrackerCtCardSizeLevel(value: number): Promise<void> {
 	await game.settings.set(
-		'nimble' as 'core',
+		SYSTEM_ID as 'core',
 		COMBAT_TRACKER_CARD_SIZE_LEVEL_SETTING_KEY as 'rollMode',
 		normalizeCtCardSizeLevel(value) as never,
 	);
@@ -682,7 +687,7 @@ export async function setCombatTrackerCtCardSizeLevel(value: number): Promise<vo
 
 export async function setCombatTrackerCtLeftToRightOrdering(value: boolean): Promise<void> {
 	await game.settings.set(
-		'nimble' as 'core',
+		SYSTEM_ID as 'core',
 		COMBAT_TRACKER_LEFT_TO_RIGHT_ORDERING_SETTING_KEY as 'rollMode',
 		Boolean(value) as never,
 	);
@@ -692,7 +697,7 @@ export async function setCombatTrackerActionDiceColor(value: string): Promise<vo
 	const normalizedColor = normalizeHexColor(value);
 	applyCtActionDiceColorCssVariable(normalizedColor);
 	await game.settings.set(
-		'nimble' as 'core',
+		SYSTEM_ID as 'core',
 		COMBAT_TRACKER_ACTION_DICE_COLOR_SETTING_KEY as 'rollMode',
 		normalizedColor as never,
 	);
@@ -702,7 +707,7 @@ export async function setCombatTrackerReactionColor(value: string): Promise<void
 	const normalizedColor = normalizeHexColor(value);
 	applyCtReactionColorCssVariable(normalizedColor);
 	await game.settings.set(
-		'nimble' as 'core',
+		SYSTEM_ID as 'core',
 		COMBAT_TRACKER_REACTION_COLOR_SETTING_KEY as 'rollMode',
 		normalizedColor as never,
 	);
@@ -719,5 +724,5 @@ export async function setCurrentTurnAnimationSetting(
 		normalizedValue = normalizeCurrentTurnAnimationSliderValue(value, 50);
 	}
 
-	await game.settings.set('nimble' as 'core', settingKey as 'rollMode', normalizedValue as never);
+	await game.settings.set(SYSTEM_ID as 'core', settingKey as 'rollMode', normalizedValue as never);
 }

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -1,5 +1,6 @@
 import type { Component } from 'svelte';
 import GenericDialog from '#documents/dialogs/GenericDialog.svelte.js';
+import { SYSTEM_ID } from '#system';
 import DiceTestbench from '#view/debug/DiceTestbench.svelte';
 import { MigrationRunnerBase } from '../migration/MigrationRunnerBase.js';
 import { registerAdjacencySettings } from './adjacencySettings.js';
@@ -33,15 +34,15 @@ function rerenderSettingsConfigIfOpen(): void {
 
 export function isDebugModeEnabled(): boolean {
 	const settings = game.settings?.settings as { has: (key: string) => boolean } | undefined;
-	if (!settings?.has(`nimble.${DEBUG_MODE_SETTING_KEY}`)) return false;
-	return Boolean(game.settings.get('nimble' as 'core', DEBUG_MODE_SETTING_KEY as 'rollMode'));
+	if (!settings?.has(`${SYSTEM_ID}.${DEBUG_MODE_SETTING_KEY}`)) return false;
+	return Boolean(game.settings.get(SYSTEM_ID as 'core', DEBUG_MODE_SETTING_KEY as 'rollMode'));
 }
 
 export const settings = [];
 
 export default function registerSystemSettings() {
 	game.settings.register(
-		'nimble' as 'core',
+		SYSTEM_ID as 'core',
 		'autoExpandRolls' as 'rollMode',
 		{
 			name: 'NIMBLE.settings.autoExpandRolls.name',
@@ -54,7 +55,7 @@ export default function registerSystemSettings() {
 	);
 
 	game.settings.register(
-		'nimble' as 'core',
+		SYSTEM_ID as 'core',
 		'hideRolls' as 'rollMode',
 		{
 			name: 'NIMBLE.hints.hideRollsFromPlayersByDefault',
@@ -67,7 +68,7 @@ export default function registerSystemSettings() {
 	);
 
 	game.settings.register(
-		'nimble' as 'core',
+		SYSTEM_ID as 'core',
 		AUTO_ADD_CHARACTER_TO_COMBAT_ON_INITIATIVE_ROLL_SETTING_KEY as 'rollMode',
 		{
 			name: 'NIMBLE.settings.autoAddCharacterToCombatOnInitiativeRoll.name',
@@ -82,7 +83,7 @@ export default function registerSystemSettings() {
 	registerAdjacencySettings();
 
 	game.settings.register(
-		'nimble' as 'core',
+		SYSTEM_ID as 'core',
 		'automation.autoApplyConditions' as 'rollMode',
 		{
 			name: 'NIMBLE.settings.autoApplyConditions.name',
@@ -99,7 +100,7 @@ export default function registerSystemSettings() {
 	registerNcswSettings();
 
 	game.settings.register(
-		'nimble' as 'core',
+		SYSTEM_ID as 'core',
 		DEBUG_MODE_SETTING_KEY as 'rollMode',
 		{
 			name: 'NIMBLE.settings.debugMode.name',
@@ -115,7 +116,7 @@ export default function registerSystemSettings() {
 	);
 
 	game.settings.register(
-		'nimble' as 'core',
+		SYSTEM_ID as 'core',
 		'worldSchemaVersion' as 'rollMode',
 		{
 			name: 'World Schema Version',

--- a/src/settings/ncswSettings.ts
+++ b/src/settings/ncswSettings.ts
@@ -1,3 +1,5 @@
+import { SYSTEM_ID } from '#system';
+
 export const NCSW_SIDEBAR_VIEW_MODE_SETTING_KEY = 'ncswSidebarViewMode';
 export const NCSW_ENABLED_SETTING_KEY = 'ncswEnabled';
 export const NCSW_ENABLED_SETTING_CHANGED_EVENT_NAME = 'nimble:ncsw-enabled-changed';
@@ -19,7 +21,7 @@ export function normalizeNcswSidebarViewMode(value: unknown): NcswSidebarViewMod
 
 export function registerNcswSettings(): void {
 	game.settings.register(
-		'nimble' as 'core',
+		SYSTEM_ID as 'core',
 		NCSW_SIDEBAR_VIEW_MODE_SETTING_KEY as 'rollMode',
 		{
 			name: 'NCSW Sidebar View Mode',
@@ -32,7 +34,7 @@ export function registerNcswSettings(): void {
 	);
 
 	game.settings.register(
-		'nimble' as 'core',
+		SYSTEM_ID as 'core',
 		NCSW_ENABLED_SETTING_KEY as 'rollMode',
 		{
 			name: 'NIMBLE.settings.ncswEnabled.name',
@@ -59,7 +61,7 @@ export function getPersistedNcswSidebarViewMode(): NcswSidebarViewMode {
 	if (!isNcswSidebarViewModeSettingRegistered()) return DEFAULT_NCSW_SIDEBAR_VIEW_MODE;
 
 	return normalizeNcswSidebarViewMode(
-		game.settings.get('nimble' as 'core', NCSW_SIDEBAR_VIEW_MODE_SETTING_KEY as 'rollMode'),
+		game.settings.get(SYSTEM_ID as 'core', NCSW_SIDEBAR_VIEW_MODE_SETTING_KEY as 'rollMode'),
 	);
 }
 
@@ -67,7 +69,7 @@ export async function setPersistedNcswSidebarViewMode(mode: NcswSidebarViewMode)
 	if (!isNcswSidebarViewModeSettingRegistered()) return;
 
 	await game.settings.set(
-		'nimble' as 'core',
+		SYSTEM_ID as 'core',
 		NCSW_SIDEBAR_VIEW_MODE_SETTING_KEY as 'rollMode',
 		normalizeNcswSidebarViewMode(mode) as never,
 	);
@@ -80,5 +82,5 @@ export function isNcswEnabledSettingRegistered(): boolean {
 
 export function getNcswEnabled(): boolean {
 	if (!isNcswEnabledSettingRegistered()) return true;
-	return Boolean(game.settings.get('nimble' as 'core', NCSW_ENABLED_SETTING_KEY as 'rollMode'));
+	return Boolean(game.settings.get(SYSTEM_ID as 'core', NCSW_ENABLED_SETTING_KEY as 'rollMode'));
 }

--- a/src/utils/chargePool/helpers.ts
+++ b/src/utils/chargePool/helpers.ts
@@ -1,3 +1,4 @@
+import { SYSTEM_ID } from '#system';
 import type { NimbleRollData } from '#types/rollData.d.ts';
 import { ChargePoolRuleConfig } from '#utils/chargePoolRuleConfig.js';
 import getDeterministicBonus from '../../dice/getDeterministicBonus.js';
@@ -381,7 +382,9 @@ function getChargeConsumers(
 	if (hasExplicitConsumer) return consumers;
 
 	if (item.flags == null || typeof item.flags !== 'object') return [];
-	const nimbleFlags = item.flags.nimble;
+	const nimbleFlags = (item.flags as Record<string, unknown>)[SYSTEM_ID] as
+		| Record<string, unknown>
+		| undefined;
 	if (nimbleFlags == null || typeof nimbleFlags !== 'object') return [];
 	const chargePoolsOnItem = nimbleFlags.chargePools;
 	if (
@@ -528,10 +531,10 @@ async function persistChargePoolMap(
 		itemUpdates.push(
 			item.update(
 				{
-					'flags.nimble.chargePools': itemPoolUpdatePayload,
+					[ChargePoolRuleConfig.flagPath]: itemPoolUpdatePayload,
 				} as Record<string, unknown>,
 				{
-					nimble: {
+					[SYSTEM_ID]: {
 						skipChargePoolSync: true,
 					},
 				} as Record<string, unknown>,

--- a/src/utils/chargePoolRuleConfig.ts
+++ b/src/utils/chargePoolRuleConfig.ts
@@ -1,3 +1,5 @@
+import { SYSTEM_ID } from '#system';
+
 const ChargePoolRuleConfig = {
 	scopes: ['item', 'actor'],
 	dieSizes: ['d4', 'd6', 'd8', 'd10', 'd12', 'd20'],
@@ -19,9 +21,9 @@ const ChargePoolRuleConfig = {
 	recoveryModes: ['add', 'set', 'refresh'],
 	restTypes: ['safe', 'field'],
 	encounterTriggerTypes: ['encounterStart', 'encounterEnd'] as const,
-	flagScope: 'nimble',
+	flagScope: SYSTEM_ID,
 	flagKey: 'chargePools',
-	flagPath: 'flags.nimble.chargePools',
+	flagPath: `flags.${SYSTEM_ID}.chargePools`,
 } as const;
 
 export { ChargePoolRuleConfig };

--- a/src/utils/combatManaRules.ts
+++ b/src/utils/combatManaRules.ts
@@ -1,3 +1,4 @@
+import { SYSTEM_ID } from '#system';
 import getDeterministicBonus from '../dice/getDeterministicBonus.js';
 import {
 	getItemSourceId,
@@ -28,7 +29,7 @@ type ActorWithCollections = Actor & {
 	getRollData?: () => Record<string, unknown>;
 };
 
-const COMBAT_MANA_FLAG_SCOPE = 'nimble';
+const COMBAT_MANA_FLAG_SCOPE = SYSTEM_ID;
 const COMBAT_MANA_FLAG_KEY = 'combatManaGrants';
 
 function normalizeGrantMap(value: unknown): CombatManaGrantMap {

--- a/src/utils/dicePool/dicePoolRuleConfig.ts
+++ b/src/utils/dicePool/dicePoolRuleConfig.ts
@@ -1,3 +1,5 @@
+import { SYSTEM_ID } from '#system';
+
 const DicePoolRuleConfig = {
 	scopes: ['item', 'actor'],
 	dieSizes: ['d4', 'd6', 'd8', 'd10', 'd12', 'd20'],
@@ -27,9 +29,9 @@ const DicePoolRuleConfig = {
 	// Optional delivery filter for autoBonus pools. When set, the pool's faces
 	// auto-add only to attacks of the matching delivery.
 	attackDeliveryFilters: ['melee', 'ranged', 'any'] as const,
-	flagScope: 'nimble',
+	flagScope: SYSTEM_ID,
 	flagKey: 'dicePools',
-	flagPath: 'flags.nimble.dicePools',
+	flagPath: `flags.${SYSTEM_ID}.dicePools`,
 } as const;
 
 export { DicePoolRuleConfig };

--- a/src/utils/dicePool/helpers.ts
+++ b/src/utils/dicePool/helpers.ts
@@ -1,3 +1,4 @@
+import { SYSTEM_ID } from '#system';
 import type { NimbleRollData } from '#types/rollData.d.ts';
 import getDeterministicBonus from '../../dice/getDeterministicBonus.js';
 import { DicePoolRuleConfig } from './dicePoolRuleConfig.js';
@@ -519,10 +520,10 @@ async function persistDicePoolMap(actor: CharacterActorLike, pools: DicePoolMap)
 		updates.push(
 			item.update(
 				{
-					'flags.nimble.dicePools': itemPoolUpdatePayload,
+					[DicePoolRuleConfig.flagPath]: itemPoolUpdatePayload,
 				} as Record<string, unknown>,
 				{
-					nimble: {
+					[SYSTEM_ID]: {
 						skipDicePoolSync: true,
 					},
 				} as Record<string, unknown>,

--- a/src/utils/initiativeRollLock.ts
+++ b/src/utils/initiativeRollLock.ts
@@ -1,10 +1,12 @@
+import { SYSTEM_ID } from '#system';
+
 interface InitiativeRollLockData {
 	requestId: string;
 	userId: string | null;
 	startedAt: number;
 }
 
-const INITIATIVE_ROLL_LOCK_PATH = 'flags.nimble.initiativeRollLock';
+const INITIATIVE_ROLL_LOCK_PATH = `flags.${SYSTEM_ID}.initiativeRollLock`;
 const INITIATIVE_ROLL_LOCK_TIMEOUT_MS = 15_000;
 
 function normalizeInitiativeRollLockData(value: unknown): InitiativeRollLockData | null {

--- a/src/utils/minionGrouping.ts
+++ b/src/utils/minionGrouping.ts
@@ -1,6 +1,7 @@
+import { SYSTEM_ID } from '#system';
 import { isCombatantDead } from './isCombatantDead.js';
 
-export const MINION_GROUP_FLAG_ROOT = 'flags.nimble.minionGroup';
+export const MINION_GROUP_FLAG_ROOT = `flags.${SYSTEM_ID}.minionGroup`;
 export const MINION_GROUP_ID_PATH = `${MINION_GROUP_FLAG_ROOT}.id`;
 export const MINION_GROUP_ROLE_PATH = `${MINION_GROUP_FLAG_ROOT}.role`;
 export const MINION_GROUP_TEMPORARY_PATH = `${MINION_GROUP_FLAG_ROOT}.temporary`;

--- a/src/utils/systemId.test.ts
+++ b/src/utils/systemId.test.ts
@@ -62,6 +62,9 @@ const EXCLUDE_GLOBS: readonly string[] = [
 	'src/**/*.spec.ts',
 	// systemId.ts is the source of truth for the value.
 	'src/utils/systemId.ts',
+	// The dev-build rebrand module *must* reference the legacy 'nimble' id —
+	// its whole job is migrating data away from that key. Audited exception.
+	'src/migration/devFlagRebrand.ts',
 ];
 
 const SELF_PATH_FRAGMENT = 'src/utils/systemId.test.ts';

--- a/src/utils/systemId.test.ts
+++ b/src/utils/systemId.test.ts
@@ -1,0 +1,104 @@
+import { readFileSync } from 'node:fs';
+import { glob } from 'glob';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Foundry namespaces flags, settings, sheet registration, and pack UUIDs by the
+ * system's installed id. The stable build installs as `nimble`; the dev rolling
+ * release installs as `nimble-dev`. Hardcoded `'nimble'` literals in source
+ * silently break under the dev id.
+ *
+ * Every system-id usage MUST go through SYSTEM_ID / SYSTEM_PATH (imported from
+ * `#system`), so the value is baked from `public/system.json` at build time and
+ * `dev-rebrand.mjs`'s manifest mutation flows through automatically.
+ *
+ * This test scans production source for the forbidden forms. Test files are
+ * exempt because SYSTEM_ID === 'nimble' in the test environment.
+ */
+
+interface ForbiddenPattern {
+	readonly id: string;
+	readonly re: RegExp;
+	readonly hint: string;
+}
+
+const FORBIDDEN_PATTERNS: readonly ForbiddenPattern[] = [
+	{
+		id: 'flag-api-quoted-scope',
+		re: /\b(?:setFlag|getFlag|unsetFlag)\s*\(\s*['"]nimble['"]/,
+		hint: "Use SYSTEM_ID — `actor.setFlag(SYSTEM_ID, ...)`. Import from '#system'.",
+	},
+	{
+		id: 'settings-quoted-scope',
+		re: /game\.(?:settings|keybindings)[\s\S]*?\(\s*['"]nimble['"]/,
+		hint: "Use SYSTEM_ID — `game.settings.get(SYSTEM_ID as 'core', ...)`. Import from '#system'.",
+	},
+	{
+		id: 'register-sheet-quoted-scope',
+		re: /\.(?:registerSheet|unregisterSheet)\s*\(\s*['"]nimble['"]/,
+		hint: 'Use SYSTEM_ID for sheet registration.',
+	},
+	{
+		id: 'nimble-as-core-cast',
+		re: /['"]nimble['"]\s+as\s+['"]core['"]/,
+		hint: "Use `SYSTEM_ID as 'core'` instead of `'nimble' as 'core'`.",
+	},
+	{
+		id: 'flags-nimble-string-path',
+		re: /['"`]flags\.nimble\./,
+		hint: 'Use a template literal `flags.{SYSTEM_ID}.X` (or the relevant *RuleConfig.flagPath constant).',
+	},
+	{
+		id: 'flags-nimble-property-access',
+		re: /\.flags\.nimble(?=[\s.?[)\];,}]|$)/,
+		hint: 'Use `flags[SYSTEM_ID]` for property access instead of `flags.nimble`.',
+	},
+];
+
+const SOURCE_GLOB = 'src/**/*.{ts,svelte,svelte.ts}';
+const EXCLUDE_GLOBS: readonly string[] = [
+	'src/**/*.test.ts',
+	'src/**/*.test.svelte.ts',
+	'src/**/*.spec.ts',
+	// systemId.ts is the source of truth for the value.
+	'src/utils/systemId.ts',
+];
+
+const SELF_PATH_FRAGMENT = 'src/utils/systemId.test.ts';
+
+function findOffenders(file: string, source: string): string[] {
+	const offenders: string[] = [];
+	const lines = source.split(/\r?\n/);
+	for (let i = 0; i < lines.length; i += 1) {
+		const line = lines[i];
+		// Allow inline opt-out for any genuinely correct usage that happens to
+		// match a pattern (vanishingly rare; reviewers should be skeptical).
+		if (line.includes('// allow-hardcoded-system-id')) continue;
+
+		for (const { id, re, hint } of FORBIDDEN_PATTERNS) {
+			if (re.test(line)) {
+				offenders.push(`${file}:${i + 1}  [${id}]\n    ${line.trim()}\n    → ${hint}`);
+			}
+		}
+	}
+	return offenders;
+}
+
+describe('SYSTEM_ID enforcement', () => {
+	it('no hardcoded "nimble" literal targets the runtime system id in production source', async () => {
+		const files = await glob(SOURCE_GLOB, { ignore: [...EXCLUDE_GLOBS], posix: true });
+		const offenders: string[] = [];
+
+		for (const file of files) {
+			if (file.endsWith(SELF_PATH_FRAGMENT)) continue;
+			const source = readFileSync(file, 'utf8');
+			offenders.push(...findOffenders(file, source));
+		}
+
+		expect(
+			offenders,
+			`Hardcoded system id found. Import SYSTEM_ID from '#system' and use it instead. ` +
+				`See AGENTS.md → "Never hardcode 'nimble' as the system id". Offenders:\n\n${offenders.join('\n\n')}`,
+		).toEqual([]);
+	});
+});

--- a/src/utils/systemId.ts
+++ b/src/utils/systemId.ts
@@ -1,4 +1,5 @@
 import systemJson from '../../public/system.json';
 
-export const SYSTEM_ID: string = systemJson.id;
+// typed as any to make all the setFlag/getFlag etc calls happy
+export const SYSTEM_ID: any = systemJson.id;
 export const SYSTEM_PATH = `systems/${SYSTEM_ID}`;

--- a/src/view/chat/components/RollSummary.svelte
+++ b/src/view/chat/components/RollSummary.svelte
@@ -4,6 +4,7 @@
 
 	import { getContext } from 'svelte';
 	import localize from '#utils/localize.ts';
+	import { SYSTEM_ID } from '#system';
 	import { useDispositionState } from '../utils/useDispositionState.svelte.ts';
 
 	const {
@@ -17,7 +18,7 @@
 		targetDisposition,
 	}: RollSummaryProps = $props();
 	const { hitDice } = CONFIG.NIMBLE;
-	const autoExpand = game.settings.get('nimble', 'autoExpandRolls');
+	const autoExpand = game.settings.get(SYSTEM_ID, 'autoExpandRolls');
 	const messageDocument = getContext<NimbleChatMessage | undefined>('messageDocument');
 	let expanded = $state(autoExpand);
 

--- a/src/view/components/ActorConditionsList.svelte
+++ b/src/view/components/ActorConditionsList.svelte
@@ -2,6 +2,7 @@
 	import { onMount } from 'svelte';
 	import prepareActorConditions from '../dataPreparationHelpers/prepareActorConditions.js';
 	import localize from '../../utils/localize.js';
+	import { SYSTEM_ID } from '#system';
 
 	interface Props {
 		actor: (Actor.Implementation & { reactive: Actor.Implementation }) | null;
@@ -25,7 +26,7 @@
 	let { actor, mode = 'sheet', allowRemove = true }: Props = $props();
 	let effectVersion = $state(0);
 
-	let flags = $derived(actor?.reactive.flags.nimble);
+	let flags = $derived(actor?.reactive.flags[SYSTEM_ID]);
 	let editingEnabled = $derived(flags?.editingEnabled ?? false);
 
 	let actorConditions = $derived.by(() => {

--- a/src/view/dialogs/CheckRollDialog.svelte
+++ b/src/view/dialogs/CheckRollDialog.svelte
@@ -3,6 +3,7 @@
 
 	import { untrack } from 'svelte';
 
+	import { SYSTEM_ID } from '#system';
 	import getRollFormula from '../../utils/getRollFormula.js';
 	import RollModeConfig from './components/RollModeConfig.svelte';
 
@@ -10,7 +11,7 @@
 
 	let { actor, dialog, type = 'abilityCheck', ...data }: CheckRollDialogProps = $props();
 	let selectedRollMode = $state(untrack(() => Math.clamp(Number(data.rollMode ?? 0), -6, 6)));
-	let shouldRollBeHidden = $state(Boolean(game.settings.get('nimble', 'hideRolls')));
+	let shouldRollBeHidden = $state(Boolean(game.settings.get(SYSTEM_ID, 'hideRolls')));
 
 	let rollFormula = $derived.by(() => {
 		if (type === 'initiative') {

--- a/src/view/dialogs/ItemActivationConfigDialog.svelte
+++ b/src/view/dialogs/ItemActivationConfigDialog.svelte
@@ -3,6 +3,7 @@
 	import type { ItemActivationConfigDialogProps } from '#types/components/ItemActivationConfigDialog.d.ts';
 	import { getDieFaceIcon } from '#utils/dicePool/dieFaceIcons.js';
 	import localize from '#utils/localize.js';
+	import { SYSTEM_ID } from '#system';
 	import { createItemActivationConfigDialogState } from './itemActivationConfigDialogState.svelte.ts';
 	import RollModeConfig from './components/RollModeConfig.svelte';
 
@@ -14,7 +15,7 @@
 		actor: () => actor,
 		item: () => item,
 		initialRollMode: untrack(() => rollMode),
-		hideRollsDefault: !!game.settings.get('nimble', 'hideRolls'),
+		hideRollsDefault: !!game.settings.get(SYSTEM_ID, 'hideRolls'),
 	});
 
 	function onSubmit() {

--- a/src/view/dialogs/SpellUpcastDialog.svelte
+++ b/src/view/dialogs/SpellUpcastDialog.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { untrack } from 'svelte';
 	import type { ScalingDelta } from '#types/spellScaling.js';
+	import { SYSTEM_ID } from '#system';
 	import { NimbleRoll } from '../../dice/NimbleRoll';
 	import RollModeConfig from './components/RollModeConfig.svelte';
 	import RangeSlider from 'svelte-range-slider-pips';
@@ -13,7 +14,7 @@
 	let primaryDieValue = $state();
 	let primaryDieModifier = $state();
 	// @ts-expect-error - nimble isn't included in the type
-	let shouldRollBeHidden = $state(!!game.settings.get('nimble', 'hideRolls'));
+	let shouldRollBeHidden = $state(!!game.settings.get(SYSTEM_ID, 'hideRolls'));
 
 	// I18n helpers
 	const {

--- a/src/view/sheets/NPCSheet.svelte
+++ b/src/view/sheets/NPCSheet.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { setContext, untrack } from 'svelte';
+	import { SYSTEM_ID } from '#system';
 	import { PORTRAIT_FALLBACK_IMAGE } from '../ui/ctTopTracker/constants.js';
 	import PrimaryNavigation from '../components/PrimaryNavigation.svelte';
 	import updateDocumentImage from '../handlers/updateDocumentImage.js';
@@ -96,7 +97,7 @@
 	});
 
 	// Flags
-	let flags = $derived(actor.reactive.flags.nimble);
+	let flags = $derived(actor.reactive.flags[SYSTEM_ID]);
 	let actorImageXOffset = $derived(flags?.actorImageXOffset ?? 0);
 	let actorImageYOffset = $derived(flags?.actorImageYOffset ?? 0);
 	let actorImageScale = $derived(flags?.actorImageScale ?? 100);

--- a/src/view/sheets/PlayerCharacterSheet.state.svelte.ts
+++ b/src/view/sheets/PlayerCharacterSheet.state.svelte.ts
@@ -2,6 +2,7 @@ import { setContext, untrack } from 'svelte';
 import { createSubscriber } from 'svelte/reactivity';
 import { readable } from 'svelte/store';
 import { incrementDieSize } from '#managers/HitDiceManager.js';
+import { SYSTEM_ID } from '#system';
 import {
 	getInitiativeCombatManaRules,
 	primeActorCombatManaSourceRules,
@@ -178,7 +179,7 @@ export function createPlayerCharacterSheetState(params: {
 		return classHasManaFormula;
 	});
 
-	const flags = $derived(actor.reactive.flags.nimble);
+	const flags = $derived(actor.reactive.flags[SYSTEM_ID]);
 	const actorImageXOffset = $derived(flags?.actorImageXOffset ?? 0);
 	const actorImageYOffset = $derived(flags?.actorImageYOffset ?? 0);
 	const actorImageScale = $derived(flags?.actorImageScale ?? 100);
@@ -317,7 +318,7 @@ export function createPlayerCharacterSheetState(params: {
 	}
 
 	async function toggleEditingEnabled(): Promise<void> {
-		await actor.setFlag('nimble', 'editingEnabled', !editingEnabled);
+		await actor.setFlag(SYSTEM_ID, 'editingEnabled', !editingEnabled);
 	}
 
 	return {

--- a/src/view/sheets/components/AbilityScores.svelte
+++ b/src/view/sheets/components/AbilityScores.svelte
@@ -1,13 +1,14 @@
 <script>
 	import { getContext } from 'svelte';
 	import localize from '../../../utils/localize.js';
+	import { SYSTEM_ID } from '#system';
 	import replaceHyphenWithMinusSign from '../../dataPreparationHelpers/replaceHyphenWithMinusSign.js';
 
 	let { abilities } = $props();
 
 	const { abilityScores, abilityScoreAbbreviations, sectionHeaders } = CONFIG.NIMBLE;
 	const actor = getContext('actor');
-	let flags = $derived(actor.reactive.flags.nimble);
+	let flags = $derived(actor.reactive.flags[SYSTEM_ID]);
 	let editingEnabled = $derived(flags?.editingEnabled ?? false);
 </script>
 

--- a/src/view/sheets/components/MonsterFeature.svelte
+++ b/src/view/sheets/components/MonsterFeature.svelte
@@ -1,10 +1,12 @@
 <script>
 	import { getContext } from 'svelte';
 
+	import { SYSTEM_ID } from '#system';
+
 	let { icon = 'fa-solid fa-message', item } = $props();
 
 	let actor = getContext('actor');
-	let flags = $derived(actor.reactive.flags.nimble);
+	let flags = $derived(actor.reactive.flags[SYSTEM_ID]);
 	let editingEnabled = $derived(flags?.editingEnabled ?? false);
 	let hasUses = false;
 </script>

--- a/src/view/sheets/components/MovementSpeed.svelte
+++ b/src/view/sheets/components/MovementSpeed.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
 	import localize from '../../../utils/localize.js';
+	import { SYSTEM_ID } from '#system';
 
 	const { movementTypes, movementTypeIcons } = CONFIG.NIMBLE;
 
 	let { actor, showDefaultSpeed = false, editingEnabled: editingEnabledProp } = $props();
-	let flags = $derived(actor?.reactive.flags.nimble);
+	let flags = $derived(actor?.reactive.flags[SYSTEM_ID]);
 	let editingEnabledFromFlags = $derived(flags?.editingEnabled ?? false);
 	let editingEnabled = $derived(editingEnabledProp ?? editingEnabledFromFlags);
 

--- a/src/view/sheets/components/SavingThrows.svelte
+++ b/src/view/sheets/components/SavingThrows.svelte
@@ -1,6 +1,7 @@
 <script>
 	import { getContext } from 'svelte';
 	import localize from '../../../utils/localize.js';
+	import { SYSTEM_ID } from '#system';
 	import replaceHyphenWithMinusSign from '../../dataPreparationHelpers/replaceHyphenWithMinusSign.js';
 
 	function formatModifier(value) {
@@ -15,7 +16,7 @@
 
 	const { saves, savingThrows, savingThrowAbbreviations } = CONFIG.NIMBLE;
 	const actor = getContext('actor');
-	let flags = $derived(actor.reactive.flags.nimble);
+	let flags = $derived(actor.reactive.flags[SYSTEM_ID]);
 	let editingEnabledFromFlags = $derived(flags?.editingEnabled ?? false);
 	let editingEnabled = $derived(editingEnabledProp ?? editingEnabledFromFlags);
 </script>

--- a/src/view/sheets/components/Skills.svelte
+++ b/src/view/sheets/components/Skills.svelte
@@ -2,6 +2,7 @@
 	import { getContext } from 'svelte';
 
 	import localize from '../../../utils/localize.js';
+	import { SYSTEM_ID } from '#system';
 	import replaceHyphenWithMinusSign from '../../dataPreparationHelpers/replaceHyphenWithMinusSign.js';
 
 	function getSkillValueLabel(modifier) {
@@ -21,7 +22,7 @@
 
 	const actor = getContext('actor');
 
-	let flags = $derived(actor.reactive.flags.nimble);
+	let flags = $derived(actor.reactive.flags[SYSTEM_ID]);
 	let editingEnabled = $derived(flags?.editingEnabled ?? false);
 	let compactSkillsView = $derived(flags?.compactSkillsView ?? true);
 	let showPassiveSkillScores = $derived(flags?.showPassiveSkillScores ?? false);

--- a/src/view/sheets/pages/NPCCoreTab.svelte
+++ b/src/view/sheets/pages/NPCCoreTab.svelte
@@ -3,6 +3,7 @@
 	import { SvelteMap } from 'svelte/reactivity';
 	import { getPools, getPoolsForItem } from '#utils/chargePool/chargePoolSync.js';
 	import sortItems from '#utils/sortItems.js';
+	import { SYSTEM_ID } from '#system';
 	import ChargeIndicator from '#view/components/ChargeIndicator.svelte';
 	import ArmorClass from '#view/sheets/components/ArmorClass.svelte';
 	import MovementSpeed from '#view/sheets/components/MovementSpeed.svelte';
@@ -374,7 +375,7 @@
 
 		// Persist to document in background if editable (non-blocking)
 		if (isEditable) {
-			item.reactive.update({ 'flags.nimble.collapsed': shouldCollapse });
+			item.reactive.update({ [`flags.${SYSTEM_ID}.collapsed`]: shouldCollapse });
 		}
 	}
 
@@ -385,7 +386,7 @@
 			return localCollapsedState.get(item.reactive._id);
 		}
 		// Fall back to document flags
-		return item.reactive.flags.nimble?.collapsed ?? false;
+		return item.reactive.flags[SYSTEM_ID]?.collapsed ?? false;
 	}
 
 	let dragOverItemId = $state(null);
@@ -398,7 +399,7 @@
 	let categorizedItems = $derived(groupItemsByType(items));
 	let flatActionList = $derived(getFlatActionList(categorizedItems['action'] || []));
 
-	let flags = $derived(actor.reactive.flags.nimble);
+	let flags = $derived(actor.reactive.flags[SYSTEM_ID]);
 	let showEmbeddedDocumentImages = $derived(flags?.showEmbeddedDocumentImages ?? true);
 
 	let allCollapsed = $derived(items.every((item) => getItemCollapsed(item)));

--- a/src/view/sheets/pages/NPCSettingsTab.svelte
+++ b/src/view/sheets/pages/NPCSettingsTab.svelte
@@ -1,8 +1,10 @@
 <script>
 	import { getContext } from 'svelte';
 
+	import { SYSTEM_ID } from '#system';
+
 	let actor = getContext('actor');
-	let flags = $derived(actor.reactive.flags.nimble);
+	let flags = $derived(actor.reactive.flags[SYSTEM_ID]);
 	let actorImageXOffset = $derived(flags?.actorImageXOffset ?? 0);
 	let actorImageYOffset = $derived(flags?.actorImageYOffset ?? 0);
 	let actorImageScale = $derived(flags?.actorImageScale ?? 100);
@@ -23,7 +25,7 @@
 				<input
 					type="number"
 					value={actorImageXOffset}
-					onchange={({ target }) => actor.setFlag('nimble', 'actorImageXOffset', target.value)}
+					onchange={({ target }) => actor.setFlag(SYSTEM_ID, 'actorImageXOffset', target.value)}
 				/>
 			</label>
 
@@ -35,7 +37,7 @@
 				<input
 					type="number"
 					value={actorImageYOffset}
-					onchange={({ target }) => actor.setFlag('nimble', 'actorImageYOffset', target.value)}
+					onchange={({ target }) => actor.setFlag(SYSTEM_ID, 'actorImageYOffset', target.value)}
 				/>
 			</label>
 
@@ -47,7 +49,7 @@
 				<input
 					type="number"
 					value={actorImageScale}
-					onchange={({ target }) => actor.setFlag('nimble', 'actorImageScale', target.value)}
+					onchange={({ target }) => actor.setFlag(SYSTEM_ID, 'actorImageScale', target.value)}
 				/>
 			</label>
 		</div>

--- a/src/view/sheets/pages/PlayerCharacterCoreTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterCoreTab.svelte
@@ -9,6 +9,7 @@
 	import { registerCombatStateHooks } from '../../../utils/combatState.js';
 	import { initiativeRollLock } from '../../../utils/initiativeRollLock.js';
 	import localize from '../../../utils/localize.js';
+	import { SYSTEM_ID } from '#system';
 	import replaceHyphenWithMinusSign from '../../dataPreparationHelpers/replaceHyphenWithMinusSign.js';
 	// Components
 	import AbilityScores from '../components/AbilityScores.svelte';
@@ -57,7 +58,7 @@
 			const lateJoinCombat = combat as CombatWithLateJoinCharacterSupport;
 			const autoAddCharacterToCombatOnInitiativeRoll = Boolean(
 				game.settings?.get?.(
-					'nimble' as 'core',
+					SYSTEM_ID as 'core',
 					AUTO_ADD_CHARACTER_TO_COMBAT_ON_INITIATIVE_ROLL_SETTING_KEY as 'rollMode',
 				),
 			);
@@ -98,7 +99,7 @@
 	const subscribeCombatState = createSubscriber(registerCombatStateHooks);
 	let initiativeRequestPending = $state(false);
 
-	let flags = $derived(actor.reactive.flags.nimble);
+	let flags = $derived(actor.reactive.flags[SYSTEM_ID]);
 	let editingEnabled = $derived(flags?.editingEnabled ?? false);
 
 	let skills = $derived(actor.reactive.system.skills);

--- a/src/view/sheets/pages/PlayerCharacterFeaturesTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterFeaturesTab.svelte
@@ -6,6 +6,7 @@
 	import { getContext } from 'svelte';
 	import shouldFlashDroppedItem from '../../../utils/shouldFlashDroppedItem.js';
 	import { getPools, getPoolsForItem } from '../../../utils/chargePool/chargePoolSync.js';
+	import { SYSTEM_ID } from '#system';
 	import {
 		DROP_ITEM_FLASH_ANIMATION_NAME,
 		getDroppedItemFlashIds,
@@ -153,7 +154,7 @@
 	);
 
 	// Settings
-	let flags = $derived(actor.reactive.flags.nimble);
+	let flags = $derived(actor.reactive.flags[SYSTEM_ID]);
 	let showEmbeddedDocumentImages = $derived(flags?.showEmbeddedDocumentImages ?? true);
 
 	// All charge pools for the actor

--- a/src/view/sheets/pages/PlayerCharacterHeroicActionsTab.svelte.ts
+++ b/src/view/sheets/pages/PlayerCharacterHeroicActionsTab.svelte.ts
@@ -1,6 +1,7 @@
 import { createSubscriber } from 'svelte/reactivity';
 import type { NimbleCharacter } from '#documents/actor/character.js';
 import GenericDialog from '#documents/dialogs/GenericDialog.svelte.js';
+import { SYSTEM_ID } from '#system';
 import { getActiveCombatForCurrentScene, registerCombatStateHooks } from '#utils/combatState.js';
 import { getHeroicReactionUsageState } from '#utils/getHeroicReactionUsageState.js';
 import {
@@ -326,7 +327,7 @@ export function createHeroicActionsTabState(getActor: () => NimbleCharacter) {
 	// Derived State
 	// ============================================================================
 
-	const flags = $derived(getActor().reactive.flags.nimble);
+	const flags = $derived(getActor().reactive.flags[SYSTEM_ID]);
 	const showEmbeddedDocumentImages = $derived(flags?.showEmbeddedDocumentImages ?? true);
 
 	function isActionDisabled(action: HeroicAction): boolean {

--- a/src/view/sheets/pages/PlayerCharacterInventoryTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterInventoryTab.svelte
@@ -6,6 +6,7 @@
 	import { getPools, getPoolsForItem } from '#utils/chargePool/chargePoolSync.js';
 	import shouldFlashDroppedItem from '#utils/shouldFlashDroppedItem.js';
 	import sortItems from '#utils/sortItems.js';
+	import { SYSTEM_ID } from '#system';
 	import ChargeIndicator from '#view/components/ChargeIndicator.svelte';
 	import filterItems from '#view/dataPreparationHelpers/filterItems.js';
 	import prepareObjectTooltip from '#view/dataPreparationHelpers/documentTooltips/prepareObjectTooltip.js';
@@ -146,7 +147,7 @@
 	let currency = $derived(actor.reactive?.system?.currency);
 
 	// Settings
-	let flags = $derived(actor.reactive.flags.nimble);
+	let flags = $derived(actor.reactive.flags[SYSTEM_ID]);
 	let showEmbeddedDocumentImages = $derived(flags?.showEmbeddedDocumentImages ?? true);
 	let trackInventorySlots = $derived(flags?.trackInventorySlots ?? true);
 </script>

--- a/src/view/sheets/pages/PlayerCharacterSettingsTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterSettingsTab.svelte
@@ -1,8 +1,9 @@
 <script>
 	import { getHighestSpellTier } from '#utils/spell/getHighestSpellTier.ts';
+	import { SYSTEM_ID } from '#system';
 	import { getContext } from 'svelte';
 	let actor = getContext('actor');
-	let flags = $derived(actor.reactive.flags.nimble);
+	let flags = $derived(actor.reactive.flags[SYSTEM_ID]);
 
 	const editingEnabledStore = getContext('editingEnabled');
 	let editingEnabled = $derived($editingEnabledStore ?? true);
@@ -54,7 +55,7 @@
 				<input
 					type="number"
 					value={actorImageXOffset}
-					onchange={({ target }) => actor.setFlag('nimble', 'actorImageXOffset', target.value)}
+					onchange={({ target }) => actor.setFlag(SYSTEM_ID, 'actorImageXOffset', target.value)}
 					disabled={!editingEnabled}
 				/>
 			</label>
@@ -67,7 +68,7 @@
 				<input
 					type="number"
 					value={actorImageYOffset}
-					onchange={({ target }) => actor.setFlag('nimble', 'actorImageYOffset', target.value)}
+					onchange={({ target }) => actor.setFlag(SYSTEM_ID, 'actorImageYOffset', target.value)}
 					disabled={!editingEnabled}
 				/>
 			</label>
@@ -80,7 +81,7 @@
 				<input
 					type="number"
 					value={actorImageScale}
-					onchange={({ target }) => actor.setFlag('nimble', 'actorImageScale', target.value)}
+					onchange={({ target }) => actor.setFlag(SYSTEM_ID, 'actorImageScale', target.value)}
 					disabled={!editingEnabled}
 				/>
 			</label>
@@ -97,7 +98,7 @@
 				type="checkbox"
 				checked={automaticallyExecuteAvailableMacros}
 				onchange={({ target }) =>
-					actor.setFlag('nimble', 'automaticallyExecuteAvailableMacros', target.checked)}
+					actor.setFlag(SYSTEM_ID, 'automaticallyExecuteAvailableMacros', target.checked)}
 				disabled={!editingEnabled}
 			/>
 
@@ -109,7 +110,7 @@
 				type="checkbox"
 				checked={showEmbeddedDocumentImages}
 				onchange={({ target }) =>
-					actor.setFlag('nimble', 'showEmbeddedDocumentImages', target.checked)}
+					actor.setFlag(SYSTEM_ID, 'showEmbeddedDocumentImages', target.checked)}
 				disabled={!editingEnabled}
 			/>
 
@@ -126,7 +127,7 @@
 			<input
 				type="checkbox"
 				checked={trackInventorySlots}
-				onchange={({ target }) => actor.setFlag('nimble', 'trackInventorySlots', target.checked)}
+				onchange={({ target }) => actor.setFlag(SYSTEM_ID, 'trackInventorySlots', target.checked)}
 				disabled={!editingEnabled}
 			/>
 
@@ -138,7 +139,7 @@
 				<input
 					type="checkbox"
 					checked={includeCurrencyBulk}
-					onchange={({ target }) => actor.setFlag('nimble', 'includeCurrencyBulk', target.checked)}
+					onchange={({ target }) => actor.setFlag(SYSTEM_ID, 'includeCurrencyBulk', target.checked)}
 					disabled={!editingEnabled}
 				/>
 
@@ -188,7 +189,7 @@
 			<input
 				type="checkbox"
 				checked={compactSkillsView}
-				onchange={({ target }) => actor.setFlag('nimble', 'compactSkillsView', target.checked)}
+				onchange={({ target }) => actor.setFlag(SYSTEM_ID, 'compactSkillsView', target.checked)}
 				disabled={!editingEnabled}
 			/>
 
@@ -199,7 +200,8 @@
 			<input
 				type="checkbox"
 				checked={showPassiveSkillScores}
-				onchange={({ target }) => actor.setFlag('nimble', 'showPassiveSkillScores', target.checked)}
+				onchange={({ target }) =>
+					actor.setFlag(SYSTEM_ID, 'showPassiveSkillScores', target.checked)}
 				disabled={!editingEnabled}
 			/>
 

--- a/src/view/sheets/pages/PlayerCharacterSpellsTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterSpellsTab.svelte
@@ -8,6 +8,7 @@
 	import SecondaryNavigation from '#view/components/SecondaryNavigation.svelte';
 	import filterItems from '#view/dataPreparationHelpers/filterItems.js';
 	import prepareSpellTooltip from '#view/dataPreparationHelpers/documentTooltips/prepareSpellTooltip.js';
+	import { SYSTEM_ID } from '#system';
 	import SearchBar from '#view/sheets/components/SearchBar.svelte';
 	import {
 		DROP_ITEM_FLASH_ANIMATION_NAME,
@@ -163,7 +164,7 @@
 	let droppedItemFlashIds = $derived(new Set(getDroppedItemFlashIds(sheetState)));
 
 	// Settings
-	let flags = $derived(actor.reactive.flags.nimble);
+	let flags = $derived(actor.reactive.flags[SYSTEM_ID]);
 	let editingEnabled = $derived(flags?.editingEnabled ?? false);
 	let showEmbeddedDocumentImages = $derived(flags?.showEmbeddedDocumentImages ?? true);
 

--- a/src/view/ui/ctTopTracker/constants.ts
+++ b/src/view/ui/ctTopTracker/constants.ts
@@ -1,3 +1,5 @@
+import { SYSTEM_ID } from '#system';
+
 /** Foundry core: humanoid silhouette — default portrait for characters when missing or failed to load. */
 export const PORTRAIT_FALLBACK_IMAGE = 'icons/svg/mystery-man.svg';
 
@@ -29,6 +31,6 @@ export const CT_ESTIMATED_ENTRY_WIDTH_REM = 6.53;
 export const CT_SETTINGS_DIALOG_UNIQUE_ID = 'nimble-ct-settings-dialog';
 export const CT_WIDTH_PREVIEW_EVENT_NAME = 'nimble:ct-width-preview';
 export const CT_CARD_SIZE_PREVIEW_EVENT_NAME = 'nimble:ct-card-size-preview';
-export const CT_MONSTER_CARDS_EXPANDED_FLAG_PATH = 'flags.nimble.ctMonsterCardsExpanded';
-export const CT_PLAYERS_CAN_VIEW_EXPANDED_MONSTERS_FLAG_PATH =
-	'flags.nimble.ctPlayersCanViewExpandedMonsters';
+
+export const CT_MONSTER_CARDS_EXPANDED_FLAG_PATH = `flags.${SYSTEM_ID}.ctMonsterCardsExpanded`;
+export const CT_PLAYERS_CAN_VIEW_EXPANDED_MONSTERS_FLAG_PATH = `flags.${SYSTEM_ID}.ctPlayersCanViewExpandedMonsters`;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
 			"#lib/*": ["./lib/*"],
 			"#managers/*": ["./src/managers/*"],
 			"#stores/*": ["./src/stores/*"],
+			"#system": ["./src/utils/systemId.ts"],
 			"#types/*": ["./types/*"],
 			"#utils/*": ["./src/utils/*"],
 			"#view/*": ["./src/view/*"]

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -176,6 +176,7 @@ const config = defineConfig({
 			'#lib': path.resolve(__dirname, 'lib'),
 			'#managers': path.resolve(__dirname, 'src/managers'),
 			'#stores': path.resolve(__dirname, 'src/stores'),
+			'#system': path.resolve(__dirname, 'src/utils/systemId.ts'),
 			'#types': path.resolve(__dirname, 'types'),
 			'#utils': path.resolve(__dirname, 'src/utils'),
 			'#view': path.resolve(__dirname, 'src/view'),


### PR DESCRIPTION
## Summary

The dev rolling release (`nimble-dev`) wasn't fully functional. Two compounding problems:

1. **Source code hardcoded `'nimble'`** in ~80 places — flag scopes, settings namespaces, sheet registration, `flags.nimble.X` update payloads, and property access. All of these resolved under the wrong namespace when Foundry installed the package as `nimble-dev`.
2. **Stable→dev worlds still had legacy data on disk** — `flags.nimble.*` keys and `nimble.*` settings keyed under the old system id. Foundry's `getFlag` validates scopes against installed packages and threw on every actor's `prepareDerivedData` run, breaking world load entirely.

This PR addresses both. The source now routes every system-id usage through a `SYSTEM_ID` constant derived from `public/system.json` at build time, so the existing `dev-rebrand.mjs` manifest mutation flows through automatically. A new dev-build-only migration rebrands legacy flags/settings on world load, with a confirmation dialog.

## Changes

### Source refactor

- Refactor all `'nimble'` literals targeting the runtime system id to import `SYSTEM_ID` (or `SYSTEM_PATH`) from `#system`. Covers `setFlag`/`getFlag`/`unsetFlag`, `game.settings.{get,set,register}`, `Actors.registerSheet`/`Items.registerSheet`, `game.keybindings.register`, `'flags.nimble.X'` update payloads, and `actor.reactive.flags.nimble` property access.
- `ItemActivationManager` now reads pool flag paths from `DicePoolRuleConfig.flagPath` / `ChargePoolRuleConfig.flagPath` instead of hardcoded strings.
- New `#system` path alias (`package.json#imports`, `tsconfig.json`, `vite.config.mts`) so `SYSTEM_ID`/`SYSTEM_PATH` have a single short import (`import { SYSTEM_ID } from '#system';`) regardless of file depth.

### Dev-build flag/settings migration

New `src/migration/devFlagRebrand.ts` runs on the dev build only. Two phases:

- **Phase 1 (`init` hook, registered before the main `init` handler):** walks raw `game.data.*` arrays and rewrites `flags.nimble.*` → `flags.nimble-dev.*` in memory *before* Foundry instantiates documents. This prevents `prepareDerivedData` → `getFlag` from throwing on the stale scope. A confirmation dialog prompts the GM before mutating; settings storage is rebranded the same way.
- **Phase 2 (`ready` hook):** persists the rebrand to the database via `Document#update` and creates/deletes Setting docs directly. Toasts ("starting…" / "completed") fire here.

No-op on the stable install (early-return on `SYSTEM_ID` check). No-op on already-clean dev worlds (legacy-data detection short-circuits on the first scan).

### Guardrails

- New `src/utils/systemId.test.ts` source-scan test fails CI if any future production file reintroduces hardcoded `'nimble'` (flag-API calls, settings/keybinding namespaces, sheet registration, `'flags.nimble.X'` strings, `.flags.nimble` property access).
- New Critical Rule in `AGENTS.md` requiring `SYSTEM_ID` for every system-id usage, plus `SYSTEM_ID`/`SYSTEM_PATH` added to the Shared Code Inventory in `STYLE_GUIDE.md`.
- New i18n keys under `NIMBLE.devRebrand.*` for the dialog and notifications.

## Test Plan

- `pnpm type-check`, `pnpm lint:svelte`, `pnpm test` (1304 tests) all pass locally.
- **Reviewer steps:**
  1. **Stable install** under the normal `nimble` id. Confirm: open a character sheet, toggle the "editing enabled" pencil, change a setting in the system settings dialog, roll a check, start combat. No console errors; flags persist across reloads.
  2. **Fresh dev install** (build `nimble-dev` and install side-by-side). Create a new world under it. Same checks as step 1. Confirm flags live under `actor.flags['nimble-dev']` and settings under the `nimble-dev` namespace.
  3. **Stable→dev migration** (the headline scenario). Create a world under the stable install, populate it with characters/items/settings, then switch the same world's system to `nimble-dev`. On load: a confirmation dialog should appear before the world finishes loading. Accept it; verify the world loads without `getFlag` errors and all flags/settings carry over (`actor.flags['nimble-dev'].X` populated, `actor.flags.nimble` removed). Verify the migration is a silent no-op on subsequent loads.
  4. **GM-vs-player** — log in as a non-GM after step 3 is complete; the migration should not run again and there should be no console errors.

## Checklist

- [x] Added or updated unit tests
- [x] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [ ] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** yes
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues

<!-- Link related issues if applicable -->
