### PR TITLE
fix: apply negative max hit dice bonuses

### DIFF
--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -1462,6 +1462,7 @@ export const myStore = writable<MyStoreState>(initialState);
 | `itemSourceRules` | `src/utils/itemSourceRules.ts` | Resolve compendium source IDs and rules for embedded items |
 | `ChargePoolRuleConfig` | `src/utils/chargePoolRuleConfig.ts` | Shared charge-system constants (scopes, triggers, flags) |
 | `ChargePoolService` | `src/utils/chargePool/chargePoolConsume.ts`, `chargePoolRecover.ts`, `chargePoolPreview.ts`, `chargePoolSync.ts` | Charge pool sync, consumption, and recovery operations |
+| `clampHitDiceBySize()` | `src/utils/clampHitDiceBySize.ts` | Clamp hit-dice totals to zero or higher and current values between zero and total |
 | `manaRecovery` | `src/utils/manaRecovery.ts` | Mana recovery calculations |
 | `prelocalize()` | `src/utils/prelocalize.ts` | Pre-localize configuration objects |
 | `getChoicesFromCompendium()` | `src/utils/getChoicesFromCompendium.ts` | Fetch selectable options from compendiums |

--- a/src/documents/actor/character.ts
+++ b/src/documents/actor/character.ts
@@ -609,7 +609,7 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 			const oldBonus = oldBonusContributions[size] ?? 0;
 			const newBonus = newBonusContributions[size] ?? 0;
 			const bonusDelta = newBonus - oldBonus;
-			const newMax = classTotal + newBonus;
+			const newMax = Math.max(classTotal + newBonus, 0);
 
 			const currentValue = this.system.attributes.hitDice[size]?.current ?? 0;
 

--- a/src/managers/HitDiceManager.test.ts
+++ b/src/managers/HitDiceManager.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { HitDiceManager } from './HitDiceManager.js';
+
+function createActor(hitDiceBonus: number, current = 3) {
+	return {
+		classes: {
+			fighter: {
+				hitDice: {
+					size: 8,
+					total: 3,
+				},
+			},
+		},
+		system: {
+			abilities: {
+				strength: {
+					mod: 0,
+				},
+			},
+			attributes: {
+				hitDice: {
+					8: {
+						current,
+						bonus: hitDiceBonus,
+					},
+				},
+				bonusHitDice: [],
+			},
+		},
+		update: () => undefined,
+		applyHealing: () => undefined,
+	} as unknown as ConstructorParameters<typeof HitDiceManager>[0];
+}
+
+describe('HitDiceManager', () => {
+	it('applies negative maxHitDice bonuses to the rollable pool', () => {
+		const manager = new HitDiceManager(createActor(-1));
+
+		expect(manager.max).toBe(2);
+		expect(manager.value).toBe(2);
+		expect(manager.bySize[8]).toEqual({
+			current: 2,
+			total: 2,
+		});
+	});
+
+	it('does not let negative maxHitDice bonuses create negative totals', () => {
+		const manager = new HitDiceManager(createActor(-5));
+
+		expect(manager.max).toBe(0);
+		expect(manager.value).toBe(0);
+		expect(manager.bySize[8]).toEqual({
+			current: 0,
+			total: 0,
+		});
+	});
+});

--- a/src/managers/HitDiceManager.ts
+++ b/src/managers/HitDiceManager.ts
@@ -9,6 +9,17 @@ function incrementDieSize(baseSize: number, steps: number): number {
 	return DIE_SIZES[newIndex];
 }
 
+function clampHitDiceBySize(
+	hitDiceBySize: Record<string, { current: number; total: number }>,
+): Record<string, { current: number; total: number }> {
+	for (const data of Object.values(hitDiceBySize)) {
+		data.total = Math.max(data.total, 0);
+		data.current = Math.min(Math.max(data.current, 0), data.total);
+	}
+
+	return hitDiceBySize;
+}
+
 class HitDiceManager {
 	#actor: NimbleCharacterInterface;
 
@@ -66,7 +77,7 @@ class HitDiceManager {
 			const baseSize = Number(sizeStr);
 			const size = incrementDieSize(baseSize, hitDiceSizeBonus);
 			const bonus = (hitDieData as { bonus?: number }).bonus ?? 0;
-			if (bonus > 0) {
+			if (bonus !== 0) {
 				this.#max += bonus;
 
 				// If this is a new size not from classes or bonusHitDice array, get stored current
@@ -76,6 +87,18 @@ class HitDiceManager {
 					currentCounted.add(size);
 				}
 				this.dieSizes.add(size);
+			}
+		}
+
+		const bySize = this.bySize;
+		this.#max = 0;
+		this.#value = 0;
+		this.dieSizes = new Set<number>();
+		for (const [size, { current, total }] of Object.entries(bySize)) {
+			this.#max += total;
+			this.#value += current;
+			if (total > 0) {
+				this.dieSizes.add(Number(size));
 			}
 		}
 	}
@@ -143,7 +166,7 @@ class HitDiceManager {
 			const baseSize = Number(sizeStr);
 			const size = incrementDieSize(baseSize, hitDiceSizeBonus);
 			const bonus = (hitDieData as { bonus?: number }).bonus ?? 0;
-			if (bonus > 0) {
+			if (bonus !== 0) {
 				hitDiceByClass[size] ??= { current: 0, total: 0 };
 				hitDiceByClass[size].total += bonus;
 
@@ -156,7 +179,7 @@ class HitDiceManager {
 			}
 		}
 
-		return hitDiceByClass;
+		return clampHitDiceBySize(hitDiceByClass);
 	}
 
 	getHitDieData(size: number) {

--- a/src/managers/HitDiceManager.ts
+++ b/src/managers/HitDiceManager.ts
@@ -9,9 +9,11 @@ function incrementDieSize(baseSize: number, steps: number): number {
 	return DIE_SIZES[newIndex];
 }
 
-function clampHitDiceBySize(
-	hitDiceBySize: Record<string, { current: number; total: number }>,
-): Record<string, { current: number; total: number }> {
+type HitDiceBySize =
+	| Record<number, { current: number; total: number }>
+	| Record<string, { current: number; total: number }>;
+
+function clampHitDiceBySize<T extends HitDiceBySize>(hitDiceBySize: T): T {
 	for (const data of Object.values(hitDiceBySize)) {
 		data.total = Math.max(data.total, 0);
 		data.current = Math.min(Math.max(data.current, 0), data.total);
@@ -32,68 +34,7 @@ class HitDiceManager {
 	constructor(actor: NimbleCharacterInterface) {
 		this.#actor = actor;
 
-		// Get hit dice size bonus from rules (e.g., Oozeling's Odd Constitution)
-		const hitDiceSizeBonus =
-			(this.#actor.system.attributes as { hitDiceSizeBonus?: number }).hitDiceSizeBonus ?? 0;
-
-		// Track which sizes we've already counted current for
-		const currentCounted = new Set<number>();
-
-		// Process class hit dice
-		Object.values(this.#actor.classes).forEach((cls) => {
-			// Apply hit dice size bonus to get effective size
-			const size = incrementDieSize(cls.hitDice.size, hitDiceSizeBonus);
-			const current = this.#actor.system.attributes.hitDice[size]?.current ?? 0;
-
-			this.#max += cls.hitDice.total;
-			if (!currentCounted.has(size)) {
-				this.#value += current;
-				currentCounted.add(size);
-			}
-			this.dieSizes.add(size);
-		});
-
-		// Account for bonus hit dice from the bonusHitDice array
-		// Apply hitDiceSizeBonus to increment these dice as well
-		for (const entry of this.#actor.system.attributes.bonusHitDice ?? []) {
-			const size = incrementDieSize(entry.size, hitDiceSizeBonus);
-			this.#max += entry.value;
-
-			// If this is a new size not from classes, get its current value
-			if (!currentCounted.has(size)) {
-				const current = this.#actor.system.attributes.hitDice[size]?.current ?? 0;
-				this.#value += current;
-				currentCounted.add(size);
-			}
-			this.dieSizes.add(size);
-		}
-
-		// Account for bonus hit dice from rules (stored in hitDice[size].bonus)
-		// Rule bonuses add to max; current comes from stored value (restored on rest)
-		// Apply hitDiceSizeBonus to increment these dice as well
-		for (const [sizeStr, hitDieData] of Object.entries(
-			this.#actor.system.attributes.hitDice ?? {},
-		)) {
-			const baseSize = Number(sizeStr);
-			const size = incrementDieSize(baseSize, hitDiceSizeBonus);
-			const bonus = (hitDieData as { bonus?: number }).bonus ?? 0;
-			if (bonus !== 0) {
-				this.#max += bonus;
-
-				// If this is a new size not from classes or bonusHitDice array, get stored current
-				if (!currentCounted.has(size)) {
-					const current = this.#actor.system.attributes.hitDice[size]?.current ?? 0;
-					this.#value += current;
-					currentCounted.add(size);
-				}
-				this.dieSizes.add(size);
-			}
-		}
-
 		const bySize = this.bySize;
-		this.#max = 0;
-		this.#value = 0;
-		this.dieSizes = new Set<number>();
 		for (const [size, { current, total }] of Object.entries(bySize)) {
 			this.#max += total;
 			this.#value += current;
@@ -324,4 +265,4 @@ export interface UpdateDataOptions {
 	restoreLargest?: boolean | undefined;
 }
 
-export { HitDiceManager, incrementDieSize };
+export { HitDiceManager, clampHitDiceBySize, incrementDieSize };

--- a/src/managers/HitDiceManager.ts
+++ b/src/managers/HitDiceManager.ts
@@ -1,3 +1,5 @@
+import { clampHitDiceBySize } from '#utils/clampHitDiceBySize.ts';
+
 // Die size progression: d4 -> d6 -> d8 -> d10 -> d12 -> d20
 const DIE_SIZES = [4, 6, 8, 10, 12, 20];
 
@@ -7,19 +9,6 @@ function incrementDieSize(baseSize: number, steps: number): number {
 
 	const newIndex = Math.min(currentIndex + steps, DIE_SIZES.length - 1);
 	return DIE_SIZES[newIndex];
-}
-
-type HitDiceBySize =
-	| Record<number, { current: number; total: number }>
-	| Record<string, { current: number; total: number }>;
-
-function clampHitDiceBySize<T extends HitDiceBySize>(hitDiceBySize: T): T {
-	for (const data of Object.values(hitDiceBySize)) {
-		data.total = Math.max(data.total, 0);
-		data.current = Math.min(Math.max(data.current, 0), data.total);
-	}
-
-	return hitDiceBySize;
 }
 
 class HitDiceManager {
@@ -265,4 +254,4 @@ export interface UpdateDataOptions {
 	restoreLargest?: boolean | undefined;
 }
 
-export { HitDiceManager, clampHitDiceBySize, incrementDieSize };
+export { HitDiceManager, incrementDieSize };

--- a/src/utils/clampHitDiceBySize.ts
+++ b/src/utils/clampHitDiceBySize.ts
@@ -1,0 +1,14 @@
+type HitDiceBySize =
+	| Record<number, { current: number; total: number }>
+	| Record<string, { current: number; total: number }>;
+
+function clampHitDiceBySize<T extends HitDiceBySize>(hitDiceBySize: T): T {
+	for (const data of Object.values(hitDiceBySize)) {
+		data.total = Math.max(data.total, 0);
+		data.current = Math.min(Math.max(data.current, 0), data.total);
+	}
+
+	return hitDiceBySize;
+}
+
+export { clampHitDiceBySize };

--- a/src/view/dialogs/FieldRestDialog.svelte
+++ b/src/view/dialogs/FieldRestDialog.svelte
@@ -2,7 +2,7 @@
 	import { untrack } from 'svelte';
 	import type { NimbleCharacter } from '../../documents/actor/character.js';
 	import type GenericDialog from '../../documents/dialogs/GenericDialog.svelte.js';
-	import { incrementDieSize } from '../../managers/HitDiceManager.js';
+	import { clampHitDiceBySize, incrementDieSize } from '../../managers/HitDiceManager.js';
 
 	interface HitDiceAdvantageRule {
 		id: string;
@@ -102,12 +102,7 @@
 			}
 		}
 
-		for (const data of Object.values(bySize)) {
-			data.total = Math.max(data.total, 0);
-			data.current = Math.min(Math.max(data.current, 0), data.total);
-		}
-
-		return bySize;
+		return clampHitDiceBySize(bySize);
 	});
 
 	// Get hit dice advantage rules from the actor

--- a/src/view/dialogs/FieldRestDialog.svelte
+++ b/src/view/dialogs/FieldRestDialog.svelte
@@ -2,7 +2,8 @@
 	import { untrack } from 'svelte';
 	import type { NimbleCharacter } from '../../documents/actor/character.js';
 	import type GenericDialog from '../../documents/dialogs/GenericDialog.svelte.js';
-	import { clampHitDiceBySize, incrementDieSize } from '../../managers/HitDiceManager.js';
+	import { incrementDieSize } from '../../managers/HitDiceManager.js';
+	import { clampHitDiceBySize } from '#utils/clampHitDiceBySize.ts';
 
 	interface HitDiceAdvantageRule {
 		id: string;

--- a/src/view/dialogs/FieldRestDialog.svelte
+++ b/src/view/dialogs/FieldRestDialog.svelte
@@ -90,7 +90,7 @@
 			const baseSize = Number(sizeStr);
 			const size = incrementDieSize(baseSize, hitDiceSizeBonus);
 			const bonus = hitDieData?.bonus ?? 0;
-			if (bonus > 0) {
+			if (bonus !== 0) {
 				bySize[size] ??= { current: 0, total: 0 };
 				bySize[size].total += bonus;
 
@@ -100,6 +100,11 @@
 					bySize[size].current = hitDiceAttr[size]?.current ?? 0;
 				}
 			}
+		}
+
+		for (const data of Object.values(bySize)) {
+			data.total = Math.max(data.total, 0);
+			data.current = Math.min(Math.max(data.current, 0), data.total);
 		}
 
 		return bySize;

--- a/src/view/dialogs/SafeRestDialog.svelte
+++ b/src/view/dialogs/SafeRestDialog.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { NimbleCharacter } from '#documents/actor/character.js';
 	import type GenericDialog from '#documents/dialogs/GenericDialog.svelte.js';
-	import { incrementDieSize } from '#managers/HitDiceManager.js';
+	import { clampHitDiceBySize, incrementDieSize } from '#managers/HitDiceManager.js';
 	import { previewRecovery } from '#utils/chargePool/chargePoolPreview.js';
 	import { ChargeUiConfig } from '#utils/chargeUiConfig.js';
 	import { getManaRecoveryTypesFromClasses, restoresManaOnRest } from '#utils/manaRecovery.js';
@@ -109,12 +109,7 @@
 			}
 		}
 
-		for (const data of Object.values(bySize)) {
-			data.total = Math.max(data.total, 0);
-			data.current = Math.min(Math.max(data.current, 0), data.total);
-		}
-
-		return bySize;
+		return clampHitDiceBySize(bySize);
 	});
 
 	let hitDiceRecovery = $derived(

--- a/src/view/dialogs/SafeRestDialog.svelte
+++ b/src/view/dialogs/SafeRestDialog.svelte
@@ -97,7 +97,7 @@
 			const baseSize = Number(sizeStr);
 			const size = incrementDieSize(baseSize, hitDiceSizeBonus);
 			const bonus = hitDieData?.bonus ?? 0;
-			if (bonus > 0) {
+			if (bonus !== 0) {
 				bySize[size] ??= { current: 0, total: 0 };
 				bySize[size].total += bonus;
 
@@ -107,6 +107,11 @@
 					bySize[size].current = hitDiceAttr[size]?.current ?? 0;
 				}
 			}
+		}
+
+		for (const data of Object.values(bySize)) {
+			data.total = Math.max(data.total, 0);
+			data.current = Math.min(Math.max(data.current, 0), data.total);
 		}
 
 		return bySize;

--- a/src/view/dialogs/SafeRestDialog.svelte
+++ b/src/view/dialogs/SafeRestDialog.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
 	import type { NimbleCharacter } from '#documents/actor/character.js';
 	import type GenericDialog from '#documents/dialogs/GenericDialog.svelte.js';
-	import { clampHitDiceBySize, incrementDieSize } from '#managers/HitDiceManager.js';
+	import { incrementDieSize } from '#managers/HitDiceManager.js';
 	import { previewRecovery } from '#utils/chargePool/chargePoolPreview.js';
 	import { ChargeUiConfig } from '#utils/chargeUiConfig.js';
+	import { clampHitDiceBySize } from '#utils/clampHitDiceBySize.ts';
 	import { getManaRecoveryTypesFromClasses, restoresManaOnRest } from '#utils/manaRecovery.js';
 
 	interface Props {

--- a/src/view/sheets/PlayerCharacterSheet.state.svelte.ts
+++ b/src/view/sheets/PlayerCharacterSheet.state.svelte.ts
@@ -1,7 +1,7 @@
 import { setContext, untrack } from 'svelte';
 import { createSubscriber } from 'svelte/reactivity';
 import { readable } from 'svelte/store';
-import { incrementDieSize } from '#managers/HitDiceManager.js';
+import { clampHitDiceBySize, incrementDieSize } from '#managers/HitDiceManager.js';
 import { SYSTEM_ID } from '#system';
 import {
 	getInitiativeCombatManaRules,
@@ -247,16 +247,16 @@ export function createPlayerCharacterSheetState(params: {
 			}
 		}
 
+		const clampedBySize = clampHitDiceBySize(bySize);
+
 		let value = 0;
 		let max = 0;
-		for (const data of Object.values(bySize)) {
-			data.total = Math.max(data.total, 0);
-			data.current = Math.min(Math.max(data.current, 0), data.total);
+		for (const data of Object.values(clampedBySize)) {
 			value += data.current;
 			max += data.total;
 		}
 
-		return { bySize, value, max };
+		return { bySize: clampedBySize, value, max };
 	});
 
 	{

--- a/src/view/sheets/PlayerCharacterSheet.state.svelte.ts
+++ b/src/view/sheets/PlayerCharacterSheet.state.svelte.ts
@@ -235,7 +235,7 @@ export function createPlayerCharacterSheetState(params: {
 			const baseSize = Number(sizeStr);
 			const size = incrementDieSize(baseSize, hitDiceSizeBonus);
 			const bonus = (hitDieData as { bonus?: number })?.bonus ?? 0;
-			if (bonus > 0) {
+			if (bonus !== 0) {
 				bySize[size] ??= { current: 0, total: 0 };
 				bySize[size].total += bonus;
 
@@ -250,6 +250,8 @@ export function createPlayerCharacterSheetState(params: {
 		let value = 0;
 		let max = 0;
 		for (const data of Object.values(bySize)) {
+			data.total = Math.max(data.total, 0);
+			data.current = Math.min(Math.max(data.current, 0), data.total);
 			value += data.current;
 			max += data.total;
 		}

--- a/src/view/sheets/PlayerCharacterSheet.state.svelte.ts
+++ b/src/view/sheets/PlayerCharacterSheet.state.svelte.ts
@@ -1,8 +1,9 @@
 import { setContext, untrack } from 'svelte';
 import { createSubscriber } from 'svelte/reactivity';
 import { readable } from 'svelte/store';
-import { clampHitDiceBySize, incrementDieSize } from '#managers/HitDiceManager.js';
+import { incrementDieSize } from '#managers/HitDiceManager.js';
 import { SYSTEM_ID } from '#system';
+import { clampHitDiceBySize } from '#utils/clampHitDiceBySize.ts';
 import {
 	getInitiativeCombatManaRules,
 	primeActorCombatManaSourceRules,


### PR DESCRIPTION
## Summary
- Apply rule-based maxHitDice bonuses when they are negative, not only when positive.
- Clamp derived hit dice totals/current values so negative bonuses reduce the rollable pool without creating negative dice.
- Clamp configured hit dice current values when a bonus decrease lowers the maximum below the stored current value.

Fixes #741.

## Tests
- `pnpm exec vitest run src/managers/HitDiceManager.test.ts`
- `pnpm exec vitest run src/managers/HitDiceManager.test.ts src/models/rules/maxHitDice.test.ts`
- `pnpm exec vitest run src/hooks/combatantHooks/combatantDefeatSync.test.ts`
- `pnpm exec biome check src/managers/HitDiceManager.ts src/managers/HitDiceManager.test.ts src/documents/actor/character.ts src/view/sheets/PlayerCharacterSheet.state.svelte.ts`
- `pnpm exec eslint src/view/dialogs/FieldRestDialog.svelte src/view/dialogs/SafeRestDialog.svelte`
- `pnpm lint:svelte`
- `pnpm type-check`
- `pnpm exec biome lint ./src/ ./types/ ./lib/`

## Notes
- `pnpm test` was also attempted; one full run hit a Vitest fork startup timeout in `combatantDefeatSync.test.ts`, and that same file passed when rerun alone.
- This PR was AI-assisted; I reviewed and verified the resulting changes.