### PR TITLE
fix(npc-sheet): restore scroll on monster conditions tab

### DIFF
--- a/src/view/sheets/pages/NPCConditionsTab.svelte
+++ b/src/view/sheets/pages/NPCConditionsTab.svelte
@@ -5,6 +5,6 @@
 	let actor = getContext('actor');
 </script>
 
-<section class="nimble-sheet__body">
+<section class="nimble-sheet__body nimble-sheet__body--player-character">
 	<ActorConditionsList {actor} mode="sheet" allowRemove={true} />
 </section>


### PR DESCRIPTION
## Summary

- The compendium-sheets CSS sets `overflow: hidden` on all `.nimble-sheet__body` elements so prose-mirror editors can fill available height correctly
- It re-enables scrolling for `--npc`, `--item`, and nested `--player-character` body variants — but `NPCConditionsTab` used a plain `.nimble-sheet__body` with no modifier, leaving it locked
- `PlayerCharacterConditionsTab` already used `nimble-sheet__body--player-character` (which has `overflow-y: auto !important`), so it was unaffected
- Fix: add `nimble-sheet__body--player-character` to the NPC conditions tab body, matching the PC tab

## Test plan

- [ ] Open an NPC sheet and navigate to the Conditions tab — conditions list should now scroll when content overflows
- [ ] Open a PC sheet Conditions tab — scrolling still works
- [ ] Open an NPC sheet Core tab — features list still scrolls normally
- [ ] All 1442 unit tests pass (`pnpm check`)