### PR TITLE
fix(armor): AC not updating on item change; fix Iron Defense level 13

### DIFF
--- a/packs/ancestries/core/exotic/turtlefolk.json
+++ b/packs/ancestries/core/exotic/turtlefolk.json
@@ -14,13 +14,18 @@
 				"label": "Slow & Steady",
 				"predicate": {},
 				"priority": 1,
-				"formula": "+4",
+				"formula": "4",
 				"mode": "add"
 			},
 			{
 				"type": "speedBonus",
-				"value": "-2",
-				"label": "Slow & Steady"
+				"disabled": false,
+				"id": "Xk9mNpQ2rLsYvWtH",
+				"identifier": "",
+				"label": "Slow & Steady",
+				"predicate": {},
+				"priority": 1,
+				"value": "-2"
 			}
 		],
 		"description": "<p>Turtlefolk take their time in everything they do; they are patient, sturdy, and slow to anger. They rely on their thick shells for protection, making them difficult to harm, but their cautious movements come at the cost of speed.</p><hr><p><strong>Slow & Steady</strong></p><p>+4 Armor [A]</p><p>–2 speed [M]</p>",

--- a/packs/classFeatures/core/zephyr/zephyr-progression/iron-defense.json
+++ b/packs/classFeatures/core/zephyr/zephyr-progression/iron-defense.json
@@ -20,9 +20,10 @@
 			{
 				"id": "iron-defense-l13",
 				"type": "armorClass",
-				"mode": "multiply",
-				"formula": "2",
+				"mode": "override",
+				"formula": "(@dexterity + @strength) * 2",
 				"label": "Iron Defense (2)",
+				"priority": 2,
 				"predicate": {
 					"armor": "unarmored",
 					"level": {

--- a/packs/magicItems/core/coreRules/resolute-fangs-golden-bastion.json
+++ b/packs/magicItems/core/coreRules/resolute-fangs-golden-bastion.json
@@ -15,7 +15,7 @@
 				"label": "Resolute fangs",
 				"predicate": {},
 				"priority": 1,
-				"formula": "+8",
+				"formula": "8",
 				"mode": "add"
 			}
 		],

--- a/src/documents/actor/base.svelte.ts
+++ b/src/documents/actor/base.svelte.ts
@@ -202,8 +202,6 @@ class NimbleBaseActor<ActorType extends SystemActorTypes = SystemActorTypes> ext
 	}
 
 	override prepareData(): void {
-		if (this.initialized) return;
-
 		this.initialized = true;
 		super.prepareData();
 

--- a/src/documents/actor/character.ts
+++ b/src/documents/actor/character.ts
@@ -171,6 +171,10 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 	}
 
 	override prepareDerivedData(): void {
+		// Reset armor components so afterPrepareData() rules always start from a clean slate.
+		// Without this, removing an ancestry then re-adding it leaves stale entries in the array.
+		this.system.attributes.armor.components = [];
+
 		super.prepareDerivedData();
 
 		// Setup Managers - cast to NimbleCharacterInterface to satisfy type requirements


### PR DESCRIPTION
## Summary

- **`NimbleBaseActor.prepareData()`**: Remove the `initialized` guard that was short-circuiting every call after the first `_initialize()`. Foundry v13 calls `prepareData()` directly (not via `_initialize()`) after embedded items are created/deleted, so the guard prevented `afterPrepareData()` from ever re-running — leaving `armorClass` components stale and AC frozen at its initial value.
- **`NimbleCharacter.prepareDerivedData()`**: Reset `armor.components = []` at the top of each cycle so `afterPrepareData()` rules always push into a clean array rather than accumulating stale entries from the previous run.
- **Iron Defense level 13**: The level 13 rule used `mode: "multiply"` which, in `_prepareArmorClass()`, sorts *before* the level 1 `mode: "override"` and gets completely overwritten by it — dead code. Changed to `mode: "override"` with `formula: "(@dexterity + @strength) * 2"` and `priority: 2` so it runs after the level 1 rule and produces the correct doubled value.
- **Pack data cleanup**: Normalize `armorClass` formula strings — strip leading `+` from `"+4"` / `"+8"` values in turtlefolk and resolute-fangs-golden-bastion.

## Test plan

- [ ] Add Dragonborn ancestry to a character — AC increases by 1
- [ ] Remove Dragonborn ancestry — AC decreases by 1
- [ ] Re-add Dragonborn ancestry — AC increases by 1 again
- [ ] Zephyr with Iron Defense (unarmored, level 1–12): AC = DEX + STR
- [ ] Zephyr with Iron Defense (unarmored, level 13+): AC = (DEX + STR) × 2
- [ ] Zephyr with Iron Defense wearing armor: Iron Defense predicate does not fire, AC from armor applies normally
- [ ] All 1091 existing tests pass (`pnpm check`)