### PR TITLE
fix(css): make prose-mirror editors visible in roll table dialogs

### DIFF
--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -45,6 +45,7 @@
 @use "vendor/foundry/cards-config";
 @use "vendor/foundry/compendium-sheets";
 @use "vendor/foundry/playlist-config";
+@use "vendor/foundry/roll-table";
 @use "vendor/foundry/chat";
 @use "vendor/foundry/editor";
 @use "vendor/foundry/initiative";

--- a/src/scss/vendor/foundry/_roll-table.scss
+++ b/src/scss/vendor/foundry/_roll-table.scss
@@ -1,0 +1,34 @@
+// Styling for FoundryVTT RollTableSheet and TableResultConfig Applications
+//
+// prose-mirror (display:flex; min-height:200px) gives .editor-container (flex:1)
+// zero height because min-height is not a definite size for the flex algorithm.
+// Switching to display:block with an explicit height and overflow:hidden fixes the
+// editor layout and prevents the positioned prose-mirror element from covering the
+// form footer button below it via stacking-context overflow.
+.system-nimble {
+  .application.table-result-config {
+    prose-mirror[name="description"] {
+      display: block;
+      height: 200px;
+      overflow: hidden;
+
+      .editor-container {
+        height: calc(100% - 68px);
+      }
+    }
+  }
+
+  .application.roll-table-sheet {
+    .tab[data-tab="summary"] {
+      prose-mirror[name="description"] {
+        display: block;
+        height: 200px;
+        overflow: hidden;
+
+        .editor-container {
+          height: calc(100% - 68px);
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Fixes the `TableResultConfig` outcome description editor appearing empty and unclickable (reported workaround: use HTML source mode)
- Fixes the same issue in the `RollTableSheet` summary tab description editor
- Fixes a related issue where the "Update Table Result" submit button was non-clickable due to the positioned `prose-mirror` element covering it

## Root Cause

`prose-mirror` uses `display: flex; flex-direction: column; min-height: 200px`. CSS flex only distributes free space to `flex: 1` children when the container has a **definite** main size — `min-height` alone is not definite. So `.editor-container { flex: 1 }` collapsed to `0px`, and `.editor-content { position: absolute; inset: 0 }` inside it also became `0px` — invisible and unclickable.

Additionally, `prose-mirror { position: relative }` (from Foundry) causes it to paint above non-positioned siblings in stacking order. With `overflow: visible` on the active state, any overflow could cover the form-footer button below it.

## Fix

Adds `src/scss/vendor/foundry/_roll-table.scss` following the established pattern from `_cards-config.scss` and `_playlist-config.scss`:

- `display: block` — removes flex layout, sidesteps the definite-main-size issue
- `height: 200px` — matches Foundry's `--min-height: 200px` intent and makes `calc(100% - 68px)` resolve correctly
- `overflow: hidden` — clips all content to the 200px boundary, preventing stacking-context paint overlap with the footer button
- `.editor-container { height: calc(100% - 68px) }` — gives the editor area 132px (200px minus ~68px toolbar)

## Test plan

- [ ] Open a Roll Table, click Edit, open an outcome to edit — description field should be visible and editable (WYSIWYG mode, not just source code)
- [ ] "Update Table Result" button should be fully clickable
- [ ] Open Roll Table summary tab — description editor should be visible and editable
- [ ] Existing `CardsConfig` and `PlaylistConfig` description editors unaffected