### PR TITLE
fix(dice): route bare khn/kln formulas into DamageRoll modifier-mode

### DIFF
--- a/src/dice/DamageRoll.test.ts
+++ b/src/dice/DamageRoll.test.ts
@@ -1951,6 +1951,61 @@ describe('die modifier vocabulary — modifier-mode', () => {
 			expect(roll.modifierMode).toBe(false);
 			expect(roll.primaryDie).toBeDefined(); // legacy PrimaryDie
 		});
+
+		it('2d20khn (initiative-with-advantage) enters modifier-mode and does not split', () => {
+			const roll = new DamageRoll(
+				'2d20khn',
+				{},
+				{
+					canCrit: true,
+					canMiss: true,
+					rollMode: 0,
+					primaryDieValue: 0,
+					primaryDieModifier: 0,
+				},
+			);
+			expect(roll.modifierMode).toBe(true);
+			expect(roll.primaryDie).toBeUndefined();
+			// Single 2d20khn Die term — must NOT have been split into PrimaryDie + Die.
+			const dieTerms = roll.terms.filter((t) => t instanceof foundry.dice.terms.Die);
+			expect(dieTerms).toHaveLength(1);
+			expect(dieTerms[0].number).toBe(2);
+			expect(dieTerms[0].modifiers).toContain('khn');
+		});
+
+		it('2d20kln (initiative-with-disadvantage) enters modifier-mode and does not split', () => {
+			const roll = new DamageRoll(
+				'2d20kln',
+				{},
+				{
+					canCrit: true,
+					canMiss: true,
+					rollMode: 0,
+					primaryDieValue: 0,
+					primaryDieModifier: 0,
+				},
+			);
+			expect(roll.modifierMode).toBe(true);
+			expect(roll.primaryDie).toBeUndefined();
+			const dieTerms = roll.terms.filter((t) => t instanceof foundry.dice.terms.Die);
+			expect(dieTerms).toHaveLength(1);
+			expect(dieTerms[0].modifiers).toContain('kln');
+		});
+
+		it('khn with explicit count (khn2) enters modifier-mode', () => {
+			const roll = new DamageRoll(
+				'3d20khn2',
+				{},
+				{
+					canCrit: true,
+					canMiss: true,
+					rollMode: 0,
+					primaryDieValue: 0,
+					primaryDieModifier: 0,
+				},
+			);
+			expect(roll.modifierMode).toBe(true);
+		});
 	});
 
 	describe('per-die crit detection', () => {

--- a/src/dice/DamageRoll.ts
+++ b/src/dice/DamageRoll.ts
@@ -241,9 +241,18 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 	/** Nimble modifier tokens that trigger modifier-mode when present on any Die term. */
 	private static readonly NIMBLE_MODIFIER_TOKENS = new Set(['c', 'cv', 'v', 'n']);
 
+	/** Matches `khn` / `kln` with an optional positive integer count (e.g. `khn`, `kln3`). */
+	private static readonly NIMBLE_KEEP_MODIFIER_RE = /^(?:khn|kln)\d*$/;
+
 	/**
 	 * Check whether any Die term in `this.terms` carries a Nimble modifier.
 	 * If so, the roll enters modifier-mode and skips PrimaryDie extraction.
+	 *
+	 * Recognises both the metadata modifiers (`c`/`cv`/`v`/`n`) and the keep
+	 * modifiers (`khn`/`kln`, with optional count). A bare `khn`/`kln` formula
+	 * (e.g. `2d20khn` for initiative-with-advantage) must skip primary-die
+	 * extraction — otherwise the legacy path splits it into a PrimaryDie plus
+	 * leftover Die and sums them, which is wrong for advantage/disadvantage.
 	 */
 	private _hasNimbleModifiers(): boolean {
 		for (const term of this.terms) {
@@ -251,6 +260,7 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 			if (!Array.isArray(term.modifiers)) continue;
 			for (const m of term.modifiers) {
 				if (DamageRoll.NIMBLE_MODIFIER_TOKENS.has(m)) return true;
+				if (DamageRoll.NIMBLE_KEEP_MODIFIER_RE.test(m)) return true;
 			}
 		}
 		return false;


### PR DESCRIPTION
## Summary

`khn`/`kln` formulas without a `c`/`cv`/`v`/`n` partner (notably `2d20khn` from initiative-with-advantage and any `/r 2d20khn` typed in chat) were being claimed by `DamageRoll` and then routed through legacy primary-die extraction, which split the formula into `1d20x[Primary] + 1d20khn` and summed both dice. Initiative with advantage produced the sum of two d20s instead of the higher one.

## Changes

- `_hasNimbleModifiers()` now also matches `khn`/`kln` (with optional count suffix), so any formula carrying a Nimble keep modifier enters modifier-mode and skips primary-die extraction.
- Added regression tests for `2d20khn`, `2d20kln`, and `3d20khn2`.

## Test Plan

1. In chat, run `/r 2d20khn`. Expect a single Die term with one die kept and one discarded; total equals the kept die.
2. Same with `/r 2d20kln`, `/r 3d20khn2`.
3. Give a character advantage on initiative (e.g. Lithe ancestry, Eager for Battle, or set the dialog rollMode to +1) and roll initiative. Expect `2d20khn + mod` to keep one d20, not sum both.
4. Roll a weapon with `c`/`cv` (existing modifier-mode path) to confirm crit/miss detection still works.
5. Roll a weapon with advantage (e.g. greataxe `2d6` at advantage 1 → `3d6khn2c`) to confirm advantage damage still works.

## Checklist

- [x] Added or updated unit tests
- [x] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [x] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** yes
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)