### PR TITLE
fix(ci): remove tsx/jsx globs that crash format auto-commit

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           commit_message: 'Format code with Biome'
           branch: ${{ github.head_ref }}
-          file_pattern: '*.ts *.tsx *.js *.jsx *.json *.svelte *.css *.scss *.md'
+          file_pattern: '*.ts *.js *.json *.svelte *.css *.scss *.md'
 
       - name: Check format (fork PRs)
         if: github.event.pull_request.head.repo.full_name != github.repository


### PR DESCRIPTION
## Summary

The `Format Code` job fails on any same-repo PR where Biome produces changes, e.g. [this run on #808](https://github.com/Nimble-Co/FoundryVTT-Nimble/pull/808):

```
fatal: pathspec '*.tsx' did not match any files
Error: Invalid status code: 128
```

`stefanzweifel/git-auto-commit-action` passes `file_pattern` directly to `git add`, which exits 128 when a glob matches no tracked files. This repo has no `.tsx` or `.jsx` files (`git ls-files '*.tsx'` and `'*.jsx'` are both empty), so the auto-commit step crashes before pushing the formatting fixes.

This removes the two dead globs from the pattern:

```yaml
file_pattern: '*.ts *.js *.json *.svelte *.css *.scss *.md'
```

All remaining extensions have tracked files in the repo, so `git add` can't hit the no-match failure.