### PR TITLE
chore(compendia): add per-group sub-folders and subclass folder wrappers

### DIFF
--- a/build/lib/Pack.mjs
+++ b/build/lib/Pack.mjs
@@ -22,6 +22,8 @@ export default class Pack {
 		['the-cheat', 1],
 	]);
 
+	static #GROUP_FOLDER_DISPLAY_NAME = new Map([['commanders-orders', "Commander's Orders"]]);
+
 	constructor(dirName, data) {
 		const metadata = Pack.#packsMetadata.find(
 			(p) => path.basename(p.path).split('.')[0] === path.basename(dirName),
@@ -253,16 +255,31 @@ export default class Pack {
 				classData = {
 					name: className,
 					progressionName: `${className} Progression`,
+					subclassesName: `${className} Subclasses`,
 					subclasses: new Map(),
+					abilityGroups: new Map(),
 				};
 				classFolderData.set(classId, classData);
 			}
 
 			const subclassId = this.#getSubclassId(file, source);
-			if (!subclassId) continue;
+			if (subclassId) {
+				const subclassName = this.#getSubclassFolderName(file, source, subclassId);
+				if (!classData.subclasses.has(subclassId))
+					classData.subclasses.set(subclassId, subclassName);
+				continue;
+			}
 
-			const subclassName = this.#getSubclassFolderName(file, source, subclassId);
-			if (!classData.subclasses.has(subclassId)) classData.subclasses.set(subclassId, subclassName);
+			const groupName = source?.system?.group;
+			if (
+				groupName &&
+				!groupName.endsWith('-progression') &&
+				!classData.abilityGroups.has(groupName)
+			) {
+				const displayName =
+					Pack.#GROUP_FOLDER_DISPLAY_NAME.get(groupName) ?? this.#toDisplayClassName(groupName);
+				classData.abilityGroups.set(groupName, displayName);
+			}
 		}
 
 		const folders = [];
@@ -309,6 +326,22 @@ export default class Pack {
 				type: this.documentType,
 			});
 
+			const subclassesFolderId = Pack.#folderIdForSubclassesId(classId);
+			if (classData.subclasses.size > 0) {
+				folders.push({
+					_id: subclassesFolderId,
+					_stats: { ...statsTemplate },
+					color: null,
+					description: '',
+					flags: {},
+					folder: classFolderId,
+					name: classData.subclassesName,
+					sort: 10,
+					sorting: 'm',
+					type: this.documentType,
+				});
+			}
+
 			const subclassFolderLookup = new Map();
 			const sortedSubclasses = [...classData.subclasses.entries()].sort(([, aName], [, bName]) =>
 				aName.localeCompare(bName, undefined, { sensitivity: 'base' }),
@@ -324,10 +357,33 @@ export default class Pack {
 					color: null,
 					description: '',
 					flags: {},
-					folder: classFolderId,
+					folder: subclassesFolderId,
 					name: subclassName,
-					sort: (subclassIndex + 1) * 10,
+					sort: subclassIndex * 10,
 					sorting: 'm',
+					type: this.documentType,
+				});
+			});
+
+			const groupFolderLookup = new Map();
+			const sortedGroups = [...classData.abilityGroups.entries()].sort(([, aName], [, bName]) =>
+				aName.localeCompare(bName, undefined, { sensitivity: 'base' }),
+			);
+
+			sortedGroups.forEach(([groupName, groupDisplayName], groupIndex) => {
+				const groupFolderId = Pack.#folderIdForGroupId(classId, groupName);
+				groupFolderLookup.set(groupName, groupFolderId);
+
+				folders.push({
+					_id: groupFolderId,
+					_stats: { ...statsTemplate },
+					color: null,
+					description: '',
+					flags: {},
+					folder: progressionFolderId,
+					name: groupDisplayName,
+					sort: groupIndex * 10,
+					sorting: 'a',
 					type: this.documentType,
 				});
 			});
@@ -336,6 +392,7 @@ export default class Pack {
 				classFolderId,
 				progressionFolderId,
 				subclassFolderLookup,
+				groupFolderLookup,
 			});
 		});
 
@@ -352,6 +409,12 @@ export default class Pack {
 			const subclassId = this.#getSubclassId(file, source);
 			if (subclassId && classFolders.subclassFolderLookup.has(subclassId)) {
 				folderAssignments.set(source._id, classFolders.subclassFolderLookup.get(subclassId));
+				continue;
+			}
+
+			const groupName = source?.system?.group;
+			if (groupName && classFolders.groupFolderLookup.has(groupName)) {
+				folderAssignments.set(source._id, classFolders.groupFolderLookup.get(groupName));
 				continue;
 			}
 
@@ -628,5 +691,13 @@ export default class Pack {
 
 	static #folderIdForProgressionId(classId) {
 		return Pack.#folderIdForDocument(`nimble-class-features-${classId}-progression`);
+	}
+
+	static #folderIdForSubclassesId(classId) {
+		return Pack.#folderIdForDocument(`nimble-class-features-${classId}-subclasses`);
+	}
+
+	static #folderIdForGroupId(classId, groupName) {
+		return Pack.#folderIdForDocument(`nimble-class-features-${classId}-group-${groupName}`);
 	}
 }

--- a/build/lib/Pack.mjs
+++ b/build/lib/Pack.mjs
@@ -22,8 +22,6 @@ export default class Pack {
 		['the-cheat', 1],
 	]);
 
-	static #GROUP_FOLDER_DISPLAY_NAME = new Map([['commanders-orders', "Commander's Orders"]]);
-
 	constructor(dirName, data) {
 		const metadata = Pack.#packsMetadata.find(
 			(p) => path.basename(p.path).split('.')[0] === path.basename(dirName),
@@ -277,7 +275,8 @@ export default class Pack {
 				!classData.abilityGroups.has(groupName)
 			) {
 				const displayName =
-					Pack.#GROUP_FOLDER_DISPLAY_NAME.get(groupName) ?? this.#toDisplayClassName(groupName);
+					(typeof source?.system?.groupLabel === 'string' && source.system.groupLabel) ||
+					this.#toDisplayClassName(groupName);
 				classData.abilityGroups.set(groupName, displayName);
 			}
 		}

--- a/packs/classFeatures/core/berserker/savage-arsenal/death-blow.json
+++ b/packs/classFeatures/core/berserker/savage-arsenal/death-blow.json
@@ -1,5 +1,5 @@
 {
-	"folder": "d40bf36abe9f4b0a",
+	"folder": "c9f719f21d801dd3",
 	"name": "Death Blow",
 	"type": "feature",
 	"img": "icons/weapons/axes/axe-double-short-orange.webp",

--- a/packs/classFeatures/core/berserker/savage-arsenal/deathless-rage.json
+++ b/packs/classFeatures/core/berserker/savage-arsenal/deathless-rage.json
@@ -1,5 +1,5 @@
 {
-	"folder": "d40bf36abe9f4b0a",
+	"folder": "c9f719f21d801dd3",
 	"name": "Deathless Rage",
 	"type": "feature",
 	"img": "icons/weapons/axes/axe-double-short-orange.webp",

--- a/packs/classFeatures/core/berserker/savage-arsenal/eager-for-battle.json
+++ b/packs/classFeatures/core/berserker/savage-arsenal/eager-for-battle.json
@@ -1,5 +1,5 @@
 {
-	"folder": "d40bf36abe9f4b0a",
+	"folder": "c9f719f21d801dd3",
 	"name": "Eager for Battle",
 	"type": "feature",
 	"img": "icons/weapons/axes/axe-double-short-orange.webp",

--- a/packs/classFeatures/core/berserker/savage-arsenal/into-the-fray.json
+++ b/packs/classFeatures/core/berserker/savage-arsenal/into-the-fray.json
@@ -1,5 +1,5 @@
 {
-	"folder": "d40bf36abe9f4b0a",
+	"folder": "c9f719f21d801dd3",
 	"name": "Into the Fray",
 	"type": "feature",
 	"img": "icons/weapons/axes/axe-double-short-orange.webp",

--- a/packs/classFeatures/core/berserker/savage-arsenal/mighty-endurance.json
+++ b/packs/classFeatures/core/berserker/savage-arsenal/mighty-endurance.json
@@ -1,5 +1,5 @@
 {
-	"folder": "d40bf36abe9f4b0a",
+	"folder": "c9f719f21d801dd3",
 	"name": "Mighty Endurance",
 	"type": "feature",
 	"img": "icons/weapons/axes/axe-double-short-orange.webp",

--- a/packs/classFeatures/core/berserker/savage-arsenal/more-blood.json
+++ b/packs/classFeatures/core/berserker/savage-arsenal/more-blood.json
@@ -1,5 +1,5 @@
 {
-	"folder": "d40bf36abe9f4b0a",
+	"folder": "c9f719f21d801dd3",
 	"name": "MORE BLOOD!",
 	"type": "feature",
 	"img": "icons/weapons/axes/axe-double-short-orange.webp",

--- a/packs/classFeatures/core/berserker/savage-arsenal/rampage.json
+++ b/packs/classFeatures/core/berserker/savage-arsenal/rampage.json
@@ -1,5 +1,5 @@
 {
-	"folder": "d40bf36abe9f4b0a",
+	"folder": "c9f719f21d801dd3",
 	"name": "Rampage",
 	"type": "feature",
 	"img": "icons/weapons/axes/axe-double-short-orange.webp",

--- a/packs/classFeatures/core/berserker/savage-arsenal/swift-fury.json
+++ b/packs/classFeatures/core/berserker/savage-arsenal/swift-fury.json
@@ -1,5 +1,5 @@
 {
-	"folder": "d40bf36abe9f4b0a",
+	"folder": "c9f719f21d801dd3",
 	"name": "Swift Fury",
 	"type": "feature",
 	"img": "icons/weapons/axes/axe-double-short-orange.webp",

--- a/packs/classFeatures/core/berserker/savage-arsenal/thunderous-steps.json
+++ b/packs/classFeatures/core/berserker/savage-arsenal/thunderous-steps.json
@@ -1,5 +1,5 @@
 {
-	"folder": "d40bf36abe9f4b0a",
+	"folder": "c9f719f21d801dd3",
 	"name": "Thunderous Steps",
 	"type": "feature",
 	"img": "icons/weapons/axes/axe-double-short-orange.webp",

--- a/packs/classFeatures/core/berserker/savage-arsenal/unstoppable-force.json
+++ b/packs/classFeatures/core/berserker/savage-arsenal/unstoppable-force.json
@@ -1,5 +1,5 @@
 {
-	"folder": "d40bf36abe9f4b0a",
+	"folder": "c9f719f21d801dd3",
 	"name": "Unstoppable Force",
 	"type": "feature",
 	"img": "icons/weapons/axes/axe-double-short-orange.webp",

--- a/packs/classFeatures/core/berserker/savage-arsenal/whirlwind.json
+++ b/packs/classFeatures/core/berserker/savage-arsenal/whirlwind.json
@@ -1,5 +1,5 @@
 {
-	"folder": "d40bf36abe9f4b0a",
+	"folder": "c9f719f21d801dd3",
 	"name": "Whirlwind",
 	"type": "feature",
 	"img": "icons/weapons/axes/axe-double-short-orange.webp",

--- a/packs/classFeatures/core/berserker/savage-arsenal/your-next.json
+++ b/packs/classFeatures/core/berserker/savage-arsenal/your-next.json
@@ -1,5 +1,5 @@
 {
-	"folder": "d40bf36abe9f4b0a",
+	"folder": "c9f719f21d801dd3",
 	"name": "You're Next!",
 	"type": "feature",
 	"img": "icons/weapons/axes/axe-double-short-orange.webp",

--- a/packs/classFeatures/core/commander/combat-tactics/commanding-presence.json
+++ b/packs/classFeatures/core/commander/combat-tactics/commanding-presence.json
@@ -100,7 +100,7 @@
 		]
 	},
 	"effects": [],
-	"folder": "406c4e162069a4a8",
+	"folder": "f563302e535168ab",
 	"flags": {},
 	"_stats": {
 		"coreVersion": "13.347",

--- a/packs/classFeatures/core/commander/combat-tactics/heavy-strike.json
+++ b/packs/classFeatures/core/commander/combat-tactics/heavy-strike.json
@@ -71,7 +71,7 @@
 		]
 	},
 	"effects": [],
-	"folder": "406c4e162069a4a8",
+	"folder": "f563302e535168ab",
 	"flags": {},
 	"_stats": {
 		"coreVersion": "13.347",

--- a/packs/classFeatures/core/commander/combat-tactics/inerrant-strike.json
+++ b/packs/classFeatures/core/commander/combat-tactics/inerrant-strike.json
@@ -71,7 +71,7 @@
 		]
 	},
 	"effects": [],
-	"folder": "406c4e162069a4a8",
+	"folder": "f563302e535168ab",
 	"flags": {},
 	"_stats": {
 		"coreVersion": "13.347",

--- a/packs/classFeatures/core/commander/combat-tactics/lunging-strike.json
+++ b/packs/classFeatures/core/commander/combat-tactics/lunging-strike.json
@@ -71,7 +71,7 @@
 		]
 	},
 	"effects": [],
-	"folder": "406c4e162069a4a8",
+	"folder": "f563302e535168ab",
 	"flags": {},
 	"_stats": {
 		"coreVersion": "13.347",

--- a/packs/classFeatures/core/commander/combat-tactics/sweeping-strike.json
+++ b/packs/classFeatures/core/commander/combat-tactics/sweeping-strike.json
@@ -71,7 +71,7 @@
 		]
 	},
 	"effects": [],
-	"folder": "406c4e162069a4a8",
+	"folder": "f563302e535168ab",
 	"flags": {},
 	"_stats": {
 		"coreVersion": "13.347",

--- a/packs/classFeatures/core/commander/commanders-order/coordinated-strike.json
+++ b/packs/classFeatures/core/commander/commanders-order/coordinated-strike.json
@@ -74,7 +74,7 @@
 		}
 	},
 	"effects": [],
-	"folder": "406c4e162069a4a8",
+	"folder": "6a51bc6ac831498c",
 	"flags": {},
 	"_stats": {
 		"coreVersion": "13.347",

--- a/packs/classFeatures/core/commander/commanders-order/coordinated-strike.json
+++ b/packs/classFeatures/core/commander/commanders-order/coordinated-strike.json
@@ -59,6 +59,7 @@
 		"featureType": "class",
 		"class": "commander",
 		"group": "commanders-orders",
+		"groupLabel": "Commander's Orders",
 		"gainedAtLevel": 1,
 		"subclass": false,
 		"gainedAtLevels": [

--- a/packs/classFeatures/core/commander/commanders-order/face-me.json
+++ b/packs/classFeatures/core/commander/commanders-order/face-me.json
@@ -59,7 +59,7 @@
 		}
 	},
 	"effects": [],
-	"folder": "406c4e162069a4a8",
+	"folder": "6a51bc6ac831498c",
 	"flags": {},
 	"_stats": {
 		"coreVersion": "13.347",

--- a/packs/classFeatures/core/commander/commanders-order/face-me.json
+++ b/packs/classFeatures/core/commander/commanders-order/face-me.json
@@ -44,6 +44,7 @@
 		"featureType": "class",
 		"class": "commander",
 		"group": "commanders-orders",
+		"groupLabel": "Commander's Orders",
 		"gainedAtLevel": 2,
 		"subclass": false,
 		"gainedAtLevels": [

--- a/packs/classFeatures/core/commander/commanders-order/hold-the-line.json
+++ b/packs/classFeatures/core/commander/commanders-order/hold-the-line.json
@@ -74,7 +74,7 @@
 		}
 	},
 	"effects": [],
-	"folder": "406c4e162069a4a8",
+	"folder": "6a51bc6ac831498c",
 	"flags": {},
 	"_stats": {
 		"coreVersion": "13.347",

--- a/packs/classFeatures/core/commander/commanders-order/hold-the-line.json
+++ b/packs/classFeatures/core/commander/commanders-order/hold-the-line.json
@@ -59,6 +59,7 @@
 		"featureType": "class",
 		"class": "commander",
 		"group": "commanders-orders",
+		"groupLabel": "Commander's Orders",
 		"gainedAtLevel": 2,
 		"subclass": false,
 		"gainedAtLevels": [

--- a/packs/classFeatures/core/commander/commanders-order/i-can-do-this-all-day.json
+++ b/packs/classFeatures/core/commander/commanders-order/i-can-do-this-all-day.json
@@ -79,7 +79,7 @@
 		}
 	},
 	"effects": [],
-	"folder": "406c4e162069a4a8",
+	"folder": "6a51bc6ac831498c",
 	"flags": {},
 	"_stats": {
 		"coreVersion": "13.347",

--- a/packs/classFeatures/core/commander/commanders-order/i-can-do-this-all-day.json
+++ b/packs/classFeatures/core/commander/commanders-order/i-can-do-this-all-day.json
@@ -64,6 +64,7 @@
 		"featureType": "class",
 		"class": "commander",
 		"group": "commanders-orders",
+		"groupLabel": "Commander's Orders",
 		"gainedAtLevel": 2,
 		"subclass": false,
 		"gainedAtLevels": [

--- a/packs/classFeatures/core/commander/commanders-order/move-it-move-it.json
+++ b/packs/classFeatures/core/commander/commanders-order/move-it-move-it.json
@@ -66,6 +66,7 @@
 		"featureType": "class",
 		"class": "commander",
 		"group": "commanders-orders",
+		"groupLabel": "Commander's Orders",
 		"gainedAtLevel": 2,
 		"subclass": false,
 		"gainedAtLevels": [

--- a/packs/classFeatures/core/commander/commanders-order/move-it-move-it.json
+++ b/packs/classFeatures/core/commander/commanders-order/move-it-move-it.json
@@ -81,7 +81,7 @@
 		}
 	},
 	"effects": [],
-	"folder": "406c4e162069a4a8",
+	"folder": "6a51bc6ac831498c",
 	"flags": {},
 	"_stats": {
 		"coreVersion": "13.347",

--- a/packs/classFeatures/core/commander/commanders-order/reposition.json
+++ b/packs/classFeatures/core/commander/commanders-order/reposition.json
@@ -51,7 +51,7 @@
 		}
 	},
 	"effects": [],
-	"folder": "406c4e162069a4a8",
+	"folder": "6a51bc6ac831498c",
 	"flags": {},
 	"_stats": {
 		"coreVersion": "13.347",

--- a/packs/classFeatures/core/commander/commanders-order/reposition.json
+++ b/packs/classFeatures/core/commander/commanders-order/reposition.json
@@ -36,6 +36,7 @@
 		"featureType": "class",
 		"class": "commander",
 		"group": "commanders-orders",
+		"groupLabel": "Commander's Orders",
 		"gainedAtLevel": 2,
 		"subclass": false,
 		"gainedAtLevels": [

--- a/packs/classFeatures/core/commander/weapon-mastery/bludgeoning.json
+++ b/packs/classFeatures/core/commander/weapon-mastery/bludgeoning.json
@@ -45,7 +45,7 @@
 		]
 	},
 	"effects": [],
-	"folder": "406c4e162069a4a8",
+	"folder": "f93b9aaec0c2aef9",
 	"flags": {},
 	"_stats": {
 		"coreVersion": "13.347",

--- a/packs/classFeatures/core/commander/weapon-mastery/piercing.json
+++ b/packs/classFeatures/core/commander/weapon-mastery/piercing.json
@@ -45,7 +45,7 @@
 		]
 	},
 	"effects": [],
-	"folder": "406c4e162069a4a8",
+	"folder": "f93b9aaec0c2aef9",
 	"flags": {},
 	"_stats": {
 		"coreVersion": "13.347",

--- a/packs/classFeatures/core/commander/weapon-mastery/slashing.json
+++ b/packs/classFeatures/core/commander/weapon-mastery/slashing.json
@@ -45,7 +45,7 @@
 		]
 	},
 	"effects": [],
-	"folder": "406c4e162069a4a8",
+	"folder": "f93b9aaec0c2aef9",
 	"flags": {},
 	"_stats": {
 		"coreVersion": "13.347",

--- a/packs/classFeatures/core/hunter/thrill-of-the-hunt/addling-arrow.json
+++ b/packs/classFeatures/core/hunter/thrill-of-the-hunt/addling-arrow.json
@@ -1,5 +1,5 @@
 {
-	"folder": "2e9e32bf9e74e633",
+	"folder": "0c275f447085bbe1",
 	"name": "Addling Arrow",
 	"type": "feature",
 	"img": "icons/skills/ranged/arrow-gem-flying-poisoned-green.webp",

--- a/packs/classFeatures/core/hunter/thrill-of-the-hunt/come-get-some.json
+++ b/packs/classFeatures/core/hunter/thrill-of-the-hunt/come-get-some.json
@@ -1,5 +1,5 @@
 {
-	"folder": "2e9e32bf9e74e633",
+	"folder": "0c275f447085bbe1",
 	"name": "Come Get Some!",
 	"type": "feature",
 	"img": "icons/skills/melee/weapons-crossed-daggers-orange.webp",

--- a/packs/classFeatures/core/hunter/thrill-of-the-hunt/decoy.json
+++ b/packs/classFeatures/core/hunter/thrill-of-the-hunt/decoy.json
@@ -1,5 +1,5 @@
 {
-	"folder": "2e9e32bf9e74e633",
+	"folder": "0c275f447085bbe1",
 	"name": "Decoy",
 	"type": "feature",
 	"img": "icons/magic/defensive/illusion-evasion-echo-purple.webp",

--- a/packs/classFeatures/core/hunter/thrill-of-the-hunt/fleet-feet.json
+++ b/packs/classFeatures/core/hunter/thrill-of-the-hunt/fleet-feet.json
@@ -1,5 +1,5 @@
 {
-	"folder": "2e9e32bf9e74e633",
+	"folder": "0c275f447085bbe1",
 	"name": "Fleet Feet",
 	"type": "feature",
 	"img": "icons/skills/movement/feet-winged-boots-brown.webp",

--- a/packs/classFeatures/core/hunter/thrill-of-the-hunt/grease-trap.json
+++ b/packs/classFeatures/core/hunter/thrill-of-the-hunt/grease-trap.json
@@ -1,5 +1,5 @@
 {
-	"folder": "2e9e32bf9e74e633",
+	"folder": "0c275f447085bbe1",
 	"name": "Grease Trap",
 	"type": "feature",
 	"img": "icons/consumables/potions/potion-flask-corked-yellow.webp",

--- a/packs/classFeatures/core/hunter/thrill-of-the-hunt/hail-of-arrows.json
+++ b/packs/classFeatures/core/hunter/thrill-of-the-hunt/hail-of-arrows.json
@@ -1,5 +1,5 @@
 {
-	"folder": "2e9e32bf9e74e633",
+	"folder": "0c275f447085bbe1",
 	"name": "Hail of Arrows",
 	"type": "feature",
 	"img": "icons/skills/ranged/arrows-flying-salvo-blue.webp",

--- a/packs/classFeatures/core/hunter/thrill-of-the-hunt/heavy-shot.json
+++ b/packs/classFeatures/core/hunter/thrill-of-the-hunt/heavy-shot.json
@@ -1,5 +1,5 @@
 {
-	"folder": "2e9e32bf9e74e633",
+	"folder": "0c275f447085bbe1",
 	"name": "Heavy Shot",
 	"type": "feature",
 	"img": "icons/skills/ranged/arrow-flying-white-blue.webp",

--- a/packs/classFeatures/core/hunter/thrill-of-the-hunt/incendiary-shot.json
+++ b/packs/classFeatures/core/hunter/thrill-of-the-hunt/incendiary-shot.json
@@ -1,5 +1,5 @@
 {
-	"folder": "2e9e32bf9e74e633",
+	"folder": "0c275f447085bbe1",
 	"name": "Incendiary Shot",
 	"type": "feature",
 	"img": "icons/magic/fire/projectile-arrow-fire-orange-yellow.webp",

--- a/packs/classFeatures/core/hunter/thrill-of-the-hunt/multishot.json
+++ b/packs/classFeatures/core/hunter/thrill-of-the-hunt/multishot.json
@@ -1,5 +1,5 @@
 {
-	"folder": "2e9e32bf9e74e633",
+	"folder": "0c275f447085bbe1",
 	"name": "Multishot",
 	"type": "feature",
 	"img": "icons/skills/ranged/arrows-flying-triple-blue.webp",

--- a/packs/classFeatures/core/hunter/thrill-of-the-hunt/pinning-shot.json
+++ b/packs/classFeatures/core/hunter/thrill-of-the-hunt/pinning-shot.json
@@ -1,5 +1,5 @@
 {
-	"folder": "2e9e32bf9e74e633",
+	"folder": "0c275f447085bbe1",
 	"name": "Pinning Shot",
 	"type": "feature",
 	"img": "icons/skills/ranged/arrow-flying-broadhead-metal.webp",

--- a/packs/classFeatures/core/hunter/thrill-of-the-hunt/sharpshooter.json
+++ b/packs/classFeatures/core/hunter/thrill-of-the-hunt/sharpshooter.json
@@ -1,5 +1,5 @@
 {
-	"folder": "2e9e32bf9e74e633",
+	"folder": "0c275f447085bbe1",
 	"name": "Sharpshooter",
 	"type": "feature",
 	"img": "icons/skills/targeting/crosshair-pointed-orange.webp",

--- a/packs/classFeatures/core/hunter/thrill-of-the-hunt/snare-trap.json
+++ b/packs/classFeatures/core/hunter/thrill-of-the-hunt/snare-trap.json
@@ -1,5 +1,5 @@
 {
-	"folder": "2e9e32bf9e74e633",
+	"folder": "0c275f447085bbe1",
 	"name": "Snare Trap",
 	"type": "feature",
 	"img": "icons/environment/traps/trap-jaw-steel.webp",

--- a/packs/classFeatures/core/hunter/thrill-of-the-hunt/vital-shot.json
+++ b/packs/classFeatures/core/hunter/thrill-of-the-hunt/vital-shot.json
@@ -1,5 +1,5 @@
 {
-	"folder": "2e9e32bf9e74e633",
+	"folder": "0c275f447085bbe1",
 	"name": "Vital Shot",
 	"type": "feature",
 	"img": "icons/skills/wounds/anatomy-organ-heart-red.webp",

--- a/packs/classFeatures/core/hunter/thrill-of-the-hunt/wild-instinct.json
+++ b/packs/classFeatures/core/hunter/thrill-of-the-hunt/wild-instinct.json
@@ -1,5 +1,5 @@
 {
-	"folder": "2e9e32bf9e74e633",
+	"folder": "0c275f447085bbe1",
 	"name": "Wild Instinct",
 	"type": "feature",
 	"img": "icons/magic/perception/eye-ringed-green.webp",

--- a/packs/classFeatures/core/mage/spellshaper/dimensional-compression.json
+++ b/packs/classFeatures/core/mage/spellshaper/dimensional-compression.json
@@ -1,5 +1,5 @@
 {
-	"folder": "a95d9a582c294f7c",
+	"folder": "781afc848b4d7ea4",
 	"name": "Dimensional Compression",
 	"type": "feature",
 	"img": "icons/magic/movement/trail-streak-impact-blue.webp",

--- a/packs/classFeatures/core/mage/spellshaper/echo-casting.json
+++ b/packs/classFeatures/core/mage/spellshaper/echo-casting.json
@@ -1,5 +1,5 @@
 {
-	"folder": "a95d9a582c294f7c",
+	"folder": "781afc848b4d7ea4",
 	"name": "Echo Casting",
 	"type": "feature",
 	"img": "icons/magic/sonic/projectile-sound-rings-wave.webp",

--- a/packs/classFeatures/core/mage/spellshaper/elemental-destruction.json
+++ b/packs/classFeatures/core/mage/spellshaper/elemental-destruction.json
@@ -1,5 +1,5 @@
 {
-	"folder": "a95d9a582c294f7c",
+	"folder": "781afc848b4d7ea4",
 	"name": "Elemental Destruction",
 	"type": "feature",
 	"img": "icons/magic/earth/explosion-lava-stone-green.webp",

--- a/packs/classFeatures/core/mage/spellshaper/elemental-transmutation.json
+++ b/packs/classFeatures/core/mage/spellshaper/elemental-transmutation.json
@@ -1,5 +1,5 @@
 {
-	"folder": "a95d9a582c294f7c",
+	"folder": "781afc848b4d7ea4",
 	"name": "Elemental Transmutation",
 	"type": "feature",
 	"img": "icons/magic/light/hand-sparks-glow-yellow.webp",

--- a/packs/classFeatures/core/mage/spellshaper/extra-dimensional-vision.json
+++ b/packs/classFeatures/core/mage/spellshaper/extra-dimensional-vision.json
@@ -1,5 +1,5 @@
 {
-	"folder": "a95d9a582c294f7c",
+	"folder": "781afc848b4d7ea4",
 	"name": "Extra-Dimensional Vision",
 	"type": "feature",
 	"img": "icons/magic/perception/eye-ringed-glow-angry-teal.webp",

--- a/packs/classFeatures/core/mage/spellshaper/methodical-spellweaver.json
+++ b/packs/classFeatures/core/mage/spellshaper/methodical-spellweaver.json
@@ -1,5 +1,5 @@
 {
-	"folder": "a95d9a582c294f7c",
+	"folder": "781afc848b4d7ea4",
 	"name": "Methodical Spellweaver",
 	"type": "feature",
 	"img": "icons/magic/symbols/circled-gem-pink.webp",

--- a/packs/classFeatures/core/mage/spellshaper/precise-casting.json
+++ b/packs/classFeatures/core/mage/spellshaper/precise-casting.json
@@ -1,5 +1,5 @@
 {
-	"folder": "a95d9a582c294f7c",
+	"folder": "781afc848b4d7ea4",
 	"name": "Precise Casting",
 	"type": "feature",
 	"img": "icons/magic/movement/trail-streak-pink.webp",

--- a/packs/classFeatures/core/mage/spellshaper/stretch-time.json
+++ b/packs/classFeatures/core/mage/spellshaper/stretch-time.json
@@ -1,5 +1,5 @@
 {
-	"folder": "a95d9a582c294f7c",
+	"folder": "781afc848b4d7ea4",
 	"name": "Stretch Time",
 	"type": "feature",
 	"img": "icons/magic/time/hourglass-tilted-glowing-gold.webp",

--- a/packs/classFeatures/core/oathsworn/sacred-decree/blinding-aura.json
+++ b/packs/classFeatures/core/oathsworn/sacred-decree/blinding-aura.json
@@ -1,5 +1,5 @@
 {
-	"folder": "c5f324248b31dabc",
+	"folder": "1e5a9d564fb847da",
 	"name": "Blinding Aura",
 	"type": "feature",
 	"img": "icons/magic/light/beam-strike-orange-gold.webp",

--- a/packs/classFeatures/core/oathsworn/sacred-decree/courage.json
+++ b/packs/classFeatures/core/oathsworn/sacred-decree/courage.json
@@ -1,5 +1,5 @@
 {
-	"folder": "c5f324248b31dabc",
+	"folder": "1e5a9d564fb847da",
 	"name": "Courage!",
 	"type": "feature",
 	"img": "icons/magic/defensive/shield-barrier-deflect-gold.webp",

--- a/packs/classFeatures/core/oathsworn/sacred-decree/explosive-judgment.json
+++ b/packs/classFeatures/core/oathsworn/sacred-decree/explosive-judgment.json
@@ -1,5 +1,5 @@
 {
-	"folder": "c5f324248b31dabc",
+	"folder": "1e5a9d564fb847da",
 	"name": "Explosive Judgment",
 	"type": "feature",
 	"img": "icons/magic/fire/explosion-fireball-large-orange.webp",

--- a/packs/classFeatures/core/oathsworn/sacred-decree/improved-aura.json
+++ b/packs/classFeatures/core/oathsworn/sacred-decree/improved-aura.json
@@ -1,5 +1,5 @@
 {
-	"folder": "c5f324248b31dabc",
+	"folder": "1e5a9d564fb847da",
 	"name": "Improved Aura",
 	"type": "feature",
 	"img": "icons/magic/lightning/bolt-strike-explosion-yellow.webp",

--- a/packs/classFeatures/core/oathsworn/sacred-decree/radiant-aura.json
+++ b/packs/classFeatures/core/oathsworn/sacred-decree/radiant-aura.json
@@ -1,5 +1,5 @@
 {
-	"folder": "c5f324248b31dabc",
+	"folder": "1e5a9d564fb847da",
 	"name": "Radiant Aura",
 	"type": "feature",
 	"img": "icons/magic/light/beam-rays-yellow.webp",

--- a/packs/classFeatures/core/oathsworn/sacred-decree/reliable-justice.json
+++ b/packs/classFeatures/core/oathsworn/sacred-decree/reliable-justice.json
@@ -1,5 +1,5 @@
 {
-	"folder": "c5f324248b31dabc",
+	"folder": "1e5a9d564fb847da",
 	"name": "Reliable Justice",
 	"type": "feature",
 	"img": "icons/skills/melee/strike-polearm-light-orange.webp",

--- a/packs/classFeatures/core/oathsworn/sacred-decree/shining-mandate.json
+++ b/packs/classFeatures/core/oathsworn/sacred-decree/shining-mandate.json
@@ -1,5 +1,5 @@
 {
-	"folder": "c5f324248b31dabc",
+	"folder": "1e5a9d564fb847da",
 	"name": "Shining Mandate",
 	"type": "feature",
 	"img": "icons/skills/melee/strike-hammer-destructive-orange.webp",

--- a/packs/classFeatures/core/oathsworn/sacred-decree/stand-fast-friends.json
+++ b/packs/classFeatures/core/oathsworn/sacred-decree/stand-fast-friends.json
@@ -1,5 +1,5 @@
 {
-	"folder": "c5f324248b31dabc",
+	"folder": "1e5a9d564fb847da",
 	"name": "Stand Fast, Friends!",
 	"type": "feature",
 	"img": "icons/environment/people/infantry-army.webp",

--- a/packs/classFeatures/core/oathsworn/sacred-decree/unstoppable-protector.json
+++ b/packs/classFeatures/core/oathsworn/sacred-decree/unstoppable-protector.json
@@ -1,5 +1,5 @@
 {
-	"folder": "c5f324248b31dabc",
+	"folder": "1e5a9d564fb847da",
 	"name": "Unstoppable Protector",
 	"type": "feature",
 	"img": "icons/magic/holy/barrier-shield-winged-cross.webp",

--- a/packs/classFeatures/core/oathsworn/sacred-decree/well-armored.json
+++ b/packs/classFeatures/core/oathsworn/sacred-decree/well-armored.json
@@ -1,5 +1,5 @@
 {
-	"folder": "c5f324248b31dabc",
+	"folder": "1e5a9d564fb847da",
 	"name": "Well Armored",
 	"type": "feature",
 	"img": "icons/equipment/chest/breastplate-collared-leather-brown.webp",

--- a/packs/classFeatures/core/shadowmancer/greater-invocations/armor-of-shadows.json
+++ b/packs/classFeatures/core/shadowmancer/greater-invocations/armor-of-shadows.json
@@ -1,5 +1,5 @@
 {
-	"folder": "81e685bc5c9127ce",
+	"folder": "9956e54839216503",
 	"name": "Armor of Shadows",
 	"type": "feature",
 	"img": "icons/magic/defensive/barrier-shield-dome-pink.webp",

--- a/packs/classFeatures/core/shadowmancer/greater-invocations/fiendish-boon.json
+++ b/packs/classFeatures/core/shadowmancer/greater-invocations/fiendish-boon.json
@@ -1,5 +1,5 @@
 {
-	"folder": "81e685bc5c9127ce",
+	"folder": "9956e54839216503",
 	"name": "Fiendish Boon",
 	"type": "feature",
 	"img": "icons/magic/unholy/orb-droplet-pink.webp",

--- a/packs/classFeatures/core/shadowmancer/greater-invocations/hungering-shadows.json
+++ b/packs/classFeatures/core/shadowmancer/greater-invocations/hungering-shadows.json
@@ -1,5 +1,5 @@
 {
-	"folder": "81e685bc5c9127ce",
+	"folder": "9956e54839216503",
 	"name": "Hungering Shadows",
 	"type": "feature",
 	"img": "icons/magic/unholy/hand-claw-glow-orange.webp",

--- a/packs/classFeatures/core/shadowmancer/greater-invocations/one-with-shadows.json
+++ b/packs/classFeatures/core/shadowmancer/greater-invocations/one-with-shadows.json
@@ -1,5 +1,5 @@
 {
-	"folder": "81e685bc5c9127ce",
+	"folder": "9956e54839216503",
 	"name": "One with Shadows",
 	"type": "feature",
 	"img": "icons/magic/unholy/silhouette-robe-evil-glow.webp",

--- a/packs/classFeatures/core/shadowmancer/greater-invocations/repelling-blast.json
+++ b/packs/classFeatures/core/shadowmancer/greater-invocations/repelling-blast.json
@@ -1,5 +1,5 @@
 {
-	"folder": "81e685bc5c9127ce",
+	"folder": "9956e54839216503",
 	"name": "Repelling Blast",
 	"type": "feature",
 	"img": "icons/magic/unholy/projectile-bullet-orb-pink.webp",

--- a/packs/classFeatures/core/shadowmancer/greater-invocations/shadow-magus.json
+++ b/packs/classFeatures/core/shadowmancer/greater-invocations/shadow-magus.json
@@ -1,5 +1,5 @@
 {
-	"folder": "81e685bc5c9127ce",
+	"folder": "9956e54839216503",
 	"name": "Shadow Magus",
 	"type": "feature",
 	"img": "icons/magic/fire/projectile-arrow-fire-purple.webp",

--- a/packs/classFeatures/core/shadowmancer/greater-invocations/shadow-rush.json
+++ b/packs/classFeatures/core/shadowmancer/greater-invocations/shadow-rush.json
@@ -1,5 +1,5 @@
 {
-	"folder": "81e685bc5c9127ce",
+	"folder": "9956e54839216503",
 	"name": "Shadow Rush",
 	"type": "feature",
 	"img": "icons/magic/fire/explosion-fireball-medium-purple-pink.webp",

--- a/packs/classFeatures/core/shadowmancer/greater-invocations/shadow-spear.json
+++ b/packs/classFeatures/core/shadowmancer/greater-invocations/shadow-spear.json
@@ -1,5 +1,5 @@
 {
-	"folder": "81e685bc5c9127ce",
+	"folder": "9956e54839216503",
 	"name": "Shadow Spear",
 	"type": "feature",
 	"img": "icons/magic/light/beam-rays-magenta.webp",

--- a/packs/classFeatures/core/shadowmancer/greater-invocations/shadow-warp.json
+++ b/packs/classFeatures/core/shadowmancer/greater-invocations/shadow-warp.json
@@ -1,5 +1,5 @@
 {
-	"folder": "81e685bc5c9127ce",
+	"folder": "9956e54839216503",
 	"name": "Shadow Warp",
 	"type": "feature",
 	"img": "icons/magic/movement/trail-streak-pink.webp",

--- a/packs/classFeatures/core/shadowmancer/greater-invocations/swarming-shadows.json
+++ b/packs/classFeatures/core/shadowmancer/greater-invocations/swarming-shadows.json
@@ -1,5 +1,5 @@
 {
-	"folder": "81e685bc5c9127ce",
+	"folder": "9956e54839216503",
 	"name": "Swarming Shadows",
 	"type": "feature",
 	"img": "icons/magic/defensive/illusion-evasion-echo-purple.webp",

--- a/packs/classFeatures/core/shadowmancer/greater-invocations/vengeful-blast.json
+++ b/packs/classFeatures/core/shadowmancer/greater-invocations/vengeful-blast.json
@@ -1,5 +1,5 @@
 {
-	"folder": "81e685bc5c9127ce",
+	"folder": "9956e54839216503",
 	"name": "Vengeful Blast",
 	"type": "feature",
 	"img": "icons/magic/unholy/beam-impact-purple.webp",

--- a/packs/classFeatures/core/shadowmancer/lesser-invocations/abhorrent-speech.json
+++ b/packs/classFeatures/core/shadowmancer/lesser-invocations/abhorrent-speech.json
@@ -1,5 +1,5 @@
 {
-	"folder": "81e685bc5c9127ce",
+	"folder": "c3ebcab2be869390",
 	"name": "Abhorrent Speech",
 	"type": "feature",
 	"img": "icons/magic/symbols/rune-sigil-black-pink.webp",

--- a/packs/classFeatures/core/shadowmancer/lesser-invocations/beguiling-influence.json
+++ b/packs/classFeatures/core/shadowmancer/lesser-invocations/beguiling-influence.json
@@ -1,5 +1,5 @@
 {
-	"folder": "81e685bc5c9127ce",
+	"folder": "c3ebcab2be869390",
 	"name": "Beguiling Influence",
 	"type": "feature",
 	"img": "icons/magic/control/debuff-energy-hold-pink.webp",

--- a/packs/classFeatures/core/shadowmancer/lesser-invocations/blood-sight.json
+++ b/packs/classFeatures/core/shadowmancer/lesser-invocations/blood-sight.json
@@ -1,5 +1,5 @@
 {
-	"folder": "81e685bc5c9127ce",
+	"folder": "c3ebcab2be869390",
 	"name": "Blood Sight",
 	"type": "feature",
 	"img": "icons/magic/perception/eye-ringed-glow-angry-small-teal.webp",

--- a/packs/classFeatures/core/shadowmancer/lesser-invocations/devoted-acolyte.json
+++ b/packs/classFeatures/core/shadowmancer/lesser-invocations/devoted-acolyte.json
@@ -1,5 +1,5 @@
 {
-	"folder": "81e685bc5c9127ce",
+	"folder": "c3ebcab2be869390",
 	"name": "Devoted Acolyte",
 	"type": "feature",
 	"img": "icons/sundries/books/book-embossed-spiral-purple-white.webp",

--- a/packs/classFeatures/core/shadowmancer/lesser-invocations/eldritch-sense.json
+++ b/packs/classFeatures/core/shadowmancer/lesser-invocations/eldritch-sense.json
@@ -1,5 +1,5 @@
 {
-	"folder": "81e685bc5c9127ce",
+	"folder": "c3ebcab2be869390",
 	"name": "Eldritch Sense",
 	"type": "feature",
 	"img": "icons/magic/control/silhouette-hold-change-blue.webp",

--- a/packs/classFeatures/core/shadowmancer/lesser-invocations/gaze-of-two-minds.json
+++ b/packs/classFeatures/core/shadowmancer/lesser-invocations/gaze-of-two-minds.json
@@ -1,5 +1,5 @@
 {
-	"folder": "81e685bc5c9127ce",
+	"folder": "c3ebcab2be869390",
 	"name": "Gaze of Two Minds",
 	"type": "feature",
 	"img": "icons/creatures/eyes/humanoid-single-purple-blue.webp",

--- a/packs/classFeatures/core/shadowmancer/lesser-invocations/knowledge-from-beyond.json
+++ b/packs/classFeatures/core/shadowmancer/lesser-invocations/knowledge-from-beyond.json
@@ -1,5 +1,5 @@
 {
-	"folder": "81e685bc5c9127ce",
+	"folder": "c3ebcab2be869390",
 	"name": "Knowledge from Beyond",
 	"type": "feature",
 	"img": "icons/sundries/scrolls/scroll-plain-red.webp",

--- a/packs/classFeatures/core/shadowmancer/lesser-invocations/my-favored-pet.json
+++ b/packs/classFeatures/core/shadowmancer/lesser-invocations/my-favored-pet.json
@@ -1,5 +1,5 @@
 {
-	"folder": "81e685bc5c9127ce",
+	"folder": "c3ebcab2be869390",
 	"name": "My Favored Pet",
 	"type": "feature",
 	"img": "icons/creatures/magical/spirit-fear-energy-pink.webp",

--- a/packs/classFeatures/core/shadowmancer/lesser-invocations/voice-of-the-dark.json
+++ b/packs/classFeatures/core/shadowmancer/lesser-invocations/voice-of-the-dark.json
@@ -1,5 +1,5 @@
 {
-	"folder": "81e685bc5c9127ce",
+	"folder": "c3ebcab2be869390",
 	"name": "Voice of the Dark",
 	"type": "feature",
 	"img": "icons/magic/control/energy-stream-link-teal.webp",

--- a/packs/classFeatures/core/shadowmancer/lesser-invocations/whispers-of-the-grave.json
+++ b/packs/classFeatures/core/shadowmancer/lesser-invocations/whispers-of-the-grave.json
@@ -1,5 +1,5 @@
 {
-	"folder": "81e685bc5c9127ce",
+	"folder": "c3ebcab2be869390",
 	"name": "Whispers of the Grave",
 	"type": "feature",
 	"img": "icons/magic/unholy/hand-fire-skeleton-pink.webp",

--- a/packs/classFeatures/core/shepherd/sacred-graces/assist-me-my-friend.json
+++ b/packs/classFeatures/core/shepherd/sacred-graces/assist-me-my-friend.json
@@ -1,5 +1,5 @@
 {
-	"folder": "c1face1ec4d1249a",
+	"folder": "dff9b50ccda66be9",
 	"name": "Assist Me, My Friend!",
 	"type": "feature",
 	"img": "icons/creatures/abilities/wolf-heads-swirl-purple.webp",

--- a/packs/classFeatures/core/shepherd/sacred-graces/empowered-companion.json
+++ b/packs/classFeatures/core/shepherd/sacred-graces/empowered-companion.json
@@ -1,5 +1,5 @@
 {
-	"folder": "c1face1ec4d1249a",
+	"folder": "dff9b50ccda66be9",
 	"name": "Empowered Companion",
 	"type": "feature",
 	"img": "icons/creatures/abilities/lion-roar-yellow.webp",

--- a/packs/classFeatures/core/shepherd/sacred-graces/guiding-spirit.json
+++ b/packs/classFeatures/core/shepherd/sacred-graces/guiding-spirit.json
@@ -1,5 +1,5 @@
 {
-	"folder": "c1face1ec4d1249a",
+	"folder": "dff9b50ccda66be9",
 	"name": "Guiding Spirit",
 	"type": "feature",
 	"img": "icons/magic/light/projectile-smoke-pink.webp",

--- a/packs/classFeatures/core/shepherd/sacred-graces/hasty-companion.json
+++ b/packs/classFeatures/core/shepherd/sacred-graces/hasty-companion.json
@@ -1,5 +1,5 @@
 {
-	"folder": "c1face1ec4d1249a",
+	"folder": "dff9b50ccda66be9",
 	"name": "Hasty Companion",
 	"type": "feature",
 	"img": "icons/magic/movement/trail-streak-zigzag-yellow.webp",

--- a/packs/classFeatures/core/shepherd/sacred-graces/illuminate-soul.json
+++ b/packs/classFeatures/core/shepherd/sacred-graces/illuminate-soul.json
@@ -1,5 +1,5 @@
 {
-	"folder": "c1face1ec4d1249a",
+	"folder": "dff9b50ccda66be9",
 	"name": "Illuminate Soul",
 	"type": "feature",
 	"img": "icons/magic/light/beam-explosion-orange.webp",

--- a/packs/classFeatures/core/shepherd/sacred-graces/light-bearer.json
+++ b/packs/classFeatures/core/shepherd/sacred-graces/light-bearer.json
@@ -1,5 +1,5 @@
 {
-	"folder": "c1face1ec4d1249a",
+	"folder": "dff9b50ccda66be9",
 	"name": "Light Bearer",
 	"type": "feature",
 	"img": "icons/magic/light/hand-sparks-glow-yellow.webp",

--- a/packs/classFeatures/core/shepherd/sacred-graces/not-beyond-my-reach.json
+++ b/packs/classFeatures/core/shepherd/sacred-graces/not-beyond-my-reach.json
@@ -1,5 +1,5 @@
 {
-	"folder": "c1face1ec4d1249a",
+	"folder": "dff9b50ccda66be9",
 	"name": "Not Beyond MY Reach",
 	"type": "feature",
 	"img": "icons/magic/life/cross-embers-glow-yellow-purple.webp",

--- a/packs/classFeatures/core/shepherd/sacred-graces/vengeful-spirit.json
+++ b/packs/classFeatures/core/shepherd/sacred-graces/vengeful-spirit.json
@@ -1,5 +1,5 @@
 {
-	"folder": "c1face1ec4d1249a",
+	"folder": "dff9b50ccda66be9",
 	"name": "Vengeful Spirit",
 	"type": "feature",
 	"img": "icons/magic/air/wind-tornado-cyclone-white.webp",

--- a/packs/classFeatures/core/songweaver/a-people-person/gran-gran-not-a-hag.json
+++ b/packs/classFeatures/core/songweaver/a-people-person/gran-gran-not-a-hag.json
@@ -1,5 +1,5 @@
 {
-	"folder": "910213b07f81138f",
+	"folder": "9c830a958d7a3d84",
 	"name": "Gran Gran (NOT a hag)",
 	"type": "feature",
 	"img": "icons/consumables/grains/donut-baked-brown.webp",

--- a/packs/classFeatures/core/songweaver/a-people-person/linos-the-everfriendly.json
+++ b/packs/classFeatures/core/songweaver/a-people-person/linos-the-everfriendly.json
@@ -1,5 +1,5 @@
 {
-	"folder": "910213b07f81138f",
+	"folder": "9c830a958d7a3d84",
 	"name": "Linos, the Everfriendly",
 	"type": "feature",
 	"img": "icons/creatures/magical/humanoid-giant-forest-blue.webp",

--- a/packs/classFeatures/core/songweaver/a-people-person/mal-the-malevolent-imp.json
+++ b/packs/classFeatures/core/songweaver/a-people-person/mal-the-malevolent-imp.json
@@ -1,5 +1,5 @@
 {
-	"folder": "910213b07f81138f",
+	"folder": "9c830a958d7a3d84",
 	"name": "Mal, the Malevolent Imp",
 	"type": "feature",
 	"img": "icons/creatures/unholy/demon-fanged-horned-yellow.webp",

--- a/packs/classFeatures/core/songweaver/a-people-person/stompy.json
+++ b/packs/classFeatures/core/songweaver/a-people-person/stompy.json
@@ -1,5 +1,5 @@
 {
-	"folder": "910213b07f81138f",
+	"folder": "9c830a958d7a3d84",
 	"name": "Stompy",
 	"type": "feature",
 	"img": "icons/creatures/magical/construct-iron-stomping-yellow.webp",

--- a/packs/classFeatures/core/songweaver/lyrical-weaponry/heroic-ballad.json
+++ b/packs/classFeatures/core/songweaver/lyrical-weaponry/heroic-ballad.json
@@ -1,5 +1,5 @@
 {
-	"folder": "910213b07f81138f",
+	"folder": "08d09127eed3061c",
 	"name": "Heroic Ballad",
 	"type": "feature",
 	"img": "icons/tools/instruments/harp-lap-brown.webp",

--- a/packs/classFeatures/core/songweaver/lyrical-weaponry/inspiring-anthem.json
+++ b/packs/classFeatures/core/songweaver/lyrical-weaponry/inspiring-anthem.json
@@ -1,5 +1,5 @@
 {
-	"folder": "910213b07f81138f",
+	"folder": "08d09127eed3061c",
 	"name": "Inspiring Anthem",
 	"type": "feature",
 	"img": "icons/tools/instruments/harp-gold-glowing.webp",

--- a/packs/classFeatures/core/songweaver/lyrical-weaponry/not-my-beautiful-faaace.json
+++ b/packs/classFeatures/core/songweaver/lyrical-weaponry/not-my-beautiful-faaace.json
@@ -1,5 +1,5 @@
 {
-	"folder": "910213b07f81138f",
+	"folder": "08d09127eed3061c",
 	"name": "Not My Beautiful Faaace!",
 	"type": "feature",
 	"img": "icons/skills/wounds/injury-face-impact-orange.webp",

--- a/packs/classFeatures/core/songweaver/lyrical-weaponry/rhapsody-of-the-normal.json
+++ b/packs/classFeatures/core/songweaver/lyrical-weaponry/rhapsody-of-the-normal.json
@@ -1,5 +1,5 @@
 {
-	"folder": "910213b07f81138f",
+	"folder": "08d09127eed3061c",
 	"name": "Rhapsody of the Normal",
 	"type": "feature",
 	"img": "icons/environment/people/group.webp",

--- a/packs/classFeatures/core/songweaver/lyrical-weaponry/song-of-domination.json
+++ b/packs/classFeatures/core/songweaver/lyrical-weaponry/song-of-domination.json
@@ -1,5 +1,5 @@
 {
-	"folder": "910213b07f81138f",
+	"folder": "08d09127eed3061c",
 	"name": "Song of Domination",
 	"type": "feature",
 	"img": "icons/magic/control/debuff-chains-shackles-movement-blue.webp",

--- a/packs/classFeatures/core/stormshifter/chimeric-boon/beast-of-the-sea.json
+++ b/packs/classFeatures/core/stormshifter/chimeric-boon/beast-of-the-sea.json
@@ -1,5 +1,5 @@
 {
-	"folder": "0075e1e989d0552b",
+	"folder": "39bca0df0773bd38",
 	"name": "Beast of the Sea",
 	"type": "feature",
 	"img": "icons/creatures/fish/fish-marlin-swordfight-blue.webp",

--- a/packs/classFeatures/core/stormshifter/chimeric-boon/climber.json
+++ b/packs/classFeatures/core/stormshifter/chimeric-boon/climber.json
@@ -1,5 +1,5 @@
 {
-	"folder": "0075e1e989d0552b",
+	"folder": "39bca0df0773bd38",
 	"name": "Climber",
 	"type": "feature",
 	"img": "icons/commodities/claws/claw-bear-brown.webp",

--- a/packs/classFeatures/core/stormshifter/chimeric-boon/earthwalker.json
+++ b/packs/classFeatures/core/stormshifter/chimeric-boon/earthwalker.json
@@ -1,5 +1,5 @@
 {
-	"folder": "0075e1e989d0552b",
+	"folder": "39bca0df0773bd38",
 	"name": "Earthwalker",
 	"type": "feature",
 	"img": "icons/environment/wilderness/terrain-rocky-ground.webp",

--- a/packs/classFeatures/core/stormshifter/chimeric-boon/fleet-footed.json
+++ b/packs/classFeatures/core/stormshifter/chimeric-boon/fleet-footed.json
@@ -1,5 +1,5 @@
 {
-	"folder": "0075e1e989d0552b",
+	"folder": "39bca0df0773bd38",
 	"name": "Fleet Footed",
 	"type": "feature",
 	"img": "icons/commodities/claws/claw-lizard-white-black.webp",

--- a/packs/classFeatures/core/stormshifter/chimeric-boon/keen-senses.json
+++ b/packs/classFeatures/core/stormshifter/chimeric-boon/keen-senses.json
@@ -1,5 +1,5 @@
 {
-	"folder": "0075e1e989d0552b",
+	"folder": "39bca0df0773bd38",
 	"name": "Keen Senses",
 	"type": "feature",
 	"img": "icons/commodities/biological/eye-blue-gold.webp",

--- a/packs/classFeatures/core/stormshifter/chimeric-boon/leader-of-the-pack.json
+++ b/packs/classFeatures/core/stormshifter/chimeric-boon/leader-of-the-pack.json
@@ -1,5 +1,5 @@
 {
-	"folder": "0075e1e989d0552b",
+	"folder": "39bca0df0773bd38",
 	"name": "Leader of the Pack",
 	"type": "feature",
 	"img": "icons/creatures/mammals/humanoid-wolf-dog-blue.webp",

--- a/packs/classFeatures/core/stormshifter/chimeric-boon/phasebeast.json
+++ b/packs/classFeatures/core/stormshifter/chimeric-boon/phasebeast.json
@@ -1,5 +1,5 @@
 {
-	"folder": "0075e1e989d0552b",
+	"folder": "39bca0df0773bd38",
 	"name": "Phasebeast",
 	"type": "feature",
 	"img": "icons/creatures/abilities/dragon-breath-purple.webp",

--- a/packs/classFeatures/core/stormshifter/chimeric-boon/prehensile-tail.json
+++ b/packs/classFeatures/core/stormshifter/chimeric-boon/prehensile-tail.json
@@ -1,5 +1,5 @@
 {
-	"folder": "0075e1e989d0552b",
+	"folder": "39bca0df0773bd38",
 	"name": "Prehensile Tail",
 	"type": "feature",
 	"img": "icons/creatures/abilities/tail-swipe-green.webp",

--- a/packs/classFeatures/core/stormshifter/chimeric-boon/winged.json
+++ b/packs/classFeatures/core/stormshifter/chimeric-boon/winged.json
@@ -1,5 +1,5 @@
 {
-	"folder": "0075e1e989d0552b",
+	"folder": "39bca0df0773bd38",
 	"name": "Winged",
 	"type": "feature",
 	"img": "icons/creatures/abilities/wing-batlike-white-blue.webp",

--- a/packs/classFeatures/core/stormshifter/direbeast-form/beast-of-nightmares.json
+++ b/packs/classFeatures/core/stormshifter/direbeast-form/beast-of-nightmares.json
@@ -1,5 +1,5 @@
 {
-	"folder": "0075e1e989d0552b",
+	"folder": "21f4160b615ca685",
 	"name": "Beast of Nightmares",
 	"type": "feature",
 	"img": "icons/creatures/invertebrates/spider-skull-green.webp",

--- a/packs/classFeatures/core/stormshifter/direbeast-form/beast-of-the-pack.json
+++ b/packs/classFeatures/core/stormshifter/direbeast-form/beast-of-the-pack.json
@@ -1,5 +1,5 @@
 {
-	"folder": "0075e1e989d0552b",
+	"folder": "21f4160b615ca685",
 	"name": "Beast of the Pack",
 	"type": "feature",
 	"img": "icons/creatures/abilities/wolf-howl-moon-purple.webp",

--- a/packs/classFeatures/core/stormshifter/direbeast-form/fearsome-beast.json
+++ b/packs/classFeatures/core/stormshifter/direbeast-form/fearsome-beast.json
@@ -1,5 +1,5 @@
 {
-	"folder": "0075e1e989d0552b",
+	"folder": "21f4160b615ca685",
 	"name": "Fearsome Beast",
 	"type": "feature",
 	"img": "icons/creatures/abilities/bear-roar-bite-brown.webp",

--- a/packs/classFeatures/core/the-cheat/underhanded-abilities/creative-accounting.json
+++ b/packs/classFeatures/core/the-cheat/underhanded-abilities/creative-accounting.json
@@ -1,5 +1,5 @@
 {
-	"folder": "4915fea5a41fc733",
+	"folder": "2dea512a27e20491",
 	"name": "\"Creative\" Accounting",
 	"type": "feature",
 	"img": "icons/magic/air/air-smoke-casting.webp",

--- a/packs/classFeatures/core/the-cheat/underhanded-abilities/exploit-weakness.json
+++ b/packs/classFeatures/core/the-cheat/underhanded-abilities/exploit-weakness.json
@@ -1,5 +1,5 @@
 {
-	"folder": "4915fea5a41fc733",
+	"folder": "2dea512a27e20491",
 	"name": "Exploit Weakness",
 	"type": "feature",
 	"img": "icons/magic/air/air-smoke-casting.webp",

--- a/packs/classFeatures/core/the-cheat/underhanded-abilities/feinting-attack.json
+++ b/packs/classFeatures/core/the-cheat/underhanded-abilities/feinting-attack.json
@@ -1,5 +1,5 @@
 {
-	"folder": "4915fea5a41fc733",
+	"folder": "2dea512a27e20491",
 	"name": "Feinting Attack",
 	"type": "feature",
 	"img": "icons/magic/air/air-smoke-casting.webp",

--- a/packs/classFeatures/core/the-cheat/underhanded-abilities/how-you-get-here.json
+++ b/packs/classFeatures/core/the-cheat/underhanded-abilities/how-you-get-here.json
@@ -1,5 +1,5 @@
 {
-	"folder": "4915fea5a41fc733",
+	"folder": "2dea512a27e20491",
 	"name": "How'd YOU get here?!",
 	"type": "feature",
 	"img": "icons/magic/air/air-smoke-casting.webp",

--- a/packs/classFeatures/core/the-cheat/underhanded-abilities/im-outta-here.json
+++ b/packs/classFeatures/core/the-cheat/underhanded-abilities/im-outta-here.json
@@ -1,5 +1,5 @@
 {
-	"folder": "4915fea5a41fc733",
+	"folder": "2dea512a27e20491",
 	"name": "I'm Outta Here!",
 	"type": "feature",
 	"img": "icons/magic/air/air-smoke-casting.webp",

--- a/packs/classFeatures/core/the-cheat/underhanded-abilities/misdirection.json
+++ b/packs/classFeatures/core/the-cheat/underhanded-abilities/misdirection.json
@@ -1,5 +1,5 @@
 {
-	"folder": "4915fea5a41fc733",
+	"folder": "2dea512a27e20491",
 	"name": "Misdirection",
 	"type": "feature",
 	"img": "icons/magic/air/air-smoke-casting.webp",

--- a/packs/classFeatures/core/the-cheat/underhanded-abilities/steal-tempo.json
+++ b/packs/classFeatures/core/the-cheat/underhanded-abilities/steal-tempo.json
@@ -1,5 +1,5 @@
 {
-	"folder": "4915fea5a41fc733",
+	"folder": "2dea512a27e20491",
 	"name": "Steal Tempo",
 	"type": "feature",
 	"img": "icons/magic/air/air-smoke-casting.webp",

--- a/packs/classFeatures/core/the-cheat/underhanded-abilities/sunder-armor-heavy.json
+++ b/packs/classFeatures/core/the-cheat/underhanded-abilities/sunder-armor-heavy.json
@@ -1,5 +1,5 @@
 {
-	"folder": "4915fea5a41fc733",
+	"folder": "2dea512a27e20491",
 	"name": "Sunder Armor (Heavy)",
 	"type": "feature",
 	"img": "icons/magic/air/air-smoke-casting.webp",

--- a/packs/classFeatures/core/the-cheat/underhanded-abilities/sunder-armor-medium.json
+++ b/packs/classFeatures/core/the-cheat/underhanded-abilities/sunder-armor-medium.json
@@ -1,5 +1,5 @@
 {
-	"folder": "4915fea5a41fc733",
+	"folder": "2dea512a27e20491",
 	"name": "Sunder Armor (Medium)",
 	"type": "feature",
 	"img": "icons/magic/air/air-smoke-casting.webp",

--- a/packs/classFeatures/core/the-cheat/underhanded-abilities/trickshot.json
+++ b/packs/classFeatures/core/the-cheat/underhanded-abilities/trickshot.json
@@ -1,5 +1,5 @@
 {
-	"folder": "4915fea5a41fc733",
+	"folder": "2dea512a27e20491",
 	"name": "Trickshot",
 	"type": "feature",
 	"img": "icons/magic/air/air-smoke-casting.webp",

--- a/packs/classFeatures/core/zephyr/martial-arts-ability/airshift.json
+++ b/packs/classFeatures/core/zephyr/martial-arts-ability/airshift.json
@@ -1,5 +1,5 @@
 {
-	"folder": "a03073c1f33d5b34",
+	"folder": "1b4c9d4ab8770176",
 	"name": "Airshift",
 	"type": "feature",
 	"img": "icons/magic/air/wind-stream-purple-blue.webp",

--- a/packs/classFeatures/core/zephyr/martial-arts-ability/blur.json
+++ b/packs/classFeatures/core/zephyr/martial-arts-ability/blur.json
@@ -1,5 +1,5 @@
 {
-	"folder": "a03073c1f33d5b34",
+	"folder": "1b4c9d4ab8770176",
 	"name": "Blur",
 	"type": "feature",
 	"img": "icons/skills/movement/figure-running-gray.webp",

--- a/packs/classFeatures/core/zephyr/martial-arts-ability/bodily-discipline.json
+++ b/packs/classFeatures/core/zephyr/martial-arts-ability/bodily-discipline.json
@@ -1,5 +1,5 @@
 {
-	"folder": "a03073c1f33d5b34",
+	"folder": "1b4c9d4ab8770176",
 	"name": "Bodily Discipline",
 	"type": "feature",
 	"img": "icons/magic/holy/meditation-chi-focus-blue.webp",

--- a/packs/classFeatures/core/zephyr/martial-arts-ability/enduring-soul.json
+++ b/packs/classFeatures/core/zephyr/martial-arts-ability/enduring-soul.json
@@ -1,5 +1,5 @@
 {
-	"folder": "a03073c1f33d5b34",
+	"folder": "1b4c9d4ab8770176",
 	"name": "Enduring Soul",
 	"type": "feature",
 	"img": "icons/magic/holy/angel-winged-humanoid-blue.webp",

--- a/packs/classFeatures/core/zephyr/martial-arts-ability/i-jump-on-his-back.json
+++ b/packs/classFeatures/core/zephyr/martial-arts-ability/i-jump-on-his-back.json
@@ -1,5 +1,5 @@
 {
-	"folder": "a03073c1f33d5b34",
+	"folder": "1b4c9d4ab8770176",
 	"name": "I Jump On His Back!",
 	"type": "feature",
 	"img": "icons/skills/movement/arrow-upward-yellow.webp",

--- a/packs/classFeatures/core/zephyr/martial-arts-ability/kinetic-barrage.json
+++ b/packs/classFeatures/core/zephyr/martial-arts-ability/kinetic-barrage.json
@@ -1,5 +1,5 @@
 {
-	"folder": "a03073c1f33d5b34",
+	"folder": "1b4c9d4ab8770176",
 	"name": "Kinetic Barrage",
 	"type": "feature",
 	"img": "icons/skills/melee/strikes-sword-triple-gray.webp",

--- a/packs/classFeatures/core/zephyr/martial-arts-ability/mighty-soul.json
+++ b/packs/classFeatures/core/zephyr/martial-arts-ability/mighty-soul.json
@@ -1,5 +1,5 @@
 {
-	"folder": "a03073c1f33d5b34",
+	"folder": "1b4c9d4ab8770176",
 	"name": "Mighty Soul",
 	"type": "feature",
 	"img": "icons/magic/earth/construct-stone.webp",

--- a/packs/classFeatures/core/zephyr/martial-arts-ability/quickstrike.json
+++ b/packs/classFeatures/core/zephyr/martial-arts-ability/quickstrike.json
@@ -1,5 +1,5 @@
 {
-	"folder": "a03073c1f33d5b34",
+	"folder": "1b4c9d4ab8770176",
 	"name": "Quickstrike",
 	"type": "feature",
 	"img": "icons/magic/control/buff-strength-muscle-damage-orange.webp",

--- a/packs/classFeatures/core/zephyr/martial-arts-ability/use-momentum.json
+++ b/packs/classFeatures/core/zephyr/martial-arts-ability/use-momentum.json
@@ -1,5 +1,5 @@
 {
-	"folder": "a03073c1f33d5b34",
+	"folder": "1b4c9d4ab8770176",
 	"name": "Use Momentum",
 	"type": "feature",
 	"img": "icons/magic/control/energy-stream-link-spiral-white.webp",

--- a/packs/classFeatures/core/zephyr/martial-arts-ability/vital-rejuvenation.json
+++ b/packs/classFeatures/core/zephyr/martial-arts-ability/vital-rejuvenation.json
@@ -1,5 +1,5 @@
 {
-	"folder": "a03073c1f33d5b34",
+	"folder": "1b4c9d4ab8770176",
 	"name": "Vital Rejuvenation",
 	"type": "feature",
 	"img": "icons/magic/life/heart-cross-purple-orange.webp",

--- a/packs/classFeatures/core/zephyr/martial-arts-ability/windstrider.json
+++ b/packs/classFeatures/core/zephyr/martial-arts-ability/windstrider.json
@@ -1,5 +1,5 @@
 {
-	"folder": "a03073c1f33d5b34",
+	"folder": "1b4c9d4ab8770176",
 	"name": "Windstrider",
 	"type": "feature",
 	"img": "icons/skills/movement/ball-spinning-blue.webp",


### PR DESCRIPTION
## Summary

- Updates `build/lib/Pack.mjs` to generate grouped ability folders (e.g. "Savage Arsenal", "Commander's Orders") and a "[Class] Subclasses" wrapper for each class in the Foundry compendium folder tree
- Updates `folder` references in all 130 sub-ability JSON files to point to their new grouped folder IDs

## Test plan

- [ ] Build compendia and verify ability items appear nested inside their group folders in Foundry
- [ ] Verify subclass items appear under a "[Class] Subclasses" wrapper folder
- [ ] Confirm no item data (stats, rules, descriptions) was modified