### PR TITLE
feat: Foundry v14 compability

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
 		"dependency-cruiser": "^16.10.0",
 		"eslint": "^9.38.0",
 		"eslint-plugin-svelte": "^3.12.5",
-		"fvtt-types": "npm:@league-of-foundry-developers/foundry-vtt-types@^13.345.1",
+		"fvtt-types": "github:Fronix/foundry-vtt-types#v14.363.0",
 		"glob": "^11.0.3",
 		"globals": "^16.4.0",
 		"happy-dom": "^20.0.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,8 +67,8 @@ importers:
         specifier: ^3.12.5
         version: 3.15.0(eslint@9.39.2)(svelte@5.53.0)
       fvtt-types:
-        specifier: npm:@league-of-foundry-developers/foundry-vtt-types@^13.345.1
-        version: '@league-of-foundry-developers/foundry-vtt-types@13.345.1(6c574db58d500d3ecfd5fe5f98038db3)'
+        specifier: github:Fronix/foundry-vtt-types#v14.363.0
+        version: '@league-of-foundry-developers/foundry-vtt-types@https://codeload.github.com/Fronix/foundry-vtt-types/tar.gz/773353f0255f1cdb862db33eac01326b5d1f1542(6c574db58d500d3ecfd5fe5f98038db3)'
       glob:
         specifier: ^11.0.3
         version: 11.1.0
@@ -197,11 +197,11 @@ packages:
   '@cacheable/utils@2.1.0':
     resolution: {integrity: sha512-ZdxfOiaarMqMj+H7qwlt5EBKWaeGihSYVHdQv5lUsbn8MJJOTW82OIwirQ39U5tMZkNvy3bQE+ryzC+xTAb9/g==}
 
-  '@codemirror/autocomplete@6.20.0':
-    resolution: {integrity: sha512-bOwvTOIJcG5FVo5gUUupiwYh8MioPLQ4UcqbcRf7UQ98X90tCa9E1kZ3Z7tqwpZxYyOvh1YTYbmZE9RTfTp5hg==}
+  '@codemirror/autocomplete@6.20.1':
+    resolution: {integrity: sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==}
 
-  '@codemirror/commands@6.10.0':
-    resolution: {integrity: sha512-2xUIc5mHXQzT16JnyOFkh8PvfeXuIut3pslWGfsGOhxP/lpgRm9HOl/mpzLErgt5mXDovqA0d11P21gofRLb9w==}
+  '@codemirror/commands@6.10.2':
+    resolution: {integrity: sha512-vvX1fsih9HledO1c9zdotZYUZnE4xV0m6i3m25s5DIfXofuprk6cRcLUZvSk3CASUbwjQX21tOGbkY2BH8TpnQ==}
 
   '@codemirror/lang-css@6.3.1':
     resolution: {integrity: sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==}
@@ -209,8 +209,8 @@ packages:
   '@codemirror/lang-html@6.4.11':
     resolution: {integrity: sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==}
 
-  '@codemirror/lang-javascript@6.2.4':
-    resolution: {integrity: sha512-0WVmhp1QOqZ4Rt6GlVGwKJN3KW7Xh4H2q8ZZNGZaP6lRdxXJzmjm4FqvmOojVj6khWJHIb9sp7U/72W7xQgqAA==}
+  '@codemirror/lang-javascript@6.2.5':
+    resolution: {integrity: sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==}
 
   '@codemirror/lang-json@6.0.2':
     resolution: {integrity: sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==}
@@ -218,20 +218,20 @@ packages:
   '@codemirror/lang-markdown@6.5.0':
     resolution: {integrity: sha512-0K40bZ35jpHya6FriukbgaleaqzBLZfOh7HuzqbMxBXkbYMJDxfF39c23xOgxFezR+3G+tR2/Mup+Xk865OMvw==}
 
-  '@codemirror/language@6.11.3':
-    resolution: {integrity: sha512-9HBM2XnwDj7fnu0551HkGdrUrrqmYq/WC5iv6nbY2WdicXdGbhR/gfbZOH73Aqj4351alY1+aoG9rCNfiwS1RA==}
+  '@codemirror/language@6.12.2':
+    resolution: {integrity: sha512-jEPmz2nGGDxhRTg3lTpzmIyGKxz3Gp3SJES4b0nAuE5SWQoKdT5GoQ69cwMmFd+wvFUhYirtDTr0/DRHpQAyWg==}
 
-  '@codemirror/lint@6.9.2':
-    resolution: {integrity: sha512-sv3DylBiIyi+xKwRCJAAsBZZZWo82shJ/RTMymLabAdtbkV5cSKwWDeCgtUq3v8flTaXS2y1kKkICuRYtUswyQ==}
+  '@codemirror/lint@6.9.5':
+    resolution: {integrity: sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==}
 
-  '@codemirror/search@6.5.11':
-    resolution: {integrity: sha512-KmWepDE6jUdL6n8cAAqIpRmLPBZ5ZKnicE8oGU/s3QrAVID+0VhLFrzUucVKHG5035/BSykhExDL/Xm7dHthiA==}
+  '@codemirror/search@6.6.0':
+    resolution: {integrity: sha512-koFuNXcDvyyotWcgOnZGmY7LZqEOXZaaxD/j6n18TCLx2/9HieZJ5H6hs1g8FiRxBD0DNfs0nXn17g872RmYdw==}
 
-  '@codemirror/state@6.5.2':
-    resolution: {integrity: sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==}
+  '@codemirror/state@6.5.4':
+    resolution: {integrity: sha512-8y7xqG/hpB53l25CIoit9/ngxdfoG+fx+V3SHBrinnhOtLvKHRyAJJuHzkWrR4YXXLX8eXBsejgAAxHUOdW1yw==}
 
-  '@codemirror/view@6.39.2':
-    resolution: {integrity: sha512-YCbOfs4cq49ulN/MVhrUV22rKDJv/fHUs4cR98McAI59/coVwUa2N3RAoNVDgeJNchrQzBxTT3vzto4ZbTYVtw==}
+  '@codemirror/view@6.39.16':
+    resolution: {integrity: sha512-m6S22fFpKtOWhq8HuhzsI1WzUP/hB9THbDj0Tl5KX4gbO6Y91hwBl7Yky33NdvB6IffuRFiBxf1R8kJMyXmA4Q==}
 
   '@csstools/css-parser-algorithms@3.0.5':
     resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
@@ -511,22 +511,29 @@ packages:
   '@keyv/serialize@1.1.1':
     resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
 
-  '@league-of-foundry-developers/foundry-vtt-types@13.345.1':
-    resolution: {integrity: sha512-7lWpbriLGK0gd6XLC/srYCdzAEkhb+YJoU/9ygefBHqq55ce2zKtm8/zFn8zFmZJlwEa2RUUEPqGmKDLU3tmvw==}
+  '@league-of-foundry-developers/foundry-vtt-types@https://codeload.github.com/Fronix/foundry-vtt-types/tar.gz/773353f0255f1cdb862db33eac01326b5d1f1542':
+    resolution: {tarball: https://codeload.github.com/Fronix/foundry-vtt-types/tar.gz/773353f0255f1cdb862db33eac01326b5d1f1542}
+    version: 14.363.0
     peerDependencies:
-      typescript: ^5.4
+      '@typescript/native-preview': '*'
+      typescript: '>=5.4'
+    peerDependenciesMeta:
+      '@typescript/native-preview':
+        optional: true
+      typescript:
+        optional: true
 
-  '@lezer/common@1.4.0':
-    resolution: {integrity: sha512-DVeMRoGrgn/k45oQNu189BoW4SZwgZFzJ1+1TV5j2NJ/KFC83oa/enRqZSGshyeMk5cPWMhsKs9nx+8o0unwGg==}
+  '@lezer/common@1.5.1':
+    resolution: {integrity: sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==}
 
-  '@lezer/css@1.3.0':
-    resolution: {integrity: sha512-pBL7hup88KbI7hXnZV3PQsn43DHy6TWyzuyk2AO9UyoXcDltvIdqWKE1dLL/45JVZ+YZkHe1WVHqO6wugZZWcw==}
+  '@lezer/css@1.3.1':
+    resolution: {integrity: sha512-PYAKeUVBo3HFThruRyp/iK91SwiZJnzXh8QzkQlwijB5y+N5iB28+iLk78o2zmKqqV0uolNhCwFqB8LA7b0Svg==}
 
   '@lezer/highlight@1.2.3':
     resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
 
-  '@lezer/html@1.3.12':
-    resolution: {integrity: sha512-RJ7eRWdaJe3bsiiLLHjCFT1JMk8m1YP9kaUbvu2rMLEoOnke9mcTVDyfOslsln0LtujdWespjJ39w6zo+RsQYw==}
+  '@lezer/html@1.3.13':
+    resolution: {integrity: sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==}
 
   '@lezer/javascript@1.5.4':
     resolution: {integrity: sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==}
@@ -534,11 +541,11 @@ packages:
   '@lezer/json@1.0.3':
     resolution: {integrity: sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==}
 
-  '@lezer/lr@1.4.5':
-    resolution: {integrity: sha512-/YTRKP5yPPSo1xImYQk7AZZMAgap0kegzqCSYHjAL9x1AZ0ZQW+IpcEzMKagCsbTsLnVeWkxYrCNeXG8xEPrjg==}
+  '@lezer/lr@1.4.8':
+    resolution: {integrity: sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA==}
 
-  '@lezer/markdown@1.6.1':
-    resolution: {integrity: sha512-72ah+Sml7lD8Wn7lnz9vwYmZBo9aQT+I2gjK/0epI+gjdwUbWw3MJ/ZBGEqG1UfrIauRqH37/c5mVHXeCTGXtA==}
+  '@lezer/markdown@1.6.3':
+    resolution: {integrity: sha512-jpGm5Ps+XErS+xA4urw7ogEGkeZOahVQF21Z6oECF0sj+2liwZopd2+I8uH5I/vZsRuuze3OxBREIANLf6KKUw==}
 
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
@@ -1096,8 +1103,8 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
-  '@types/jquery@3.5.32':
-    resolution: {integrity: sha512-b9Xbf4CkMqS02YH8zACqN1xzdxc3cO735Qe5AbSUFmyOiaWAbcpqh9Wna+Uk0vgACvoQHpWDg2rGdHkYPLmCiQ==}
+  '@types/jquery@3.5.34':
+    resolution: {integrity: sha512-3m3939S3erqmTLJANS/uy0B6V7BorKx7RorcGZVjZ62dF5PAGbKEDZK1CuLtKombJkFA2T1jl8LAIIs7IV6gBQ==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -1111,11 +1118,11 @@ packages:
   '@types/showdown@2.0.6':
     resolution: {integrity: sha512-pTvD/0CIeqe4x23+YJWlX2gArHa8G0J0Oh6GKaVXV7TAeickpkkZiNOgFcFcmLQ5lB/K0qBJL1FtRYltBfbGCQ==}
 
-  '@types/simple-peer@9.11.8':
-    resolution: {integrity: sha512-rvqefdp2rvIA6wiomMgKWd2UZNPe6LM2EV5AuY3CPQJF+8TbdrL5TjYdMf0VAjGczzlkH4l1NjDkihwbj3Xodw==}
+  '@types/simple-peer@9.11.9':
+    resolution: {integrity: sha512-6Gdl7TSS5oh9nuwKD4Pl8cSmaxWycYeZz9HLnJBNvIwWjZuGVsmHe9RwW3+9RxfhC1aIR9Z83DvaJoMw6rhkbg==}
 
-  '@types/sizzle@2.3.9':
-    resolution: {integrity: sha512-xzLEyKB50yqCUPUJkIsrVvoWNfFUbIZI+RspLWt8u+tIW/BetMBZtgV2LY/2o+tYH8dRvQ+eoPf3NdhQCcLE2w==}
+  '@types/sizzle@2.3.10':
+    resolution: {integrity: sha512-TC0dmN0K8YcWEAEfiPi5gJP14eJe30TTGjkvek3iM/1NdHHsdCA/Td6GvNndMOo/iSnIsZ4HuuhrYPDAmbxzww==}
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
@@ -1435,8 +1442,8 @@ packages:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
-  cors@2.8.5:
-    resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
 
   cosmiconfig@9.0.0:
@@ -1470,15 +1477,6 @@ packages:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
-
-  debug@4.3.7:
-    resolution: {integrity: sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1562,15 +1560,15 @@ packages:
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
-  engine.io-client@6.6.3:
-    resolution: {integrity: sha512-T0iLjnyNWahNyv/lcjS2y4oE358tVS/SYQNxYXGAJ9/GLgH4VCvOQ/mhTjqU88mLZCQgiG8RIegFHYCdVC+j5w==}
+  engine.io-client@6.6.4:
+    resolution: {integrity: sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==}
 
   engine.io-parser@5.2.3:
     resolution: {integrity: sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==}
     engines: {node: '>=10.0.0'}
 
-  engine.io@6.6.4:
-    resolution: {integrity: sha512-ZCkIjSYNDyGn0R6ewHDtXgns/Zre/NT6Agvq1/WobF7JXgFff4SeDroKiCO3fNJreU9YG429Sc81o4w5ok/W5g==}
+  engine.io@6.6.5:
+    resolution: {integrity: sha512-2RZdgEbXmp5+dVbRm0P7HQUImZpICccJy7rN7Tv+SFa55pH+lxnuw6/K1ZxxBfHoYpSkHLAO92oa8O4SwFXA2A==}
     engines: {node: '>=10.2.0'}
 
   enhanced-resolve@5.18.3:
@@ -2418,35 +2416,35 @@ packages:
   prosemirror-dropcursor@1.8.2:
     resolution: {integrity: sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==}
 
-  prosemirror-gapcursor@1.3.2:
-    resolution: {integrity: sha512-wtjswVBd2vaQRrnYZaBCbyDqr232Ed4p2QPtRIUK5FuqHYKGWkEwl08oQM4Tw7DOR0FsasARV5uJFvMZWxdNxQ==}
+  prosemirror-gapcursor@1.4.0:
+    resolution: {integrity: sha512-z00qvurSdCEWUIulij/isHaqu4uLS8r/Fi61IbjdIPJEonQgggbJsLnstW7Lgdk4zQ68/yr6B6bf7sJXowIgdQ==}
 
-  prosemirror-history@1.4.1:
-    resolution: {integrity: sha512-2JZD8z2JviJrboD9cPuX/Sv/1ChFng+xh2tChQ2X4bB2HeK+rra/bmJ3xGntCcjhOqIzSDG6Id7e8RJ9QPXLEQ==}
+  prosemirror-history@1.5.0:
+    resolution: {integrity: sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==}
 
-  prosemirror-inputrules@1.5.0:
-    resolution: {integrity: sha512-K0xJRCmt+uSw7xesnHmcn72yBGTbY45vm8gXI4LZXbx2Z0jwh5aF9xrGQgrVPu0WbyFVFF3E/o9VhJYz6SQWnA==}
+  prosemirror-inputrules@1.5.1:
+    resolution: {integrity: sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==}
 
   prosemirror-keymap@1.2.3:
     resolution: {integrity: sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==}
 
-  prosemirror-model@1.25.1:
-    resolution: {integrity: sha512-AUvbm7qqmpZa5d9fPKMvH1Q5bqYQvAZWOGRvxsB6iFLyycvC9MwNemNVjHVrWgjaoxAfY8XVg7DbvQ/qxvI9Eg==}
+  prosemirror-model@1.25.4:
+    resolution: {integrity: sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==}
 
   prosemirror-schema-list@1.5.1:
     resolution: {integrity: sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==}
 
-  prosemirror-state@1.4.3:
-    resolution: {integrity: sha512-goFKORVbvPuAQaXhpbemJFRKJ2aixr+AZMGiquiqKxaucC6hlpHNZHWgz5R7dS4roHiwq9vDctE//CZ++o0W1Q==}
+  prosemirror-state@1.4.4:
+    resolution: {integrity: sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==}
 
-  prosemirror-tables@1.7.1:
-    resolution: {integrity: sha512-eRQ97Bf+i9Eby99QbyAiyov43iOKgWa7QCGly+lrDt7efZ1v8NWolhXiB43hSDGIXT1UXgbs4KJN3a06FGpr1Q==}
+  prosemirror-tables@1.8.5:
+    resolution: {integrity: sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==}
 
-  prosemirror-transform@1.10.4:
-    resolution: {integrity: sha512-pwDy22nAnGqNR1feOQKHxoFkkUtepoFAd3r2hbEDsnf4wp57kKA36hXsB3njA9FtONBEwSDnDeCiJe+ItD+ykw==}
+  prosemirror-transform@1.11.0:
+    resolution: {integrity: sha512-4I7Ce4KpygXb9bkiPS3hTEk4dSHorfRw8uI0pE8IhxlK2GXsqv5tIA7JUSxtSu7u8APVOTtbUBxTmnHIxVkIJw==}
 
-  prosemirror-view@1.40.0:
-    resolution: {integrity: sha512-2G3svX0Cr1sJjkD/DYWSe3cfV5VPVTBOxI9XQEGWJDFEpsZb/gh4MV29ctv+OJx2RFX4BLt09i+6zaGM/ldkCw==}
+  prosemirror-view@1.41.6:
+    resolution: {integrity: sha512-mxpcDG4hNQa/CPtzxjdlir5bJFDlm0/x5nGBbStB2BWX+XOQ9M8ekEG+ojqB5BcVu2Rc80/jssCMZzSstJuSYg==}
 
   punycode@1.4.1:
     resolution: {integrity: sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==}
@@ -2459,8 +2457,8 @@ packages:
     resolution: {integrity: sha512-+BtFN3dCP+IaFA6IYNOu/f/uK1B8xD2QWyOeCse0rjtAebBmkzgd2d1OAXi3ikAzJMIBSdzZDNZ3wZKEUDQs5w==}
     engines: {node: '>=20'}
 
-  qs@6.15.0:
-    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
     engines: {node: '>=0.6'}
 
   queue-microtask@1.2.3:
@@ -2541,8 +2539,8 @@ packages:
   safe-regex@2.1.1:
     resolution: {integrity: sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==}
 
-  sanitize-html@2.17.0:
-    resolution: {integrity: sha512-dLAADUSS8rBwhaevT12yCezvioCA+bmUTPH/u57xKPT8d++voeYE6HeluA/bPbQ15TwDBG2ii+QZIEmYx8VdxA==}
+  sanitize-html@2.17.1:
+    resolution: {integrity: sha512-ehFCW+q1a4CSOWRAdX97BX/6/PDEkCqw7/0JXZAGQV57FQB3YOkTa/rrzHPeJ+Aghy4vZAFfWMYyfxIiB7F/gw==}
 
   sass@1.93.2:
     resolution: {integrity: sha512-t+YPtOQHpGW1QWsh1CHQ5cPIr9lbbGZLZnbihP/D/qZj/yuV68m8qarcV17nvkOX81BCrvzAlq2klCQFZghyTg==}
@@ -2575,8 +2573,8 @@ packages:
     resolution: {integrity: sha512-/6NVYu4U819R2pUIk79n67SYgJHWCce0a5xTP979WbNp0FL9MN1I1QK662IDU1b6JzKTvmhgI7T7JYIxBi3kMQ==}
     hasBin: true
 
-  side-channel-list@1.0.0:
-    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
     engines: {node: '>= 0.4'}
 
   side-channel-map@1.0.1:
@@ -2624,19 +2622,19 @@ packages:
     resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
     engines: {node: '>=18'}
 
-  socket.io-adapter@2.5.5:
-    resolution: {integrity: sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==}
+  socket.io-adapter@2.5.6:
+    resolution: {integrity: sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==}
 
-  socket.io-client@4.8.1:
-    resolution: {integrity: sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==}
+  socket.io-client@4.8.3:
+    resolution: {integrity: sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==}
     engines: {node: '>=10.0.0'}
 
-  socket.io-parser@4.2.4:
-    resolution: {integrity: sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==}
+  socket.io-parser@4.2.5:
+    resolution: {integrity: sha512-bPMmpy/5WWKHea5Y/jYAP6k74A+hvmRCQaJuJB6I/ML5JZq/KfNieUVo/3Mh7SAqn7TyFdIo6wqYHInG1MU1bQ==}
     engines: {node: '>=10.0.0'}
 
-  socket.io@4.8.1:
-    resolution: {integrity: sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg==}
+  socket.io@4.8.3:
+    resolution: {integrity: sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==}
     engines: {node: '>=10.2.0'}
 
   source-map-generator@0.8.0:
@@ -3028,8 +3026,8 @@ packages:
     resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
-  ws@8.17.1:
-    resolution: {integrity: sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==}
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -3125,93 +3123,93 @@ snapshots:
     dependencies:
       keyv: 5.5.3
 
-  '@codemirror/autocomplete@6.20.0':
+  '@codemirror/autocomplete@6.20.1':
     dependencies:
-      '@codemirror/language': 6.11.3
-      '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.39.2
-      '@lezer/common': 1.4.0
+      '@codemirror/language': 6.12.2
+      '@codemirror/state': 6.5.4
+      '@codemirror/view': 6.39.16
+      '@lezer/common': 1.5.1
 
-  '@codemirror/commands@6.10.0':
+  '@codemirror/commands@6.10.2':
     dependencies:
-      '@codemirror/language': 6.11.3
-      '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.39.2
-      '@lezer/common': 1.4.0
+      '@codemirror/language': 6.12.2
+      '@codemirror/state': 6.5.4
+      '@codemirror/view': 6.39.16
+      '@lezer/common': 1.5.1
 
   '@codemirror/lang-css@6.3.1':
     dependencies:
-      '@codemirror/autocomplete': 6.20.0
-      '@codemirror/language': 6.11.3
-      '@codemirror/state': 6.5.2
-      '@lezer/common': 1.4.0
-      '@lezer/css': 1.3.0
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/language': 6.12.2
+      '@codemirror/state': 6.5.4
+      '@lezer/common': 1.5.1
+      '@lezer/css': 1.3.1
 
   '@codemirror/lang-html@6.4.11':
     dependencies:
-      '@codemirror/autocomplete': 6.20.0
+      '@codemirror/autocomplete': 6.20.1
       '@codemirror/lang-css': 6.3.1
-      '@codemirror/lang-javascript': 6.2.4
-      '@codemirror/language': 6.11.3
-      '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.39.2
-      '@lezer/common': 1.4.0
-      '@lezer/css': 1.3.0
-      '@lezer/html': 1.3.12
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/language': 6.12.2
+      '@codemirror/state': 6.5.4
+      '@codemirror/view': 6.39.16
+      '@lezer/common': 1.5.1
+      '@lezer/css': 1.3.1
+      '@lezer/html': 1.3.13
 
-  '@codemirror/lang-javascript@6.2.4':
+  '@codemirror/lang-javascript@6.2.5':
     dependencies:
-      '@codemirror/autocomplete': 6.20.0
-      '@codemirror/language': 6.11.3
-      '@codemirror/lint': 6.9.2
-      '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.39.2
-      '@lezer/common': 1.4.0
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/language': 6.12.2
+      '@codemirror/lint': 6.9.5
+      '@codemirror/state': 6.5.4
+      '@codemirror/view': 6.39.16
+      '@lezer/common': 1.5.1
       '@lezer/javascript': 1.5.4
 
   '@codemirror/lang-json@6.0.2':
     dependencies:
-      '@codemirror/language': 6.11.3
+      '@codemirror/language': 6.12.2
       '@lezer/json': 1.0.3
 
   '@codemirror/lang-markdown@6.5.0':
     dependencies:
-      '@codemirror/autocomplete': 6.20.0
+      '@codemirror/autocomplete': 6.20.1
       '@codemirror/lang-html': 6.4.11
-      '@codemirror/language': 6.11.3
-      '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.39.2
-      '@lezer/common': 1.4.0
-      '@lezer/markdown': 1.6.1
+      '@codemirror/language': 6.12.2
+      '@codemirror/state': 6.5.4
+      '@codemirror/view': 6.39.16
+      '@lezer/common': 1.5.1
+      '@lezer/markdown': 1.6.3
 
-  '@codemirror/language@6.11.3':
+  '@codemirror/language@6.12.2':
     dependencies:
-      '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.39.2
-      '@lezer/common': 1.4.0
+      '@codemirror/state': 6.5.4
+      '@codemirror/view': 6.39.16
+      '@lezer/common': 1.5.1
       '@lezer/highlight': 1.2.3
-      '@lezer/lr': 1.4.5
+      '@lezer/lr': 1.4.8
       style-mod: 4.1.3
 
-  '@codemirror/lint@6.9.2':
+  '@codemirror/lint@6.9.5':
     dependencies:
-      '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.39.2
+      '@codemirror/state': 6.5.4
+      '@codemirror/view': 6.39.16
       crelt: 1.0.6
 
-  '@codemirror/search@6.5.11':
+  '@codemirror/search@6.6.0':
     dependencies:
-      '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.39.2
+      '@codemirror/state': 6.5.4
+      '@codemirror/view': 6.39.16
       crelt: 1.0.6
 
-  '@codemirror/state@6.5.2':
+  '@codemirror/state@6.5.4':
     dependencies:
       '@marijn/find-cluster-break': 1.0.2
 
-  '@codemirror/view@6.39.2':
+  '@codemirror/view@6.39.16':
     dependencies:
-      '@codemirror/state': 6.5.2
+      '@codemirror/state': 6.5.4
       crelt: 1.0.6
       style-mod: 4.1.3
       w3c-keyname: 2.2.8
@@ -3410,18 +3408,18 @@ snapshots:
 
   '@keyv/serialize@1.1.1': {}
 
-  '@league-of-foundry-developers/foundry-vtt-types@13.345.1(6c574db58d500d3ecfd5fe5f98038db3)':
+  '@league-of-foundry-developers/foundry-vtt-types@https://codeload.github.com/Fronix/foundry-vtt-types/tar.gz/773353f0255f1cdb862db33eac01326b5d1f1542(6c574db58d500d3ecfd5fe5f98038db3)':
     dependencies:
       '@codemirror/lang-html': 6.4.11
-      '@codemirror/lang-javascript': 6.2.4
+      '@codemirror/lang-javascript': 6.2.5
       '@codemirror/lang-json': 6.0.2
       '@codemirror/lang-markdown': 6.5.0
       '@pixi/basis': https://codeload.github.com/foundry-vtt-types/pixi-basis/tar.gz/d0956799d7c23f59e12b7b2ec4dc21c041180b0e(@pixi/assets@7.4.3(@pixi/core@https://codeload.github.com/foundry-vtt-types/pixi-core/tar.gz/b2554df0b43183980830a08d92a960ede78ad25e))(@pixi/core@https://codeload.github.com/foundry-vtt-types/pixi-core/tar.gz/b2554df0b43183980830a08d92a960ede78ad25e)
       '@pixi/graphics-smooth': 1.1.1(@pixi/core@https://codeload.github.com/foundry-vtt-types/pixi-core/tar.gz/b2554df0b43183980830a08d92a960ede78ad25e)(@pixi/display@7.4.3(@pixi/core@https://codeload.github.com/foundry-vtt-types/pixi-core/tar.gz/b2554df0b43183980830a08d92a960ede78ad25e))(@pixi/graphics@7.4.3(@pixi/core@https://codeload.github.com/foundry-vtt-types/pixi-core/tar.gz/b2554df0b43183980830a08d92a960ede78ad25e)(@pixi/display@7.4.3(@pixi/core@https://codeload.github.com/foundry-vtt-types/pixi-core/tar.gz/b2554df0b43183980830a08d92a960ede78ad25e))(@pixi/sprite@7.4.3(@pixi/core@https://codeload.github.com/foundry-vtt-types/pixi-core/tar.gz/b2554df0b43183980830a08d92a960ede78ad25e)(@pixi/display@7.4.3(@pixi/core@https://codeload.github.com/foundry-vtt-types/pixi-core/tar.gz/b2554df0b43183980830a08d92a960ede78ad25e))))
       '@pixi/particle-emitter': https://codeload.github.com/foundry-vtt-types/pixi-particle-emitter/tar.gz/9bd3cb53826b2c7d4c407db183f4dd93edd50aae(@pixi/constants@7.4.3)(@pixi/core@https://codeload.github.com/foundry-vtt-types/pixi-core/tar.gz/b2554df0b43183980830a08d92a960ede78ad25e)(@pixi/display@7.4.3(@pixi/core@https://codeload.github.com/foundry-vtt-types/pixi-core/tar.gz/b2554df0b43183980830a08d92a960ede78ad25e))(@pixi/math@7.4.3)(@pixi/sprite@7.4.3(@pixi/core@https://codeload.github.com/foundry-vtt-types/pixi-core/tar.gz/b2554df0b43183980830a08d92a960ede78ad25e)(@pixi/display@7.4.3(@pixi/core@https://codeload.github.com/foundry-vtt-types/pixi-core/tar.gz/b2554df0b43183980830a08d92a960ede78ad25e)))(@pixi/ticker@7.4.3)
-      '@types/jquery': 3.5.32
+      '@types/jquery': 3.5.34
       '@types/showdown': 2.0.6
-      '@types/simple-peer': 9.11.8
+      '@types/simple-peer': 9.11.9
       '@types/youtube': 0.0.50
       codemirror: 6.0.2
       handlebars: 4.7.8
@@ -3434,23 +3432,24 @@ snapshots:
       prosemirror-collab: 1.3.1
       prosemirror-commands: 1.7.1
       prosemirror-dropcursor: 1.8.2
-      prosemirror-gapcursor: 1.3.2
-      prosemirror-history: 1.4.1
-      prosemirror-inputrules: 1.5.0
+      prosemirror-gapcursor: 1.4.0
+      prosemirror-history: 1.5.0
+      prosemirror-inputrules: 1.5.1
       prosemirror-keymap: 1.2.3
-      prosemirror-model: 1.25.1
+      prosemirror-model: 1.25.4
       prosemirror-schema-list: 1.5.1
-      prosemirror-state: 1.4.3
-      prosemirror-tables: 1.7.1
-      prosemirror-transform: 1.10.4
-      prosemirror-view: 1.40.0
-      sanitize-html: 2.17.0
+      prosemirror-state: 1.4.4
+      prosemirror-tables: 1.8.5
+      prosemirror-transform: 1.11.0
+      prosemirror-view: 1.41.6
+      sanitize-html: 2.17.1
       showdown: 2.1.0
       simple-peer: 9.11.1
-      socket.io: 4.8.1
-      socket.io-client: 4.8.1
+      socket.io: 4.8.3
+      socket.io-client: 4.8.3
       spark-md5: 3.0.2
       tinymce: 6.8.6
+    optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - '@pixi/assets'
@@ -3466,43 +3465,43 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@lezer/common@1.4.0': {}
+  '@lezer/common@1.5.1': {}
 
-  '@lezer/css@1.3.0':
+  '@lezer/css@1.3.1':
     dependencies:
-      '@lezer/common': 1.4.0
+      '@lezer/common': 1.5.1
       '@lezer/highlight': 1.2.3
-      '@lezer/lr': 1.4.5
+      '@lezer/lr': 1.4.8
 
   '@lezer/highlight@1.2.3':
     dependencies:
-      '@lezer/common': 1.4.0
+      '@lezer/common': 1.5.1
 
-  '@lezer/html@1.3.12':
+  '@lezer/html@1.3.13':
     dependencies:
-      '@lezer/common': 1.4.0
+      '@lezer/common': 1.5.1
       '@lezer/highlight': 1.2.3
-      '@lezer/lr': 1.4.5
+      '@lezer/lr': 1.4.8
 
   '@lezer/javascript@1.5.4':
     dependencies:
-      '@lezer/common': 1.4.0
+      '@lezer/common': 1.5.1
       '@lezer/highlight': 1.2.3
-      '@lezer/lr': 1.4.5
+      '@lezer/lr': 1.4.8
 
   '@lezer/json@1.0.3':
     dependencies:
-      '@lezer/common': 1.4.0
+      '@lezer/common': 1.5.1
       '@lezer/highlight': 1.2.3
-      '@lezer/lr': 1.4.5
+      '@lezer/lr': 1.4.8
 
-  '@lezer/lr@1.4.5':
+  '@lezer/lr@1.4.8':
     dependencies:
-      '@lezer/common': 1.4.0
+      '@lezer/common': 1.5.1
 
-  '@lezer/markdown@1.6.1':
+  '@lezer/markdown@1.6.3':
     dependencies:
-      '@lezer/common': 1.4.0
+      '@lezer/common': 1.5.1
       '@lezer/highlight': 1.2.3
 
   '@marijn/find-cluster-break@1.0.2': {}
@@ -3969,9 +3968,9 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
-  '@types/jquery@3.5.32':
+  '@types/jquery@3.5.34':
     dependencies:
-      '@types/sizzle': 2.3.9
+      '@types/sizzle': 2.3.10
 
   '@types/json-schema@7.0.15': {}
 
@@ -3985,11 +3984,11 @@ snapshots:
 
   '@types/showdown@2.0.6': {}
 
-  '@types/simple-peer@9.11.8':
+  '@types/simple-peer@9.11.9':
     dependencies:
       '@types/node': 24.9.1
 
-  '@types/sizzle@2.3.9': {}
+  '@types/sizzle@2.3.10': {}
 
   '@types/trusted-types@2.0.7': {}
 
@@ -4313,13 +4312,13 @@ snapshots:
 
   codemirror@6.0.2:
     dependencies:
-      '@codemirror/autocomplete': 6.20.0
-      '@codemirror/commands': 6.10.0
-      '@codemirror/language': 6.11.3
-      '@codemirror/lint': 6.9.2
-      '@codemirror/search': 6.5.11
-      '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.39.2
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/commands': 6.10.2
+      '@codemirror/language': 6.12.2
+      '@codemirror/lint': 6.9.5
+      '@codemirror/search': 6.6.0
+      '@codemirror/state': 6.5.4
+      '@codemirror/view': 6.39.16
 
   color-convert@2.0.1:
     dependencies:
@@ -4343,7 +4342,7 @@ snapshots:
 
   cookie@0.7.2: {}
 
-  cors@2.8.5:
+  cors@2.8.6:
     dependencies:
       object-assign: 4.1.1
       vary: 1.1.2
@@ -4375,10 +4374,6 @@ snapshots:
   css.escape@1.5.1: {}
 
   cssesc@3.0.0: {}
-
-  debug@4.3.7:
-    dependencies:
-      ms: 2.1.3
 
   debug@4.4.3:
     dependencies:
@@ -4470,12 +4465,12 @@ snapshots:
 
   emoji-regex@9.2.2: {}
 
-  engine.io-client@6.6.3:
+  engine.io-client@6.6.4:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
-      debug: 4.3.7
+      debug: 4.4.3
       engine.io-parser: 5.2.3
-      ws: 8.17.1
+      ws: 8.18.3
       xmlhttprequest-ssl: 2.1.2
     transitivePeerDependencies:
       - bufferutil
@@ -4484,17 +4479,17 @@ snapshots:
 
   engine.io-parser@5.2.3: {}
 
-  engine.io@6.6.4:
+  engine.io@6.6.5:
     dependencies:
       '@types/cors': 2.8.19
       '@types/node': 24.9.1
       accepts: 1.3.8
       base64id: 2.0.0
       cookie: 0.7.2
-      cors: 2.8.5
-      debug: 4.3.7
+      cors: 2.8.6
+      debug: 4.4.3
       engine.io-parser: 5.2.3
-      ws: 8.17.1
+      ws: 8.18.3
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -5330,77 +5325,77 @@ snapshots:
 
   prosemirror-collab@1.3.1:
     dependencies:
-      prosemirror-state: 1.4.3
+      prosemirror-state: 1.4.4
 
   prosemirror-commands@1.7.1:
     dependencies:
-      prosemirror-model: 1.25.1
-      prosemirror-state: 1.4.3
-      prosemirror-transform: 1.10.4
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.11.0
 
   prosemirror-dropcursor@1.8.2:
     dependencies:
-      prosemirror-state: 1.4.3
-      prosemirror-transform: 1.10.4
-      prosemirror-view: 1.40.0
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.11.0
+      prosemirror-view: 1.41.6
 
-  prosemirror-gapcursor@1.3.2:
+  prosemirror-gapcursor@1.4.0:
     dependencies:
       prosemirror-keymap: 1.2.3
-      prosemirror-model: 1.25.1
-      prosemirror-state: 1.4.3
-      prosemirror-view: 1.40.0
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-view: 1.41.6
 
-  prosemirror-history@1.4.1:
+  prosemirror-history@1.5.0:
     dependencies:
-      prosemirror-state: 1.4.3
-      prosemirror-transform: 1.10.4
-      prosemirror-view: 1.40.0
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.11.0
+      prosemirror-view: 1.41.6
       rope-sequence: 1.3.4
 
-  prosemirror-inputrules@1.5.0:
+  prosemirror-inputrules@1.5.1:
     dependencies:
-      prosemirror-state: 1.4.3
-      prosemirror-transform: 1.10.4
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.11.0
 
   prosemirror-keymap@1.2.3:
     dependencies:
-      prosemirror-state: 1.4.3
+      prosemirror-state: 1.4.4
       w3c-keyname: 2.2.8
 
-  prosemirror-model@1.25.1:
+  prosemirror-model@1.25.4:
     dependencies:
       orderedmap: 2.1.1
 
   prosemirror-schema-list@1.5.1:
     dependencies:
-      prosemirror-model: 1.25.1
-      prosemirror-state: 1.4.3
-      prosemirror-transform: 1.10.4
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.11.0
 
-  prosemirror-state@1.4.3:
+  prosemirror-state@1.4.4:
     dependencies:
-      prosemirror-model: 1.25.1
-      prosemirror-transform: 1.10.4
-      prosemirror-view: 1.40.0
+      prosemirror-model: 1.25.4
+      prosemirror-transform: 1.11.0
+      prosemirror-view: 1.41.6
 
-  prosemirror-tables@1.7.1:
+  prosemirror-tables@1.8.5:
     dependencies:
       prosemirror-keymap: 1.2.3
-      prosemirror-model: 1.25.1
-      prosemirror-state: 1.4.3
-      prosemirror-transform: 1.10.4
-      prosemirror-view: 1.40.0
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.11.0
+      prosemirror-view: 1.41.6
 
-  prosemirror-transform@1.10.4:
+  prosemirror-transform@1.11.0:
     dependencies:
-      prosemirror-model: 1.25.1
+      prosemirror-model: 1.25.4
 
-  prosemirror-view@1.40.0:
+  prosemirror-view@1.41.6:
     dependencies:
-      prosemirror-model: 1.25.1
-      prosemirror-state: 1.4.3
-      prosemirror-transform: 1.10.4
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.11.0
 
   punycode@1.4.1: {}
 
@@ -5410,7 +5405,7 @@ snapshots:
     dependencies:
       hookified: 1.12.2
 
-  qs@6.15.0:
+  qs@6.15.1:
     dependencies:
       side-channel: 1.1.0
 
@@ -5506,7 +5501,7 @@ snapshots:
     dependencies:
       regexp-tree: 0.1.27
 
-  sanitize-html@2.17.0:
+  sanitize-html@2.17.1:
     dependencies:
       deepmerge: 4.3.1
       escape-string-regexp: 4.0.0
@@ -5546,7 +5541,7 @@ snapshots:
     dependencies:
       commander: 9.5.0
 
-  side-channel-list@1.0.0:
+  side-channel-list@1.0.1:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
@@ -5570,7 +5565,7 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
-      side-channel-list: 1.0.0
+      side-channel-list: 1.0.1
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
@@ -5613,42 +5608,42 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
 
-  socket.io-adapter@2.5.5:
+  socket.io-adapter@2.5.6:
     dependencies:
-      debug: 4.3.7
-      ws: 8.17.1
+      debug: 4.4.3
+      ws: 8.18.3
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  socket.io-client@4.8.1:
+  socket.io-client@4.8.3:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
-      debug: 4.3.7
-      engine.io-client: 6.6.3
-      socket.io-parser: 4.2.4
+      debug: 4.4.3
+      engine.io-client: 6.6.4
+      socket.io-parser: 4.2.5
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  socket.io-parser@4.2.4:
+  socket.io-parser@4.2.5:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
-      debug: 4.3.7
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
-  socket.io@4.8.1:
+  socket.io@4.8.3:
     dependencies:
       accepts: 1.3.8
       base64id: 2.0.0
-      cors: 2.8.5
-      debug: 4.3.7
-      engine.io: 6.6.4
-      socket.io-adapter: 2.5.5
-      socket.io-parser: 4.2.4
+      cors: 2.8.6
+      debug: 4.4.3
+      engine.io: 6.6.5
+      socket.io-adapter: 2.5.6
+      socket.io-parser: 4.2.5
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -5919,7 +5914,7 @@ snapshots:
   url@0.11.4:
     dependencies:
       punycode: 1.4.1
-      qs: 6.15.0
+      qs: 6.15.1
 
   util-deprecate@1.0.2: {}
 
@@ -6029,7 +6024,7 @@ snapshots:
       imurmurhash: 0.1.4
       signal-exit: 4.1.0
 
-  ws@8.17.1: {}
+  ws@8.18.3: {}
 
   xmlhttprequest-ssl@2.1.2: {}
 

--- a/public/system.json
+++ b/public/system.json
@@ -58,8 +58,7 @@
 	"secondaryTokenAttribute": null,
 	"compatibility": {
 		"minimum": "13",
-		"verified": "13",
-		"maximum": "13"
+		"verified": "14"
 	},
 	"documentTypes": {
 		"ActiveEffect": {

--- a/src/documents/actor/base.svelte.ts
+++ b/src/documents/actor/base.svelte.ts
@@ -19,6 +19,10 @@ export type { ActorRollOptions, CheckRollDialogData, SystemActorTypes };
 import type { SystemItemTypes } from '../item/itemInterfaces.js';
 
 interface NimbleBaseItem extends Item {
+	// Items in an actor's embedded collection are always stored, so these are non-null.
+	id: string;
+	_id: string;
+	uuid: string;
 	rules: RulesManagerInterface;
 	identifier: string;
 	hasMacro?: boolean;
@@ -29,7 +33,7 @@ interface NimbleBaseItem extends Item {
 	): this is NimbleBaseItem & {
 		type: TypeName;
 		system: TypeName extends keyof DataModelConfig['Item']
-			? DataModelConfig['Item'][TypeName]
+			? InstanceType<DataModelConfig['Item'][TypeName]>
 			: object;
 	};
 }
@@ -83,14 +87,22 @@ function toSignedIntegerString(value: number): string {
 	return `${integerValue}`;
 }
 
-class NimbleBaseActor<ActorType extends SystemActorTypes = SystemActorTypes> extends Actor {
+// @ts-expect-error TS2321: comparing the generic subclass `NimbleBaseActor<ActorType>` against
+// the generic `Actor<ActorType>` base exceeds v14 fvtt-types' instantiation-depth limit. This is
+// a type-checker depth ceiling, not a real type error; `system` still resolves correctly per subtype.
+class NimbleBaseActor<
+	ActorType extends SystemActorTypes = SystemActorTypes,
+> extends Actor<ActorType> {
 	declare type: ActorType;
 
 	declare initialized: boolean;
 
 	declare rules: NimbleBaseRule[];
 
-	declare items: foundry.abstract.EmbeddedCollection<NimbleBaseItem, Actor.Implementation>;
+	declare items: foundry.abstract.EmbeddedCollection<
+		NimbleBaseItem & Item.Stored,
+		Actor.Implementation
+	>;
 
 	#subscribe: ReturnType<typeof createSubscriber>;
 	#lastHpSnapshot: HpSnapshot | null = null;
@@ -98,7 +110,7 @@ class NimbleBaseActor<ActorType extends SystemActorTypes = SystemActorTypes> ext
 	tags: Set<string> = new Set();
 
 	// *************************************************
-	constructor(data: Actor.CreateData, context?: Actor.ConstructionContext) {
+	constructor(data: Actor.CreateData<ActorType>, context?: Actor.ConstructionContext) {
 		super(data, context);
 		this.#lastHpSnapshot = this.#getCurrentHpSnapshot();
 
@@ -542,7 +554,7 @@ class NimbleBaseActor<ActorType extends SystemActorTypes = SystemActorTypes> ext
 			return undefined;
 		}
 
-		return item.update(data);
+		return item.update(data) as unknown as Promise<NimbleBaseItem | undefined>;
 	}
 
 	/** ------------------------------------------------------ */
@@ -623,7 +635,10 @@ class NimbleBaseActor<ActorType extends SystemActorTypes = SystemActorTypes> ext
 		rollMode: number,
 		options = {} as ActorRollOptions,
 	) {
-		const rollFormula = getRollFormula(this, {
+		// `this` (a generic NimbleBaseActor<ActorType>) is not assignable to the
+		// non-generic NimbleBaseActor param due to the polymorphic `_initializeSource`
+		// contravariance introduced by v14 fvtt-types; the value is correct at runtime.
+		const rollFormula = getRollFormula(this as unknown as NimbleBaseActor, {
 			abilityKey,
 			rollMode,
 			situationalMods: options.situationalMods ?? '',
@@ -685,7 +700,7 @@ class NimbleBaseActor<ActorType extends SystemActorTypes = SystemActorTypes> ext
 
 		const chatData = (await roll.toMessage(
 			{
-				speaker: ChatMessage.getSpeaker({ actor: this }),
+				speaker: ChatMessage.getSpeaker({ actor: this as object as Actor }),
 				flavor: game.i18n.format('COMBAT.RollsInitiative', { name: this.name }),
 				flags: { core: { initiativeRoll: true } },
 			},
@@ -744,7 +759,8 @@ class NimbleBaseActor<ActorType extends SystemActorTypes = SystemActorTypes> ext
 		rollMode: number,
 		options = {} as ActorRollOptions,
 	) {
-		const rollFormula = getRollFormula(this, {
+		// See note in getDefaultAbilityCheckData re: `this` cast.
+		const rollFormula = getRollFormula(this as unknown as NimbleBaseActor, {
 			saveKey,
 			rollMode,
 			situationalMods: options.situationalMods ?? '',
@@ -888,7 +904,7 @@ class NimbleBaseActor<ActorType extends SystemActorTypes = SystemActorTypes> ext
 	override async _preUpdate(
 		changes: Actor.UpdateData,
 		options: Actor.Database.PreUpdateOptions,
-		user: User.Implementation,
+		user: User.Stored,
 	) {
 		const changesObj = changes as Record<string, unknown>;
 		const hpWasChanged =

--- a/src/documents/actor/character.ts
+++ b/src/documents/actor/character.ts
@@ -95,7 +95,7 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 
 	#dialogs: Record<string, GenericDialog>;
 
-	constructor(data: Actor.CreateData, context?: Actor.ConstructionContext) {
+	constructor(data: Actor.CreateData<'character'>, context?: Actor.ConstructionContext) {
 		super(data, context);
 
 		this.#dialogs = {};
@@ -865,7 +865,7 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 			flavor: `${this.name}: Hit Dice Roll`,
 			content,
 			rolls: [roll],
-			speaker: ChatMessage.getSpeaker({ actor: this }),
+			speaker: ChatMessage.getSpeaker({ actor: this as object as Actor }),
 		};
 
 		ChatMessage.applyRollMode(
@@ -1234,7 +1234,7 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 				// Create a copy of the subclass for the character
 				const subclassData = subclass.toObject();
 				(subclassData as { _stats: { compendiumSource?: string } })._stats.compendiumSource =
-					subclass.uuid;
+					subclass.uuid ?? undefined;
 
 				await this.createEmbeddedDocuments('Item', [subclassData]);
 			} else {
@@ -1249,7 +1249,7 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 		if (typedDialogData.selectedEpicBoon) {
 			const boonData = typedDialogData.selectedEpicBoon.toObject();
 			(boonData as { _stats: { compendiumSource?: string } })._stats.compendiumSource =
-				typedDialogData.selectedEpicBoon.uuid;
+				typedDialogData.selectedEpicBoon.uuid ?? undefined;
 			const created = await this.createEmbeddedDocuments('Item', [boonData] as Parameters<
 				typeof this.createEmbeddedDocuments
 			>[1]);
@@ -1581,7 +1581,7 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 	protected override async _preCreate(
 		data: Actor.CreateData,
 		options: Actor.Database.PreCreateOptions,
-		user: User.Implementation,
+		user: User.Stored,
 		// biome-ignore lint/suspicious/noConfusingVoidType: Matching parent class signature
 	): Promise<boolean | void> {
 		// Player character configuration

--- a/src/documents/actor/minion.ts
+++ b/src/documents/actor/minion.ts
@@ -4,7 +4,7 @@ import NPCMetaConfigDialog from '../../view/dialogs/NPCMetaConfigDialog.svelte';
 import GenericDialog from '../dialogs/GenericDialog.svelte.js';
 import { NimbleBaseActor } from './base.svelte.js';
 
-export class NimbleMinion extends NimbleBaseActor {
+export class NimbleMinion extends NimbleBaseActor<'minion'> {
 	declare system: NimbleMinionData;
 
 	#dialogs: Record<string, any>;

--- a/src/documents/actor/npc.ts
+++ b/src/documents/actor/npc.ts
@@ -4,7 +4,7 @@ import NPCMetaConfigDialog from '../../view/dialogs/NPCMetaConfigDialog.svelte';
 import GenericDialog from '../dialogs/GenericDialog.svelte.js';
 import { NimbleBaseActor } from './base.svelte.js';
 
-export class NimbleNPC extends NimbleBaseActor {
+export class NimbleNPC extends NimbleBaseActor<'npc'> {
 	declare system: NimbleNPCData;
 
 	#dialogs: Record<string, any>;

--- a/src/documents/actor/soloMonster.ts
+++ b/src/documents/actor/soloMonster.ts
@@ -6,7 +6,7 @@ import { NimbleBaseActor } from './base.svelte.js';
 
 type MonsterFeatureSubtype = 'bloodied' | 'lastStand';
 
-export class NimbleSoloMonster extends NimbleBaseActor {
+export class NimbleSoloMonster extends NimbleBaseActor<'soloMonster'> {
 	declare system: NimbleSoloMonsterData;
 
 	#dialogs: Record<string, any>;
@@ -53,7 +53,7 @@ export class NimbleSoloMonster extends NimbleBaseActor {
 		const chatData = {
 			author: game.user?.id,
 			flavor: `${this?.name}: Bloodied`,
-			speaker: ChatMessage.getSpeaker({ actor: this }),
+			speaker: ChatMessage.getSpeaker({ actor: this as object as Actor }),
 			style: CONST.CHAT_MESSAGE_STYLES.OTHER,
 			sound: CONFIG.sounds.dice,
 			rolls: [] as Roll[],
@@ -83,7 +83,7 @@ export class NimbleSoloMonster extends NimbleBaseActor {
 		const chatData = {
 			author: game.user?.id,
 			flavor: `${this?.name}: Last Stand`,
-			speaker: ChatMessage.getSpeaker({ actor: this }),
+			speaker: ChatMessage.getSpeaker({ actor: this as object as Actor }),
 			style: CONST.CHAT_MESSAGE_STYLES.OTHER,
 			rolls: [] as Roll[],
 			rollMode,

--- a/src/documents/combat/combat.svelte.ts
+++ b/src/documents/combat/combat.svelte.ts
@@ -659,9 +659,9 @@ class NimbleCombat extends Combat {
 
 	override async createEmbeddedDocuments<EmbeddedName extends Combat.Embedded.Name>(
 		embeddedName: EmbeddedName,
-		data: foundry.abstract.Document.CreateDataForName<EmbeddedName>[] | undefined,
-		operation?: object,
-	): Promise<foundry.abstract.Document.StoredForName<EmbeddedName>[] | undefined> {
+		data: foundry.abstract.Document.CreateDataForName<EmbeddedName>[],
+		operation?: foundry.abstract.Document.Database.CreateDocumentsOperationForName<EmbeddedName>,
+	): Promise<foundry.abstract.Document.StoredForName<EmbeddedName>[]> {
 		let normalizedData = data;
 
 		if (embeddedName === 'Combatant' && Array.isArray(data)) {
@@ -708,7 +708,7 @@ class NimbleCombat extends Combat {
 		await this.#applyNpcActionResetUpdates();
 
 		await dissolveRoundBoundaryMinionGroups({
-			combat: this,
+			combat: this as Combat,
 			resolveCurrentTurnIdentity: () => this.#resolveCurrentTurnIdentity(),
 			syncTurnToCombatant: (combatantIdOrIdentity, options) =>
 				this.#syncTurnToCombatant(combatantIdOrIdentity, options),
@@ -740,14 +740,14 @@ class NimbleCombat extends Combat {
 
 		const changed =
 			(await queueCombatantMutationWithFreshDocument({
-				combat: this,
+				combat: this as Combat,
 				combatantId,
 				mutation: async (combatant) => {
 					if (combatant.parent?.id !== this.id) return false;
 					if (combatant.type !== 'character') return false;
 
 					const usageState = getHeroicReactionUsageState({
-						combat: this,
+						combat: this as Combat,
 						combatant,
 						reactionKeys,
 					});
@@ -790,7 +790,7 @@ class NimbleCombat extends Combat {
 
 		const changed =
 			(await queueCombatantMutationWithFreshDocument({
-				combat: this,
+				combat: this as Combat,
 				combatantId,
 				mutation: async (combatant) => {
 					if (combatant.parent?.id !== this.id) return false;
@@ -844,11 +844,11 @@ class NimbleCombat extends Combat {
 		params: MinionGroupAttackParams,
 	): Promise<MinionGroupAttackResult> {
 		return performMinionGroupAttack({
-			combat: this,
+			combat: this as Combat,
 			attackParams: params,
 			assignNcsTemporaryGroupFromAttackMembers: (memberCombatantIds) =>
 				assignNcsTemporaryGroupFromAttackMembers({
-					combat: this,
+					combat: this as Combat,
 					turns: this.turns,
 					memberCombatantIds,
 					resolveCurrentTurnIdentity: () => this.#resolveCurrentTurnIdentity(),
@@ -943,7 +943,7 @@ class NimbleCombat extends Combat {
 			}
 
 			const rollOutcome = await rollInitiativeForCombatant({
-				combat: this,
+				combat: this as Combat,
 				combatantId: params.combatantId,
 				formula: promptedRollData?.rollFormula ?? params.formula,
 				messageOptions: resolvedMessageOptions,
@@ -1176,7 +1176,7 @@ class NimbleCombat extends Combat {
 		event.preventDefault();
 
 		const dropResolution = resolveDropContext({
-			combat: this,
+			combat: this as Combat,
 			turns: this.turns,
 			event,
 			previousActiveTurnIdentity: this.#resolveCurrentTurnIdentity(),
@@ -1185,7 +1185,7 @@ class NimbleCombat extends Combat {
 
 		if (game.user?.isGM) {
 			return applyGmSort({
-				combat: this,
+				combat: this as Combat,
 				dropResolution,
 				syncTurnToCombatant: (combatantIdOrIdentity, options) =>
 					this.#syncTurnToCombatant(combatantIdOrIdentity, options),
@@ -1193,7 +1193,7 @@ class NimbleCombat extends Combat {
 		}
 
 		return applyOwnerSort({
-			combat: this,
+			combat: this as Combat,
 			dropResolution,
 			syncTurnToCombatant: (combatantIdOrIdentity, options) =>
 				this.#syncTurnToCombatant(combatantIdOrIdentity, options),

--- a/src/documents/combat/combatSorting.ts
+++ b/src/documents/combat/combatSorting.ts
@@ -61,7 +61,7 @@ function resolveDropSource(params: {
 	if (sourceCombatantIds.length > 0) {
 		const sourceCombatants = sourceCombatantIds
 			.map((combatantId) => combat.combatants.get(combatantId) ?? null)
-			.filter((combatant): combatant is Combatant.Implementation => Boolean(combatant));
+			.filter((combatant) => Boolean(combatant)) as Combatant.Implementation[];
 		if (sourceCombatants.length !== sourceCombatantIds.length) return null;
 		if (
 			sourceCombatants.some(

--- a/src/documents/combat/combatantSystem.ts
+++ b/src/documents/combat/combatantSystem.ts
@@ -3,7 +3,7 @@ import type { CombatantBaseActions, NimbleCombatantSystem } from './combatTypes.
 function getCombatantSystem(combatant: Combatant.Implementation): NimbleCombatantSystem | null {
 	const system = combatant.system;
 	if (!system || typeof system !== 'object') return null;
-	return system as NimbleCombatantSystem;
+	return system as unknown as NimbleCombatantSystem;
 }
 
 function normalizeNonNegativeInteger(value: unknown): number {

--- a/src/documents/dialogs/ActorCreationDialog.svelte.ts
+++ b/src/documents/dialogs/ActorCreationDialog.svelte.ts
@@ -65,7 +65,7 @@ export default class ActorCreationDialog extends SvelteApplicationMixin(Applicat
 			const characterCreationDialog = new CharacterCreationDialog({}, { folder });
 			characterCreationDialog.render(true);
 		} else {
-			(documentClasses as Record<string, typeof Actor>)[actorType].create(
+			(documentClasses as unknown as Record<string, typeof Actor>)[actorType].create(
 				{ name: 'New Actor', type: actorType, ...this.data } as object as Actor.CreateData,
 				{ pack: this.pack, parent: this.parent, renderSheet: true } as object,
 			);

--- a/src/documents/dialogs/CharacterCreationDialog.test.ts
+++ b/src/documents/dialogs/CharacterCreationDialog.test.ts
@@ -72,7 +72,7 @@ function createItemDocument({
 		sheet: {
 			render: vi.fn(),
 		},
-	} as unknown as Item;
+	} as unknown as Item & { uuid: string };
 }
 
 describe('CharacterCreationDialog.submitCharacterCreation saving throw resolution', () => {

--- a/src/documents/item/ancestry.ts
+++ b/src/documents/item/ancestry.ts
@@ -2,7 +2,7 @@ import type { NimbleAncestryData } from '../../models/item/AncestryDataModel.js'
 
 import { NimbleBaseItem } from './base.svelte.js';
 
-export class NimbleAncestryItem extends NimbleBaseItem {
+export class NimbleAncestryItem extends NimbleBaseItem<'ancestry'> {
 	declare system: NimbleAncestryData;
 
 	override async prepareChatCardData() {
@@ -28,7 +28,7 @@ export class NimbleAncestryItem extends NimbleBaseItem {
 	override async _preCreate(
 		data: Item.CreateData,
 		options: Item.Database.PreCreateOptions,
-		user: User,
+		user: User.Stored,
 	) {
 		if (this.isEmbedded) {
 			const actor = this.parent;

--- a/src/documents/item/background.ts
+++ b/src/documents/item/background.ts
@@ -2,7 +2,7 @@ import type { NimbleBackgroundData } from '../../models/item/BackgroundDataModel
 
 import { NimbleBaseItem } from './base.svelte.js';
 
-export class NimbleBackgroundItem extends NimbleBaseItem {
+export class NimbleBackgroundItem extends NimbleBaseItem<'background'> {
 	declare system: NimbleBackgroundData;
 
 	override async prepareChatCardData() {
@@ -28,7 +28,7 @@ export class NimbleBackgroundItem extends NimbleBaseItem {
 	override async _preCreate(
 		data: Item.CreateData,
 		options: Item.Database.PreCreateOptions,
-		user: User,
+		user: User.Stored,
 	) {
 		if (this.isEmbedded) {
 			const actor = this.parent;

--- a/src/documents/item/base.svelte.ts
+++ b/src/documents/item/base.svelte.ts
@@ -25,7 +25,7 @@ interface BaseItemSystemData {
  * Override and extend the basic Item implementation.
  * @extends {Item}
  */
-class NimbleBaseItem<ItemType extends SystemItemTypes = SystemItemTypes> extends Item {
+class NimbleBaseItem<ItemType extends SystemItemTypes = SystemItemTypes> extends Item<ItemType> {
 	declare type: ItemType;
 
 	declare parent: NimbleBaseActor | null;
@@ -41,7 +41,7 @@ class NimbleBaseItem<ItemType extends SystemItemTypes = SystemItemTypes> extends
 
 	#subscribe: ReturnType<typeof createSubscriber>;
 
-	constructor(data: Item.CreateData, context?: Item.ConstructionContext) {
+	constructor(data: Item.CreateData<ItemType>, context?: Item.ConstructionContext) {
 		super(data, context);
 
 		this.#subscribe = createSubscriber((update) => {
@@ -312,7 +312,7 @@ class NimbleBaseItem<ItemType extends SystemItemTypes = SystemItemTypes> extends
 	protected override async _preUpdate(
 		changed: Record<string, unknown>,
 		options: Item.Database.UpdateOptions,
-		user: User.Implementation,
+		user: User.Stored,
 	): Promise<boolean | undefined> {
 		// Call preUpdate on all rules
 		if (this.rules) {
@@ -345,9 +345,9 @@ class NimbleBaseItem<ItemType extends SystemItemTypes = SystemItemTypes> extends
 	/** ------------------------------------------------------ */
 	/**                    Document CRUD                       */
 	/** ------------------------------------------------------ */
-	static override async createDocuments<Temporary extends boolean | undefined = undefined>(
+	static override async createDocuments(
 		data: Array<Item | Item.CreateData> | undefined,
-		operation?: Item.Database.CreateDocumentsOperation<Temporary>,
+		operation?: Item.Database.CreateDocumentsOperation,
 	): Promise<Item.Stored[]> {
 		if (!data) return [] as Item.Stored[];
 		const itemSources = data.map((d) => (d instanceof NimbleBaseItem ? d.toObject() : d)) as Array<

--- a/src/documents/item/boon.ts
+++ b/src/documents/item/boon.ts
@@ -2,7 +2,7 @@ import type { NimbleBoonData } from '../../models/item/BoonDataModel.js';
 
 import { NimbleBaseItem } from './base.svelte.js';
 
-export class NimbleBoonItem extends NimbleBaseItem {
+export class NimbleBoonItem extends NimbleBaseItem<'boon'> {
 	declare system: NimbleBoonData;
 
 	override async prepareChatCardData() {

--- a/src/documents/item/class.ts
+++ b/src/documents/item/class.ts
@@ -6,7 +6,7 @@ import type { NimbleClassData } from '../../models/item/ClassDataModel.js';
 import type { NimbleCharacter } from '../actor/character.js';
 import { NimbleBaseItem } from './base.svelte.js';
 
-export class NimbleClassItem extends NimbleBaseItem {
+export class NimbleClassItem extends NimbleBaseItem<'class'> {
 	declare ASI: Record<string, number>;
 
 	declare totalASI: Record<string, number>;
@@ -181,7 +181,7 @@ export class NimbleClassItem extends NimbleBaseItem {
 	override async _preUpdate(
 		changed: Record<string, unknown>,
 		options: Item.Database.UpdateOptions,
-		user: User.Implementation,
+		user: User.Stored,
 	): Promise<boolean | undefined> {
 		const result = await super._preUpdate(changed, options, user);
 

--- a/src/documents/item/feature.ts
+++ b/src/documents/item/feature.ts
@@ -2,7 +2,7 @@ import type { NimbleFeatureData } from '../../models/item/FeatureDataModel.js';
 
 import { NimbleBaseItem } from './base.svelte.js';
 
-export class NimbleFeatureItem extends NimbleBaseItem {
+export class NimbleFeatureItem extends NimbleBaseItem<'feature'> {
 	declare system: NimbleFeatureData;
 
 	override _populateBaseTags(): void {

--- a/src/documents/item/monsterFeature.ts
+++ b/src/documents/item/monsterFeature.ts
@@ -2,7 +2,7 @@ import type { NimbleMonsterFeatureData } from '../../models/item/MonsterFeatureD
 
 import { NimbleBaseItem } from './base.svelte.js';
 
-export class NimbleMonsterFeatureItem extends NimbleBaseItem {
+export class NimbleMonsterFeatureItem extends NimbleBaseItem<'monsterFeature'> {
 	declare system: NimbleMonsterFeatureData;
 
 	override async prepareChatCardData(_options) {

--- a/src/documents/item/object.ts
+++ b/src/documents/item/object.ts
@@ -26,7 +26,7 @@ function syncRuleSourcesToEquippedState(item: NimbleObjectItem): void {
 	} as Record<string, unknown>);
 }
 
-export class NimbleObjectItem extends NimbleBaseItem {
+export class NimbleObjectItem extends NimbleBaseItem<'object'> {
 	declare system: NimbleObjectData;
 
 	override _populateBaseTags(): void {
@@ -74,7 +74,7 @@ export class NimbleObjectItem extends NimbleBaseItem {
 	override async _preCreate(
 		data: Item.CreateData,
 		options: Item.Database.PreCreateOptions,
-		user: User,
+		user: User.Stored,
 	) {
 		// Update quantity if object already exists and is stackable or smallSized
 		const objectSizeTypesWithQuantity = new Set(['stackable', 'smallSized']);

--- a/src/documents/item/spell.ts
+++ b/src/documents/item/spell.ts
@@ -4,7 +4,7 @@ import { ItemActivationManager } from '../../managers/ItemActivationManager.js';
 import type { NimbleSpellData } from '../../models/item/SpellDataModel.js';
 import { NimbleBaseItem } from './base.svelte.js';
 
-export class NimbleSpellItem extends NimbleBaseItem {
+export class NimbleSpellItem extends NimbleBaseItem<'spell'> {
 	declare system: NimbleSpellData;
 
 	override _populateBaseTags() {

--- a/src/documents/item/subclass.ts
+++ b/src/documents/item/subclass.ts
@@ -1,13 +1,13 @@
 import {
-	ClassResourceManager,
 	type ClassResourceItem,
+	ClassResourceManager,
 } from '../../managers/ClassResourceManager.js';
 import type { NimbleSubclassData } from '../../models/item/SubclassDataModel.js';
 
 import { NimbleBaseItem } from './base.svelte.js';
 import type { NimbleClassItem } from './class.js';
 
-export class NimbleSubclassItem extends NimbleBaseItem {
+export class NimbleSubclassItem extends NimbleBaseItem<'subclass'> {
 	declare class: NimbleClassItem | null;
 
 	declare system: NimbleSubclassData;

--- a/src/documents/scene/scene.ts
+++ b/src/documents/scene/scene.ts
@@ -107,7 +107,7 @@ export class NimbleScene extends Scene {
 	protected override async _preCreate(
 		data: Scene.CreateData,
 		options: Scene.Database.PreCreateOptions,
-		user: User.Implementation,
+		user: User.Stored,
 		// biome-ignore lint/suspicious/noConfusingVoidType: Matching parent class signature
 	): Promise<boolean | void> {
 		if (!shouldConvertSceneFromFeetToSpaces(this)) {

--- a/src/documents/sheets/NPCSheet.svelte.ts
+++ b/src/documents/sheets/NPCSheet.svelte.ts
@@ -62,7 +62,16 @@ export default class NPCSheet extends SvelteApplicationMixin(
 	/**
 	 * Handle drop events on the NPC sheet
 	 */
-	async _onDropItem(event: DragEvent, data: Record<string, unknown>) {
+	// v14's ActorSheetV2 resolves the drop into an Item before calling
+	// `_onDropItem(event, item: Item)`. Nimble never uses that core dispatch: its Svelte sheet
+	// components (NPCCoreTab.svelte) call this method directly with raw drop *data*, so the override
+	// resolves the Item itself via fromDropData. The signature intentionally diverges from the base.
+	// @ts-expect-error TS2416: deliberate v13/v14 signature divergence (see comment above).
+	override async _onDropItem(
+		event: DragEvent,
+		dropArg: Record<string, unknown> | Item.Implementation,
+	) {
+		const data = dropArg as Record<string, unknown>;
 		event.preventDefault();
 		event.stopPropagation();
 

--- a/src/documents/sheets/PlayerCharacterSheet.svelte.ts
+++ b/src/documents/sheets/PlayerCharacterSheet.svelte.ts
@@ -91,7 +91,16 @@ export default class PlayerCharacterSheet extends SvelteApplicationMixin(
 	/**
 	 * Handle drop events on the character sheet
 	 */
-	async _onDropItem(event: DragEvent, data: Record<string, unknown>) {
+	// v14's ActorSheetV2 resolves the drop into an Item before calling
+	// `_onDropItem(event, item: Item)`. Nimble never uses that core dispatch: its Svelte sheet
+	// components (PlayerCharacterInventoryTab.svelte) call this method directly with raw drop *data*,
+	// so the override resolves the Item itself via fromDropData. The signature diverges from the base.
+	// @ts-expect-error TS2416: deliberate v13/v14 signature divergence (see comment above).
+	override async _onDropItem(
+		event: DragEvent,
+		dropArg: Record<string, unknown> | Item.Implementation,
+	) {
+		const data = dropArg as Record<string, unknown>;
 		event.preventDefault();
 		event.stopPropagation();
 

--- a/src/hooks/chargePoolTriggers/turnTrigger.ts
+++ b/src/hooks/chargePoolTriggers/turnTrigger.ts
@@ -11,8 +11,8 @@ export function registerTurnTriggerHooks(): void {
 		'combatTurn',
 		(
 			combat: Combat,
-			_updateData: { round: number; turn: number },
-			_updateOptions: { advanceTime: number; direction: number },
+			_updateData: { round?: number; turn?: number },
+			_updateOptions: { advanceTime?: number; direction?: number },
 		) => {
 			const combatant = combat.combatant;
 			if (!combatant || combatant.type !== 'character') return;

--- a/src/hooks/chargeSystem.test.ts
+++ b/src/hooks/chargeSystem.test.ts
@@ -87,10 +87,10 @@ describe('registerChargeSystemHooks encounter recovery hooks', () => {
 		).foundry = {
 			utils: {
 				getProperty,
-				hasProperty: (object: unknown, path: string) =>
+				hasProperty: ((object: unknown, path: string) =>
 					typeof object === 'object' && object !== null
 						? getProperty(object, path) !== undefined
-						: false,
+						: false) as unknown as typeof foundry.utils.hasProperty,
 			},
 		};
 		(globalThis as unknown as { game: { combat: Combat | null } }).game = {

--- a/src/hooks/combatantHooks/adjacencySync.ts
+++ b/src/hooks/combatantHooks/adjacencySync.ts
@@ -120,9 +120,10 @@ export default function registerAdjacencySync() {
 				foundry.utils.hasProperty(changes, 'x') || foundry.utils.hasProperty(changes, 'y');
 			if (!hasPos) return;
 			if (_tokenDoc.id) {
+				const changeData = changes as Record<string, unknown>;
 				pendingPositions.set(_tokenDoc.id, {
-					x: typeof changes.x === 'number' ? changes.x : _tokenDoc.x,
-					y: typeof changes.y === 'number' ? changes.y : _tokenDoc.y,
+					x: typeof changeData.x === 'number' ? changeData.x : _tokenDoc.x,
+					y: typeof changeData.y === 'number' ? changeData.y : _tokenDoc.y,
 				});
 			}
 			scheduleSync();

--- a/src/hooks/dicePoolTriggers/encounterEndTrigger.test.ts
+++ b/src/hooks/dicePoolTriggers/encounterEndTrigger.test.ts
@@ -50,10 +50,10 @@ describe('registerEncounterEndTriggerHooks', () => {
 		).foundry = {
 			utils: {
 				getProperty,
-				hasProperty: (object: unknown, path: string) =>
+				hasProperty: ((object: unknown, path: string) =>
 					typeof object === 'object' && object !== null
 						? getProperty(object, path) !== undefined
-						: false,
+						: false) as unknown as typeof foundry.utils.hasProperty,
 			},
 		};
 	});

--- a/src/hooks/init.ts
+++ b/src/hooks/init.ts
@@ -36,8 +36,10 @@ export default function init() {
 	CONFIG.NIMBLE = NIMBLE;
 	CONFIG.Actor.documentClass = ActorProxy as typeof CONFIG.Actor.documentClass;
 	CONFIG.Combat.documentClass = NimbleCombat as typeof CONFIG.Combat.documentClass;
-	CONFIG.Combatant.documentClass = NimbleCombatant as typeof CONFIG.Combatant.documentClass;
-	CONFIG.ChatMessage.documentClass = NimbleChatMessage as typeof CONFIG.ChatMessage.documentClass;
+	CONFIG.Combatant.documentClass =
+		NimbleCombatant as unknown as typeof CONFIG.Combatant.documentClass;
+	CONFIG.ChatMessage.documentClass =
+		NimbleChatMessage as unknown as typeof CONFIG.ChatMessage.documentClass;
 	CONFIG.Item.documentClass = ItemProxy as typeof CONFIG.Item.documentClass;
 	CONFIG.Scene.documentClass = NimbleScene as typeof CONFIG.Scene.documentClass;
 	CONFIG.Token.documentClass = NimbleTokenDocument as typeof CONFIG.Token.documentClass;

--- a/src/import/nimbleNexus/NimbleNexusParser.ts
+++ b/src/import/nimbleNexus/NimbleNexusParser.ts
@@ -556,7 +556,7 @@ export async function importMonster(
 
 		// Set folder if provided
 		if (options.folderId) {
-			(actorData as Record<string, unknown>).folder = options.folderId;
+			(actorData as unknown as Record<string, unknown>).folder = options.folderId;
 		}
 
 		const actor = await Actor.create(actorData);

--- a/src/macros/activateHeroicActionMacro.ts
+++ b/src/macros/activateHeroicActionMacro.ts
@@ -323,7 +323,7 @@ async function executeChatReaction(
 	const reactionName = localize(config.localizationKey);
 	if (!(await resolveAndUseReaction(actor, config.reactionKeys, reactionName))) return;
 
-	const targetUuids = getTargetedTokens(actor.id ?? '').map((t) => t.document.uuid);
+	const targetUuids = getTargetedTokens(actor.id ?? '').map((t) => t.document.uuid ?? '');
 
 	for (const msg of config.messages) {
 		await ChatMessage.create(
@@ -461,7 +461,7 @@ async function executeUnarmedStrike(actor: NimbleCharacter): Promise<void> {
 		},
 	];
 
-	const targetUuids = getTargetedTokens(actor.id ?? '').map((t) => t.document.uuid);
+	const targetUuids = getTargetedTokens(actor.id ?? '').map((t) => t.document.uuid ?? '');
 
 	const chatData = {
 		author: game.user?.id,

--- a/src/models/actor/actorDataModels.ts
+++ b/src/models/actor/actorDataModels.ts
@@ -1,6 +1,6 @@
 import { NimbleCharacterData } from './CharacterDataModel.js';
-import { NimbleNPCData } from './NPCDataModel.js';
 import { NimbleMinionData } from './MinionDataModel.js';
+import { NimbleNPCData } from './NPCDataModel.js';
 import { NimbleSoloMonsterData } from './SoloMonsterDataModel.js';
 
 const actorDataModels = {
@@ -16,9 +16,10 @@ export default actorDataModels;
 declare global {
 	interface DataModelConfig {
 		Actor: {
-			character: NimbleCharacterData;
-			npc: NimbleNPCData;
-			soloMonster: NimbleSoloMonsterData;
+			character: typeof NimbleCharacterData;
+			npc: typeof NimbleNPCData;
+			minion: typeof NimbleMinionData;
+			soloMonster: typeof NimbleSoloMonsterData;
 		};
 	}
 }

--- a/src/models/fields/RecordField.ts
+++ b/src/models/fields/RecordField.ts
@@ -163,9 +163,7 @@ class RecordField<
 		options: foundry.data.fields.DataField.ValidationOptions & { partial?: boolean } = {},
 	): void {
 		if (!(values instanceof Object)) {
-			throw new foundry.data.validation.DataModelValidationFailure({
-				message: 'must be an Object',
-			});
+			throw new foundry.data.validation.DataModelValidationFailure('must be an Object');
 		}
 
 		const failure = this._validateValues(

--- a/src/models/item/itemDataModels.ts
+++ b/src/models/item/itemDataModels.ts
@@ -1,10 +1,10 @@
+import { NimbleAncestryData } from './AncestryDataModel.js';
 import { NimbleBackgroundData } from './BackgroundDataModel.js';
 import { NimbleBoonData } from './BoonDataModel.js';
 import { NimbleClassData } from './ClassDataModel.js';
 import { NimbleFeatureData } from './FeatureDataModel.js';
 import { NimbleMonsterFeatureData } from './MonsterFeatureDataModel.js';
 import { NimbleObjectData } from './ObjectDataModel.js';
-import { NimbleAncestryData } from './AncestryDataModel.js';
 import { NimbleSpellData } from './SpellDataModel.js';
 import { NimbleSubclassData } from './SubclassDataModel.js';
 
@@ -26,15 +26,15 @@ export default itemDataModels;
 declare global {
 	interface DataModelConfig {
 		Item: {
-			background: NimbleBackgroundData;
-			boon: NimbleBoonData;
-			class: NimbleClassData;
-			feature: NimbleFeatureData;
-			monsterFeature: NimbleMonsterFeatureData;
-			object: NimbleObjectData;
-			ancestry: NimbleAncestryData;
-			spell: NimbleSpellData;
-			subclass: NimbleSubclassData;
+			background: typeof NimbleBackgroundData;
+			boon: typeof NimbleBoonData;
+			class: typeof NimbleClassData;
+			feature: typeof NimbleFeatureData;
+			monsterFeature: typeof NimbleMonsterFeatureData;
+			object: typeof NimbleObjectData;
+			ancestry: typeof NimbleAncestryData;
+			spell: typeof NimbleSpellData;
+			subclass: typeof NimbleSubclassData;
 		};
 	}
 }

--- a/src/pixi/NimbleTokenHUD.ts
+++ b/src/pixi/NimbleTokenHUD.ts
@@ -3,7 +3,7 @@ import { unmount } from 'svelte';
 export class NimbleTokenHUD extends foundry.applications.hud.TokenHUD {
 	declare _svelteComponent: object | null;
 
-	clear() {
+	override clear() {
 		const baseClass = Object.getPrototypeOf(Object.getPrototypeOf(this));
 		if (baseClass.clear) baseClass.clear.call(this);
 

--- a/src/utils/buildSubclassFeatureIndex.ts
+++ b/src/utils/buildSubclassFeatureIndex.ts
@@ -55,10 +55,9 @@ export default async function buildSubclassFeatureIndex(): Promise<SubclassFeatu
 
 	for (const pack of game.packs) {
 		if (pack.documentName !== 'Item') continue;
-		// @ts-expect-error - Foundry types don't include custom index fields, but the API accepts them
 		const packIndex = await pack.getIndex({ fields: FEATURE_INDEX_FIELDS as unknown as string[] });
 		for (const indexEntry of packIndex) {
-			const packEntry = indexEntry as FeaturePackEntry;
+			const packEntry = indexEntry as unknown as FeaturePackEntry;
 			if (packEntry.type !== 'feature') continue;
 			indexFeature(index, packEntry.uuid, packEntry.system);
 		}

--- a/src/utils/getClassFeatures.ts
+++ b/src/utils/getClassFeatures.ts
@@ -136,7 +136,8 @@ export async function buildClassFeatureIndex(): Promise<ClassFeatureIndex> {
 	for (const item of game.items) {
 		if (item.type !== 'feature') continue;
 		const featureItem = item as NimbleFeatureItem;
-		processFeature(featureItem.uuid, featureItem.system);
+		// World items are stored, so `uuid` is always present.
+		processFeature(featureItem.uuid ?? '', featureItem.system);
 	}
 
 	// Process compendium packs
@@ -152,7 +153,6 @@ export async function buildClassFeatureIndex(): Promise<ClassFeatureIndex> {
 	for (const pack of game.packs) {
 		if (pack.documentName !== 'Item') continue;
 
-		// @ts-expect-error - Foundry types don't include custom index fields, but the API accepts them
 		const packIndex = await pack.getIndex({ fields: indexFields });
 		for (const indexEntry of packIndex) {
 			const packEntry = indexEntry as FeatureIndexEntry;

--- a/src/utils/getEpicBoons.ts
+++ b/src/utils/getEpicBoons.ts
@@ -49,7 +49,7 @@ export default async function getEpicBoons(): Promise<EpicBoonChoice[]> {
 				if (boon.system.boonType !== 'epic') continue;
 
 				epicBoons.push({
-					uuid: boon.uuid,
+					uuid: boon.uuid ?? '',
 					name: boon.name,
 					img: (boon.img as string) ?? 'icons/svg/item-bag.svg',
 					system: {

--- a/src/utils/getSpells.ts
+++ b/src/utils/getSpells.ts
@@ -129,7 +129,6 @@ export async function buildSpellIndex(): Promise<SpellIndex> {
 	for (const pack of game.packs) {
 		if (pack.documentName !== 'Item') continue;
 
-		// @ts-expect-error - Foundry types don't include custom index fields, but the API accepts them
 		const packIndex = await pack.getIndex({ fields: indexFields });
 		for (const indexEntry of packIndex) {
 			const packEntry = indexEntry as SpellPackIndexEntry;

--- a/src/view/chat/ReactionCardState.svelte.ts
+++ b/src/view/chat/ReactionCardState.svelte.ts
@@ -22,7 +22,7 @@ export function createReactionCardState(
 	getMessageDocument: () => ReactionCardProps['messageDocument'],
 ) {
 	const system = $derived(getMessageDocument().reactive.system as unknown as ReactionSystemData);
-	const headerBackgroundColor = $derived(getMessageDocument().reactive.author.color);
+	const headerBackgroundColor = $derived(getMessageDocument().reactive.author?.color);
 	const headerTextColor = $derived(calculateHeaderTextColor(headerBackgroundColor));
 
 	const reactionType = $derived(system.reactionType);

--- a/src/view/components/ExpandableDocumentList.svelte.ts
+++ b/src/view/components/ExpandableDocumentList.svelte.ts
@@ -25,7 +25,6 @@ export function createExpandableDocumentListState(
 			expandedDataMap = new Map(expandedDataMap);
 		} else {
 			try {
-				// @ts-expect-error — Foundry's fromUuid accepts any string at runtime
 				const data = await fromUuid(uuid);
 				expandedUuids.add(uuid);
 				expandedUuids = new Set(expandedUuids);

--- a/src/view/dialogs/AssessActionDialog.svelte.ts
+++ b/src/view/dialogs/AssessActionDialog.svelte.ts
@@ -137,7 +137,7 @@ export function createAssessDialogState(
 			option: selectedOption,
 			skill: selectedSkill,
 			isSuccess,
-			target: selectedTarget?.document.uuid,
+			target: selectedTarget?.document.uuid ?? undefined,
 		});
 	}
 

--- a/src/view/dialogs/CharacterLevelUpDialogState.svelte.ts
+++ b/src/view/dialogs/CharacterLevelUpDialogState.svelte.ts
@@ -195,7 +195,7 @@ export function createLevelUpState(
 				// Subclass features are resolved separately, so filter already-owned
 				// entries here before merging them into the current level grants.
 				const filteredAutoGrant = [...rawFeatures.autoGrant, ...subclassFeatures].filter(
-					(feature) => !ownedFeatureUuids.has(feature.uuid),
+					(feature) => !ownedFeatureUuids.has(feature.uuid ?? ''),
 				);
 
 				classFeatures = {

--- a/src/view/dialogs/characterCreation/state.svelte.ts
+++ b/src/view/dialogs/characterCreation/state.svelte.ts
@@ -696,7 +696,7 @@ export function createCharacterCreationState(params: CharacterCreationStateParam
 	function submit() {
 		// Prepare class features data
 		const classFeatureData = {
-			autoGrant: classFeatures?.autoGrant?.map((f) => f.uuid) ?? [],
+			autoGrant: classFeatures?.autoGrant?.map((f) => f.uuid ?? '') ?? [],
 			selected: selectedClassFeatures,
 		};
 

--- a/src/view/sheets/components/ClassProgressionLevelRow.state.svelte.ts
+++ b/src/view/sheets/components/ClassProgressionLevelRow.state.svelte.ts
@@ -55,7 +55,7 @@ export function createClassProgressionLevelRowState(getProps: () => ClassProgres
 						feature.system?.gainedAtLevel ?? level,
 					);
 					if (!raw) return;
-					result.set(feature.uuid, await TextEditor.enrichHTML(raw));
+					result.set(feature.uuid ?? '', await TextEditor.enrichHTML(raw));
 				}),
 			);
 			if (!cancelled) levelDescriptions = result;
@@ -80,7 +80,7 @@ export function createClassProgressionLevelRowState(getProps: () => ClassProgres
 
 	function handleDeleteWorldItem(event: MouseEvent, feature: NimbleFeatureItem): void {
 		event.stopPropagation();
-		getProps().onDeleteWorldItem(feature.uuid, feature.name);
+		getProps().onDeleteWorldItem(feature.uuid ?? '', feature.name);
 	}
 
 	function handleAddFeature(event: MouseEvent): void {

--- a/src/view/sheets/pages/ClassProgressionTab.state.svelte.ts
+++ b/src/view/sheets/pages/ClassProgressionTab.state.svelte.ts
@@ -29,7 +29,7 @@ export function createClassProgressionTabState(getItem: () => NimbleClassItem) {
 	let enrichedFeatureDescriptions = $state<Map<string, string>>(new Map());
 
 	const identifier = $derived(getItem().reactive.system.identifier);
-	const classSource = $derived(getItemSource(getItem().uuid));
+	const classSource = $derived(getItemSource(getItem().uuid ?? ''));
 	const groupIdentifiers = $derived(getItem().reactive.system.groupIdentifiers || []);
 	const abilityScoreData = $derived(getItem().reactive.system.abilityScoreData);
 	const keyAbilityScores = $derived(getItem().reactive.system.keyAbilityScores || []);
@@ -133,7 +133,7 @@ export function createClassProgressionTabState(getItem: () => NimbleClassItem) {
 				featuresToEnrich.map(async (feature) => {
 					const desc = feature.system?.description ?? '';
 					if (!desc) return;
-					result.set(feature.uuid, await TextEditor.enrichHTML(desc));
+					result.set(feature.uuid ?? '', await TextEditor.enrichHTML(desc));
 				}),
 			);
 			if (!cancelled) enrichedFeatureDescriptions = result;
@@ -176,7 +176,6 @@ export function createClassProgressionTabState(getItem: () => NimbleClassItem) {
 	}
 
 	function handleSubclassClick(uuid: string): void {
-		// @ts-expect-error — Foundry's fromUuid accepts any string at runtime
 		fromUuid(uuid).then((subclass) => {
 			if (subclass) {
 				(subclass as Item).sheet?.render(true);

--- a/src/view/ui/CtTopTracker.state.svelte.ts
+++ b/src/view/ui/CtTopTracker.state.svelte.ts
@@ -1043,7 +1043,7 @@ export function createCtTopTrackerState() {
 
 		const sourceCombatants = activeDragSourceCombatantIds
 			.map((combatantId) => currentCombat.combatants.get(combatantId) ?? null)
-			.filter((combatant): combatant is Combatant.Implementation => Boolean(combatant));
+			.filter((combatant) => Boolean(combatant)) as Combatant.Implementation[];
 		if (sourceCombatants.length !== activeDragSourceCombatantIds.length) return null;
 		if (sourceCombatants.some((combatant) => combatant.parent?.id !== currentCombat.id))
 			return null;
@@ -1111,7 +1111,7 @@ export function createCtTopTrackerState() {
 
 		const sourceDocuments = sourceCombatantIds
 			.map((combatantId) => combat.combatants.get(combatantId) ?? null)
-			.filter((combatant): combatant is Combatant.Implementation => Boolean(combatant));
+			.filter((combatant) => Boolean(combatant)) as Combatant.Implementation[];
 		if (sourceDocuments.length !== sourceCombatantIds.length) {
 			event.preventDefault();
 			return;


### PR DESCRIPTION
## Summary

Makes the system type-compatible with the Foundry v14 fvtt-types fork while keeping v13 runtime compatibility, so the same build loads on both generations.

## Changes

- Bump `fvtt-types` to the v14.363 fork and drive `tsc` from 166 errors to 0.
- Register DataModel **constructors** (not instances) in `DataModelConfig.Actor`/`.Item` so v14's `SystemOfType` resolution works; add the missing `minion` registration.
- Thread the subtype generic through the `NimbleBaseActor`/`NimbleBaseItem` base classes so `system` types resolve per subtype.
- Mechanical v14 type fixes: nullable document `id` handling, `User.Stored` param types on `_pre*` overrides, document-union to Nimble-subclass casts, filter-predicate narrowing, and `override` modifiers.
- `public/system.json` compatibility set to `minimum: 13`, `verified: 14` (no `maximum`).

## Test Plan

1. Check out the branch and run `pnpm check` (type-check is green; lint/tests run here).
2. Build and load the system in a **Foundry v13** world: open a character, NPC, and item sheet; drag-drop an item onto a character sheet; roll an attack; apply/remove a condition. Confirm no console errors and no behavior change.
3. Repeat step 2 in a **Foundry v14** world (the real validation, since type-clean is not the same as verified-working). Pay attention to sheet drops (the `_onDropItem` path) and condition toggling.
4. Confirm compendium packs still import correctly in a v14 world (the build pipeline is unchanged, but pack loading is the thing to eyeball).

## Checklist

- [ ] Added or updated unit tests
- [x] PR targets the `dev` branch
- [ ] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [ ] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** yes
- [ ] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

## Notes for reviewer

- The fixes are type-only and inert at runtime; no version-gating code was added. Verified that the two flagged v14 divergences are non-issues here: ActiveEffect `changes`/`mode` reshape does not apply (conditions use `statuses` + a custom system model), and `MeasuredTemplate` is still present in 14.363.
- Two intentional `@ts-expect-error TS2416` remain on `_onDropItem` in the player/NPC sheets: v14's `ActorSheetV2._onDrop` resolves the drop to an `Item` then calls `_onDropItem(event, item)`, but Nimble's Svelte components call `_onDropItem(event, dropData)` directly with raw data and never use the core dispatch. Documented inline.
- The "Added/updated unit tests" and "tested in Foundry" boxes are left unchecked deliberately: this needs a live smoke test on both v13 and v14 before merge.
