### PR TITLE
fix(types): resolve svelte-check type errors

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -785,6 +785,7 @@ const charges = {
 	saveChanges: 'NIMBLE.charges.saveChanges',
 	max: 'NIMBLE.charges.setMax',
 	empty: 'NIMBLE.charges.setEmpty',
+	manuallyAdjusted: 'NIMBLE.charges.manuallyAdjusted',
 };
 
 const safeRest = {

--- a/src/documents/dialogs/GenericDialog.svelte.ts
+++ b/src/documents/dialogs/GenericDialog.svelte.ts
@@ -38,7 +38,9 @@ export default class GenericDialog extends SvelteApplicationMixin(ApplicationV2)
 
 	constructor(
 		title: string,
-		component: svelte.Component<Record<string, never>>,
+		// Dialogs accept components with arbitrary prop shapes; props are supplied via `data`.
+		// biome-ignore lint/suspicious/noExplicitAny: heterogeneous component container
+		component: svelte.Component<any>,
 		data: Record<string, unknown> = {},
 		options: GenericDialogOptions = {},
 	) {
@@ -77,7 +79,8 @@ export default class GenericDialog extends SvelteApplicationMixin(ApplicationV2)
 	 */
 	static getOrCreate(
 		title: string,
-		component: svelte.Component<Record<string, never>>,
+		// biome-ignore lint/suspicious/noExplicitAny: heterogeneous component container
+		component: svelte.Component<any>,
 		data: Record<string, unknown> = {},
 		options: GenericDialogOptions & { uniqueId: string },
 	): GenericDialog {

--- a/src/documents/dialogs/ItemMacroDialog.svelte.ts
+++ b/src/documents/dialogs/ItemMacroDialog.svelte.ts
@@ -1,3 +1,4 @@
+import type * as svelte from 'svelte';
 import {
 	SvelteApplicationMixin,
 	type SvelteApplicationRenderContext,
@@ -11,7 +12,7 @@ export default class ItemMacroDialog extends SvelteApplicationMixin(ApplicationV
 
 	data: any;
 
-	protected root = ItemMacroDialogComponent;
+	protected root = ItemMacroDialogComponent as unknown as svelte.Component<Record<string, never>>;
 
 	constructor(item, data = {}, options = {} as SvelteApplicationRenderContext) {
 		super(

--- a/src/utils/localize.ts
+++ b/src/utils/localize.ts
@@ -1,7 +1,9 @@
 import isObject from './isObject.js';
 
-export default function localize(stringId: string, data?: Record<string, string>) {
-	const result = !isObject(data) ? game.i18n.localize(stringId) : game.i18n.format(stringId, data);
+export default function localize(stringId: string, data?: Record<string, string | number>) {
+	const result = !isObject(data)
+		? game.i18n.localize(stringId)
+		: game.i18n.format(stringId, data as Record<string, string>);
 
 	return result !== undefined ? result : '';
 }

--- a/src/utils/sortItems.ts
+++ b/src/utils/sortItems.ts
@@ -1,3 +1,3 @@
-export default function sortItems(items: Item[]): Item[] {
+export default function sortItems<T extends Item>(items: T[]): T[] {
 	return items.sort((a, b) => a.sort - b.sort);
 }

--- a/src/view/chat/MinionGroupAttackCard.svelte
+++ b/src/view/chat/MinionGroupAttackCard.svelte
@@ -27,7 +27,7 @@
 	let groupLabel = $derived((system.groupLabel as string | undefined)?.trim() ?? '');
 	const i18nLocalize = (key: string): string => game.i18n.localize(key as never);
 	const i18nFormat = (key: string, data: Record<string, unknown>): string =>
-		game.i18n.format(key as never, data);
+		game.i18n.format(key as never, data as Record<string, string>);
 
 	let subheading = $derived(
 		groupLabel.length > 0
@@ -50,7 +50,7 @@
 	function getRowRolledTotal(row: MinionGroupAttackRow): number | null {
 		if (row.roll) {
 			try {
-				const roll = Roll.fromData(row.roll as Roll.JSON);
+				const roll = Roll.fromData(row.roll as Roll.Data);
 				const rollTotal = Number(roll.total ?? 0);
 				if (Number.isFinite(rollTotal)) return Math.max(0, Math.floor(rollTotal));
 			} catch (_error) {
@@ -75,7 +75,7 @@
 			return prepareRollTooltip(
 				String(system.actorType ?? ''),
 				Number(system.permissions ?? 0),
-				Roll.fromData(row.roll as Roll.JSON),
+				Roll.fromData(row.roll as Roll.Data),
 			);
 		} catch (_error) {
 			return null;

--- a/src/view/chat/MinionGroupAttackCard.svelte
+++ b/src/view/chat/MinionGroupAttackCard.svelte
@@ -50,7 +50,7 @@
 	function getRowRolledTotal(row: MinionGroupAttackRow): number | null {
 		if (row.roll) {
 			try {
-				const roll = Roll.fromData(row.roll as Roll.Data);
+				const roll = Roll.fromData(row.roll as unknown as Roll.Data);
 				const rollTotal = Number(roll.total ?? 0);
 				if (Number.isFinite(rollTotal)) return Math.max(0, Math.floor(rollTotal));
 			} catch (_error) {
@@ -75,7 +75,7 @@
 			return prepareRollTooltip(
 				String(system.actorType ?? ''),
 				Number(system.permissions ?? 0),
-				Roll.fromData(row.roll as Roll.Data),
+				Roll.fromData(row.roll as unknown as Roll.Data),
 			);
 		} catch (_error) {
 			return null;

--- a/src/view/chat/MoveActionCard.svelte
+++ b/src/view/chat/MoveActionCard.svelte
@@ -7,7 +7,9 @@
 
 	const { messageDocument }: MoveActionCardProps = $props();
 
-	const system = $derived(messageDocument.reactive.system);
+	const system = $derived(
+		messageDocument.reactive.system as unknown as { actorName: string; speed: number },
+	);
 	const headerBackgroundColor = $derived(messageDocument.reactive.author.color);
 	const headerTextColor = $derived(calculateHeaderTextColor(headerBackgroundColor));
 

--- a/src/view/chat/components/ChargeConsumptionNode.svelte
+++ b/src/view/chat/components/ChargeConsumptionNode.svelte
@@ -2,11 +2,12 @@
 	import { SYSTEM_ID } from '#system';
 	import { ChargeUiConfig } from '#utils/chargeUiConfig.js';
 	import localize from '#utils/localize.js';
+	import type { NimbleChatMessage } from '#documents/chatMessage.js';
 	import { getContext } from 'svelte';
 
 	let { node: _node } = $props();
 
-	const messageDocument = getContext('messageDocument');
+	const messageDocument = getContext('messageDocument') as NimbleChatMessage;
 	let consumption = $derived(
 		messageDocument?.reactive?.flags?.[SYSTEM_ID]?.chargeConsumption ?? [],
 	);

--- a/src/view/chat/components/DamageNode.svelte
+++ b/src/view/chat/components/DamageNode.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { getContext } from 'svelte';
+	import type { NimbleChatMessage } from '../../../documents/chatMessage.js';
 	import DamageRoll from './DamageRoll.svelte';
 
 	let { node } = $props();
@@ -8,8 +9,10 @@
 	let roll = $derived(node.roll);
 	let targetDisposition = $derived(node.targetDisposition);
 
-	const messageDocument = getContext('messageDocument');
-	let outcome = $derived(messageDocument?.system?.isMiss ? 'noDamage' : 'fullDamage');
+	const messageDocument = getContext('messageDocument') as NimbleChatMessage;
+	let outcome = $derived(
+		(messageDocument?.system as { isMiss?: boolean })?.isMiss ? 'noDamage' : 'fullDamage',
+	);
 </script>
 
 <DamageRoll {damageType} {ignoreArmor} {outcome} {roll} {targetDisposition} />

--- a/src/view/chat/components/RollSummary.svelte
+++ b/src/view/chat/components/RollSummary.svelte
@@ -18,7 +18,9 @@
 		targetDisposition,
 	}: RollSummaryProps = $props();
 	const { hitDice } = CONFIG.NIMBLE;
-	const autoExpand = game.settings.get(SYSTEM_ID, 'autoExpandRolls');
+	const autoExpand = Boolean(
+		game.settings.get(SYSTEM_ID as 'core', 'autoExpandRolls' as 'rollMode'),
+	);
 	const messageDocument = getContext<NimbleChatMessage | undefined>('messageDocument');
 	let expanded = $state(autoExpand);
 
@@ -28,7 +30,11 @@
 		const canApplyDamageFunction = messageDocument?.canApplyDamage;
 		if (typeof canApplyDamageFunction !== 'function') return true;
 
-		return canApplyDamageFunction.call(messageDocument, total, options);
+		return canApplyDamageFunction.call(
+			messageDocument,
+			total,
+			options as Parameters<NimbleChatMessage['canApplyDamage']>[1],
+		);
 	});
 	let applyDamageLabel = $derived(localize('NIMBLE.chat.applyDamage'));
 	let applyDamageTooltip = $derived(
@@ -76,8 +82,8 @@
 
 {#if showRollDetails}
 	<div class="roll-details">
-		<span>{hitDice.primaryDieValue}: {options.rollOptions.primaryDieValue}</span>
-		<span>{hitDice.primaryDieModifier}: {options.rollOptions.primaryDieModifier}</span>
+		<span>{hitDice.primaryDieValue}: {options?.rollOptions?.primaryDieValue}</span>
+		<span>{hitDice.primaryDieModifier}: {options?.rollOptions?.primaryDieModifier}</span>
 	</div>
 {/if}
 
@@ -96,7 +102,11 @@
 		data-tooltip={applyDamageTooltip}
 		data-tooltip-direction="UP"
 		disabled={!canApplyDamage}
-		onclick={() => messageDocument?.applyDamage(total, options)}
+		onclick={() =>
+			messageDocument?.applyDamage(
+				total,
+				options as Parameters<NimbleChatMessage['applyDamage']>[1],
+			)}
 	>
 		{applyDamageLabel}
 	</button>

--- a/src/view/chat/components/Targets.svelte
+++ b/src/view/chat/components/Targets.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { getContext } from 'svelte';
+	import type { NimbleChatMessage } from '../../../documents/chatMessage.js';
 	import localize from '../../../utils/localize.js';
 	import { tokenHoverIn, tokenHoverOut } from '../../../utils/tokenHoverHighlight.js';
 
@@ -12,7 +13,9 @@
 	}
 
 	function getArmorIcon(token: TokenDocument.Implementation) {
-		const armor = token.actor?.system?.attributes.armor;
+		const armor = (token.actor?.system as { attributes?: { armor?: string } } | undefined)
+			?.attributes?.armor;
+		if (!armor) return null;
 		const armorIcon = npcArmorIcons[armor];
 
 		if (armor !== 'heavy' && armor !== 'medium') return null;
@@ -44,9 +47,11 @@
     `;
 	}
 
-	async function prepareTargets(targetIDs: string[]) {
-		const tokenDocuments = await Promise.all(targetIDs.map((id) => fromUuid(id)));
-		return tokenDocuments.filter(Boolean);
+	async function prepareTargets(targetIDs: string[]): Promise<TokenDocument.Implementation[]> {
+		const tokenDocuments = await Promise.all(
+			targetIDs.map((id) => fromUuid(id as Parameters<typeof fromUuid>[0])),
+		);
+		return tokenDocuments.filter(Boolean) as unknown as TokenDocument.Implementation[];
 	}
 
 	function removeTarget(targetId: string) {
@@ -55,8 +60,10 @@
 
 	const { npcArmorEffects, npcArmorIcons, npcArmorTypes } = CONFIG.NIMBLE;
 
-	let messageDocument = getContext('messageDocument');
-	let targets = $derived(messageDocument?.reactive?.system?.targets ?? []);
+	let messageDocument = getContext('messageDocument') as NimbleChatMessage;
+	let targets = $derived(
+		(messageDocument?.reactive?.system as { targets?: string[] } | undefined)?.targets ?? [],
+	);
 </script>
 
 <section class="nimble-card-section nimble-card-section--targets">

--- a/src/view/components/ActorConditionsList.test.ts
+++ b/src/view/components/ActorConditionsList.test.ts
@@ -10,7 +10,7 @@ function createActor({
 	owner?: boolean;
 	statuses?: string[];
 	effects?: ActiveEffect[];
-} = {}): Actor.Implementation {
+} = {}): Actor.Implementation & { reactive: Actor.Implementation } {
 	const actor = {
 		id: 'actor-1',
 		name: 'Hero',
@@ -40,7 +40,7 @@ function createActor({
 		flags: { nimble: { editingEnabled: owner } },
 	};
 
-	return actor as unknown as Actor.Implementation;
+	return actor as unknown as Actor.Implementation & { reactive: Actor.Implementation };
 }
 
 describe('ActorConditionsList', () => {

--- a/src/view/components/TagGroup.svelte
+++ b/src/view/components/TagGroup.svelte
@@ -6,7 +6,7 @@
 		grid?: boolean;
 		options: TagGroupOption[];
 		selectedOptions: (string | number)[] | Set<string | number>;
-		toggleOption: (newValue: string | number) => Promise<void>;
+		toggleOption: (newValue: string | number, event?: MouseEvent) => void | Promise<void>;
 	}
 
 	let { disabled = false, grid = false, options, selectedOptions, toggleOption }: props = $props();

--- a/src/view/dialogs/CharacterLevelDownDialog.svelte
+++ b/src/view/dialogs/CharacterLevelDownDialog.svelte
@@ -1,14 +1,17 @@
 <script lang="ts">
 	import type { CharacterLevelDownDialogProps } from '#types/components/CharacterLevelDownDialog.d.ts';
 
-	import { createLevelDownState } from './CharacterLevelDownDialogState.svelte.ts';
+	import {
+		createLevelDownState,
+		type LevelDownActor,
+	} from './CharacterLevelDownDialogState.svelte.ts';
 
 	let { document: actor, dialog }: CharacterLevelDownDialogProps = $props();
 
 	const { levelDownDialog } = CONFIG.NIMBLE;
 
 	const state = createLevelDownState(
-		() => actor,
+		() => actor as unknown as LevelDownActor,
 		() => dialog,
 	);
 

--- a/src/view/dialogs/CharacterLevelDownDialogState.svelte.ts
+++ b/src/view/dialogs/CharacterLevelDownDialogState.svelte.ts
@@ -6,7 +6,7 @@ interface ClassItemShape {
 }
 
 /** Structural type for what the factory accesses on the actor document */
-interface LevelDownActor {
+export interface LevelDownActor {
 	system: {
 		levelUpHistory: Array<{
 			classIdentifier: string;

--- a/src/view/dialogs/CharacterLevelUpDialog.svelte
+++ b/src/view/dialogs/CharacterLevelUpDialog.svelte
@@ -8,7 +8,7 @@
 	import LevelUpSpellGrants from './components/levelUpHelper/LevelUpSpellGrants.svelte';
 	import SkillPointAssignment from './components/levelUpHelper/SkillPointAssignment.svelte';
 	import SubclassSelection from './components/levelUpHelper/SubclassSelection.svelte';
-	import { createLevelUpState } from './CharacterLevelUpDialogState.svelte.ts';
+	import { createLevelUpState, type LevelUpDocument } from './CharacterLevelUpDialogState.svelte.ts';
 	import { SUBCLASS_LEVEL, EPIC_BOON_LEVEL } from './const/levelUpConstants.ts';
 
 	let { document, dialog }: CharacterLevelUpDialogProps = $props();
@@ -16,11 +16,11 @@
 	const { forms } = CONFIG.NIMBLE;
 
 	const state = createLevelUpState(
-		() => document,
+		() => document as unknown as LevelUpDocument,
 		() => dialog,
 	);
 
-	const { boons, submit, getSubmitButtonTooltip, getSubmitButtonAriaLabel } = state;
+	const { submit, getSubmitButtonTooltip, getSubmitButtonAriaLabel } = state;
 	const characterClass = $derived(state.characterClass);
 	const levelingTo = $derived(state.levelingTo);
 	const subclasses = $derived(state.subclasses);
@@ -35,7 +35,6 @@
 	<HitPointSelection {document} bind:hitPointRollSelection={state.hitPointRollSelection} />
 
 	<AbilityScoreIncrease
-		{boons}
 		{characterClass}
 		{document}
 		{levelingTo}
@@ -46,10 +45,8 @@
 	/>
 
 	<SkillPointAssignment
-		chooseBoon={state.chooseBoon}
 		{document}
 		selectedBoon={state.selectedBoon}
-		selectedAbilityScore={state.selectedAbilityScores}
 		bind:skillPointChanges={state.skillPointChanges}
 		bind:selectedAbilityScores={state.selectedAbilityScores}
 		bind:skillPointsOverMax={state.skillPointsOverMax}

--- a/src/view/dialogs/CharacterLevelUpDialogState.svelte.ts
+++ b/src/view/dialogs/CharacterLevelUpDialogState.svelte.ts
@@ -24,7 +24,7 @@ interface ClassItemShape {
 }
 
 /** Structural type for what the factory accesses on the actor document */
-interface LevelUpDocument {
+export interface LevelUpDocument {
 	classes: Record<string, ClassItemShape | undefined>;
 	items: Array<{
 		type: string;

--- a/src/view/dialogs/CharacterSkillsConfigDialogState.svelte.ts
+++ b/src/view/dialogs/CharacterSkillsConfigDialogState.svelte.ts
@@ -11,7 +11,7 @@ interface LevelUpHistoryEntry {
 	skillIncreases: Record<string, number>;
 }
 
-interface SkillsDocument {
+export interface SkillsDocument {
 	reactive: {
 		system: {
 			skills: Record<string, SkillData>;

--- a/src/view/dialogs/CharacterStatConfigDialog.svelte
+++ b/src/view/dialogs/CharacterStatConfigDialog.svelte
@@ -42,7 +42,7 @@
 	const asiTotals = $derived(state.asiTotals);
 </script>
 
-{#snippet sectionHeader(title, subtitle = null)}
+{#snippet sectionHeader(title: string, subtitle: string | null = null)}
 	<tr class="nimble-stat-config__section-header">
 		<th colspan={abilityScoreCount + 1}>
 			<div class="nimble-stat-config__section-title">
@@ -211,8 +211,9 @@
 										role="listitem"
 										draggable="true"
 										ondragstart={(e) => {
+											if (!e.dataTransfer) return;
 											e.dataTransfer.dropEffect = 'move';
-											e.dataTransfer.setData('modifier', arrayIndex);
+											e.dataTransfer.setData('modifier', String(arrayIndex));
 										}}
 									>
 										<i class="fa-solid fa-grip-vertical drag-icon"></i>
@@ -253,8 +254,9 @@
 										class="nimble-array-value-list__option"
 										draggable="true"
 										ondragstart={(e) => {
+											if (!e.dataTransfer) return;
 											e.dataTransfer.dropEffect = 'move';
-											e.dataTransfer.setData('modifier', modifierIndex);
+											e.dataTransfer.setData('modifier', String(modifierIndex));
 										}}
 									>
 										<i class="fa-solid fa-grip-vertical drag-icon"></i>

--- a/src/view/dialogs/CharacterStatConfigDialogState.svelte.ts
+++ b/src/view/dialogs/CharacterStatConfigDialogState.svelte.ts
@@ -32,7 +32,7 @@ interface ClassItem {
 	items?: unknown;
 }
 
-interface StatConfigDocument {
+export interface StatConfigDocument {
 	reactive: {
 		items: ClassItem[];
 		system: { abilities: Record<string, AbilityData> };
@@ -404,7 +404,8 @@ export function createCharacterStatConfigDialogState(getDocument: () => StatConf
 		});
 	}
 
-	function getStatIncreaseTypeLabel(type: string): string {
+	function getStatIncreaseTypeLabel(type: string | null): string {
+		if (!type) return '';
 		const labels: Record<string, string> = {
 			primary: localize('NIMBLE.statConfig.primary'),
 			secondary: localize('NIMBLE.statConfig.secondary'),
@@ -413,7 +414,8 @@ export function createCharacterStatConfigDialogState(getDocument: () => StatConf
 		return labels[type] ?? type;
 	}
 
-	function getStatIncreaseTypeTooltip(type: string): string {
+	function getStatIncreaseTypeTooltip(type: string | null): string {
+		if (!type) return '';
 		const tooltips: Record<string, string> = {
 			primary: localize('NIMBLE.statConfig.primaryTooltip'),
 			secondary: localize('NIMBLE.statConfig.secondaryTooltip'),

--- a/src/view/dialogs/CheckRollDialog.svelte
+++ b/src/view/dialogs/CheckRollDialog.svelte
@@ -11,14 +11,16 @@
 
 	let { actor, dialog, type = 'abilityCheck', ...data }: CheckRollDialogProps = $props();
 	let selectedRollMode = $state(untrack(() => Math.clamp(Number(data.rollMode ?? 0), -6, 6)));
-	let shouldRollBeHidden = $state(Boolean(game.settings.get(SYSTEM_ID, 'hideRolls')));
+	let shouldRollBeHidden = $state(
+		Boolean(game.settings.get(SYSTEM_ID as 'core', 'hideRolls' as 'rollMode')),
+	);
 
 	let rollFormula = $derived.by(() => {
 		if (type === 'initiative') {
 			return actor._getInitiativeFormula({ rollMode: selectedRollMode });
 		}
 
-		return getRollFormula(actor as Parameters<typeof getRollFormula>[0], {
+		return getRollFormula(actor as unknown as Parameters<typeof getRollFormula>[0], {
 			...data,
 			rollMode: selectedRollMode,
 			type,

--- a/src/view/dialogs/ConfigureChargesDialog.svelte
+++ b/src/view/dialogs/ConfigureChargesDialog.svelte
@@ -123,7 +123,7 @@
 					itemName,
 					pools: poolData,
 				},
-			});
+			} as Parameters<typeof ChatMessage.create>[0]);
 		}
 
 		dialog.submit();

--- a/src/view/dialogs/ConfigureChargesDialog.svelte
+++ b/src/view/dialogs/ConfigureChargesDialog.svelte
@@ -123,7 +123,7 @@
 					itemName,
 					pools: poolData,
 				},
-			} as Parameters<typeof ChatMessage.create>[0]);
+			} as unknown as Parameters<typeof ChatMessage.create>[0]);
 		}
 
 		dialog.submit();

--- a/src/view/dialogs/EditManaDialog.svelte
+++ b/src/view/dialogs/EditManaDialog.svelte
@@ -42,7 +42,9 @@
 	let baseMax = $state(untrack(() => actor.system.resources.mana.baseMax ?? 0));
 
 	let classManaContributions = $derived.by(() => {
-		const classes = actor.items.filter((i: Item) => i.type === 'class') as ClassWithManaFormula[];
+		const classes = actor.items.filter(
+			(i: Item) => i.type === 'class',
+		) as unknown as ClassWithManaFormula[];
 		const includeClassFormula = actor.levels.character > 1;
 		const rollData = actor.getRollData();
 
@@ -68,7 +70,9 @@
 
 	let effectiveRecoveryTypes = $derived.by(() => {
 		const classes = actor.items.filter((i: Item) => i.type === 'class');
-		const types = getManaRecoveryTypesFromClasses(classes);
+		const types = getManaRecoveryTypesFromClasses(
+			classes as Parameters<typeof getManaRecoveryTypesFromClasses>[0],
+		);
 		if (types.size === 0) {
 			types.add('safeRest');
 		}

--- a/src/view/dialogs/FieldRestDialog.svelte
+++ b/src/view/dialogs/FieldRestDialog.svelte
@@ -53,22 +53,27 @@
 		const hitDiceAttr = actor.reactive.system.attributes.hitDice;
 		const bonusHitDice = actor.reactive.system.attributes.bonusHitDice ?? [];
 		const classes = actor.reactive.items.filter((i) => i.type === 'class');
-		const hitDiceSizeBonus = actor.reactive.system.attributes.hitDiceSizeBonus ?? 0;
+		const hitDiceSizeBonus =
+			(actor.reactive.system.attributes as { hitDiceSizeBonus?: number }).hitDiceSizeBonus ?? 0;
 
 		const bySize: Record<number, { current: number; total: number }> = {};
 
 		// Add from classes (apply hitDiceSizeBonus to get effective size)
 		for (const cls of classes) {
-			const baseSize = cls.system.hitDieSize;
+			const classSystem = cls.system as unknown as { hitDieSize: number; classLevel: number };
+			const baseSize = classSystem.hitDieSize;
 			const size = incrementDieSize(baseSize, hitDiceSizeBonus);
 			bySize[size] ??= { current: 0, total: 0 };
-			bySize[size].total += cls.system.classLevel;
+			bySize[size].total += classSystem.classLevel;
 			bySize[size].current = hitDiceAttr[size]?.current ?? 0;
 		}
 
 		// Get effective class sizes (after applying bonus) for later checks
 		const effectiveClassSizes = classes.map((cls) =>
-			incrementDieSize(cls.system.hitDieSize, hitDiceSizeBonus),
+			incrementDieSize(
+				(cls.system as unknown as { hitDieSize: number }).hitDieSize,
+				hitDiceSizeBonus,
+			),
 		);
 
 		// Add from bonusHitDice array (apply hitDiceSizeBonus to increment)
@@ -285,7 +290,7 @@
 				totalSelected === 1
 					? CONFIG.NIMBLE.fieldRest.restAndSpendHitDie
 					: CONFIG.NIMBLE.fieldRest.restAndSpendHitDice,
-				{ count: totalSelected },
+				{ count: String(totalSelected) },
 			)}
 		{:else}
 			{CONFIG.NIMBLE.fieldRest.restWithoutSpending}

--- a/src/view/dialogs/ItemActivationConfigDialog.svelte
+++ b/src/view/dialogs/ItemActivationConfigDialog.svelte
@@ -15,7 +15,7 @@
 		actor: () => actor,
 		item: () => item,
 		initialRollMode: untrack(() => rollMode),
-		hideRollsDefault: !!game.settings.get(SYSTEM_ID, 'hideRolls'),
+		hideRollsDefault: !!game.settings.get(SYSTEM_ID as 'core', 'hideRolls' as 'rollMode'),
 	});
 
 	function onSubmit() {

--- a/src/view/dialogs/NPCMetaConfigDialog.svelte
+++ b/src/view/dialogs/NPCMetaConfigDialog.svelte
@@ -24,7 +24,8 @@
 		<input
 			type="text"
 			value={actor.reactive.system.details.level}
-			onchange={({ target }) => actor.update({ 'system.details.level': target.value })}
+			onchange={({ target }) =>
+				actor.update({ 'system.details.level': (target as HTMLInputElement).value })}
 		/>
 	</label>
 
@@ -36,7 +37,8 @@
 		<input
 			type="text"
 			value={actor.reactive.system.details.creatureType}
-			onchange={({ target }) => actor.update({ 'system.details.creatureType': target.value })}
+			onchange={({ target }) =>
+				actor.update({ 'system.details.creatureType': (target as HTMLInputElement).value })}
 		/>
 	</label>
 
@@ -57,7 +59,8 @@
 			<input
 				type="checkbox"
 				checked={actor.reactive.system.details.isFlunky}
-				onchange={({ target }) => actor.update({ 'system.details.isFlunky': target.checked })}
+				onchange={({ target }) =>
+					actor.update({ 'system.details.isFlunky': (target as HTMLInputElement).checked })}
 			/>
 
 			<h3 class="nimble-heading" data-heading-variant="field">

--- a/src/view/dialogs/RollHitDiceDialog.svelte
+++ b/src/view/dialogs/RollHitDiceDialog.svelte
@@ -175,7 +175,7 @@
 			<input type="checkbox" bind:checked={addStrBonus} />
 			<span
 				>{game.i18n.format(CONFIG.NIMBLE.hitDice.addStrBonus, {
-					bonus: actor.system.abilities.strength.mod,
+					bonus: String(actor.system.abilities.strength.mod),
 				})}</span
 			>
 		</label>
@@ -210,7 +210,7 @@
 	<button class="nimble-button" data-button-variant="basic" onclick={submit} disabled={!canRoll}>
 		<i class="fa-solid fa-dice"></i>
 		{game.i18n.format(CONFIG.NIMBLE.hitDice.rollHitDice, {
-			count: totalSelected,
+			count: String(totalSelected),
 			dieWord: totalSelected === 1 ? 'Die' : 'Dice',
 		})}
 	</button>

--- a/src/view/dialogs/SafeRestDialog.svelte
+++ b/src/view/dialogs/SafeRestDialog.svelte
@@ -47,7 +47,11 @@
 
 	let mana = $derived(actor.reactive.system.resources.mana);
 	let manaRecoveryTypes = $derived.by(() =>
-		getManaRecoveryTypesFromClasses(actor.reactive.items.filter((i) => i.type === 'class')),
+		getManaRecoveryTypesFromClasses(
+			actor.reactive.items.filter((i) => i.type === 'class') as Parameters<
+				typeof getManaRecoveryTypesFromClasses
+			>[0],
+		),
 	);
 	let restoresManaOnSafeRest = $derived.by(() => restoresManaOnRest(manaRecoveryTypes, 'safe'));
 	let manaRecovery = $derived(restoresManaOnSafeRest ? mana.max - mana.current : 0);
@@ -60,22 +64,27 @@
 		const hitDiceAttr = actor.reactive.system.attributes.hitDice;
 		const bonusHitDice = actor.reactive.system.attributes.bonusHitDice ?? [];
 		const classes = actor.reactive.items.filter((i) => i.type === 'class');
-		const hitDiceSizeBonus = actor.reactive.system.attributes.hitDiceSizeBonus ?? 0;
+		const hitDiceSizeBonus =
+			(actor.reactive.system.attributes as { hitDiceSizeBonus?: number }).hitDiceSizeBonus ?? 0;
 
 		const bySize: Record<number, { current: number; total: number }> = {};
 
 		// Add from classes (apply hitDiceSizeBonus to get effective size)
 		for (const cls of classes) {
-			const baseSize = cls.system.hitDieSize;
+			const classSystem = cls.system as unknown as { hitDieSize: number; classLevel: number };
+			const baseSize = classSystem.hitDieSize;
 			const size = incrementDieSize(baseSize, hitDiceSizeBonus);
 			bySize[size] ??= { current: 0, total: 0 };
-			bySize[size].total += cls.system.classLevel;
+			bySize[size].total += classSystem.classLevel;
 			bySize[size].current = hitDiceAttr[size]?.current ?? 0;
 		}
 
 		// Get effective class sizes (after applying bonus) for later checks
 		const effectiveClassSizes = classes.map((cls) =>
-			incrementDieSize(cls.system.hitDieSize, hitDiceSizeBonus),
+			incrementDieSize(
+				(cls.system as unknown as { hitDieSize: number }).hitDieSize,
+				hitDiceSizeBonus,
+			),
 		);
 
 		// Add from bonusHitDice array (apply hitDiceSizeBonus to increment)

--- a/src/view/dialogs/components/characterCreator/FeatureGroupSelection.svelte
+++ b/src/view/dialogs/components/characterCreator/FeatureGroupSelection.svelte
@@ -28,7 +28,7 @@
 		}
 
 		return game.i18n.format('NIMBLE.classFeatureSelection.chooseN', {
-			count: selectionCount,
+			count: String(selectionCount),
 		});
 	}
 
@@ -36,8 +36,8 @@
 		if (state.isFixed) return null;
 
 		return game.i18n.format('NIMBLE.classFeatureSelection.nOfMSelected', {
-			current: state.selectedCount,
-			required: selectionCount,
+			current: String(state.selectedCount),
+			required: String(selectionCount),
 		});
 	}
 </script>

--- a/src/view/dialogs/components/characterCreator/SpellGrantDisplay.svelte
+++ b/src/view/dialogs/components/characterCreator/SpellGrantDisplay.svelte
@@ -274,7 +274,7 @@
 				{@const spellUuids = selectedSpells.get(group.ruleId) ?? []}
 				{@const spells = spellUuids
 					.map((uuid) => group.availableSpells.find((s) => s.uuid === uuid))
-					.filter(Boolean)}
+					.filter((spell): spell is NonNullable<typeof spell> => spell !== undefined)}
 				{#if spells.length > 0}
 					<div class="spell-grants__school-group">
 						<h4 class="spell-grants__school-label nimble-heading" data-heading-variant="subsection">

--- a/src/view/dialogs/components/levelUpHelper/HitPointSelection.svelte
+++ b/src/view/dialogs/components/levelUpHelper/HitPointSelection.svelte
@@ -63,7 +63,9 @@
 				class:nimble-hit-point-selection__option--selected={hitPointRollSelection === 'average'}
 			>
 				<i class="fa-solid fa-gauge"></i>
-				{game.i18n.format(CONFIG.NIMBLE.levelUpDialog.takeAverage, { average: averageHp })}
+				{game.i18n.format(CONFIG.NIMBLE.levelUpDialog.takeAverage, {
+					average: String(averageHp),
+				})}
 
 				<input
 					class="nimble-hit-point-selection__input"

--- a/src/view/sheets/ClassSheet.state.svelte.ts
+++ b/src/view/sheets/ClassSheet.state.svelte.ts
@@ -67,12 +67,13 @@ export function createClassSheetState(getProps: () => ClassSheetProps) {
 				),
 			} as Record<string, unknown>);
 		},
-		toggleAdvantageSavingThrow(savingThrow: string) {
+		toggleAdvantageSavingThrow(savingThrow: string | number) {
 			void getProps().item.update({
-				'system.savingThrows.advantage': savingThrow,
+				'system.savingThrows.advantage': String(savingThrow),
 			} as Record<string, unknown>);
 		},
-		toggleArmorProficiency(armorType: string) {
+		toggleArmorProficiency(armorTypeValue: string | number) {
+			const armorType = String(armorTypeValue);
 			const { item } = getProps();
 			const current = item.reactive.system.armorProficiencies;
 			void item.update({
@@ -81,20 +82,23 @@ export function createClassSheetState(getProps: () => ClassSheetProps) {
 					: [...current, armorType],
 			} as Record<string, unknown>);
 		},
-		toggleDisadvantageSavingThrow(savingThrow: string) {
+		toggleDisadvantageSavingThrow(savingThrow: string | number) {
 			void getProps().item.update({
-				'system.savingThrows.disadvantage': savingThrow,
+				'system.savingThrows.disadvantage': String(savingThrow),
 			} as Record<string, unknown>);
 		},
-		toggleHitDieSize(hitDie: number) {
-			void getProps().item.update({ 'system.hitDieSize': hitDie } as Record<string, unknown>);
-		},
-		toggleManaRecoveryType(recoveryType: string) {
+		toggleHitDieSize(hitDie: string | number) {
 			void getProps().item.update({
-				'system.mana.recovery': recoveryType,
+				'system.hitDieSize': Number(hitDie),
 			} as Record<string, unknown>);
 		},
-		toggleKeyAbilityScoreOption(abilityScore: string) {
+		toggleManaRecoveryType(recoveryType: string | number) {
+			void getProps().item.update({
+				'system.mana.recovery': String(recoveryType),
+			} as Record<string, unknown>);
+		},
+		toggleKeyAbilityScoreOption(abilityScoreValue: string | number) {
+			const abilityScore = String(abilityScoreValue);
 			const { item } = getProps();
 			const current = item.reactive.system.keyAbilityScores;
 			void item.update({

--- a/src/view/sheets/ClassSheet.svelte
+++ b/src/view/sheets/ClassSheet.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { setContext, untrack } from 'svelte';
+	import { setContext, untrack, type Snippet } from 'svelte';
 	import localize from '../../utils/localize.js';
 	import updateDocumentImage from '../handlers/updateDocumentImage.js';
 	import { CLASS_SHEET_TAB_CONFIG, type ClassSheetTabName } from './ClassSheetConstants.js';
@@ -17,7 +17,7 @@
 
 	const classState = createClassSheetState(() => ({ item, sheet }));
 
-	const snippetsByTab: Record<ClassSheetTabName, () => void> = {
+	const snippetsByTab: Record<ClassSheetTabName, Snippet> = {
 		description: descriptionTab,
 		config: configTab,
 		progression: progressionTab,
@@ -54,7 +54,10 @@
 			<input
 				type="text"
 				value={item.reactive.identifier || ''}
-				onchange={({ target }) => item.update({ 'system.identifier': target.value })}
+				onchange={({ target }) =>
+					item.update({
+						'system.identifier': (target as HTMLInputElement).value,
+					} as Record<string, unknown>)}
 			/>
 		</section>
 
@@ -71,7 +74,7 @@
 				onchange={({ currentTarget }) =>
 					item.update({
 						'system.complexity': Number(currentTarget.value),
-					})}
+					} as Record<string, unknown>)}
 			/>
 		</section>
 
@@ -151,7 +154,7 @@
 				type="text"
 				value={item.reactive.system.mana.formula || ''}
 				onchange={({ currentTarget }) =>
-					item.update({ 'system.mana.formula': currentTarget.value })}
+					item.update({ 'system.mana.formula': currentTarget.value } as Record<string, unknown>)}
 			/>
 		</section>
 
@@ -212,7 +215,11 @@
 							<input
 								type="text"
 								value={weapon}
-								onchange={(event) => classState.updateWeaponProficiency(index, event.target.value)}
+								onchange={(event) =>
+									classState.updateWeaponProficiency(
+										index,
+										(event.target as HTMLInputElement).value,
+									)}
 							/>
 
 							<button
@@ -260,7 +267,8 @@
 							<input
 								type="text"
 								value={featureGroup}
-								onchange={(event) => classState.updateFeatureGroup(index, event.target.value)}
+								onchange={(event) =>
+									classState.updateFeatureGroup(index, (event.target as HTMLInputElement).value)}
 							/>
 
 							<button

--- a/src/view/sheets/FeatureSheet.state.svelte.ts
+++ b/src/view/sheets/FeatureSheet.state.svelte.ts
@@ -26,8 +26,8 @@ export function createFeatureSheetState(getProps: () => FeatureSheetProps) {
 			const { item } = getProps();
 			return getSelectionCountByLevelDisplayValue(item.reactive.system.selectionCountByLevel ?? {});
 		},
-		updateFeatureType(newSelection: string) {
-			void getProps().item.update({ 'system.featureType': newSelection } as Record<
+		updateFeatureType(newSelection: string | number) {
+			void getProps().item.update({ 'system.featureType': String(newSelection) } as Record<
 				string,
 				unknown
 			>);

--- a/src/view/sheets/FeatureSheet.svelte
+++ b/src/view/sheets/FeatureSheet.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { setContext, untrack } from 'svelte';
+	import { setContext, untrack, type Snippet } from 'svelte';
 	import localize from '../../utils/localize.js';
 	import updateDocumentImage from '../handlers/updateDocumentImage.js';
 
@@ -22,7 +22,7 @@
 
 	const featureState = createFeatureSheetState(() => ({ item, sheet }));
 
-	const snippetsByTab: Record<FeatureSheetTabName, () => void> = {
+	const snippetsByTab: Record<FeatureSheetTabName, Snippet> = {
 		description: descriptionTab,
 		config: configTab,
 		activationConfig: activationConfigTab,
@@ -61,7 +61,10 @@
 			<input
 				type="text"
 				value={item.reactive.identifier || ''}
-				onchange={({ target }) => item.update({ 'system.identifier': target.value })}
+				onchange={({ target }) =>
+					item.update({
+						'system.identifier': (target as HTMLInputElement).value,
+					} as Record<string, unknown>)}
 			/>
 		</div>
 
@@ -86,7 +89,11 @@
 				<input
 					type="text"
 					value={item.reactive.system.class || ''}
-					onchange={({ target }) => item.update({ 'system.class': target.value })}
+					onchange={({ target }) =>
+						item.update({ 'system.class': (target as HTMLInputElement).value } as Record<
+							string,
+							unknown
+						>)}
 				/>
 			</div>
 
@@ -98,7 +105,11 @@
 				<input
 					type="text"
 					value={item.reactive.system.group || ''}
-					onchange={({ target }) => item.update({ 'system.group': target.value })}
+					onchange={({ target }) =>
+						item.update({ 'system.group': (target as HTMLInputElement).value } as Record<
+							string,
+							unknown
+						>)}
 				/>
 			</div>
 

--- a/src/view/sheets/NPCSheet.svelte
+++ b/src/view/sheets/NPCSheet.svelte
@@ -173,7 +173,7 @@
 			value={actor.reactive.name}
 			autocomplete="off"
 			spellcheck="false"
-			onchange={({ target }) => actor.update({ name: target.value })}
+			onchange={({ target }) => actor.update({ name: (target as HTMLInputElement).value })}
 		/>
 
 		<h4 class="nimble-monster-meta">

--- a/src/view/sheets/PlayerCharacterSheet.state.svelte.ts
+++ b/src/view/sheets/PlayerCharacterSheet.state.svelte.ts
@@ -1,4 +1,4 @@
-import { setContext, untrack } from 'svelte';
+import { type Component, setContext, untrack } from 'svelte';
 import { createSubscriber } from 'svelte/reactivity';
 import { readable } from 'svelte/store';
 import { incrementDieSize } from '#managers/HitDiceManager.js';
@@ -10,15 +10,19 @@ import {
 } from '#utils/combatManaRules.js';
 import { getActiveCombatForCurrentScene, registerCombatStateHooks } from '#utils/combatState.js';
 
+// Tab components have heterogeneous prop shapes; they are rendered without props here.
+// biome-ignore lint/suspicious/noExplicitAny: heterogeneous tab component container
+type TabComponent = Component<any>;
+
 type NavigationComponents = {
-	core: unknown;
-	actions: unknown;
-	conditions: unknown;
-	inventory: unknown;
-	features: unknown;
-	spells: unknown;
-	bio: unknown;
-	settings: unknown;
+	core: TabComponent;
+	actions: TabComponent;
+	conditions: TabComponent;
+	inventory: TabComponent;
+	features: TabComponent;
+	spells: TabComponent;
+	bio: TabComponent;
+	settings: TabComponent;
 };
 
 function getHitPointPercentage(currentHP: number, maxHP: number): number {

--- a/src/view/sheets/components/AttackActionPanel.svelte
+++ b/src/view/sheets/components/AttackActionPanel.svelte
@@ -10,7 +10,13 @@
 	const actor = getContext<NimbleCharacter>('actor');
 	const sheet = getContext<{ _onDragStart(event: DragEvent): void }>('application');
 
-	let { onActivateItem = async () => {}, showEmbeddedDocumentImages = true } = $props();
+	let {
+		onActivateItem = async (_cost: number) => {},
+		showEmbeddedDocumentImages = true,
+	}: {
+		onActivateItem?: (cost: number) => Promise<void>;
+		showEmbeddedDocumentImages?: boolean;
+	} = $props();
 
 	const state = createAttackPanelState(
 		() => actor,
@@ -55,34 +61,40 @@
 			{/if}
 
 			{#each state.sortItems(state.weapons) as item (item._id)}
+				{@const reactiveItem = (item as unknown as { reactive: { name: string; img: string } })
+					.reactive}
+				{@const itemId = item._id ?? ''}
 				<WeaponCard
-					name={item.reactive.name}
-					image={item.reactive.img}
+					name={reactiveItem.name}
+					image={reactiveItem.img}
 					damage={state.getWeaponDamage(item)}
 					properties={state.getWeaponProperties(item)}
 					description={state.getItemDescription(item)}
-					isExpanded={state.expandedDescriptions.has(item._id)}
+					isExpanded={state.expandedDescriptions.has(itemId)}
 					showImage={showEmbeddedDocumentImages}
-					itemId={item._id}
-					onclick={() => state.handleItemClick(item._id)}
+					{itemId}
+					onclick={() => state.handleItemClick(itemId)}
 					ondragstart={(event) => sheet._onDragStart(event)}
-					onToggleDescription={(e) => state.toggleDescription(item._id, e)}
+					onToggleDescription={(e) => state.toggleDescription(itemId, e)}
 				/>
 			{/each}
 
 			{#each state.sortItems(state.attackFeatures) as item (item._id)}
+				{@const reactiveItem = (item as unknown as { reactive: { name: string; img: string } })
+					.reactive}
+				{@const itemId = item._id ?? ''}
 				<WeaponCard
-					name={item.reactive.name}
-					image={item.reactive.img}
+					name={reactiveItem.name}
+					image={reactiveItem.img}
 					damage={state.getWeaponDamage(item)}
 					properties={[localize('NIMBLE.ui.heroicActions.feature')]}
 					description={state.getItemDescription(item)}
-					isExpanded={state.expandedDescriptions.has(item._id)}
+					isExpanded={state.expandedDescriptions.has(itemId)}
 					showImage={showEmbeddedDocumentImages}
-					itemId={item._id}
-					onclick={() => state.handleItemClick(item._id)}
+					{itemId}
+					onclick={() => state.handleItemClick(itemId)}
 					ondragstart={(event) => sheet._onDragStart(event)}
-					onToggleDescription={(e) => state.toggleDescription(item._id, e)}
+					onToggleDescription={(e) => state.toggleDescription(itemId, e)}
 				/>
 			{/each}
 		</ul>

--- a/src/view/sheets/components/AttackActionPanel.svelte
+++ b/src/view/sheets/components/AttackActionPanel.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
 	import { getContext } from 'svelte';
+	import type { NimbleCharacter } from '#documents/actor/character.js';
 	import localize from '../../../utils/localize.js';
 	import { createAttackPanelState } from './AttackActionPanel.svelte.ts';
 
 	import SearchBar from './SearchBar.svelte';
 	import WeaponCard from './WeaponCard.svelte';
 
-	const actor = getContext('actor');
-	const sheet = getContext('application');
+	const actor = getContext<NimbleCharacter>('actor');
+	const sheet = getContext<{ _onDragStart(event: DragEvent): void }>('application');
 
 	let { onActivateItem = async () => {}, showEmbeddedDocumentImages = true } = $props();
 

--- a/src/view/sheets/components/ClassProgressionLevelRow.svelte
+++ b/src/view/sheets/components/ClassProgressionLevelRow.svelte
@@ -27,6 +27,7 @@
 		keyAbilityScores,
 		onFeatureClick,
 		onAddFeature,
+		getSourceTag,
 		onDeleteWorldItem,
 	}));
 </script>

--- a/src/view/sheets/components/Editor.svelte
+++ b/src/view/sheets/components/Editor.svelte
@@ -30,6 +30,16 @@
 		enrichOptions = {} as EnrichOptions,
 	}: Props = $props();
 
+	// Foundry's Document.Any does not expose the Nimble-augmented members used below.
+	let doc = $derived(
+		document as foundry.abstract.Document.Any & {
+			isOwner: boolean;
+			actor?: { getRollData(): object };
+			getRollData(): object;
+			update(data: Record<string, unknown>): Promise<unknown>;
+		},
+	);
+
 	// Check if content is empty (no text or just whitespace/empty tags)
 	function isContentEmpty(html: string): boolean {
 		if (!html) return true;
@@ -59,8 +69,8 @@
 	const mergedEnrichOptions = $derived(
 		foundry.utils.mergeObject(
 			{
-				secrets: document.isOwner || game.user?.isGM,
-				rollData: document.isEmbedded ? document.actor.getRollData() : document.getRollData(),
+				secrets: doc.isOwner || game.user?.isGM,
+				rollData: doc.isEmbedded && doc.actor ? doc.actor.getRollData() : doc.getRollData(),
 				relativeTo: document,
 			},
 			enrichOptions,
@@ -118,7 +128,7 @@
 		// Get the current value and save it to the document
 		if (typeof proseMirror._getValue === 'function') {
 			const value = proseMirror._getValue();
-			document.update({ [field]: value });
+			doc.update({ [field]: value });
 		}
 
 		// Dispatch a 'save' event on the proseMirror element to trigger save handlers
@@ -163,7 +173,7 @@
 			const target = event.target as ProseMirrorElement;
 			if (target?._getValue) {
 				const value = target._getValue();
-				document.update({ [field]: value });
+				doc.update({ [field]: value });
 			}
 		});
 
@@ -178,7 +188,8 @@
 		proseMirrorElem.replaceWith(element);
 
 		// Start observing editor state for active class changes
-		return observeEditorState();
+		// (cleanup cannot be returned from an async onMount callback)
+		observeEditorState();
 	});
 </script>
 

--- a/src/view/sheets/components/Editor.svelte
+++ b/src/view/sheets/components/Editor.svelte
@@ -3,7 +3,7 @@
 	import { tick } from 'svelte';
 
 	type EditorOptions = foundry.applications.elements.HTMLProseMirrorElement.ProseMirrorInputConfig;
-	type EnrichOptions = foundry.applications.ux.TextEditor.implementation.EnrichmentOptions;
+	type EnrichOptions = foundry.applications.ux.TextEditor.EnrichmentOptions;
 
 	interface ProseMirrorElement extends HTMLElement {
 		_getValue?(): string;

--- a/src/view/sheets/components/MoveActionPanel.svelte
+++ b/src/view/sheets/components/MoveActionPanel.svelte
@@ -53,7 +53,7 @@
 			},
 		};
 
-		await ChatMessage.create(chatData);
+		await ChatMessage.create(chatData as Parameters<typeof ChatMessage.create>[0]);
 	}
 </script>
 

--- a/src/view/sheets/components/MoveActionPanel.svelte
+++ b/src/view/sheets/components/MoveActionPanel.svelte
@@ -53,7 +53,7 @@
 			},
 		};
 
-		await ChatMessage.create(chatData as Parameters<typeof ChatMessage.create>[0]);
+		await ChatMessage.create(chatData as unknown as Parameters<typeof ChatMessage.create>[0]);
 	}
 </script>
 

--- a/src/view/sheets/components/MovementSpeed.svelte
+++ b/src/view/sheets/components/MovementSpeed.svelte
@@ -4,7 +4,11 @@
 
 	const { movementTypes, movementTypeIcons } = CONFIG.NIMBLE;
 
-	let { actor, showDefaultSpeed = false, editingEnabled: editingEnabledProp } = $props();
+	let {
+		actor,
+		showDefaultSpeed = false,
+		editingEnabled: editingEnabledProp = undefined,
+	} = $props();
 	let flags = $derived(actor?.reactive.flags[SYSTEM_ID]);
 	let editingEnabledFromFlags = $derived(flags?.editingEnabled ?? false);
 	let editingEnabled = $derived(editingEnabledProp ?? editingEnabledFromFlags);

--- a/src/view/sheets/components/OpportunityAttackPanel.svelte
+++ b/src/view/sheets/components/OpportunityAttackPanel.svelte
@@ -106,14 +106,16 @@
 		{/if}
 
 		{#each sortItems(meleeWeapons) as item (item._id)}
+			{@const reactiveItem = (item as unknown as { reactive: { name: string; img: string } })
+				.reactive}
 			<WeaponCard
-				name={item.reactive.name}
-				image={item.reactive.img}
+				name={reactiveItem.name}
+				image={reactiveItem.img}
 				damage={getWeaponDamage(item)}
 				properties={getWeaponProperties(item)}
 				showImage={showEmbeddedDocumentImages}
 				itemId={item._id}
-				onclick={() => handleItemClick(item._id)}
+				onclick={() => handleItemClick(item._id ?? '')}
 				ondragstart={(event) =>
 					(sheet as unknown as { _onDragStart(e: DragEvent): void })._onDragStart(event)}
 			/>

--- a/src/view/sheets/components/OpportunityAttackPanel.svelte
+++ b/src/view/sheets/components/OpportunityAttackPanel.svelte
@@ -114,7 +114,8 @@
 				showImage={showEmbeddedDocumentImages}
 				itemId={item._id}
 				onclick={() => handleItemClick(item._id)}
-				ondragstart={(event) => sheet._onDragStart(event)}
+				ondragstart={(event) =>
+					(sheet as unknown as { _onDragStart(e: DragEvent): void })._onDragStart(event)}
 			/>
 		{/each}
 

--- a/src/view/sheets/components/SavingThrows.svelte
+++ b/src/view/sheets/components/SavingThrows.svelte
@@ -12,7 +12,7 @@
 		);
 	}
 
-	let { characterSavingThrows, editingEnabled: editingEnabledProp } = $props();
+	let { characterSavingThrows, editingEnabled: editingEnabledProp = undefined } = $props();
 
 	const { saves, savingThrows, savingThrowAbbreviations } = CONFIG.NIMBLE;
 	const actor = getContext('actor');

--- a/src/view/sheets/pages/ClassProgressionTab.svelte
+++ b/src/view/sheets/pages/ClassProgressionTab.svelte
@@ -727,6 +727,7 @@
 			overflow: hidden;
 			display: -webkit-box;
 			-webkit-line-clamp: 2;
+			line-clamp: 2;
 			-webkit-box-orient: vertical;
 		}
 

--- a/src/view/sheets/pages/NPCCoreTab.svelte
+++ b/src/view/sheets/pages/NPCCoreTab.svelte
@@ -2,6 +2,7 @@
 	import { getContext } from 'svelte';
 	import { SvelteMap } from 'svelte/reactivity';
 	import type { NimbleBaseActor } from '#documents/actor/base.svelte.js';
+	import type { NimbleBaseItem } from '#documents/item/base.svelte.js';
 	import { getPools, getPoolsForItem } from '#utils/chargePool/chargePoolSync.js';
 	import sortItems from '#utils/sortItems.js';
 	import { SYSTEM_ID } from '#system';
@@ -28,8 +29,8 @@
 		await actor.deleteItem(id);
 	}
 
-	function groupItemsByType(items) {
-		return items.reduce((categories, item) => {
+	function groupItemsByType(items: NimbleBaseItem[]) {
+		return items.reduce<Record<string, NimbleBaseItem[]>>((categories, item) => {
 			// Group attackSequence items with action items
 			const itemType = mapMonsterFeatureToCategory(item);
 			categories[itemType] ??= [];
@@ -38,7 +39,7 @@
 		}, {});
 	}
 
-	function sortItemCategories([categoryA], [categoryB]) {
+	function sortItemCategories([categoryA]: [string, unknown], [categoryB]: [string, unknown]) {
 		return categoryOrder.indexOf(categoryA) - categoryOrder.indexOf(categoryB);
 	}
 
@@ -47,56 +48,70 @@
 	// Categories for grouping/display (attackSequence is grouped with action)
 	const categoryOrder = ['feature', 'action', 'bloodied', 'lastStand'];
 
-	function filterMonsterFeatures(actor) {
+	type FeatureLike = { system?: unknown; reactive?: { system?: unknown } };
+
+	function featureSystem(item: { system?: unknown }): { subtype?: string; parentItemId?: string } {
+		return (item.system ?? {}) as { subtype?: string; parentItemId?: string };
+	}
+
+	function filterMonsterFeatures(actor: NimbleBaseActor): NimbleBaseItem[] {
 		return actor.items.filter((item) => {
-			if (!validSubtypes.includes(item.system?.subtype)) return false;
+			if (!validSubtypes.includes(featureSystem(item).subtype ?? '')) return false;
 
-			return item.name.toLocaleLowerCase();
-		});
+			return Boolean(item.name.toLocaleLowerCase());
+		}) as unknown as NimbleBaseItem[];
 	}
 
-	function mapMonsterFeatureToType(item) {
-		return item.system?.subtype || 'feature';
+	function mapMonsterFeatureToType(item: FeatureLike) {
+		return featureSystem(item).subtype || 'feature';
 	}
 
-	function mapMonsterFeatureToCategory(item) {
-		const subtype = item.system?.subtype || 'feature';
+	function mapMonsterFeatureToCategory(item: FeatureLike) {
+		const subtype = featureSystem(item).subtype || 'feature';
 		// Group attackSequence items with action items
 		if (subtype === 'attackSequence') return 'action';
 		// Actions with a parent are still in the action category
 		return subtype;
 	}
 
-	function isAttackSequenceItem(item) {
-		const subtype = item.system?.subtype || item.reactive?.system?.subtype;
+	function isAttackSequenceItem(item: FeatureLike) {
+		const subtype = featureSystem(item).subtype || featureSystem(item.reactive ?? {}).subtype;
 		return subtype === 'attackSequence';
 	}
 
-	function isActionItem(item) {
-		const subtype = item.system?.subtype || item.reactive?.system?.subtype;
+	function isActionItem(item: FeatureLike) {
+		const subtype = featureSystem(item).subtype || featureSystem(item.reactive ?? {}).subtype;
 		return subtype === 'action';
 	}
 
-	function getParentItemId(item) {
-		return item.system?.parentItemId || item.reactive?.system?.parentItemId || null;
+	function getParentItemId(item: FeatureLike): string | null {
+		return (
+			featureSystem(item).parentItemId || featureSystem(item.reactive ?? {}).parentItemId || null
+		);
+	}
+
+	interface FlatActionEntry {
+		item: NimbleBaseItem;
+		parentId: string | null;
+		isAttackSequence?: boolean;
 	}
 
 	// Get a flat list of action items in display order (for unified drag-drop)
 	// Order: orphan actions first, then each attackSequence followed by its children
-	function getFlatActionList(actionItems) {
+	function getFlatActionList(actionItems: NimbleBaseItem[]): FlatActionEntry[] {
 		const attackSequences = sortItems(actionItems.filter(isAttackSequenceItem));
 		const actions = actionItems.filter(isActionItem);
 
 		// Build a set of valid attack sequence IDs
-		const validAttackSequenceIds = new Set();
+		const validAttackSequenceIds = new Set<string>();
 		for (const attackSeq of attackSequences) {
 			const id = attackSeq.reactive?._id || attackSeq._id;
 			if (id) validAttackSequenceIds.add(id);
 		}
 
 		// Group actions by their parent (only if parent exists)
-		const childrenByParent = new Map();
-		const orphanActions = [];
+		const childrenByParent = new Map<string, NimbleBaseItem[]>();
+		const orphanActions: NimbleBaseItem[] = [];
 
 		for (const action of actions) {
 			const parentId = getParentItemId(action);
@@ -105,7 +120,7 @@
 				if (!childrenByParent.has(parentId)) {
 					childrenByParent.set(parentId, []);
 				}
-				childrenByParent.get(parentId).push(action);
+				childrenByParent.get(parentId)?.push(action);
 			} else {
 				// Treat as orphan if no parent or parent doesn't exist
 				orphanActions.push(action);
@@ -118,7 +133,7 @@
 		}
 
 		// Build flat list in display order
-		const flatList = [];
+		const flatList: FlatActionEntry[] = [];
 
 		// First: orphan actions
 		for (const action of sortItems(orphanActions)) {
@@ -127,7 +142,7 @@
 
 		// Then: each attackSequence followed by its children
 		for (const attackSeq of attackSequences) {
-			const attackSeqId = attackSeq.reactive?._id || attackSeq._id;
+			const attackSeqId = attackSeq.reactive?._id || attackSeq._id || '';
 			flatList.push({ item: attackSeq, parentId: null, isAttackSequence: true });
 
 			const children = childrenByParent.get(attackSeqId) || [];
@@ -140,7 +155,11 @@
 	}
 
 	// Determine what parent an item would have if dropped at position relative to target
-	function getDropTargetParent(flatList, targetId, position) {
+	function getDropTargetParent(
+		flatList: FlatActionEntry[],
+		targetId: string,
+		position: 'above' | 'below' | null,
+	): string | null {
 		const targetIndex = flatList.findIndex((entry) => entry.item.reactive._id === targetId);
 		if (targetIndex === -1) return null;
 
@@ -204,11 +223,16 @@
 	// 	}
 	// }
 
-	async function handleDrop(event, targetId, position, newParentId) {
-		const draggedId = event.dataTransfer.getData('nimble/reorder');
+	async function handleDrop(
+		event: DragEvent,
+		targetId: string | null,
+		position: 'above' | 'below' | null,
+		newParentId: string | null = null,
+	) {
+		const draggedId = event.dataTransfer?.getData('nimble/reorder');
 		if (!draggedId) {
 			// No nimble/reorder data - try to handle as a standard Foundry drop
-			const textData = event.dataTransfer.getData('text/plain');
+			const textData = event.dataTransfer?.getData('text/plain');
 			if (textData) {
 				try {
 					const data = JSON.parse(textData);
@@ -231,11 +255,11 @@
 		event.preventDefault();
 
 		const draggedItem = actor.items.get(draggedId);
-		const targetItem = actor.items.get(targetId);
+		const targetItem = targetId ? actor.items.get(targetId) : undefined;
 
 		// If dragged item not found in this actor, it's from another actor - handle as external drop
 		if (!draggedItem) {
-			const textData = event.dataTransfer.getData('text/plain');
+			const textData = event.dataTransfer?.getData('text/plain');
 			if (textData) {
 				try {
 					const data = JSON.parse(textData);
@@ -320,7 +344,7 @@
 
 		const newItems = [...categoryItems];
 		newItems.splice(draggedIndex, 1);
-		newItems.splice(targetIndex, 0, draggedItem);
+		newItems.splice(targetIndex, 0, draggedItem as unknown as (typeof newItems)[number]);
 
 		const updates = newItems.map((item, index) => ({
 			_id: item.reactive._id,
@@ -333,22 +357,24 @@
 		return npcArmorTypeAbbreviations[armor] ?? '-';
 	}
 
-	function updateArmorCategory(direction) {
-		const armor = actor.reactive.system.attributes.armor;
+	function updateArmorCategory(direction: 'increase' | 'decrease') {
+		const armor = (actor.reactive.system as { attributes?: { armor?: string } }).attributes?.armor;
+		const updateArmor = (value: string) =>
+			actor.update({ 'system.attributes.armor': value } as Record<string, unknown>);
 
 		if (direction === 'increase') {
 			if (armor === 'heavy') return;
 
 			if (armor === 'medium') {
-				actor.update({ 'system.attributes.armor': 'heavy' });
+				updateArmor('heavy');
 			} else {
-				actor.update({ 'system.attributes.armor': 'medium' });
+				updateArmor('medium');
 			}
 		} else if (direction === 'decrease') {
 			if (armor === 'heavy') {
-				actor.update({ 'system.attributes.armor': 'medium' });
+				updateArmor('medium');
 			} else if (armor === 'medium') {
-				actor.update({ 'system.attributes.armor': 'none' });
+				updateArmor('none');
 			}
 		}
 	}
@@ -356,7 +382,9 @@
 	const { npcArmorTypeAbbreviations, creatureFeatures, monsterFeatureTypes } = CONFIG.NIMBLE;
 
 	let actor = getContext<NimbleBaseActor>('actor');
-	let sheet = getContext('application');
+	let sheet = getContext<{
+		_onDropItem?(event: DragEvent, data: Record<string, unknown>): Promise<unknown>;
+	}>('application');
 
 	// Local state for collapsed items - always use for immediate UI response
 	let localCollapsedState = new SvelteMap();
@@ -402,6 +430,15 @@
 
 	let flags = $derived(actor.reactive.flags[SYSTEM_ID]);
 	let showEmbeddedDocumentImages = $derived(flags?.showEmbeddedDocumentImages ?? true);
+
+	// NPC system data is a union across actor types; narrow it for template reads.
+	let npcSystem = $derived(
+		actor.reactive.system as unknown as {
+			savingThrows: Record<string, unknown>;
+			armor?: string;
+			attributes: { armor?: string };
+		},
+	);
 
 	let allCollapsed = $derived(items.every((item) => getItemCollapsed(item)));
 
@@ -453,7 +490,7 @@
 
 <section class="nimble-sheet__body nimble-sheet__body--npc">
 	<section class="nimble-monster-sheet-section nimble-monster-sheet-section--defenses">
-		<SavingThrows characterSavingThrows={actor.reactive.system.savingThrows} editingEnabled />
+		<SavingThrows characterSavingThrows={npcSystem.savingThrows} editingEnabled />
 
 		<MovementSpeed {actor} showDefaultSpeed={false} />
 
@@ -464,7 +501,7 @@
 				</h3>
 			</header>
 
-			<ArmorClass armorClass={getArmorClassLabel(actor.reactive.system.attributes.armor)} />
+			<ArmorClass armorClass={getArmorClassLabel(npcSystem.attributes.armor)} />
 
 			<button
 				class="nimble-button nimble-armor-config-button nimble-armor-config-button--decrement"
@@ -472,7 +509,7 @@
 				type="button"
 				aria-label={game.i18n.localize('NIMBLE.npcSheet.decreaseArmor')}
 				data-tooltip={game.i18n.localize('NIMBLE.npcSheet.decreaseArmor')}
-				disabled={actor.reactive.system.armor === 'none'}
+				disabled={npcSystem.armor === 'none'}
 				onclick={() => updateArmorCategory('decrease')}
 			>
 				-
@@ -484,7 +521,7 @@
 				type="button"
 				aria-label={game.i18n.localize('NIMBLE.npcSheet.increaseArmor')}
 				data-tooltip={game.i18n.localize('NIMBLE.npcSheet.increaseArmor')}
-				disabled={actor.reactive.system.armor === 'heavy'}
+				disabled={npcSystem.armor === 'heavy'}
 				onclick={() => updateArmorCategory('increase')}
 			>
 				+
@@ -943,7 +980,7 @@
 							requestAnimationFrame(() => {
 								game.tooltip.activate(event.currentTarget, {
 									text: wasCollapsed ? creatureFeatures.collapse : creatureFeatures.expand,
-									direction: 'DOWN',
+									direction: foundry.helpers.interaction.TooltipManager.TOOLTIP_DIRECTIONS.DOWN,
 									cssClass: 'nimble-tooltip nimble-tooltip--compact',
 								});
 							});
@@ -1122,7 +1159,7 @@
 							requestAnimationFrame(() => {
 								game.tooltip.activate(event.currentTarget, {
 									text: wasCollapsed ? creatureFeatures.collapse : creatureFeatures.expand,
-									direction: 'DOWN',
+									direction: foundry.helpers.interaction.TooltipManager.TOOLTIP_DIRECTIONS.DOWN,
 									cssClass: 'nimble-tooltip nimble-tooltip--compact',
 								});
 							});

--- a/src/view/sheets/pages/NPCCoreTab.svelte
+++ b/src/view/sheets/pages/NPCCoreTab.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { getContext } from 'svelte';
 	import { SvelteMap } from 'svelte/reactivity';
+	import type { NimbleBaseActor } from '#documents/actor/base.svelte.js';
 	import { getPools, getPoolsForItem } from '#utils/chargePool/chargePoolSync.js';
 	import sortItems from '#utils/sortItems.js';
 	import { SYSTEM_ID } from '#system';
@@ -354,7 +355,7 @@
 
 	const { npcArmorTypeAbbreviations, creatureFeatures, monsterFeatureTypes } = CONFIG.NIMBLE;
 
-	let actor = getContext('actor');
+	let actor = getContext<NimbleBaseActor>('actor');
 	let sheet = getContext('application');
 
 	// Local state for collapsed items - always use for immediate UI response
@@ -389,10 +390,10 @@
 		return item.reactive.flags[SYSTEM_ID]?.collapsed ?? false;
 	}
 
-	let dragOverItemId = $state(null);
-	let dragOverPosition = $state(null); // 'above' or 'below'
-	let draggedItemCategory = $state(null); // track category of item being dragged
-	let dragOverTargetParent = $state(null); // track what parent the item would have if dropped here
+	let dragOverItemId = $state<string | null>(null);
+	let dragOverPosition = $state<'above' | 'below' | null>(null); // 'above' or 'below'
+	let draggedItemCategory = $state<string | null>(null); // track category of item being dragged
+	let dragOverTargetParent = $state<string | null>(null); // track what parent the item would have if dropped here
 	let draggedItemIsAttackSequence = $state(false); // track if dragged item is an attack sequence
 
 	let items = $derived(filterMonsterFeatures(actor.reactive));
@@ -578,7 +579,7 @@
 					<ul
 						class="nimble-item-list"
 						ondragover={(event) => {
-							if (event.dataTransfer.types.includes('nimble/reorder')) event.preventDefault();
+							if (event.dataTransfer?.types.includes('nimble/reorder')) event.preventDefault();
 						}}
 					>
 						{#if categoryName === 'action'}
@@ -661,6 +662,7 @@
 			!draggedItemIsAttackSequence}
 		draggable={isEditable}
 		ondragstart={(event) => {
+			if (!event.dataTransfer) return;
 			event.dataTransfer.setData('nimble/reorder', itemId);
 			// Set standard Foundry drag data for cross-actor transfers
 			const dragData = item.toDragData();
@@ -691,7 +693,7 @@
 			}
 		}}
 		ondragleave={(event) => {
-			if (event.currentTarget.contains(event.relatedTarget)) return;
+			if (event.currentTarget.contains(event.relatedTarget as Node | null)) return;
 			if (dragOverItemId === itemId) {
 				dragOverItemId = null;
 				dragOverPosition = null;
@@ -774,6 +776,7 @@
 			!draggedItemIsAttackSequence}
 		draggable={isEditable}
 		ondragstart={(event) => {
+			if (!event.dataTransfer) return;
 			event.dataTransfer.setData('nimble/reorder', item.reactive._id);
 			// Set standard Foundry drag data for cross-actor transfers
 			const dragData = item.toDragData();
@@ -810,7 +813,7 @@
 			}
 		}}
 		ondragleave={(event) => {
-			if (event.currentTarget.contains(event.relatedTarget)) return;
+			if (event.currentTarget.contains(event.relatedTarget as Node | null)) return;
 			if (dragOverItemId === item.reactive._id) {
 				dragOverItemId = null;
 				dragOverPosition = null;
@@ -982,6 +985,7 @@
 			dragOverPosition === 'below'}
 		draggable={isEditable}
 		ondragstart={(event) => {
+			if (!event.dataTransfer) return;
 			event.dataTransfer.setData('nimble/reorder', item.reactive._id);
 			// Set standard Foundry drag data for cross-actor transfers
 			const dragData = item.toDragData();
@@ -999,7 +1003,7 @@
 			dragOverPosition = event.clientY < midpoint ? 'above' : 'below';
 		}}
 		ondragleave={(event) => {
-			if (event.currentTarget.contains(event.relatedTarget)) return;
+			if (event.currentTarget.contains(event.relatedTarget as Node | null)) return;
 			if (dragOverItemId === item.reactive._id) {
 				dragOverItemId = null;
 				dragOverPosition = null;

--- a/src/view/sheets/pages/PlayerCharacterFeaturesTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterFeaturesTab.svelte
@@ -137,19 +137,21 @@
 	// Class features (grouped, non-subclass) sorted by level — rendered nested under the class card
 	let classFeatureItems = $derived(
 		sortFeatureItems(
-			items.filter(
-				(item) =>
-					item.reactive.type === 'feature' &&
-					item.reactive.system.group &&
-					!item.reactive.system.subclass,
-			),
+			items.filter((item) => {
+				const featureSystem = item.reactive.system as { group?: unknown; subclass?: unknown };
+				return item.reactive.type === 'feature' && featureSystem.group && !featureSystem.subclass;
+			}),
 		),
 	);
 
 	// Subclass features sorted by level — rendered nested under the subclass card
 	let subclassFeatureItems = $derived(
 		sortFeatureItems(
-			items.filter((item) => item.reactive.type === 'feature' && item.reactive.system.subclass),
+			items.filter(
+				(item) =>
+					item.reactive.type === 'feature' &&
+					(item.reactive.system as { subclass?: unknown }).subclass,
+			),
 		),
 	);
 
@@ -174,7 +176,8 @@
 		)}
 		data-item-id={item.reactive._id}
 		draggable="true"
-		ondragstart={(event) => sheet._onDragStart(event)}
+		ondragstart={(event) =>
+			(sheet as unknown as { _onDragStart(e: DragEvent): void })._onDragStart(event)}
 		onanimationend={(event) => handleDropFlashAnimationEnd(event, item.reactive._id)}
 	>
 		<!-- svelte-ignore a11y_no_noninteractive_element_to_interactive_role -->

--- a/src/view/sheets/pages/PlayerCharacterHeroicActionsTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterHeroicActionsTab.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { getContext, untrack } from 'svelte';
+	import type { NimbleCharacter } from '#documents/actor/character.js';
 	import localize from '../../../utils/localize.js';
 	import { createHeroicActionsTabState } from './PlayerCharacterHeroicActionsTab.svelte.js';
 
@@ -27,7 +28,7 @@
 		heroicActionTarget?: HeroicActionTarget | null;
 	}
 
-	let actor = getContext('actor');
+	let actor = getContext<NimbleCharacter>('actor');
 	const sheetState = getContext<SheetState>('sheetState');
 	const heroicState = createHeroicActionsTabState(() => actor);
 	let forceNextOpportunityReactionUse = $state(false);

--- a/src/view/sheets/pages/PlayerCharacterInventoryTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterInventoryTab.svelte
@@ -237,7 +237,8 @@
 						onmouseenter={(event) => handleTooltipMouseEnter(event, item)}
 						draggable="true"
 						role="button"
-						ondragstart={(event) => sheet._onDragStart(event)}
+						ondragstart={(event) =>
+							(sheet as unknown as { _onDragStart(e: DragEvent): void })._onDragStart(event)}
 						ondragover={(event) => event.preventDefault()}
 						ondrop={(event) => handleItemDrop(event, item)}
 						onanimationend={(event) => handleDropFlashAnimationEnd(event, item.reactive._id)}

--- a/src/view/sheets/pages/PlayerCharacterInventoryTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterInventoryTab.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { NimbleCharacter } from '#documents/actor/character.js';
+	import type { NimbleBaseItem } from '#documents/item/base.svelte.js';
 	import type PlayerCharacterSheet from '#documents/sheets/PlayerCharacterSheet.svelte.js';
 	import { RulesManager } from '#managers/RulesManager.js';
 	import localize from '#utils/localize.js';
@@ -49,9 +50,9 @@
 		return null;
 	}
 
-	function groupItemsByType(items) {
-		return items.reduce((categories, item) => {
-			const { objectType } = item.reactive.system;
+	function groupItemsByType(items: NimbleBaseItem[]) {
+		return items.reduce<Record<string, NimbleBaseItem[]>>((categories, item) => {
+			const { objectType } = item.reactive.system as unknown as { objectType: string };
 
 			categories[objectType] ??= [];
 			categories[objectType].push(item);
@@ -113,7 +114,9 @@
 			return;
 		}
 
-		await sheet._onSortItem(event, item);
+		await (
+			sheet as unknown as { _onSortItem(e: DragEvent, i: InventorySortableItem): Promise<unknown> }
+		)._onSortItem(event, item);
 	}
 
 	function handleDropFlashAnimationEnd(event: AnimationEvent, itemId: string) {
@@ -126,7 +129,7 @@
 	let items = $derived(filterItems(actor.reactive, ['object'], searchTerm));
 	let categorizedItems = $derived(groupItemsByType(items));
 
-	let itemRulesManagers = new SvelteMap();
+	let itemRulesManagers = new SvelteMap<string, RulesManager>();
 
 	// All charge pools for the actor
 	let allPools = $derived(getPools(actor.reactive));
@@ -138,8 +141,10 @@
 	$effect(() => {
 		// Rebuild the maps when items change
 		items.forEach((item) => {
-			const rulesManager = new RulesManager(item);
-			itemRulesManagers.set(item.id, rulesManager);
+			const rulesManager = new RulesManager(
+				item as unknown as ConstructorParameters<typeof RulesManager>[0],
+			);
+			itemRulesManagers.set(item.id ?? '', rulesManager);
 		});
 	});
 
@@ -197,7 +202,7 @@
 				value={denomination.value}
 				onchange={({ target }) =>
 					actor.update({
-						[`system.currency.${key}.value`]: target.value,
+						[`system.currency.${key}.value`]: (target as HTMLInputElement).value,
 					})}
 			/>
 		</label>
@@ -205,7 +210,7 @@
 </header>
 
 <section class="nimble-sheet__body nimble-sheet__body--player-character">
-	{#each Object.entries(categorizedItems).sort(([aKey], [bKey]) => aKey - bKey) as [key, itemCategory]}
+	{#each Object.entries(categorizedItems).sort(([aKey], [bKey]) => Number(aKey) - Number(bKey)) as [key, itemCategory]}
 		{@const categoryName = objectTypeHeadings[key] ?? key}
 
 		<div>
@@ -218,7 +223,15 @@
 			<ul class="nimble-item-list">
 				{#each sortItems(itemCategory) as item (item.reactive._id)}
 					{@const metadata = getObjectMetadata(item)}
-					{@const rules = itemRulesManagers.get(item.id)}
+					{@const rules = itemRulesManagers.get(item.id ?? '')}
+					{@const itemId = item.reactive._id ?? ''}
+					{@const itemSystem = item.reactive.system as unknown as {
+						rules?: unknown[];
+						equipped?: boolean;
+						objectType?: string;
+						objectSizeType?: string;
+						quantity?: number;
+					}}
 
 					<!-- svelte-ignore a11y_no_noninteractive_element_to_interactive_role  -->
 					<!-- svelte-ignore  a11y_click_events_have_key_events -->
@@ -228,10 +241,10 @@
 						class:nimble-document-card--no-meta={!metadata}
 						class:nimble-document-card--drop-flash={shouldFlashDroppedItem(
 							droppedItemFlashIds,
-							item.reactive._id,
+							itemId,
 						)}
-						data-item-id={item.reactive._id}
-						data-tooltip={tooltipCache.get(item.reactive._id) || ''}
+						data-item-id={itemId}
+						data-tooltip={tooltipCache.get(itemId) || ''}
 						data-tooltip-class="nimble-tooltip nimble-tooltip--item"
 						data-tooltip-direction="LEFT"
 						onmouseenter={(event) => handleTooltipMouseEnter(event, item)}
@@ -240,9 +253,9 @@
 						ondragstart={(event) =>
 							(sheet as unknown as { _onDragStart(e: DragEvent): void })._onDragStart(event)}
 						ondragover={(event) => event.preventDefault()}
-						ondrop={(event) => handleItemDrop(event, item)}
-						onanimationend={(event) => handleDropFlashAnimationEnd(event, item.reactive._id)}
-						onclick={() => actor.activateItem(item._id)}
+						ondrop={(event) => handleItemDrop(event, { _id: itemId })}
+						onanimationend={(event) => handleDropFlashAnimationEnd(event, itemId)}
+						onclick={() => actor.activateItem(item._id ?? '')}
 					>
 						<header class="u-semantic-only">
 							{#if showEmbeddedDocumentImages}
@@ -260,14 +273,10 @@
 							</h4>
 
 							<div class="nimble-document-card__charges">
-								<ChargeIndicator
-									pools={getItemPools(item.reactive._id)}
-									{actor}
-									itemId={item.reactive._id}
-								/>
+								<ChargeIndicator pools={getItemPools(itemId)} {actor} {itemId} />
 							</div>
 
-							{#if rules && (item.reactive.system.rules?.length ?? 0) > 0}
+							{#if rules && (itemSystem.rules?.length ?? 0) > 0}
 								<button
 									class="nimble-button"
 									data-button-variant="icon"
@@ -275,19 +284,19 @@
 									aria-label={localize('NIMBLE.prompts.toggleEquipment', {
 										name: item.reactive.name,
 									})}
-									data-tooltip={item.reactive.system.equipped
+									data-tooltip={itemSystem.equipped
 										? localize('NIMBLE.prompts.equippedTooltip')
 										: localize('NIMBLE.prompts.unequippedTooltip')}
 									onclick={async (event) => {
 										event.stopPropagation();
-										const newEquippedState = !item.reactive.system.equipped;
+										const newEquippedState = !itemSystem.equipped;
 										const rulesUpdated = newEquippedState
 											? await rules.enableAllRules()
 											: await rules.disableAllRules();
 
 										if (!rulesUpdated) return;
 
-										const updatedItem = await actor.updateItem(item._id, {
+										const updatedItem = await actor.updateItem(item._id ?? '', {
 											'system.equipped': newEquippedState,
 										});
 
@@ -300,13 +309,13 @@
 										}
 									}}
 								>
-									{#if ['armor', 'shield'].includes(item.reactive.system.objectType)}
-										{#if item.reactive.system.equipped}
+									{#if ['armor', 'shield'].includes(itemSystem.objectType ?? '')}
+										{#if itemSystem.equipped}
 											<i class="fa-solid fa-shield"></i>
 										{:else}
 											<i class="fa-regular fa-shield"></i>
 										{/if}
-									{:else if item.reactive.system.equipped}
+									{:else if itemSystem.equipped}
 										<i class="fa-solid fa-hand"></i>
 									{:else}
 										<i class="fa-regular fa-hand"></i>
@@ -316,15 +325,15 @@
 								<input
 									class="nimble-document-card__quantity"
 									type="number"
-									value={item.reactive.system.quantity || 1}
+									value={itemSystem.quantity || 1}
 									min="0"
 									step="1"
 									onclick={(event) => event.stopPropagation()}
 									onchange={({ currentTarget }) =>
-										actor.updateItem(item._id, {
+										actor.updateItem(item._id ?? '', {
 											'system.quantity': currentTarget.value,
 										})}
-									disabled={item.system.objectSizeType === 'slots'}
+									disabled={itemSystem.objectSizeType === 'slots'}
 								/>
 							{/if}
 

--- a/src/view/sheets/pages/PlayerCharacterSpellsTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterSpellsTab.svelte
@@ -24,6 +24,15 @@
 		tooltip: string;
 	}
 
+	interface SpellSystem {
+		school?: string;
+		tier?: number;
+		properties: { selected: string[] };
+	}
+
+	const spellSystem = (spell: NimbleBaseItem): SpellSystem =>
+		spell.reactive.system as unknown as SpellSystem;
+
 	async function configureItem(event, id) {
 		event.stopPropagation();
 
@@ -95,7 +104,8 @@
 
 	function getSpellSchoolTabs(spells: NimbleBaseItem[]): SpellSchoolTab[] {
 		const actorSpellSchools = spells.reduce((relevantSpellSchools, spell) => {
-			if (spell.system.school) relevantSpellSchools.add(spell.system.school);
+			const school = (spell.system as unknown as SpellSystem).school;
+			if (school) relevantSpellSchools.add(school);
 
 			return relevantSpellSchools;
 		}, new Set());
@@ -127,16 +137,14 @@
 	function getVisibleSpells(spells: NimbleBaseItem[], tabName?: string) {
 		if (!tabName || tabName === 'all') return groupSpellsByTier(spells);
 
-		const spellsOfSpecifiedSchool = spells.filter(
-			(spell) => spell.reactive.system.school === tabName,
-		);
+		const spellsOfSpecifiedSchool = spells.filter((spell) => spellSystem(spell).school === tabName);
 
 		const spellsByTier = groupSpellsByTier(spellsOfSpecifiedSchool);
 
-		if (currentTab.name && currentTab.name !== 'all' && foundry.utils.isEmpty(spellsByTier)) {
+		if (currentTab?.name && currentTab.name !== 'all' && foundry.utils.isEmpty(spellsByTier)) {
 			currentTab = subNavigation[0];
 
-			if (currentTab.name && currentTab.name !== 'all') {
+			if (currentTab?.name && currentTab.name !== 'all') {
 				return getVisibleSpells(spells, 'all');
 			}
 		}
@@ -146,9 +154,10 @@
 
 	function groupSpellsByTier(spells: NimbleBaseItem[]) {
 		return spells.reduce<Record<number, NimbleBaseItem[]>>((tiers, spell) => {
-			const utilitySpell = spell.reactive.system.properties.selected.includes('utilitySpell');
+			const system = spellSystem(spell);
+			const utilitySpell = system.properties.selected.includes('utilitySpell');
 
-			const tier = utilitySpell ? 0 : spell.reactive.system.tier;
+			const tier = utilitySpell ? 0 : (system.tier ?? 0);
 
 			tiers[tier] ??= [];
 			tiers[tier].push(spell);
@@ -263,10 +272,11 @@
 
 			<ul class="nimble-item-list">
 				{#each sortItems(tierSpells) as spell (spell.reactive._id)}
+					{@const spellId = spell.reactive._id ?? ''}
 					{@const meta = getSpellMetadata(spell)}
 					{@const requiresConcentration =
-						spell.reactive.system.properties.selected.includes('concentration')}
-					{@const utilitySpell = spell.reactive.system.properties.selected.includes('utilitySpell')}
+						spellSystem(spell).properties.selected.includes('concentration')}
+					{@const utilitySpell = spellSystem(spell).properties.selected.includes('utilitySpell')}
 
 					<!-- svelte-ignore a11y_no_noninteractive_element_to_interactive_role  -->
 					<!-- svelte-ignore  a11y_click_events_have_key_events -->
@@ -287,8 +297,8 @@
 						role="button"
 						ondragstart={(event) =>
 							(sheet as unknown as { _onDragStart(e: DragEvent): void })._onDragStart(event)}
-						onanimationend={(event) => handleDropFlashAnimationEnd(event, spell.reactive._id)}
-						onclick={() => actor.activateItem(spell._id)}
+						onanimationend={(event) => handleDropFlashAnimationEnd(event, spellId)}
+						onclick={() => actor.activateItem(spell._id ?? '')}
 					>
 						{#if showEmbeddedDocumentImages}
 							<div class="nimble-document-card__img-wrapper">
@@ -308,7 +318,7 @@
 									{#if !currentTab || currentTab?.name === 'all'}
 										<i
 											class="nimble-document-card__marker nimble-document-card__marker--spell-school {spellSchoolIcons[
-												spell.reactive.system.school
+												spellSystem(spell).school ?? ''
 											]}"
 										></i>
 									{/if}
@@ -326,11 +336,7 @@
 							</h4>
 
 							<div class="nimble-document-card__charges">
-								<ChargeIndicator
-									pools={getItemPools(spell.reactive._id)}
-									{actor}
-									itemId={spell.reactive._id}
-								/>
+								<ChargeIndicator pools={getItemPools(spellId)} {actor} itemId={spellId} />
 							</div>
 
 							<button

--- a/src/view/sheets/pages/PlayerCharacterSpellsTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterSpellsTab.svelte
@@ -285,7 +285,8 @@
 						onmouseenter={(event) => handleTooltipMouseEnter(event, spell)}
 						draggable="true"
 						role="button"
-						ondragstart={(event) => sheet._onDragStart(event)}
+						ondragstart={(event) =>
+							(sheet as unknown as { _onDragStart(e: DragEvent): void })._onDragStart(event)}
 						onanimationend={(event) => handleDropFlashAnimationEnd(event, spell.reactive._id)}
 						onclick={() => actor.activateItem(spell._id)}
 					>

--- a/src/view/sheets/pages/PlayerCharacterSpellsTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterSpellsTab.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { NimbleCharacter } from '#documents/actor/character.js';
+	import type { NimbleBaseItem } from '#documents/item/base.svelte.js';
 	import type PlayerCharacterSheet from '#documents/sheets/PlayerCharacterSheet.svelte.js';
 	import { getPools, getPoolsForItem } from '#utils/chargePool/chargePoolSync.js';
 	import shouldFlashDroppedItem from '#utils/shouldFlashDroppedItem.js';
@@ -16,6 +17,12 @@
 		type SheetDropItemFlashState,
 	} from '#view/sheets/dropItemFlashState.js';
 	import { getContext } from 'svelte';
+
+	interface SpellSchoolTab {
+		icon: string;
+		name: string;
+		tooltip: string;
+	}
 
 	async function configureItem(event, id) {
 		event.stopPropagation();
@@ -86,7 +93,7 @@
 		return null;
 	}
 
-	function getSpellSchoolTabs(spells) {
+	function getSpellSchoolTabs(spells: NimbleBaseItem[]): SpellSchoolTab[] {
 		const actorSpellSchools = spells.reduce((relevantSpellSchools, spell) => {
 			if (spell.system.school) relevantSpellSchools.add(spell.system.school);
 
@@ -117,7 +124,7 @@
 		);
 	}
 
-	function getVisibleSpells(spells, tabName) {
+	function getVisibleSpells(spells: NimbleBaseItem[], tabName?: string) {
 		if (!tabName || tabName === 'all') return groupSpellsByTier(spells);
 
 		const spellsOfSpecifiedSchool = spells.filter(
@@ -137,8 +144,8 @@
 		return spellsByTier;
 	}
 
-	function groupSpellsByTier(spells) {
-		return spells.reduce((tiers, spell) => {
+	function groupSpellsByTier(spells: NimbleBaseItem[]) {
+		return spells.reduce<Record<number, NimbleBaseItem[]>>((tiers, spell) => {
 			const utilitySpell = spell.reactive.system.properties.selected.includes('utilitySpell');
 
 			const tier = utilitySpell ? 0 : spell.reactive.system.tier;
@@ -172,7 +179,7 @@
 	let searchTerm = $state('');
 	let spells = $derived(filterItems(actor.reactive, ['spell'], searchTerm));
 	let subNavigation = $derived(getSpellSchoolTabs(spells));
-	let currentTab = $state(null);
+	let currentTab = $state<SpellSchoolTab | null>(null);
 	let visibleSpells = $derived(getVisibleSpells(spells, currentTab?.name));
 
 	const tooltipCache = new Map();
@@ -246,7 +253,7 @@
 </header>
 
 <section class="nimble-sheet__body nimble-sheet__body--player-character">
-	{#each Object.entries(visibleSpells).sort(([aKey], [bKey]) => aKey - bKey) as [tier, tierSpells]}
+	{#each Object.entries(visibleSpells).sort(([aKey], [bKey]) => Number(aKey) - Number(bKey)) as [tier, tierSpells]}
 		<div>
 			<header>
 				<h3 class="nimble-heading" data-heading-variant="section">

--- a/src/view/ui/CanvasConditionsPanel.svelte
+++ b/src/view/ui/CanvasConditionsPanel.svelte
@@ -2,10 +2,12 @@
 	import { onMount } from 'svelte';
 	import ActorConditionsList from '../components/ActorConditionsList.svelte';
 
-	let actor = $state<Actor.Implementation | null>(null);
+	let actor = $state<(Actor.Implementation & { reactive: Actor.Implementation }) | null>(null);
 
 	function getControlledActor() {
-		return canvas?.tokens?.controlled?.[0]?.actor ?? null;
+		return (canvas?.tokens?.controlled?.[0]?.actor ?? null) as
+			| (Actor.Implementation & { reactive: Actor.Implementation })
+			| null;
 	}
 
 	function refreshActor() {
@@ -28,12 +30,12 @@
 		];
 
 		const hooks = hookListeners.map(({ hook, listener }) => {
-			return { hook, id: Hooks.on(hook, listener) };
+			return { hook, id: Hooks.on(hook as Parameters<typeof Hooks.on>[0], listener) };
 		});
 
 		return () => {
 			for (const { hook, id } of hooks) {
-				Hooks.off(hook, id);
+				Hooks.off(hook as Parameters<typeof Hooks.off>[0], id);
 			}
 		};
 	});

--- a/tests/fixtures/characters.ts
+++ b/tests/fixtures/characters.ts
@@ -3,12 +3,14 @@
  * These provide realistic test data for character documents
  */
 
+import type { NimbleCharacter } from '#documents/actor/character.js';
+
 /**
  * Creates a mock character document for testing
  * @param overrides - Object to override default values
  * @returns A mock character document with the specified overrides applied
  */
-export function createMockCharacterDocument(overrides = {}) {
+export function createMockCharacterDocument(overrides: Record<string, unknown> = {}): NimbleCharacter {
 	return {
 		id: 'test-character-id',
 		classes: {
@@ -58,5 +60,5 @@ export function createMockCharacterDocument(overrides = {}) {
 			},
 		},
 		...overrides,
-	};
+	} as unknown as NimbleCharacter;
 }

--- a/tests/fixtures/dialogs.ts
+++ b/tests/fixtures/dialogs.ts
@@ -1,13 +1,14 @@
 import { vi } from 'vitest';
+import type GenericDialog from '#documents/dialogs/GenericDialog.svelte.js';
 
 /**
  * Test fixtures for dialog-related data
  * These provide mock dialog objects for testing
  */
 
-export function createMockDialog() {
+export function createMockDialog(): GenericDialog {
 	return {
 		submit: vi.fn(),
 		close: vi.fn(),
-	};
+	} as unknown as GenericDialog;
 }

--- a/types/components/CharacterSkillsConfigDialog.d.ts
+++ b/types/components/CharacterSkillsConfigDialog.d.ts
@@ -10,6 +10,8 @@ export interface SkillHistoryEntry {
 	changes: SkillHistoryChange[];
 }
 
+import type { SkillsDocument } from '#view/dialogs/CharacterSkillsConfigDialogState.svelte.ts';
+
 export interface CharacterSkillsConfigDialogProps {
-	document: unknown;
+	document: SkillsDocument;
 }

--- a/types/components/CharacterStatConfigDialog.d.ts
+++ b/types/components/CharacterStatConfigDialog.d.ts
@@ -13,6 +13,8 @@ export interface StatIncreaseEntry {
 	label: string;
 }
 
+import type { StatConfigDocument } from '#view/dialogs/CharacterStatConfigDialogState.svelte.ts';
+
 export interface CharacterStatConfigDialogProps {
-	document: unknown;
+	document: StatConfigDocument;
 }

--- a/types/components/ChargeIndicator.d.ts
+++ b/types/components/ChargeIndicator.d.ts
@@ -1,4 +1,4 @@
-import type { NimbleCharacter } from '../../src/documents/actor/character.js';
+import type { NimbleBaseActor } from '../../src/documents/actor/base.svelte.js';
 
 export interface ChargeIndicatorPoolState {
 	id: string;
@@ -17,6 +17,6 @@ export interface ChargeIndicatorPoolState {
 
 export interface ChargeIndicatorProps {
 	pools: ChargeIndicatorPoolState[];
-	actor: NimbleCharacter;
+	actor: NimbleBaseActor;
 	itemId: string;
 }

--- a/types/components/ItemActivationConfigDialog.d.ts
+++ b/types/components/ItemActivationConfigDialog.d.ts
@@ -63,7 +63,7 @@ export interface ItemActivationConfigDialogInstance {
 }
 
 export interface ItemActivationConfigDialogProps {
-	actor: Actor;
+	actor: NimbleBaseActor;
 	dialog: ItemActivationConfigDialogInstance;
 	item: Item;
 	rollMode?: number;

--- a/types/components/TargetSelector.d.ts
+++ b/types/components/TargetSelector.d.ts
@@ -1,10 +1,12 @@
+type TargetToken = Token | null | undefined;
+
 export interface TargetSelectorProps {
 	label: string;
 	noTargetMessage: string;
 	multipleTargetsMessage: string;
-	availableTargets: unknown[];
-	selectedTarget: unknown;
-	getTargetName: (target: unknown) => string;
+	availableTargets: TargetToken[];
+	selectedTarget: TargetToken;
+	getTargetName: (target: TargetToken) => string;
 	targetBackground: string;
 	targetBorderColor: string;
 }

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -72,6 +72,7 @@ declare global {
 	/** Interface for Nimble base item with common methods */
 	interface NimbleBaseItem extends Item {
 		identifier: string;
+		reactive: this;
 		hasMacro?: boolean;
 		rules?: RulesManagerInterface;
 		tags?: Set<string>;

--- a/types/tagGroupOption.d.ts
+++ b/types/tagGroupOption.d.ts
@@ -1,4 +1,4 @@
-interface TagGroupOption {
+export interface TagGroupOption {
 	label: string;
 	value: string | number;
 	icon?: string;


### PR DESCRIPTION
## Summary

Clears the long-standing `svelte-check` type errors across the codebase. Type-only / lint cleanups — **no runtime behavior changes**.

- `svelte-check`: **356 → 3 errors** (the 3 remaining are documented false-positives)
- `pnpm type-check`: **0 errors**
- `pnpm lint:svelte`: **clean**
- `pnpm test`: **1442 passed / 118 files**, no regressions

## Root-cause fixes (cleared many files at once)

- Made `sortItems` generic (`<T extends Item>`) so it preserves item typing through sorts
- Widened `localize()` data param to `Record<string, string | number>` (Foundry stringifies values)
- `GenericDialog` constructor / `getOrCreate` now accept `Component<any>`, clearing component-assignability errors across every dialog launcher
- Typed `getContext('actor' | 'application' | 'messageDocument')` reads to their concrete types across many sheet tabs and panels

## Other categories

- `$state(null)` / null-narrowing fixes (drag & tab state, nullable `_id`)
- DOM event-target casts and `dataTransfer` null guards
- Foundry document-system union narrowing in inventory/spells/features tabs and rest dialogs
- Exported dialog `document` prop types and used them at call sites and in test fixtures
- Misc precise typings (Roll.fromData, TextEditor enrichment options, tooltip directions, ChatMessage payloads)

## Remaining (documented) — 3 svelte-check errors

`Unused '@ts-expect-error' directive` in three `*.svelte.test.ts` files (`FeatureGroupSelection`, `SchoolSelection`, `SpellSelection`). `tsc` (bundler resolution) resolves `import X from './X.svelte'` to the sibling `.svelte.ts` state module, which has no default export, so the directive is genuinely required for `type-check`. svelte-check resolves the real component and flags it as unused. Kept `@ts-expect-error` to keep `type-check` and `lint:svelte` fully clean; the cost is these 3 svelte-check false-positives.

Plus 2 svelte-check reactivity *warnings* left intentionally (fixing them would change runtime reactivity).