### PR TITLE
fix(dev-build): route hardcoded "nimble" id through SYSTEM_ID

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,11 @@ This file provides guidance for AI assistants working on this codebase.
   - **Settings:** `game.settings.get/set/register(SYSTEM_ID as 'core', ...)`
   - **Sheet/keybinding registration:** `Actors.registerSheet(SYSTEM_ID, ...)`, `game.keybindings.register(SYSTEM_ID, ...)`
   - **Asset paths:** `` `${SYSTEM_PATH}/icons/foo.svg` `` instead of `'systems/nimble/icons/foo.svg'`
+  - **Custom hook names:** use `systemHookName('suffix')` from `#system` (e.g. `systemHookName('damageApplied')` → `nimble.damageApplied` / `nimble-dev.damageApplied`) for both `Hooks.call`/`callAll` emitters and `Hooks.on` listeners, so they stay in lockstep across installs. Never write a literal `'nimble.X'` hook string. The dicePool/chargePool emit helpers build their names this way (`systemHookName(\`dicePool.${hook}\`)`); listeners use `systemHookName('dicePool.changed')` directly.
+  - **Object-literal scope keys:** use a computed key `[SYSTEM_ID]:` (or `[*RuleConfig.flagScope]:`) — never a literal `nimble:` key. This applies to flag bags (`flags: { [SYSTEM_ID]: {...} }`) and `Document#update` option scopes (`{ [SYSTEM_ID]: { skipDicePoolSync: true } }`).
+  - **Aliased flag access:** `const f = item.flags; f[SYSTEM_ID]` — not `f.nimble`. The scope key is still the system id even when the `flags` object is dereferenced through a local.
+  - **Audited exceptions:** `game.nimble` (our own arbitrary API namespace on `game`, assigned and read with the same literal key — self-consistent, not id-validated, and referenced by persisted macro command strings) and `Compendium.nimble.*` source ids in `src/migration/**` (handled by the dev-flag-rebrand) intentionally stay literal. The `systemId.test.ts` guard exempts these; new exceptions need an inline `// allow-hardcoded-system-id` comment with justification.
+  - **Enforcement:** `src/utils/systemId.test.ts` statically scans production source for the forbidden literal forms and fails the build. Run it (part of `pnpm check`) after touching anything in this area.
 
 ## References
 

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -1263,6 +1263,24 @@ export function registerReadyHooks(): void {
 }
 ```
 
+**Custom (system-namespaced) hooks must derive their name from `SYSTEM_ID`.** Foundry namespaces nothing for you here, but the dev rolling release runs under a different id (`nimble-dev`), so a hardcoded `'nimble.X'` string makes emitters and listeners silently stop matching. Use `systemHookName('suffix')` from `#system` on **both** sides:
+
+```typescript
+import { systemHookName } from '#system';
+
+// Emit (system/document/manager code)
+Hooks.callAll(systemHookName('damageApplied'), payload);
+
+// Listen (hooks/, Svelte state files)
+Hooks.on(systemHookName('damageApplied'), handler);
+
+// Subsystem emit helpers build their own infix the same way, e.g.
+// dicePoolHooks.ts: systemHookName(`dicePool.${hook}`)
+// listeners then use systemHookName('dicePool.changed') directly.
+```
+
+Never write a literal `'nimble.X'` hook string. `src/utils/systemId.test.ts` fails the build if you do.
+
 ### Sheet Registration
 
 Define sheet classes that bridge Foundry and Svelte:
@@ -1445,7 +1463,7 @@ export const myStore = writable<MyStoreState>(initialState);
 
 | Utility | Location | Purpose |
 |---------|----------|---------|
-| `SYSTEM_ID`, `SYSTEM_PATH` | `src/utils/systemId.ts` (alias: `#system`) | Build-time-baked system id from `public/system.json` and `systems/<id>` path prefix. Use for every flag scope, settings namespace, sheet/keybinding registration, and asset path — never hardcode `'nimble'`. The dev rolling release rebuilds under a different id |
+| `SYSTEM_ID`, `SYSTEM_PATH`, `systemHookName()` | `src/utils/systemId.ts` (alias: `#system`) | Build-time-baked system id from `public/system.json`, the `systems/<id>` path prefix, and a helper that namespaces custom hook names (`systemHookName('damageApplied')` → `<id>.damageApplied`). Use for every flag scope, flag-object key, settings namespace, sheet/keybinding registration, asset path, and custom hook name — never hardcode `'nimble'`. The dev rolling release rebuilds under a different id (`nimble-dev`). Enforced by `src/utils/systemId.test.ts` |
 | `localize()` | `src/utils/localize.ts` | Format i18n strings with optional interpolation |
 | `isCombatStarted()` | `src/utils/isCombatStarted.ts` | Determine whether a combat encounter has started |
 | `isCombatantDead()` | `src/utils/isCombatantDead.ts` | Check if a combatant is dead based on HP/wounds |

--- a/src/documents/actor/base.svelte.ts
+++ b/src/documents/actor/base.svelte.ts
@@ -1,6 +1,6 @@
 import type { DeepPartial, InexactPartial } from 'fvtt-types/utils';
 import { createSubscriber } from 'svelte/reactivity';
-import { SYSTEM_ID } from '#system';
+import { SYSTEM_ID, systemHookName } from '#system';
 import type { AbilityKeyType } from '#types/abilityKey.d.ts';
 import type { SaveKeyType } from '#types/saveKey.d.ts';
 import { NimbleRoll } from '../../dice/NimbleRoll.js';
@@ -701,7 +701,7 @@ class NimbleBaseActor<ActorType extends SystemActorTypes = SystemActorTypes> ext
 		const combatant = game.combat?.getCombatantByActor(this.id ?? '') ?? null;
 		if (combatant) {
 			// @ts-expect-error - nimble.initiativeRolled is a custom Nimble hook consumed by ruleEventDispatch
-			Hooks.callAll('nimble.initiativeRolled', {
+			Hooks.callAll(systemHookName('initiativeRolled'), {
 				actor: this,
 				combatant,
 			});
@@ -895,9 +895,12 @@ class NimbleBaseActor<ActorType extends SystemActorTypes = SystemActorTypes> ext
 			foundry.utils.hasProperty(changesObj, 'system.attributes.hp.value') ||
 			foundry.utils.hasProperty(changesObj, 'system.attributes.hp.temp');
 		if (hpWasChanged) {
+			// In-memory update-options passthrough (set here in _preUpdate, read in
+			// _onUpdate on the same options object); never persisted as a flag, so
+			// the literal key is self-consistent and intentional.
 			const optionsWithTracking = options as Actor.Database.PreUpdateOptions & HpTrackingOptions;
-			optionsWithTracking.nimble ??= {};
-			optionsWithTracking.nimble.previousHp = this.#getCurrentHpSnapshot();
+			optionsWithTracking.nimble ??= {}; // allow-hardcoded-system-id
+			optionsWithTracking.nimble.previousHp = this.#getCurrentHpSnapshot(); // allow-hardcoded-system-id
 		}
 
 		// If hp drops below 0, set the value to 0.
@@ -933,7 +936,7 @@ class NimbleBaseActor<ActorType extends SystemActorTypes = SystemActorTypes> ext
 
 		const currentHp = this.#getCurrentHpSnapshot();
 		const optionsWithTracking = options as Actor.Database.OnUpdateOperation & HpTrackingOptions;
-		const previousHp = optionsWithTracking.nimble?.previousHp ?? this.#lastHpSnapshot;
+		const previousHp = optionsWithTracking.nimble?.previousHp ?? this.#lastHpSnapshot; // allow-hardcoded-system-id
 
 		this.#lastHpSnapshot = currentHp;
 		if (!previousHp) return;

--- a/src/documents/actor/character.ts
+++ b/src/documents/actor/character.ts
@@ -4,7 +4,7 @@ import type { NimbleBoonItem } from '#documents/item/boon.js';
 import type { NimbleClassItem } from '#documents/item/class.js';
 import type { NimbleFeatureItem } from '#documents/item/feature.js';
 import type { NimbleSubclassItem } from '#documents/item/subclass.js';
-import { SYSTEM_ID } from '#system';
+import { SYSTEM_ID, systemHookName } from '#system';
 import type { SkillKeyType } from '#types/skillKey.js';
 import { getHighestSpellTier } from '#utils/spell/getHighestSpellTier.ts';
 import CharacterMetaConfigDialog from '#view/dialogs/CharacterMetaConfigDialog.svelte';
@@ -1546,7 +1546,7 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 		await manager.rest();
 
 		// @ts-expect-error - nimble.rest is a custom Nimble hook consumed by ruleEventDispatch
-		Hooks.callAll('nimble.rest', {
+		Hooks.callAll(systemHookName('rest'), {
 			actor: this,
 			restType: restData.restType,
 		});

--- a/src/documents/chatMessage.ts
+++ b/src/documents/chatMessage.ts
@@ -1,6 +1,7 @@
 export type SystemChatMessageTypes = Exclude<foundry.documents.BaseChatMessage.SubType, 'base'>;
 
 import { createSubscriber } from 'svelte/reactivity';
+import { systemHookName } from '#system';
 import type { DamageOutcomeNode, EffectNode } from '#types/effectTree.js';
 import localize from '#utils/localize.ts';
 import { getRelevantNodes } from '#view/dataPreparationHelpers/effectTree/getRelevantNodes.ts';
@@ -495,7 +496,7 @@ class NimbleChatMessage extends ChatMessage {
 			const wasKilled = hpBefore > 0 && hpAfter === 0;
 
 			// @ts-expect-error - nimble.damageApplied is a custom Nimble hook consumed by ruleEventDispatch
-			Hooks.callAll('nimble.damageApplied', {
+			Hooks.callAll(systemHookName('damageApplied'), {
 				sourceItem,
 				sourceActor,
 				targetActor: target.actor,

--- a/src/documents/combat/combat.svelte.ts
+++ b/src/documents/combat/combat.svelte.ts
@@ -1,6 +1,7 @@
 import { createSubscriber } from 'svelte/reactivity';
 import type { ActorRollOptions } from '#documents/actor/actorInterfaces.ts';
 import type { NimbleCombatant } from '#documents/combatant/combatant.svelte.js';
+import { systemHookName } from '#system';
 import {
 	getHeroicReactionUsageState,
 	isSoftBlockedReason,
@@ -1054,7 +1055,7 @@ class NimbleCombat extends Combat {
 			const actor = combatant?.actor;
 			if (!actor) continue;
 			// @ts-expect-error - nimble.initiativeRolled is a custom Nimble hook consumed by ruleEventDispatch and chargePool/dicePool triggers
-			Hooks.callAll('nimble.initiativeRolled', { actor, combatant });
+			Hooks.callAll(systemHookName('initiativeRolled'), { actor, combatant });
 		}
 
 		if (combatManaUpdates.length > 0) {

--- a/src/documents/combatant/combatant.svelte.ts
+++ b/src/documents/combatant/combatant.svelte.ts
@@ -9,13 +9,11 @@ function getRequestedInitiativeRollLockData(
 	if (nextLock === undefined) return undefined;
 	if (nextLock === null) return null;
 
-	return initiativeRollLock.get({
-		flags: {
-			nimble: {
-				initiativeRollLock: nextLock,
-			},
-		},
-	});
+	// Build a synthetic flag-bearing object keyed by the lock's own path so it
+	// stays consistent with the installed system id (stable vs dev).
+	const synthetic: { flags?: Record<string, unknown> } = {};
+	foundry.utils.setProperty(synthetic, initiativeRollLock.path, nextLock);
+	return initiativeRollLock.get(synthetic);
 }
 
 export class NimbleCombatant extends Combatant {

--- a/src/documents/item/base.svelte.ts
+++ b/src/documents/item/base.svelte.ts
@@ -1,4 +1,5 @@
 import { createSubscriber } from 'svelte/reactivity';
+import { SYSTEM_ID, systemHookName } from '#system';
 import { DamageRoll } from '../../dice/DamageRoll.js';
 import { ItemActivationManager } from '../../managers/ItemActivationManager.js';
 import { RulesManager } from '../../managers/RulesManager.js';
@@ -179,7 +180,7 @@ class NimbleBaseItem<ItemType extends SystemItemTypes = SystemItemTypes> extends
 		 * @returns {boolean}  Explicitly return `false` to prevent the item from being used.
 		 */
 		// @ts-expect-error - nimble.preUseItem is a custom hook
-		const allowed = Hooks.call('nimble.preUseItem', this, {
+		const allowed = Hooks.call(systemHookName('preUseItem'), this, {
 			rolls,
 			isCritical,
 			isMiss,
@@ -212,7 +213,7 @@ class NimbleBaseItem<ItemType extends SystemItemTypes = SystemItemTypes> extends
 				sound: CONFIG.sounds.dice,
 				rolls,
 				flags: {
-					nimble: {
+					[SYSTEM_ID]: {
 						itemId: this.id,
 						itemUuid: this.uuid,
 						actorId: this.actor?.id,
@@ -257,7 +258,7 @@ class NimbleBaseItem<ItemType extends SystemItemTypes = SystemItemTypes> extends
 			 * @param {Token[]} context.targets   The targets of the item use
 			 */
 			// @ts-expect-error - nimble.useItem is custom
-			Hooks.callAll('nimble.useItem', this, chatCard, {
+			Hooks.callAll(systemHookName('useItem'), this, chatCard, {
 				rolls,
 				isCritical,
 				isMiss,

--- a/src/documents/item/spell.ts
+++ b/src/documents/item/spell.ts
@@ -1,3 +1,4 @@
+import { SYSTEM_ID, systemHookName } from '#system';
 import { DamageRoll } from '../../dice/DamageRoll.js';
 import { ItemActivationManager } from '../../managers/ItemActivationManager.js';
 import type { NimbleSpellData } from '../../models/item/SpellDataModel.js';
@@ -50,7 +51,7 @@ export class NimbleSpellItem extends NimbleBaseItem {
 		 * @returns {boolean}  Explicitly return `false` to prevent the item from being used.
 		 */
 		// @ts-expect-error - nimble.preUseItem is a custom hook
-		const allowed = Hooks.call('nimble.preUseItem', this, {
+		const allowed = Hooks.call(systemHookName('preUseItem'), this, {
 			rolls,
 			isCritical,
 			isMiss,
@@ -82,7 +83,7 @@ export class NimbleSpellItem extends NimbleBaseItem {
 				sound: CONFIG.sounds.dice,
 				rolls,
 				flags: {
-					nimble: {
+					[SYSTEM_ID]: {
 						itemId: this.id,
 						itemUuid: this.uuid,
 						actorId: this.actor?.id,
@@ -128,7 +129,7 @@ export class NimbleSpellItem extends NimbleBaseItem {
 			 * @param {boolean} [context.isMiss]  Whether the item use resulted in a miss
 			 * @param {Token[]} context.targets   The targets of the item use
 			 */
-			Hooks.callAll('nimble.useItem' as any, this, chatCard, {
+			Hooks.callAll(systemHookName('useItem') as any, this, chatCard, {
 				rolls,
 				isCritical,
 				isMiss,

--- a/src/hooks/chargePoolTriggers/initiativeTrigger.ts
+++ b/src/hooks/chargePoolTriggers/initiativeTrigger.ts
@@ -1,3 +1,4 @@
+import { systemHookName } from '#system';
 import { applyRecoveryToActorIfEligible } from '#utils/chargePool/chargePoolRecover.js';
 import type { CharacterActorLike } from '#utils/chargePool/types.js';
 
@@ -16,7 +17,7 @@ export function registerInitiativeTriggerHooks(): void {
 	// @ts-expect-error nimble.initiativeRolled is a custom Nimble hook not in
 	// Foundry's typed Hooks union; emitted by combat.svelte.ts and the actor
 	// initiative-roll path, consumed here to drive onInitiativeRolled recovery.
-	Hooks.on('nimble.initiativeRolled', (payload: { actor?: unknown }) => {
+	Hooks.on(systemHookName('initiativeRolled'), (payload: { actor?: unknown }) => {
 		const actor = payload?.actor;
 		if (!actor || typeof actor !== 'object') return;
 		const typedActor = actor as Actor.Implementation;

--- a/src/hooks/chargeSystem.ts
+++ b/src/hooks/chargeSystem.ts
@@ -1,4 +1,4 @@
-import { SYSTEM_ID } from '#system';
+import { SYSTEM_ID, systemHookName } from '#system';
 import {
 	consumeOnResolvedItemUse,
 	validateItemChargeConsumption,
@@ -118,7 +118,7 @@ function registerActorSyncHooks(): void {
 }
 
 function registerItemUseHooks(): void {
-	registerCustomHook('nimble.preUseItem', (item) => {
+	registerCustomHook(systemHookName('preUseItem'), (item) => {
 		const characterItem = toCharacterItem(item);
 		if (!characterItem) return true;
 
@@ -131,7 +131,7 @@ function registerItemUseHooks(): void {
 		return false;
 	});
 
-	registerCustomHook('nimble.useItem', (item, chatMessage, context) => {
+	registerCustomHook(systemHookName('useItem'), (item, chatMessage, context) => {
 		const characterItem = toCharacterItem(item);
 		if (!characterItem) return;
 		const itemUseContext = toItemUseContext(context);
@@ -155,7 +155,7 @@ function registerItemUseHooks(): void {
 }
 
 function registerRestHooks(): void {
-	registerCustomHook('nimble.restCompleted', (actor, context) => {
+	registerCustomHook(systemHookName('restCompleted'), (actor, context) => {
 		const characterActor = toCharacterActor(actor);
 		if (!characterActor) return;
 		const restContext = toRestContext(context);

--- a/src/hooks/dicePoolTriggers/attackedTrigger.ts
+++ b/src/hooks/dicePoolTriggers/attackedTrigger.ts
@@ -1,3 +1,4 @@
+import { systemHookName } from '#system';
 import { applyRefillToActorIfEligible } from '#utils/dicePool/dicePoolRefill.js';
 import type { CharacterActorLike } from '#utils/dicePool/types.js';
 
@@ -18,7 +19,7 @@ export function registerAttackedTriggerHooks(): void {
 	// @ts-expect-error nimble.damageApplied is a custom Nimble hook not in
 	// Foundry's typed Hooks union; emitted by the damage application pipeline
 	// once per affected target, consumed here to drive onAttacked refill.
-	Hooks.on('nimble.damageApplied', (payload: { targetActor?: unknown }) => {
+	Hooks.on(systemHookName('damageApplied'), (payload: { targetActor?: unknown }) => {
 		const target = payload?.targetActor;
 		if (!target || typeof target !== 'object') return;
 		const actor = target as Actor.Implementation;

--- a/src/hooks/ruleEventDispatch.ts
+++ b/src/hooks/ruleEventDispatch.ts
@@ -1,4 +1,4 @@
-import { SYSTEM_ID } from '#system';
+import { SYSTEM_ID, systemHookName } from '#system';
 import type {
 	ActorHealthContext,
 	InitiativeRolledContext,
@@ -180,12 +180,12 @@ export default function registerRuleEventDispatch(): void {
 	if (didRegister) return;
 	didRegister = true;
 
-	onHook('nimble.damageApplied', handleDamageApplied as HookFn);
+	onHook(systemHookName('damageApplied'), handleDamageApplied as HookFn);
 	onHook('combatTurn', handleCombatTurn as HookFn);
 	onHook('updateActor', handleActorUpdate as HookFn);
-	onHook('nimble.saveResolved', handleSaveResolved as HookFn);
-	onHook('nimble.rest', handleRest as HookFn);
-	onHook('nimble.initiativeRolled', handleInitiativeRolled as HookFn);
+	onHook(systemHookName('saveResolved'), handleSaveResolved as HookFn);
+	onHook(systemHookName('rest'), handleRest as HookFn);
+	onHook(systemHookName('initiativeRolled'), handleInitiativeRolled as HookFn);
 }
 
 export {

--- a/src/macros/createHeroicActionMacro.ts
+++ b/src/macros/createHeroicActionMacro.ts
@@ -1,4 +1,4 @@
-import { SYSTEM_PATH } from '#system';
+import { SYSTEM_ID, SYSTEM_PATH } from '#system';
 
 interface HeroicActionMacroData {
 	actionId: string;
@@ -44,7 +44,7 @@ export async function createHeroicActionMacro(data: HeroicActionMacroData, slot:
 				img: expectedIcon,
 				command: command,
 				flags: {
-					nimble: {
+					[SYSTEM_ID]: {
 						heroicActionMacro: true,
 						actionId: data.actionId,
 						actionType: data.actionType,

--- a/src/macros/createMacro.ts
+++ b/src/macros/createMacro.ts
@@ -1,3 +1,5 @@
+import { SYSTEM_ID } from '#system';
+
 export async function createMacro(data: { uuid: string }, slot: number) {
 	const item = await fromUuid(data.uuid as `Item.${string}`);
 
@@ -25,7 +27,7 @@ export async function createMacro(data: { uuid: string }, slot: number) {
 				img: (item as Item).img,
 				command: command,
 				flags: {
-					nimble: {
+					[SYSTEM_ID]: {
 						itemUuid: data.uuid,
 						itemMacro: true,
 					},

--- a/src/managers/RestManager.ts
+++ b/src/managers/RestManager.ts
@@ -1,4 +1,5 @@
 import { HitDiceManager } from '#managers/HitDiceManager.js';
+import { systemHookName } from '#system';
 import { previewRecovery } from '#utils/chargePool/chargePoolPreview.js';
 import { getManaRecoveryTypesFromClasses, restoresManaOnRest } from '#utils/manaRecovery.js';
 
@@ -102,7 +103,7 @@ class RestManager {
 
 		// Broadcast rest completion for systems that react to rest events (e.g., charge recovery).
 		(Hooks.callAll as (event: string, ...args: unknown[]) => boolean)(
-			'nimble.restCompleted',
+			systemHookName('restCompleted'),
 			this.#actor,
 			{
 				restType: this.#restType,

--- a/src/models/rules/applyCondition.ts
+++ b/src/models/rules/applyCondition.ts
@@ -1,3 +1,4 @@
+import { systemHookName } from '#system';
 import type { ConditionNode, EffectNode } from '#types/effectTree.js';
 import {
 	type ActivationCardContext,
@@ -211,7 +212,7 @@ class ApplyConditionRule extends NimbleBaseRule<ApplyConditionRule.Schema> {
 		// Blocking hook — listeners can return false to prevent condition application
 		// (e.g. condition immunity, resistance, or redirect).
 		// @ts-expect-error - nimble.preApplyCondition is a custom Nimble hook
-		const allowed = Hooks.call('nimble.preApplyCondition', {
+		const allowed = Hooks.call(systemHookName('preApplyCondition'), {
 			target,
 			condition: this.condition,
 			source: this.item,
@@ -224,7 +225,7 @@ class ApplyConditionRule extends NimbleBaseRule<ApplyConditionRule.Schema> {
 
 		// Notify listeners that a condition was successfully applied.
 		// @ts-expect-error - nimble.conditionApplied is a custom Nimble hook
-		Hooks.callAll('nimble.conditionApplied', {
+		Hooks.callAll(systemHookName('conditionApplied'), {
 			target,
 			condition: this.condition,
 			effect: typeof result === 'object' ? result : null,

--- a/src/nimble.ts
+++ b/src/nimble.ts
@@ -26,7 +26,7 @@ import registerRuleEventDispatch from './hooks/ruleEventDispatch.js';
 import setup from './hooks/setup.js';
 import { runDevFlagRebrandPreInit } from './migration/devFlagRebrand.js';
 import './scss/main.scss';
-import { SYSTEM_ID } from '#system';
+import { SYSTEM_ID, systemHookName } from '#system';
 import { getCombatManaGrantForCombat, getCombatManaGrantMap } from '#utils/combatManaRules.js';
 import { injectViteHmrClient } from '#utils/viteHmr.js';
 
@@ -104,7 +104,7 @@ type HookFn = (...args: object[]) => undefined | boolean | Promise<undefined | b
 
 // Condition immunity — block protected conditions before application
 (Hooks.on as (event: string, fn: HookFn) => number)(
-	'nimble.preApplyCondition',
+	systemHookName('preApplyCondition'),
 	conditionImmunityGuard as object as HookFn,
 );
 

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -174,8 +174,8 @@ export default function registerSystemSettings() {
 		if (element.querySelector('.nimble-dice-testbench-launch')) return;
 
 		const checkbox =
-			element.querySelector<HTMLInputElement>('input[name="nimble.debugMode"]') ??
-			element.querySelector<HTMLInputElement>('[name="nimble.debugMode"]');
+			element.querySelector<HTMLInputElement>(`input[name="${SYSTEM_ID}.debugMode"]`) ??
+			element.querySelector<HTMLInputElement>(`[name="${SYSTEM_ID}.debugMode"]`);
 		if (!checkbox) return;
 
 		const formGroup = checkbox.closest('.form-group') ?? checkbox.closest('div');

--- a/src/utils/chargePool/chargePoolHooks.ts
+++ b/src/utils/chargePool/chargePoolHooks.ts
@@ -1,17 +1,16 @@
+import { systemHookName } from '#system';
 import type { CharacterActorLike } from './types.js';
-
-const HOOK_PREFIX = 'nimble.chargePool';
 
 type ChargePoolHookPayload = Record<string, unknown>;
 
 function emit(hookName: string, payload: ChargePoolHookPayload): void {
 	// @ts-expect-error Custom hooks are not typed in Foundry
-	Hooks.call(`${HOOK_PREFIX}.${hookName}`, payload);
+	Hooks.call(systemHookName(`chargePool.${hookName}`), payload);
 }
 
 function emitCancelable(hookName: string, payload: ChargePoolHookPayload): boolean {
 	// @ts-expect-error Custom hooks are not typed in Foundry
-	return Hooks.call(`${HOOK_PREFIX}.${hookName}`, payload) !== false;
+	return Hooks.call(systemHookName(`chargePool.${hookName}`), payload) !== false;
 }
 
 function emitForCharacter(

--- a/src/utils/chargePool/helpers.ts
+++ b/src/utils/chargePool/helpers.ts
@@ -125,9 +125,11 @@ function getChargePoolMapFromActor(actor: CharacterActorLike): ChargePoolMap {
 
 	for (const item of actor.items.contents) {
 		const itemFlags = item.flags as Record<string, unknown>;
-		const nimbleFlags = itemFlags.nimble;
-		if (!nimbleFlags || typeof nimbleFlags !== 'object' || Array.isArray(nimbleFlags)) continue;
-		const chargePoolsOnItem = (nimbleFlags as Record<string, unknown>).chargePools;
+		const systemFlags = itemFlags[ChargePoolRuleConfig.flagScope];
+		if (!systemFlags || typeof systemFlags !== 'object' || Array.isArray(systemFlags)) continue;
+		const chargePoolsOnItem = (systemFlags as Record<string, unknown>)[
+			ChargePoolRuleConfig.flagKey
+		];
 		if (
 			!chargePoolsOnItem ||
 			typeof chargePoolsOnItem !== 'object' ||
@@ -553,7 +555,7 @@ async function persistChargePoolMap(
 					[ChargePoolRuleConfig.flagPath]: actorPoolUpdatePayload,
 				} as Record<string, unknown>,
 				{
-					nimble: {
+					[ChargePoolRuleConfig.flagScope]: {
 						skipChargePoolSync: true,
 					},
 				} as Record<string, unknown>,

--- a/src/utils/dicePool/dicePoolHooks.ts
+++ b/src/utils/dicePool/dicePoolHooks.ts
@@ -1,17 +1,16 @@
+import { systemHookName } from '#system';
 import type { CharacterActorLike } from './types.js';
-
-const HOOK_PREFIX = 'nimble.dicePool';
 
 type DicePoolHookPayload = Record<string, unknown>;
 
 function emit(hookName: string, payload: DicePoolHookPayload): void {
 	// @ts-expect-error Custom hooks are not typed in Foundry
-	Hooks.call(`${HOOK_PREFIX}.${hookName}`, payload);
+	Hooks.call(systemHookName(`dicePool.${hookName}`), payload);
 }
 
 function emitCancelable(hookName: string, payload: DicePoolHookPayload): boolean {
 	// @ts-expect-error Custom hooks are not typed in Foundry
-	return Hooks.call(`${HOOK_PREFIX}.${hookName}`, payload) !== false;
+	return Hooks.call(systemHookName(`dicePool.${hookName}`), payload) !== false;
 }
 
 function emitForCharacter(

--- a/src/utils/dicePool/helpers.ts
+++ b/src/utils/dicePool/helpers.ts
@@ -206,9 +206,9 @@ function getDicePoolMapFromActor(actor: CharacterActorLike): DicePoolMap {
 
 	for (const item of actor.items.contents) {
 		const itemFlags = item.flags as Record<string, unknown>;
-		const nimbleFlags = itemFlags.nimble;
-		if (!nimbleFlags || typeof nimbleFlags !== 'object' || Array.isArray(nimbleFlags)) continue;
-		const dicePoolsOnItem = (nimbleFlags as Record<string, unknown>).dicePools;
+		const systemFlags = itemFlags[DicePoolRuleConfig.flagScope];
+		if (!systemFlags || typeof systemFlags !== 'object' || Array.isArray(systemFlags)) continue;
+		const dicePoolsOnItem = (systemFlags as Record<string, unknown>)[DicePoolRuleConfig.flagKey];
 		if (!dicePoolsOnItem || typeof dicePoolsOnItem !== 'object' || Array.isArray(dicePoolsOnItem)) {
 			continue;
 		}
@@ -566,7 +566,7 @@ async function persistDicePoolMap(actor: CharacterActorLike, pools: DicePoolMap)
 					[DicePoolRuleConfig.flagPath]: actorPoolUpdatePayload,
 				} as Record<string, unknown>,
 				{
-					nimble: {
+					[DicePoolRuleConfig.flagScope]: {
 						skipDicePoolSync: true,
 					},
 				} as Record<string, unknown>,

--- a/src/utils/dicePool/rollDieIntoPool.persist.test.ts
+++ b/src/utils/dicePool/rollDieIntoPool.persist.test.ts
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { rollDieIntoPool } from './dicePoolRefill.js';
+import { isDicePoolFlagUpdate, syncActorPools } from './dicePoolSync.js';
+import type { CharacterActorLike } from './types.js';
+
+/**
+ * Reproduction for the Oathsworn "Judgment Dice" bug: clicking the dashed "+"
+ * chip rolls a die (visible in chat) but the face never lands in the pool.
+ *
+ * Drives the REAL rollDieIntoPool -> persistDicePoolMap -> item.update path and
+ * reads the face back the way getDicePoolMapFromActor does
+ * (item.flags.nimble.dicePools[identifier].faces).
+ */
+
+beforeEach(() => {
+	const BaseRoll = (globalThis as unknown as { Roll: any }).Roll;
+	class StubRoll extends BaseRoll {
+		dice: unknown[] = [];
+		async evaluate(): Promise<this> {
+			await super.evaluate();
+			(this as unknown as { _total: number })._total = 4;
+			return this;
+		}
+		async toMessage(): Promise<void> {}
+	}
+	(globalThis as unknown as { Roll: unknown }).Roll = StubRoll;
+	(globalThis as unknown as { ChatMessage: unknown }).ChatMessage = {
+		getSpeaker: () => ({}),
+	};
+});
+
+/**
+ * Models FoundryVTT Document#update for `flags.*` writes with the real-engine
+ * defaults that matter here: `diff: true` and `recursive: true`.
+ *
+ *   1. expandObject(changes) — dotted keys become nested objects.
+ *   2. diff against the current source: subtrees that are deep-equal are dropped
+ *      (Foundry skips no-op writes); ARRAYS are compared atomically.
+ *   3. recursive merge of the surviving diff into the source.
+ *
+ * This is the behavior that decides whether a "whole pool object under the
+ * parent flag path" write actually lands.
+ */
+function expand(obj: Record<string, any>): Record<string, any> {
+	const out: Record<string, any> = {};
+	for (const [key, value] of Object.entries(obj)) {
+		const keys = key.split('.');
+		let cursor = out;
+		for (let i = 0; i < keys.length - 1; i += 1) {
+			cursor[keys[i]] ??= {};
+			cursor = cursor[keys[i]];
+		}
+		cursor[keys[keys.length - 1]] = value;
+	}
+	return out;
+}
+
+function isPlain(v: unknown): v is Record<string, any> {
+	return Boolean(v) && typeof v === 'object' && !Array.isArray(v);
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+	return JSON.stringify(a) === JSON.stringify(b);
+}
+
+/** Recursive merge with diff=true: skip deep-equal leaves, honor `-=` deletes. */
+function mergeDiff(target: Record<string, any>, source: Record<string, any>): void {
+	for (const [key, value] of Object.entries(source)) {
+		if (key.startsWith('-=')) {
+			delete target[key.slice(2)];
+			continue;
+		}
+		if (isPlain(value)) {
+			if (!isPlain(target[key])) target[key] = {};
+			mergeDiff(target[key], value);
+		} else {
+			// diff: true — don't rewrite identical values.
+			if (deepEqual(target[key], value)) continue;
+			target[key] = value;
+		}
+	}
+}
+
+function applyFoundryUpdate(doc: Record<string, any>, changes: Record<string, any>): void {
+	mergeDiff(doc, expand(changes));
+}
+
+function makeOathswornActor(): {
+	actor: CharacterActorLike;
+	item: Record<string, any>;
+	updateSpy: ReturnType<typeof vi.fn>;
+} {
+	const judgmentRule = {
+		type: 'dicePool',
+		disabled: false,
+		id: 'judgment-pool-base',
+		identifier: 'judgment',
+		label: 'Judgment Dice',
+		scope: 'item',
+		dieSize: 'd6',
+		max: '2',
+		initial: 'zero',
+		refills: [
+			{ trigger: 'onAttacked', mode: 'setIfEmpty', value: '@poolMax' },
+			{ trigger: 'encounterEnd', mode: 'clear', value: '0' },
+		],
+	};
+
+	const updateSpy = vi.fn();
+	const item: Record<string, any> = {
+		id: 'qiQeJrIxla9y6XY0',
+		name: 'Radiant Judgement',
+		rules: new Map([['0', judgmentRule]]),
+		flags: {},
+		actor: null,
+		async update(changes: Record<string, any>, options?: Record<string, any>) {
+			updateSpy(changes, options);
+			applyFoundryUpdate(this as Record<string, any>, changes);
+			if (!isDicePoolFlagUpdate(options) && this.actor?.type === 'character') {
+				await syncActorPools(this.actor);
+			}
+			return this;
+		},
+	};
+
+	const actor = {
+		type: 'character',
+		items: { contents: [item], get: () => item },
+		flags: {},
+		getRollData: vi.fn(() => ({})),
+	} as unknown as CharacterActorLike;
+	item.actor = actor;
+
+	return { actor, item, updateSpy };
+}
+
+describe('rollDieIntoPool — item-scoped pool persistence (Judgment Dice)', () => {
+	it('lands the rolled face in item.flags.nimble.dicePools.judgment.faces (empty pool)', async () => {
+		const { actor, item, updateSpy } = makeOathswornActor();
+
+		const result = await rollDieIntoPool(actor, 'judgment', { flavor: 'Judgment Dice' });
+
+		expect(result).toBe(true);
+		expect(updateSpy).toHaveBeenCalledTimes(1);
+		expect(item.flags?.nimble?.dicePools?.judgment?.faces).toEqual([4]);
+	});
+
+	it('adds a second face when the pool already has one (faces array grows)', async () => {
+		const { actor, item } = makeOathswornActor();
+		// Seed an existing single-die pool (as an onAttacked setIfEmpty refill would).
+		item.flags = {
+			nimble: {
+				dicePools: {
+					judgment: {
+						id: 'judgment',
+						identifier: 'judgment',
+						scope: 'item',
+						sourceItemId: 'qiQeJrIxla9y6XY0',
+						sourceItemName: 'Radiant Judgement',
+						label: 'Judgment Dice',
+						dieSize: 'd6',
+						max: 2,
+						faces: [5],
+						refills: [
+							{ trigger: 'onAttacked', mode: 'setIfEmpty', value: '@poolMax' },
+							{ trigger: 'encounterEnd', mode: 'clear', value: '0' },
+						],
+						consumption: 'manual',
+						bonusOnAttackDelivery: null,
+					},
+				},
+			},
+		};
+
+		const result = await rollDieIntoPool(actor, 'judgment', { flavor: 'Judgment Dice' });
+
+		expect(result).toBe(true);
+		expect(item.flags?.nimble?.dicePools?.judgment?.faces).toEqual([5, 4]);
+	});
+});

--- a/src/utils/systemId.test.ts
+++ b/src/utils/systemId.test.ts
@@ -53,6 +53,49 @@ const FORBIDDEN_PATTERNS: readonly ForbiddenPattern[] = [
 		re: /\.flags\.nimble(?=[\s.?[)\];,}]|$)/,
 		hint: 'Use `flags[SYSTEM_ID]` for property access instead of `flags.nimble`.',
 	},
+	{
+		// Catches `.nimble` dot-access on any identifier (e.g. a `flags` value
+		// aliased to a local: `const f = item.flags; f.nimble`). The dedicated
+		// `.flags.nimble` pattern above misses these because the `flags` part is
+		// gone by the time the scope key is dereferenced.
+		//
+		// `game.nimble` is a DELIBERATE, AUDITED exemption: it is the system's own
+		// API namespace that we assign to the global `game` object (init.ts:
+		// `game.nimble = NIMBLE_GAME`) and read back with the same literal key, so
+		// it is self-consistent and works identically on the stable (`nimble`) and
+		// dev (`nimble-dev`) installs — it is NOT validated against the installed
+		// id the way flags are. It is intentionally a fixed key (persisted macro
+		// command strings reference `game.nimble.macros.*`), so it must stay
+		// literal. This is a naming-convention choice, not a dev-build hazard.
+		id: 'nimble-property-access',
+		re: /\b(?!game\.nimble)[A-Za-z_$][\w$]*\.nimble(?=[\s.?[)\];,}]|$)/,
+		hint: 'Use `obj[SYSTEM_ID]` for the system flag scope instead of `.nimble` property access (note: `game.nimble` is a deliberate exemption — see pattern comment).',
+	},
+	{
+		// Catches an object-literal key `nimble:` (e.g. update options like
+		// `{ nimble: { skipDicePoolSync: true } }`). Use a computed key
+		// `[SYSTEM_ID]:` so it tracks the dev rebrand.
+		id: 'nimble-object-key',
+		re: /(?<![\w$.'"`])nimble\s*:/,
+		hint: 'Use a computed key `[SYSTEM_ID]:` (or a *RuleConfig.flagScope constant) instead of a literal `nimble:` key.',
+	},
+	{
+		// Catches quoted custom-hook names prefixed with the literal system id
+		// (e.g. `'nimble.damageApplied'`, `'nimble.dicePool.changed'`). Custom
+		// hooks are namespaced by the installed id, so emitter and listeners must
+		// derive the name from SYSTEM_ID (use `systemHookName('suffix')` from
+		// `#system`) or they silently stop matching under the dev id.
+		//
+		// Compendium pack collection ids (`nimble.nimble-*`) are deliberately
+		// NOT matched: those are rebranded by the dev-flag-rebrand migration, not
+		// by SYSTEM_ID at call sites. Genuinely intentional literals (clipboard
+		// copy types, DOM `name=` selectors) use the inline opt-out comment.
+		// Only single/double quotes (not backticks): JSDoc examples wrap hook
+		// names in backticks (`nimble.damageApplied`) and must not trip the guard.
+		id: 'nimble-quoted-hook-name',
+		re: /['"]nimble\.(?!nimble-)[A-Za-z]/,
+		hint: "Custom hook names must derive from SYSTEM_ID — use `systemHookName('suffix')` from '#system' (or a subsystem helper) instead of a literal `nimble.` prefix.",
+	},
 ];
 
 const SOURCE_GLOB = 'src/**/*.{ts,svelte,svelte.ts}';
@@ -62,9 +105,11 @@ const EXCLUDE_GLOBS: readonly string[] = [
 	'src/**/*.spec.ts',
 	// systemId.ts is the source of truth for the value.
 	'src/utils/systemId.ts',
-	// The dev-build rebrand module *must* reference the legacy 'nimble' id —
-	// its whole job is migrating data away from that key. Audited exception.
-	'src/migration/devFlagRebrand.ts',
+	// Migrations reference stable `Compendium.nimble.*` source ids and legacy
+	// `flags.nimble.*` keys by design — they read/rewrite data created under the
+	// stable install. The dev-flag-rebrand handles the live remapping; migration
+	// source ids must stay literal. Audited exception.
+	'src/migration/**',
 ];
 
 const SELF_PATH_FRAGMENT = 'src/utils/systemId.test.ts';

--- a/src/utils/systemId.ts
+++ b/src/utils/systemId.ts
@@ -3,3 +3,14 @@ import systemJson from '../../public/system.json';
 // typed as any to make all the setFlag/getFlag etc calls happy
 export const SYSTEM_ID: any = systemJson.id;
 export const SYSTEM_PATH = `systems/${SYSTEM_ID}`;
+
+/**
+ * Build a custom Foundry hook name namespaced by the installed system id.
+ * Custom hooks (e.g. `nimble.damageApplied`) must derive their prefix from
+ * SYSTEM_ID so emitter and listeners stay in lockstep across the stable
+ * (`nimble`) and dev (`nimble-dev`) installs. Hardcoding the `nimble.` prefix
+ * silently breaks every listener under the dev id.
+ */
+export function systemHookName(suffix: string): string {
+	return `${SYSTEM_ID}.${suffix}`;
+}

--- a/src/view/chat/components/ChargeConsumptionNode.svelte
+++ b/src/view/chat/components/ChargeConsumptionNode.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { SYSTEM_ID } from '#system';
 	import { ChargeUiConfig } from '#utils/chargeUiConfig.js';
 	import localize from '#utils/localize.js';
 	import { getContext } from 'svelte';
@@ -6,7 +7,9 @@
 	let { node: _node } = $props();
 
 	const messageDocument = getContext('messageDocument');
-	let consumption = $derived(messageDocument?.reactive?.flags?.nimble?.chargeConsumption ?? []);
+	let consumption = $derived(
+		messageDocument?.reactive?.flags?.[SYSTEM_ID]?.chargeConsumption ?? [],
+	);
 
 	function getChangeColor(change) {
 		return change < 0

--- a/src/view/rulesBuilder/RulesBuilderWindow.svelte.ts
+++ b/src/view/rulesBuilder/RulesBuilderWindow.svelte.ts
@@ -3,7 +3,9 @@ import { SvelteSet } from 'svelte/reactivity';
 import type { NimbleBaseItem } from '#documents/item/base.svelte.js';
 import type { RuleSource } from '#view/rulesBuilder/types.js';
 
-export const COPY_TYPE = 'nimble.Rule';
+// Internal clipboard drag-drop type, set and matched by the same code; never
+// crosses the Foundry system-id boundary, so the literal is intentional.
+export const COPY_TYPE = 'nimble.Rule'; // allow-hardcoded-system-id
 
 export function createRulesBuilderWindowState(getItem: () => NimbleBaseItem) {
 	const rawRules = $derived(

--- a/src/view/rulesBuilder/components/ChargePoolPicker.svelte.ts
+++ b/src/view/rulesBuilder/components/ChargePoolPicker.svelte.ts
@@ -1,10 +1,11 @@
 import { createSubscriber } from 'svelte/reactivity';
+import { systemHookName } from '#system';
 import { getPools } from '#utils/chargePool/chargePoolSync.js';
 import type { ChargePoolState } from '#utils/chargePool/types.js';
 
 const POOL_HOOK_NAMES = [
-	'nimble.chargePool.changed',
-	'nimble.chargePool.recovered',
+	systemHookName('chargePool.changed'),
+	systemHookName('chargePool.recovered'),
 	'updateItem',
 	'updateActor',
 ] as const;

--- a/src/view/rulesBuilder/components/DicePoolPicker.svelte.ts
+++ b/src/view/rulesBuilder/components/DicePoolPicker.svelte.ts
@@ -1,10 +1,11 @@
 import { createSubscriber } from 'svelte/reactivity';
+import { systemHookName } from '#system';
 import { getPools } from '#utils/dicePool/dicePoolSync.js';
 import type { DicePoolState } from '#utils/dicePool/types.js';
 
 const POOL_HOOK_NAMES = [
-	'nimble.dicePool.changed',
-	'nimble.dicePool.refilled',
+	systemHookName('dicePool.changed'),
+	systemHookName('dicePool.refilled'),
 	'updateItem',
 	'updateActor',
 ] as const;

--- a/src/view/sheets/components/DicePoolPanel.svelte.ts
+++ b/src/view/sheets/components/DicePoolPanel.svelte.ts
@@ -1,5 +1,6 @@
 import { createSubscriber } from 'svelte/reactivity';
 import type { NimbleCharacter } from '#documents/actor/character.js';
+import { systemHookName } from '#system';
 import { adjustPool } from '#utils/chargePool/chargePoolRecover.js';
 import { type DicePoolConsumer, getDicePoolConsumers } from '#utils/dicePool/dicePoolConsumers.js';
 import { setPoolFaces } from '#utils/dicePool/dicePoolRefill.js';
@@ -11,10 +12,10 @@ import type { LivePoolView } from './DicePoolTracker.svelte.ts';
 // Reactive subscription so the panel reflects pool mutations made by other
 // surfaces (sheet edits, chat-card triggered refills, GM tools) while open.
 const PANEL_HOOK_NAMES = [
-	'nimble.dicePool.changed',
-	'nimble.dicePool.refilled',
-	'nimble.chargePool.changed',
-	'nimble.chargePool.recovered',
+	systemHookName('dicePool.changed'),
+	systemHookName('dicePool.refilled'),
+	systemHookName('chargePool.changed'),
+	systemHookName('chargePool.recovered'),
 	'updateItem',
 	'createItem',
 	'deleteItem',

--- a/src/view/sheets/components/DicePoolTracker.svelte.ts
+++ b/src/view/sheets/components/DicePoolTracker.svelte.ts
@@ -1,5 +1,6 @@
 import { createSubscriber } from 'svelte/reactivity';
 import type { NimbleCharacter } from '#documents/actor/character.js';
+import { systemHookName } from '#system';
 import { rollChargeDie } from '#utils/chargePool/chargePoolRoll.js';
 import { getPools as getChargePools } from '#utils/chargePool/chargePoolSync.js';
 import type { ChargePoolState } from '#utils/chargePool/types.js';
@@ -10,10 +11,10 @@ import { dieSizeToMaxFace } from '#utils/dicePool/helpers.js';
 import type { DicePoolState, DieSize } from '#utils/dicePool/types.js';
 
 const POOL_STATE_HOOK_NAMES = [
-	'nimble.dicePool.changed',
-	'nimble.dicePool.refilled',
-	'nimble.chargePool.changed',
-	'nimble.chargePool.recovered',
+	systemHookName('dicePool.changed'),
+	systemHookName('dicePool.refilled'),
+	systemHookName('chargePool.changed'),
+	systemHookName('chargePool.recovered'),
 	'updateItem',
 	'updateActor',
 ] as const;

--- a/src/view/sheets/pages/ItemRulesTab.svelte.ts
+++ b/src/view/sheets/pages/ItemRulesTab.svelte.ts
@@ -4,7 +4,9 @@ import GenericDialog from '#documents/dialogs/GenericDialog.svelte.js';
 import type { NimbleBaseItem } from '#documents/item/base.svelte.js';
 import type { RuleSource } from '#view/rulesBuilder/types.js';
 
-export const COPY_TYPE = 'nimble.Rule';
+// Internal clipboard drag-drop type, set and matched by the same code; never
+// crosses the Foundry system-id boundary, so the literal is intentional.
+export const COPY_TYPE = 'nimble.Rule'; // allow-hardcoded-system-id
 
 type DialogComponent = Parameters<typeof GenericDialog.getOrCreate>[1];
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,6 +1,6 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { cleanup } from '@testing-library/svelte';
-import { readFileSync } from 'fs';
-import { join } from 'path';
 import { afterEach, vi } from 'vitest';
 import '@testing-library/jest-dom/vitest';
 


### PR DESCRIPTION
## Summary

On the dev build (system id `nimble-dev`), several hardcoded `nimble` references silently broke because Foundry namespaces flags, custom hooks, and settings/DOM keys by the installed package id. Most visibly, item-scoped dice pools (e.g. Oathsworn Judgment Dice) rolled to chat but the dice never landed in the pool list. This routes those references through `SYSTEM_ID` and adds guard coverage so the class of bug can't silently return.

## Changes

- Fix dicePool and chargePool item-scoped flag **reads** (read the wrong scope, so item pools always appeared empty on the dev build) and the actor-update skip-sync **option keys**.
- Fix the initiative roll-lock synthetic object, which keyed off a literal scope instead of the lock's own id-derived path.
- Fix the `chargeConsumption` chat read (literal scope while the write was id-derived).
- Fix chat-message and macro flag **writes** that used a literal `nimble` scope.
- Fix the dice-testbench settings selector that queried the wrong `name=` attribute on the dev build.
- Route custom system hooks (`damageApplied`, `rest`, `useItem`, etc.) and the dicePool/chargePool hook prefixes through a new `systemHookName()` helper so emitter and listeners stay in lockstep across installs.
- Extend `systemId.test.ts` guard to catch aliased `.nimble` access, literal `nimble:` object keys, and quoted `'nimble.'` hook strings. Exempt migrations (stable `Compendium.nimble.*` ids) and document `game.nimble` as an audited, deliberate exemption.
- Add a round-trip persist test for `rollDieIntoPool`.

## Test Plan

On a **dev build** (system installed as `nimble-dev`):

1. Open an Oathsworn character sheet (or any actor with the Radiant Judgement feature).
2. As GM, click the dashed `+` chip on the Judgment Dice pool. The rolled die should now appear in the pool list (previously it only showed in chat).
3. Confirm charge pools (e.g. Commander Combat Dice / Artificer Mana) still display and spend correctly.
4. Trigger a charge consumption and confirm the chat card renders the consumption delta.
5. Roll initiative and confirm no duplicate/stuck initiative rolls (roll-lock works).
6. Enable debug mode and confirm the dice-testbench launch button appears in Settings.
7. Run `pnpm check` and confirm `systemId.test.ts` passes.

## Checklist

- [x] Added or updated unit tests
- [x] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [x] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** yes
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues

<!-- Link related issues if any -->