### PR TITLE
fix(ui): swap Yes/No button order in confirmation dialogs to match Foundry default

### DIFF
--- a/src/view/sheets/components/ActionTracker.svelte.ts
+++ b/src/view/sheets/components/ActionTracker.svelte.ts
@@ -184,15 +184,15 @@ export function createActionTrackerState(getActor: () => NimbleCharacter) {
 			rejectClose: false,
 			buttons: [
 				{
-					action: 'no',
-					icon: 'fa-solid fa-xmark',
-					label: localize('No'),
-				},
-				{
 					action: 'yes',
 					icon: 'fa-solid fa-check',
 					label: localize('Yes'),
 					default: true,
+				},
+				{
+					action: 'no',
+					icon: 'fa-solid fa-xmark',
+					label: localize('No'),
 				},
 			],
 		});

--- a/src/view/ui/CtTopTracker.state.svelte.ts
+++ b/src/view/ui/CtTopTracker.state.svelte.ts
@@ -249,15 +249,15 @@ export function createCtTopTrackerState() {
 			rejectClose: false,
 			buttons: [
 				{
-					action: 'no',
-					icon: 'fa-solid fa-xmark',
-					label: noLabel,
-				},
-				{
 					action: 'yes',
 					icon: 'fa-solid fa-check',
 					label: yesLabel,
 					default: true,
+				},
+				{
+					action: 'no',
+					icon: 'fa-solid fa-xmark',
+					label: noLabel,
 				},
 			],
 		});
@@ -281,15 +281,15 @@ export function createCtTopTrackerState() {
 			rejectClose: false,
 			buttons: [
 				{
-					action: 'no',
-					icon: 'fa-solid fa-xmark',
-					label: localize('No'),
-				},
-				{
 					action: 'yes',
 					icon: 'fa-solid fa-check',
 					label: localize('Yes'),
 					default: true,
+				},
+				{
+					action: 'no',
+					icon: 'fa-solid fa-xmark',
+					label: localize('No'),
 				},
 			],
 		});


### PR DESCRIPTION
## Summary

- `CtTopTracker.state.svelte.ts`: swapped button order in `confirmEndEncounter()` ("End Encounter?") and `confirmEndTurnEarly()` so Yes appears left, No appears right
- `ActionTracker.svelte.ts`: same fix for the duplicate `confirmEndTurnEarly()` there

All three dialogs were rendering No on the left and Yes on the right — the opposite of Foundry's `DialogV2.confirm()` default, causing users to hit the wrong button.

## Test plan

- [ ] Open an encounter and click End Combat — verify Yes is on the left
- [ ] End a turn early with actions remaining — verify Yes is on the left
- [ ] Dismiss both dialogs with No — verify combat/turn is not affected