### PR TITLE
fix(monsters): correct Giant Spider Bite damage to 2d8+4

### DIFF
--- a/packs/monsters/core/underground/giant-spider.json
+++ b/packs/monsters/core/underground/giant-spider.json
@@ -249,7 +249,7 @@
 							"id": "hOvBWCvldkhCdAu1",
 							"type": "damage",
 							"damageType": "poison",
-							"formula": "1d8+2",
+							"formula": "2d8+4",
 							"parentContext": null,
 							"parentNode": null,
 							"canCrit": true,


### PR DESCRIPTION
## Summary

- Corrects Giant Spider Bite damage formula from `1d8+2` to `2d8+4` per the GMG

## Test plan

- [ ] Load the Giant Spider in Foundry and verify Bite rolls `2d8+4` poison damage