### PR TITLE
feat(rules): add `setIfEmpty` dice-pool refill mode

### DIFF
--- a/src/utils/dicePool/dicePoolRefill.test.ts
+++ b/src/utils/dicePool/dicePoolRefill.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { applyRefillTriggersToPools } from './dicePoolRefill.js';
+import type { CharacterActorLike, DicePoolMap, DicePoolState, DiceRefillEntry } from './types.js';
+
+// The shared Foundry Die mock in tests/mocks/foundry.ts doesn't implement
+// evaluate(), which rollSingleDieFace() in helpers.ts calls. Patch the Die
+// constructor for this suite so it produces a deterministic face value.
+beforeEach(() => {
+	class DeterministicDie {
+		faces: number;
+		total: number;
+		constructor({ faces }: { faces: number }) {
+			this.faces = faces;
+			this.total = faces;
+		}
+		async evaluate(): Promise<void> {}
+	}
+	(
+		globalThis as unknown as { foundry: { dice: { terms: { Die: unknown } } } }
+	).foundry.dice.terms.Die = DeterministicDie;
+});
+
+function makeActor(): CharacterActorLike {
+	return {
+		type: 'character',
+		getRollData: vi.fn(() => ({})),
+	} as unknown as CharacterActorLike;
+}
+
+function makePool(overrides: Partial<DicePoolState> = {}): DicePoolState {
+	return {
+		id: 'judgment',
+		identifier: 'judgment',
+		scope: 'item',
+		sourceItemId: 'item-1',
+		sourceItemName: 'Radiant Judgment',
+		label: 'Judgment Dice',
+		dieSize: 'd6',
+		max: 2,
+		faces: [],
+		refills: [],
+		consumption: 'manual',
+		bonusOnAttackDelivery: null,
+		...overrides,
+	};
+}
+
+function refill(
+	entry: Partial<DiceRefillEntry> & Pick<DiceRefillEntry, 'trigger'>,
+): DiceRefillEntry {
+	return {
+		mode: 'add',
+		value: '1',
+		...entry,
+	} as DiceRefillEntry;
+}
+
+describe('applyRefillTriggersToPools — setIfEmpty mode', () => {
+	it('rolls fresh dice up to `value` when the pool is empty', async () => {
+		const actor = makeActor();
+		const pools: DicePoolMap = {
+			judgment: makePool({
+				faces: [],
+				refills: [refill({ trigger: 'onAttacked', mode: 'setIfEmpty', value: '2' })],
+			}),
+		};
+
+		const { nextPools, entries } = await applyRefillTriggersToPools(actor, pools, ['onAttacked']);
+
+		expect(nextPools.judgment.faces).toHaveLength(2);
+		expect(entries).toHaveLength(1);
+		expect(entries[0].rolledFaces).toHaveLength(2);
+		expect(entries[0].previousFaces).toEqual([]);
+	});
+
+	it('is a no-op when the pool already has live dice', async () => {
+		const actor = makeActor();
+		const pools: DicePoolMap = {
+			judgment: makePool({
+				faces: [5],
+				refills: [refill({ trigger: 'onAttacked', mode: 'setIfEmpty', value: '2' })],
+			}),
+		};
+
+		const { nextPools, entries } = await applyRefillTriggersToPools(actor, pools, ['onAttacked']);
+
+		expect(nextPools.judgment.faces).toEqual([5]);
+		expect(entries).toEqual([]);
+	});
+
+	it('is a no-op even when the pool is below max but non-empty', async () => {
+		const actor = makeActor();
+		const pools: DicePoolMap = {
+			judgment: makePool({
+				max: 3,
+				faces: [4],
+				refills: [refill({ trigger: 'onAttacked', mode: 'setIfEmpty', value: '3' })],
+			}),
+		};
+
+		const { nextPools, entries } = await applyRefillTriggersToPools(actor, pools, ['onAttacked']);
+
+		expect(nextPools.judgment.faces).toEqual([4]);
+		expect(entries).toEqual([]);
+	});
+
+	it('clamps the roll count to pool.max', async () => {
+		const actor = makeActor();
+		const pools: DicePoolMap = {
+			judgment: makePool({
+				max: 2,
+				faces: [],
+				refills: [refill({ trigger: 'onAttacked', mode: 'setIfEmpty', value: '99' })],
+			}),
+		};
+
+		const { nextPools, entries } = await applyRefillTriggersToPools(actor, pools, ['onAttacked']);
+
+		expect(nextPools.judgment.faces).toHaveLength(2);
+		expect(entries[0].rolledFaces).toHaveLength(2);
+	});
+
+	it('does not fire when the trigger does not match', async () => {
+		const actor = makeActor();
+		const pools: DicePoolMap = {
+			judgment: makePool({
+				faces: [],
+				refills: [refill({ trigger: 'onAttacked', mode: 'setIfEmpty', value: '2' })],
+			}),
+		};
+
+		const { nextPools, entries } = await applyRefillTriggersToPools(actor, pools, ['safeRest']);
+
+		expect(nextPools.judgment.faces).toEqual([]);
+		expect(entries).toEqual([]);
+	});
+
+	it('does not affect other modes on the same pool', async () => {
+		const actor = makeActor();
+		const pools: DicePoolMap = {
+			fury: makePool({
+				id: 'fury',
+				identifier: 'fury',
+				label: 'Fury Dice',
+				max: 4,
+				faces: [3, 3],
+				refills: [refill({ trigger: 'safeRest', mode: 'refresh' })],
+			}),
+		};
+
+		const { nextPools, entries } = await applyRefillTriggersToPools(actor, pools, ['safeRest']);
+
+		expect(nextPools.fury.faces).toHaveLength(4);
+		expect(entries).toHaveLength(1);
+	});
+});

--- a/src/utils/dicePool/dicePoolRefill.ts
+++ b/src/utils/dicePool/dicePoolRefill.ts
@@ -72,6 +72,21 @@ async function applyRefillTriggersToPools(
 				continue;
 			}
 
+			if (refill.mode === 'setIfEmpty') {
+				// 'setIfEmpty' rolls `target` fresh dice only when the pool is
+				// currently empty. Matches rulebook phrasing like Oathsworn
+				// Radiant Judgment: "if you have no Judgment Dice, roll your
+				// Judgment dice (2d6)." A pool with live dice is left alone.
+				if (pool.faces.length > 0) continue;
+				const target = Math.min(amount, pool.max);
+				for (let index = 0; index < target; index += 1) {
+					const face = await rollSingleDieFace(pool.dieSize);
+					pool.faces.push(face);
+					rolledFaces.push(face);
+				}
+				continue;
+			}
+
 			// 'add' mode — push N new dice up to max.
 			const room = pool.max - pool.faces.length;
 			const toAdd = Math.max(0, Math.min(amount, room));

--- a/src/utils/dicePool/dicePoolRuleConfig.ts
+++ b/src/utils/dicePool/dicePoolRuleConfig.ts
@@ -18,7 +18,7 @@ const DicePoolRuleConfig = {
 		'onBloodied',
 		'onAttacked',
 	],
-	refillModes: ['add', 'set', 'refresh'],
+	refillModes: ['add', 'set', 'refresh', 'setIfEmpty'],
 	restTypes: ['safe', 'field'],
 	encounterTriggerTypes: ['encounterStart', 'encounterEnd'] as const,
 	// How dice are spent: 'manual' = player opts in per roll, dice consumed.


### PR DESCRIPTION
## Summary

Adds a new dice-pool refill mode `setIfEmpty` that rolls fresh dice up to `value` **only when the pool is currently empty**, otherwise no-op. Unblocks a correctness bug in Oathsworn Radiant Judgment where the existing `set` mode silently overwrote non-empty pools on every incoming attack.

## Changes

- Add `'setIfEmpty'` to `DicePoolRuleConfig.refillModes` ([src/utils/dicePool/dicePoolRuleConfig.ts](../blob/feat/dice-pool-set-if-empty/src/utils/dicePool/dicePoolRuleConfig.ts))
- Handle the mode in `applyRefillTriggersToPools`, short-circuiting when `pool.faces.length > 0` ([src/utils/dicePool/dicePoolRefill.ts](../blob/feat/dice-pool-set-if-empty/src/utils/dicePool/dicePoolRefill.ts))
- Add unit tests covering the empty / non-empty / below-max / clamping / wrong-trigger / other-mode paths ([src/utils/dicePool/dicePoolRefill.test.ts](../blob/feat/dice-pool-set-if-empty/src/utils/dicePool/dicePoolRefill.test.ts))

**Out of scope (follow-up PRs):** the Oathsworn pack migration (`radiant-judgement.json` `mode: "set"` → `mode: "setIfEmpty"`) and `@poolMax` token support for L14 scaling

## Test Plan

Engine-only change; no UI to click through.

1. `pnpm check` — passes locally (109 files / 1334 tests green, lint + type-check clean)
2. Inspect `applyRefillTriggersToPools` and confirm the new branch sits between `set` and the fall-through `add` block, with the same shape as `set` plus a `pool.faces.length > 0 → continue` guard
3. Read `dicePoolRefill.test.ts` and confirm the cases match the rulebook phrasing:
   - empty pool, `setIfEmpty value: "2"` → rolls 2 fresh dice
   - non-empty pool (1 face) → no-op
   - non-empty pool below max (1/3 faces) → still no-op (this is the key distinction from `refresh`)
   - oversized `value` (`"99"`) → clamped to `pool.max`
   - wrong trigger → untouched
   - other modes on other pools unaffected

No pack data changes in this PR

## Checklist

- [x] Added or updated unit tests
- [x] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [x] Tested in Foundry with no console errors — N/A, engine-only change with no UI surface; unit tests cover the behavior
- [x] **Have you used AI to assist with this PR?** yes
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues

Unblocks #631 (Oathsworn Radiant Judgment) and #636 (Oath of Vengeance Aura of Zeal). Part of #578 (Foundation: dicePool).