### PR TITLE
fix(import): correctly import Nexus minions as minion actors

### DIFF
--- a/src/import/nimbleNexus/NimbleNexusParser.test.ts
+++ b/src/import/nimbleNexus/NimbleNexusParser.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { determineActorType } from './NimbleNexusParser.js';
+import type { NimbleNexusMonsterAttributes } from './types.js';
+
+const baseAttributes: NimbleNexusMonsterAttributes = {
+	name: 'Test Monster',
+	hp: 10,
+	level: 1,
+	size: 'medium',
+	armor: 'none',
+	legendary: false,
+	movement: [],
+	abilities: [],
+	actions: [],
+};
+
+describe('determineActorType', () => {
+	it('returns soloMonster for legendary creatures', () => {
+		expect(determineActorType({ ...baseAttributes, legendary: true })).toBe('soloMonster');
+	});
+
+	it('returns minion when attributes.minion is true', () => {
+		expect(determineActorType({ ...baseAttributes, minion: true })).toBe('minion');
+	});
+
+	it('returns npc for standard creatures', () => {
+		expect(determineActorType({ ...baseAttributes })).toBe('npc');
+	});
+
+	it('legendary takes precedence over minion flag', () => {
+		expect(determineActorType({ ...baseAttributes, legendary: true, minion: true })).toBe(
+			'soloMonster',
+		);
+	});
+});


### PR DESCRIPTION
## Summary

- Adds unit tests for `determineActorType` verifying that minion, solo monster, and standard NPC actors are correctly identified from Nimble Nexus API attributes
- The Nexus API fix (adding `minion: boolean` to the `/api/monsters` response) is what enables this — our parser already reads `attributes.minion` and creates a `minion` actor type

## Test plan

- [ ] Import a minion from Nimble Nexus with the minion filter active — actor should be created as a Minion, not a Standard
- [ ] Import a solo/legendary monster — actor should be created as a Solo Monster
- [ ] Import a standard monster — actor should be created as a Standard NPC