### PR TITLE
fix(rules): allow walk mode in grantMovement

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -800,7 +800,7 @@
 				}
 			},
 			"grantMovement": {
-				"description": "Grant a base movement mode (fly, climb, swim, or burrow). Multiple grants of the same mode take the highest base; speed bonuses stack on top.",
+				"description": "Grant a base movement mode (walk, fly, climb, swim, or burrow). Multiple grants of the same mode take the highest base; speed bonuses stack on top.",
 				"mode": {
 					"label": "Movement mode",
 					"hint": "Which movement mode to grant."

--- a/src/models/rules/grantMovement.test.ts
+++ b/src/models/rules/grantMovement.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { GrantMovementRule } from './grantMovement.js';
 
-type MovementMode = 'fly' | 'climb' | 'swim' | 'burrow';
+type MovementMode = 'walk' | 'fly' | 'climb' | 'swim' | 'burrow';
 
 interface MockMovement {
 	walk: number;
@@ -39,6 +39,7 @@ interface MockItem {
 function createMockActor(
 	movement: Partial<MockMovement> = {},
 	rollData: Record<string, unknown> = {},
+	sourceOverrides: Partial<MockMovement> = {},
 ): MockActor {
 	const mov: MockMovement = {
 		walk: 6,
@@ -55,6 +56,7 @@ function createMockActor(
 		climb: 0,
 		swim: 0,
 		burrow: 0,
+		...sourceOverrides,
 	};
 	return {
 		system: {
@@ -390,6 +392,38 @@ describe('GrantMovementRule', () => {
 			grant2.prePrepareData();
 			// grant(12) + bonus(2) = 14
 			expect(actor.system.attributes.movement.fly).toBe(14);
+		});
+	});
+
+	describe('walk mode', () => {
+		it('should set walk speed when grant exceeds native walk', () => {
+			// Turtlefolk native walk = 5, Boots of Striding grant walk = 6 → becomes 6
+			const actor = createMockActor({ walk: 5 }, {}, { walk: 5 });
+			const rule = createGrantMovementRule({ mode: 'walk', speed: '6' }, actor);
+
+			rule.prePrepareData();
+
+			expect(actor.system.attributes.movement.walk).toBe(6);
+		});
+
+		it('should not reduce walk when grant is lower than native walk', () => {
+			// Actor native walk = 8, grant walk = 6 → stays 8
+			const actor = createMockActor({ walk: 8 }, {}, { walk: 8 });
+			const rule = createGrantMovementRule({ mode: 'walk', speed: '6' }, actor);
+
+			rule.prePrepareData();
+
+			expect(actor.system.attributes.movement.walk).toBe(8);
+		});
+
+		it('should preserve speedBonus on top of walk grant', () => {
+			// Native walk = 5, speedBonus +2 already applied (live = 7), grant = 6 → 6 + 2 = 8
+			const actor = createMockActor({ walk: 7 }, {}, { walk: 5 });
+			const rule = createGrantMovementRule({ mode: 'walk', speed: '6' }, actor);
+
+			rule.prePrepareData();
+
+			expect(actor.system.attributes.movement.walk).toBe(8);
 		});
 	});
 

--- a/src/models/rules/grantMovement.ts
+++ b/src/models/rules/grantMovement.ts
@@ -1,9 +1,9 @@
 import { withWidget } from './_widgetOption.js';
 import { NimbleBaseRule } from './base.js';
 
-type MovementMode = 'fly' | 'climb' | 'swim' | 'burrow';
+type MovementMode = 'walk' | 'fly' | 'climb' | 'swim' | 'burrow';
 
-const ALLOWED_MODES: ReadonlySet<string> = new Set(['fly', 'climb', 'swim', 'burrow']);
+const ALLOWED_MODES: ReadonlySet<string> = new Set(['walk', 'fly', 'climb', 'swim', 'burrow']);
 
 function schema() {
 	const { fields } = foundry.data;
@@ -15,7 +15,7 @@ function schema() {
 			initial: 'fly',
 			label: 'NIMBLE.rules.grantMovement.mode.label',
 			hint: 'NIMBLE.rules.grantMovement.mode.hint',
-			choices: ['fly', 'climb', 'swim', 'burrow'],
+			choices: ['walk', 'fly', 'climb', 'swim', 'burrow'],
 		}),
 		speed: new fields.StringField(
 			withWidget({
@@ -55,20 +55,20 @@ interface ActorSource {
 }
 
 /**
- * Rule that grants a base movement mode (fly, climb, swim, burrow).
+ * Rule that grants a base movement mode (walk, fly, climb, swim, burrow).
  *
  * Unlike speedBonus which adds to an existing speed, grantMovement sets a base
  * speed for a movement mode. Multiple grants use Math.max — the highest granted
  * base wins. speedBonus then stacks on top additively.
  *
  * The speed field supports formulas: '@attributes.movement.walk' gives "fly = walk speed",
- * while '12' gives a fixed fly speed of 12.
+ * while '12' gives a fixed speed of 12.
  *
- * Walk is intentionally excluded from mode choices — walk speed is always present
- * on every actor and is modified via speedBonus, not granted.
+ * Walk is supported: the final speed becomes max(grant, actor's source walk base),
+ * so a grant lower than the actor's native speed has no effect.
  *
  * Grants are accumulated in actor.system.movementGrants during both data prep phases.
- * The final movement value is computed as: max(all grants) + bonuses already applied.
+ * The final movement value is computed as: max(grant, sourceBase) + bonuses already applied.
  * This ensures speedBonus values stack on top of the granted base correctly.
  *
  * Uses two-phase processing (matching speedBonus):
@@ -143,8 +143,11 @@ class GrantMovementRule extends NimbleBaseRule<GrantMovementRule.Schema> {
 		const liveSpeed = actorSystem.system.attributes.movement[this.mode] ?? 0;
 		const appliedBonuses = liveSpeed - sourceBase - previousGrant;
 
-		// Final speed = highest grant + source base + bonuses from speedBonus
-		const finalSpeed = bestGrant + sourceBase + Math.max(0, appliedBonuses);
+		// Final speed = max(grant, sourceBase) + bonuses from speedBonus.
+		// Math.max here handles walk (sourceBase > 0): a grant lower than the
+		// actor's native speed has no effect, and the grant only wins when it's
+		// higher. For modes with sourceBase=0 this is equivalent to the old formula.
+		const finalSpeed = Math.max(bestGrant, sourceBase) + Math.max(0, appliedBonuses);
 		foundry.utils.setProperty(actor.system, `attributes.movement.${this.mode}`, finalSpeed);
 	}
 


### PR DESCRIPTION
## Summary

- `walk` was excluded from `ALLOWED_MODES` in `GrantMovementRule`, silently discarding any Grant Movement rule with mode set to `walk`
- Fixed the `finalSpeed` formula from `bestGrant + sourceBase` to `Math.max(bestGrant, sourceBase)` — for non-walk modes `sourceBase` is always 0 so the result is identical; for walk this correctly acts as a minimum speed rather than adding the grant on top of the actor's native walk base
- Added `walk` to the schema `choices` list so it appears in the Rules Builder dropdown

## Test plan

- [ ] Add a Grant Movement rule (mode: `walk`, speed: `6`) to an item on a Turtlefolk (native walk 5) — sheet should show walk 6
- [ ] Same item on an actor with native walk 8 — walk should remain 8 (grant does not reduce)
- [ ] A `speedBonus` on walk stacks on top of the granted minimum correctly
- [ ] Existing fly/climb/swim/burrow grants are unaffected
- [ ] All 1445 tests pass (`pnpm check`)