### PR TITLE
feat: ship GM-friendly default token settings

### DIFF
--- a/src/documents/actor/character.ts
+++ b/src/documents/actor/character.ts
@@ -1614,7 +1614,7 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 		const prototypeToken = {
 			sight: { enabled: true },
 			actorLink: true,
-			disposition: 1,
+			disposition: CONST.TOKEN_DISPOSITIONS.FRIENDLY,
 		};
 		this.updateSource({ prototypeToken } as Record<string, unknown>);
 

--- a/src/documents/actor/character.ts
+++ b/src/documents/actor/character.ts
@@ -1606,8 +1606,16 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 		user: User.Implementation,
 		// biome-ignore lint/suspicious/noConfusingVoidType: Matching parent class signature
 	): Promise<boolean | void> {
-		// Player character configuration
-		const prototypeToken = { vision: true, actorLink: true, disposition: 1 };
+		// Player character configuration. In Foundry v13 token sight is keyed on
+		// `sight.enabled` (the old top-level `vision` boolean no longer exists), and
+		// `enabled` only auto-defaults to true when `sight.range > 0` — which it is
+		// not — so enable it explicitly. Range stays at the default 0: Nimble has no
+		// darkvision, so the token sees illuminated areas rather than a fixed radius.
+		const prototypeToken = {
+			sight: { enabled: true },
+			actorLink: true,
+			disposition: 1,
+		};
 		this.updateSource({ prototypeToken } as Record<string, unknown>);
 
 		return super._preCreate(data, options, user);

--- a/src/documents/actor/minion.ts
+++ b/src/documents/actor/minion.ts
@@ -3,6 +3,7 @@ import CharacterMovementConfigDialog from '../../view/dialogs/CharacterMovementC
 import NPCMetaConfigDialog from '../../view/dialogs/NPCMetaConfigDialog.svelte';
 import GenericDialog from '../dialogs/GenericDialog.svelte.js';
 import { NimbleBaseActor } from './base.svelte.js';
+import { buildMonsterPrototypeTokenDefaults } from './monsterPrototypeTokenDefaults.js';
 
 export class NimbleMinion extends NimbleBaseActor {
 	declare system: NimbleMinionData;
@@ -22,6 +23,20 @@ export class NimbleMinion extends NimbleBaseActor {
 		super.prepareBaseData();
 
 		this.tags.add('minion');
+	}
+
+	protected override async _preCreate(
+		data: Actor.CreateData,
+		options: Actor.Database.PreCreateOptions,
+		user: User.Implementation,
+		// biome-ignore lint/suspicious/noConfusingVoidType: Matching parent class signature
+	): Promise<boolean | void> {
+		this.updateSource({ prototypeToken: buildMonsterPrototypeTokenDefaults() } as Record<
+			string,
+			unknown
+		>);
+
+		return super._preCreate(data, options, user);
 	}
 
 	override prepareDerivedData() {

--- a/src/documents/actor/monsterPrototypeTokenDefaults.test.ts
+++ b/src/documents/actor/monsterPrototypeTokenDefaults.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { buildMonsterPrototypeTokenDefaults } from './monsterPrototypeTokenDefaults.js';
+
+describe('buildMonsterPrototypeTokenDefaults', () => {
+	it('returns hostile, unlinked, sighted defaults', () => {
+		const defaults = buildMonsterPrototypeTokenDefaults();
+
+		expect(defaults).toEqual({
+			sight: { enabled: true },
+			actorLink: false,
+			disposition: CONST.TOKEN_DISPOSITIONS.HOSTILE,
+		});
+	});
+
+	it('returns a fresh object each call so callers cannot share mutable state', () => {
+		const first = buildMonsterPrototypeTokenDefaults();
+		const second = buildMonsterPrototypeTokenDefaults();
+
+		expect(first).not.toBe(second);
+		expect(first.sight).not.toBe(second.sight);
+	});
+});

--- a/src/documents/actor/monsterPrototypeTokenDefaults.ts
+++ b/src/documents/actor/monsterPrototypeTokenDefaults.ts
@@ -1,0 +1,24 @@
+/**
+ * Pragmatic prototype-token defaults shared by NPC, minion, and solo-monster
+ * actors. These mirror — and deliberately invert — the player-character defaults
+ * (which are friendly + linked): adversaries are hostile and unlinked so each
+ * dropped token tracks its own HP. Sight is enabled to match the world's default
+ * token configuration; Nimble has no darkvision, so range stays 0.
+ *
+ * Disposition and actorLink already match Foundry's schema defaults, but they are
+ * set explicitly here so a GM who customizes the global Default Token Configuration
+ * (e.g. flips it to friendly or linked) does not accidentally change how monsters
+ * arrive. A fresh object is returned per call so callers can pass it straight to
+ * `updateSource` without sharing mutable state.
+ */
+export function buildMonsterPrototypeTokenDefaults(): {
+	sight: { enabled: boolean };
+	actorLink: boolean;
+	disposition: number;
+} {
+	return {
+		sight: { enabled: true },
+		actorLink: false,
+		disposition: CONST.TOKEN_DISPOSITIONS.HOSTILE,
+	};
+}

--- a/src/documents/actor/monsterPrototypeTokenDefaults.ts
+++ b/src/documents/actor/monsterPrototypeTokenDefaults.ts
@@ -5,6 +5,9 @@
  * dropped token tracks its own HP. Sight is enabled to match the world's default
  * token configuration; Nimble has no darkvision, so range stays 0.
  *
+ * Solo monsters override `actorLink` to true (a single boss-tier creature is one
+ * tracked token) — see `soloMonster.ts`.
+ *
  * Disposition and actorLink already match Foundry's schema defaults, but they are
  * set explicitly here so a GM who customizes the global Default Token Configuration
  * (e.g. flips it to friendly or linked) does not accidentally change how monsters

--- a/src/documents/actor/npc.ts
+++ b/src/documents/actor/npc.ts
@@ -3,6 +3,7 @@ import CharacterMovementConfigDialog from '../../view/dialogs/CharacterMovementC
 import NPCMetaConfigDialog from '../../view/dialogs/NPCMetaConfigDialog.svelte';
 import GenericDialog from '../dialogs/GenericDialog.svelte.js';
 import { NimbleBaseActor } from './base.svelte.js';
+import { buildMonsterPrototypeTokenDefaults } from './monsterPrototypeTokenDefaults.js';
 
 export class NimbleNPC extends NimbleBaseActor {
 	declare system: NimbleNPCData;
@@ -20,6 +21,20 @@ export class NimbleNPC extends NimbleBaseActor {
 	/** ------------------------------------------------------ */
 	override prepareBaseData() {
 		super.prepareBaseData();
+	}
+
+	protected override async _preCreate(
+		data: Actor.CreateData,
+		options: Actor.Database.PreCreateOptions,
+		user: User.Implementation,
+		// biome-ignore lint/suspicious/noConfusingVoidType: Matching parent class signature
+	): Promise<boolean | void> {
+		this.updateSource({ prototypeToken: buildMonsterPrototypeTokenDefaults() } as Record<
+			string,
+			unknown
+		>);
+
+		return super._preCreate(data, options, user);
 	}
 
 	override prepareDerivedData() {

--- a/src/documents/actor/soloMonster.ts
+++ b/src/documents/actor/soloMonster.ts
@@ -33,10 +33,11 @@ export class NimbleSoloMonster extends NimbleBaseActor {
 		user: User.Implementation,
 		// biome-ignore lint/suspicious/noConfusingVoidType: Matching parent class signature
 	): Promise<boolean | void> {
-		this.updateSource({ prototypeToken: buildMonsterPrototypeTokenDefaults() } as Record<
-			string,
-			unknown
-		>);
+		// A solo monster is a single boss-tier creature, so its token is linked:
+		// it persists as one tracked actor whose HP updates live, unlike the
+		// unlinked NPC/minion tokens that each track their own HP.
+		const prototypeToken = { ...buildMonsterPrototypeTokenDefaults(), actorLink: true };
+		this.updateSource({ prototypeToken } as Record<string, unknown>);
 
 		return super._preCreate(data, options, user);
 	}

--- a/src/documents/actor/soloMonster.ts
+++ b/src/documents/actor/soloMonster.ts
@@ -3,6 +3,7 @@ import CharacterMovementConfigDialog from '../../view/dialogs/CharacterMovementC
 import NPCMetaConfigDialog from '../../view/dialogs/NPCMetaConfigDialog.svelte';
 import GenericDialog from '../dialogs/GenericDialog.svelte.js';
 import { NimbleBaseActor } from './base.svelte.js';
+import { buildMonsterPrototypeTokenDefaults } from './monsterPrototypeTokenDefaults.js';
 
 type MonsterFeatureSubtype = 'bloodied' | 'lastStand';
 
@@ -24,6 +25,20 @@ export class NimbleSoloMonster extends NimbleBaseActor {
 		super.prepareBaseData();
 
 		this.tags.add('solo-monster');
+	}
+
+	protected override async _preCreate(
+		data: Actor.CreateData,
+		options: Actor.Database.PreCreateOptions,
+		user: User.Implementation,
+		// biome-ignore lint/suspicious/noConfusingVoidType: Matching parent class signature
+	): Promise<boolean | void> {
+		this.updateSource({ prototypeToken: buildMonsterPrototypeTokenDefaults() } as Record<
+			string,
+			unknown
+		>);
+
+		return super._preCreate(data, options, user);
 	}
 
 	override prepareDerivedData() {

--- a/src/hooks/ready.ts
+++ b/src/hooks/ready.ts
@@ -77,5 +77,33 @@ export default async function ready() {
 	combatTrackerConfig.skipDefeated ??= true;
 	game.settings.set('core', 'combatTrackerConfig', combatTrackerConfig);
 
+	// Seed Foundry's Default Token Configuration so newly created tokens are usable
+	// without per-token setup:
+	//  - sight enabled — Nimble has no darkvision, so range stays 0 and the token
+	//    sees illuminated areas.
+	//  - HP on bar 1.
+	//  - Mana on bar 2 — `resources.mana` exists only on characters, so monsters and
+	//    NPCs resolve no attribute and draw no second bar ("mana bar only if they
+	//    have it").
+	//  - Bars shown on owner hover, otherwise the bar mappings would be invisible.
+	// `??=` only fills unset values, so a GM who has deliberately configured token
+	// defaults is never overridden. World-scoped, so only the GM may write it.
+	if (game.user?.isGM) {
+		const defaultToken = (game.settings.get('core', 'defaultToken') ?? {}) as {
+			sight?: { enabled?: boolean };
+			bar1?: { attribute?: string | null };
+			bar2?: { attribute?: string | null };
+			displayBars?: number;
+		};
+		defaultToken.sight ??= {};
+		defaultToken.sight.enabled ??= true;
+		defaultToken.bar1 ??= {};
+		defaultToken.bar1.attribute ??= 'attributes.hp';
+		defaultToken.bar2 ??= {};
+		defaultToken.bar2.attribute ??= 'resources.mana';
+		defaultToken.displayBars ??= CONST.TOKEN_DISPLAY_MODES.OWNER_HOVER;
+		game.settings.set('core', 'defaultToken', defaultToken);
+	}
+
 	registerCombatSidebarToggle();
 }


### PR DESCRIPTION
## Summary

Ships GM-friendly token defaults so freshly created tokens are usable without per-token setup — for both player characters and adversaries.

Motivation: a recurring Discord thread where GMs had to manually enable vision on every player token. Root cause — `character.ts` set `prototypeToken.vision = true`, but `vision` is **not** a field in the Foundry v13 token schema (sight is keyed on `sight.enabled`), so player tokens never actually received vision.

## Changes

**`src/hooks/ready.ts`** — seed Foundry's built-in `core.defaultToken` setting on `ready()` (GM only, world-scoped), mirroring the existing `combatTrackerConfig.skipDefeated` seed. All values use `??=`, so a GM's deliberate token configuration is never overwritten:
- `sight.enabled = true` — vision on. Range stays `0`: Nimble has no darkvision, so tokens see illuminated areas.
- `bar1.attribute = attributes.hp` — HP bar works out of the box.
- `bar2.attribute = resources.mana` — mana bar; `resources.mana` exists only on characters, so monsters/NPCs resolve no attribute and draw no second bar.
- `displayBars = OWNER_HOVER` — bars visible on hover for owners.

**`src/documents/actor/character.ts`** — replace the no-op `vision: true` with `sight: { enabled: true }`; keep PC-specific `actorLink: true` / friendly `disposition: 1`.

**Monster actors (`npc.ts`, `minion.ts`, `soloMonster.ts`)** — these had no `_preCreate`, so they fell back to raw Foundry defaults and a customized global token config could make them friendly/linked. Add explicit defaults via a shared `buildMonsterPrototypeTokenDefaults()` helper that mirrors and inverts the character defaults:
- `disposition = HOSTILE`
- `sight.enabled = true` (range 0)
- `actorLink = false` for NPCs and minions (each dropped token tracks its own HP); **solo monsters override to `actorLink = true`** since a boss is a single persistently tracked token.

## Notes
- A non-caster **character** (has `resources.mana` but max 0) may show an empty second bar; monsters/NPCs are unaffected. Left as-is per YAGNI.
- Scene global-illumination defaulting was considered but deliberately **not** included: it would fire on adventure-module scene imports and override map authors' intentional lighting.

## Testing
- `pnpm type-check` ✅
- biome ✅
- unit tests (incl. new `monsterPrototypeTokenDefaults.test.ts`) ✅
