### PR TITLE
feat(rules): @poolMax / @poolCurrent tokens in dice-pool refill values

### DIFF
--- a/src/utils/dicePool/dicePoolRefill.test.ts
+++ b/src/utils/dicePool/dicePoolRefill.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { applyRefillTriggersToPools } from './dicePoolRefill.js';
+import type { CharacterActorLike, DicePoolMap, DicePoolState, DiceRefillEntry } from './types.js';
+
+// The shared Foundry Die mock in tests/mocks/foundry.ts doesn't implement
+// evaluate(), which rollSingleDieFace() in helpers.ts calls. Patch the Die
+// constructor for this suite so it produces a deterministic face value.
+beforeEach(() => {
+	class DeterministicDie {
+		faces: number;
+		total: number;
+		constructor({ faces }: { faces: number }) {
+			this.faces = faces;
+			this.total = faces;
+		}
+		async evaluate(): Promise<void> {}
+	}
+	(
+		globalThis as unknown as { foundry: { dice: { terms: { Die: unknown } } } }
+	).foundry.dice.terms.Die = DeterministicDie;
+});
+
+function makeActor(rollData: Record<string, unknown> = {}): CharacterActorLike {
+	return {
+		type: 'character',
+		getRollData: vi.fn(() => rollData),
+	} as unknown as CharacterActorLike;
+}
+
+function makePool(overrides: Partial<DicePoolState> = {}): DicePoolState {
+	return {
+		id: 'judgment',
+		identifier: 'judgment',
+		scope: 'item',
+		sourceItemId: 'item-1',
+		sourceItemName: 'Radiant Judgment',
+		label: 'Judgment Dice',
+		dieSize: 'd6',
+		max: 2,
+		faces: [],
+		refills: [],
+		consumption: 'manual',
+		bonusOnAttackDelivery: null,
+		...overrides,
+	};
+}
+
+function refill(
+	entry: Partial<DiceRefillEntry> & Pick<DiceRefillEntry, 'trigger'>,
+): DiceRefillEntry {
+	return {
+		mode: 'add',
+		value: '1',
+		...entry,
+	} as DiceRefillEntry;
+}
+
+describe('applyRefillTriggersToPools — @poolMax / @poolCurrent tokens', () => {
+	it('resolves @poolMax to the pool max for set mode (Oathsworn L14 scaling)', async () => {
+		const actor = makeActor();
+		const pools: DicePoolMap = {
+			judgment: makePool({
+				max: 3,
+				faces: [],
+				refills: [refill({ trigger: 'onAttacked', mode: 'set', value: '@poolMax' })],
+			}),
+		};
+
+		const { nextPools } = await applyRefillTriggersToPools(actor, pools, ['onAttacked']);
+
+		expect(nextPools.judgment.faces).toHaveLength(3);
+	});
+
+	it('resolves @poolMax against the per-pool max — Oathsworn L1 still gets 2 dice', async () => {
+		const actor = makeActor();
+		const pools: DicePoolMap = {
+			judgment: makePool({
+				max: 2,
+				faces: [],
+				refills: [refill({ trigger: 'onAttacked', mode: 'set', value: '@poolMax' })],
+			}),
+		};
+
+		const { nextPools } = await applyRefillTriggersToPools(actor, pools, ['onAttacked']);
+
+		expect(nextPools.judgment.faces).toHaveLength(2);
+	});
+
+	it('supports arithmetic on @poolMax (e.g. "@poolMax - 1")', async () => {
+		const actor = makeActor();
+		const pools: DicePoolMap = {
+			judgment: makePool({
+				max: 3,
+				faces: [],
+				refills: [refill({ trigger: 'safeRest', mode: 'set', value: '@poolMax - 1' })],
+			}),
+		};
+
+		const { nextPools } = await applyRefillTriggersToPools(actor, pools, ['safeRest']);
+
+		expect(nextPools.judgment.faces).toHaveLength(2);
+	});
+
+	it('resolves @poolCurrent to the current face count', async () => {
+		const actor = makeActor();
+		const pools: DicePoolMap = {
+			judgment: makePool({
+				max: 5,
+				faces: [4, 5],
+				refills: [refill({ trigger: 'safeRest', mode: 'add', value: '@poolCurrent' })],
+			}),
+		};
+
+		const { nextPools } = await applyRefillTriggersToPools(actor, pools, ['safeRest']);
+
+		// add mode rolls min(@poolCurrent=2, room=3) = 2 new dice -> 4 total faces.
+		expect(nextPools.judgment.faces).toHaveLength(4);
+	});
+
+	it('mixes pool tokens with actor rollData references', async () => {
+		const actor = makeActor({ level: 5 });
+		const pools: DicePoolMap = {
+			judgment: makePool({
+				max: 10,
+				faces: [],
+				refills: [refill({ trigger: 'safeRest', mode: 'set', value: '@poolMax - @level' })],
+			}),
+		};
+
+		const { nextPools } = await applyRefillTriggersToPools(actor, pools, ['safeRest']);
+
+		expect(nextPools.judgment.faces).toHaveLength(5);
+	});
+
+	it('leaves plain numeric refill values untouched (regression)', async () => {
+		const actor = makeActor();
+		const pools: DicePoolMap = {
+			judgment: makePool({
+				max: 5,
+				faces: [],
+				refills: [refill({ trigger: 'onAttacked', mode: 'set', value: '2' })],
+			}),
+		};
+
+		const { nextPools } = await applyRefillTriggersToPools(actor, pools, ['onAttacked']);
+
+		expect(nextPools.judgment.faces).toHaveLength(2);
+	});
+});

--- a/src/utils/dicePool/dicePoolRefill.ts
+++ b/src/utils/dicePool/dicePoolRefill.ts
@@ -25,6 +25,25 @@ type RefilledEntry = {
 	trigger: DiceRefillTrigger;
 };
 
+const POOL_MAX_TOKEN_PATTERN = /@poolMax\b/g;
+const POOL_CURRENT_TOKEN_PATTERN = /@poolCurrent\b/g;
+
+// Pool-context tokens (@poolMax, @poolCurrent) can't live in actor rollData
+// because the same actor can own multiple pools with different values. Inline
+// them in the formula string so the standard evaluator handles arithmetic
+// like "@poolMax - 1" without further plumbing.
+function resolveRefillValue(
+	actor: CharacterActorLike,
+	pool: DicePoolState,
+	formula: unknown,
+): number {
+	if (typeof formula !== 'string') return resolveFormulaToInteger(actor, formula);
+	const substituted = formula
+		.replace(POOL_MAX_TOKEN_PATTERN, String(pool.max))
+		.replace(POOL_CURRENT_TOKEN_PATTERN, String(pool.faces.length));
+	return resolveFormulaToInteger(actor, substituted);
+}
+
 /**
  * Apply each pool's matching refill entries for the given triggers.
  * Returns the next state plus a per-pool diff describing what was rolled.
@@ -59,7 +78,7 @@ async function applyRefillTriggersToPools(
 				continue;
 			}
 
-			const amount = resolveFormulaToInteger(actor, refill.value);
+			const amount = resolveRefillValue(actor, pool, refill.value);
 			if (refill.mode === 'set') {
 				const target = Math.min(amount, pool.max);
 				// 'set' rebuilds the pool to exactly `target` freshly-rolled dice.


### PR DESCRIPTION
## Summary

Refill `value` expressions on a `dicePool` rule now support `@poolMax` and `@poolCurrent` tokens, resolved against the per-pool state before formula evaluation. Unblocks Oathsworn Radiant Judgment L14, where `modifyPool` bumps max from 2 to 3 but the original `value: "2"` was silently inert.

## Changes

- `resolveRefillValue` in `dicePoolRefill.ts` substitutes `@poolMax` → `pool.max` and `@poolCurrent` → `pool.faces.length` in the formula string, then delegates to `resolveFormulaToInteger`. Arithmetic (`@poolMax - 1`) and mixed actor tokens (`@poolMax - @level`) work as a side effect of running through the standard Roll evaluator.
- 6 unit tests covering: L14 scaling, L1 baseline, arithmetic, `@poolCurrent`, mixed actor+pool tokens, and plain-numeric regression.

## Test Plan

1. `pnpm vitest run src/utils/dicePool/dicePoolRefill.test.ts` — all 6 tests pass.
2. `pnpm check` — full suite green (1351/1351).
3. Manual: drop an Oathsworn at L14 (with the `maxDelta: +1` modifier active) and a pool refill of `{ trigger: "onAttacked", mode: "set", value: "@poolMax" }`. Attack the character — pool refills to 3 faces.

## Checklist

- [x] Added or updated unit tests
- [x] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [ ] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** yes
- [x] **If yes:** I have reviewed all AI-generated code against the repo's STYLE_GUIDE.md and AGENTS.md

## Related Issues

Addresses the L14 inert-refill correctness gap on #631 (Oathsworn Radiant Judgment). Pack migration to actually consume the token lands in a follow-up after this and #787 merge.