### PR TITLE
fix(inventory): make quantity input interactive without triggering item roll

### DIFF
--- a/src/scss/components/_document-card.scss
+++ b/src/scss/components/_document-card.scss
@@ -347,6 +347,24 @@
     text-align: center;
     line-height: 1;
     height: 1.5rem;
+    border: 1px solid transparent;
+    border-radius: 2px;
+    cursor: text;
+    transition: border-color var(--nimble-standard-transition);
+
+    &:not(:disabled):hover {
+      border-color: var(--nimble-medium-text-color);
+    }
+
+    &:focus {
+      border-color: var(--nimble-input-focus-border-color, var(--color-border-highlight));
+      outline: none;
+    }
+
+    &:disabled {
+      cursor: default;
+      opacity: 0.6;
+    }
   }
 
   &__charges {

--- a/src/view/sheets/pages/PlayerCharacterInventoryTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterInventoryTab.svelte
@@ -318,6 +318,7 @@
 									value={item.reactive.system.quantity || 1}
 									min="0"
 									step="1"
+									onclick={(event) => event.stopPropagation()}
 									onchange={({ currentTarget }) =>
 										actor.updateItem(item._id, {
 											'system.quantity': currentTarget.value,


### PR DESCRIPTION
## Summary

- Add hover/focus border styles to the inventory quantity field so it's visually discoverable as an editable input (previously looked identical to static text due to transparent borders)
- Stop click propagation on the quantity input so clicking it doesn't fire `activateItem`, which was rolling the item and posting it to chat
- Add `cursor: text` on hover and `:disabled` opacity/cursor styles for slot-sized items that can't be edited

## Test plan

- [ ] Open a character sheet's inventory tab
- [ ] Hover over the quantity number on a stackable item — a subtle border should appear
- [ ] Click the quantity field — no roll should fire, no chat message should appear
- [ ] Change the quantity value and confirm it saves correctly
- [ ] Verify clicking elsewhere on the item card still triggers the roll as expected
- [ ] Verify slot-sized items show the quantity as dimmed/non-interactive