### PR TITLE
feat(combat): limit actions to 1 while Dying

### DIFF
--- a/packs/classFeatures/core/berserker/berserker-progression/enduring-rage.json
+++ b/packs/classFeatures/core/berserker/berserker-progression/enduring-rage.json
@@ -6,7 +6,22 @@
 	"system": {
 		"macro": "",
 		"identifier": "",
-		"rules": [],
+		"rules": [
+			{
+				"type": "dyingActionLimit",
+				"disabled": false,
+				"id": "EnduRageDyingAct",
+				"identifier": "",
+				"label": "Enduring Rage",
+				"predicate": {
+					"$and": [
+						"self:dying"
+					]
+				},
+				"priority": 1,
+				"value": "2"
+			}
+		],
 		"activation": {
 			"acquireTargetsFromTemplate": false,
 			"cost": {

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -632,6 +632,7 @@
 			"combatMana": "Combat Mana",
 			"conditionImmunity": "Condition Immunity",
 			"damageBonus": "Damage Bonus",
+			"dyingActionLimit": "Dying Action Limit",
 			"grantMovement": "Grant Movement",
 			"diceConsumer": "Dice Consumer",
 			"dicePool": "Dice Pool",
@@ -762,6 +763,13 @@
 				"targetCondition": {
 					"label": "Target condition",
 					"hint": "Optional predicate evaluated against the target's state. Bonus only applies when the target matches. Use $and / $or with atom strings, e.g. { \"$or\": [\"target:bloodied\", \"target:concentrating\"] }."
+				}
+			},
+			"dyingActionLimit": {
+				"description": "Set the maximum number of actions the actor may take while Dying. The highest applicable limit wins, so it never lowers the baseline of 1.",
+				"value": {
+					"label": "Action limit",
+					"hint": "A flat number or formula (e.g. 2). Use a predicate such as { \"$and\": [\"self:dying\"] } to apply only while Dying."
 				}
 			},
 			"dicePool": {

--- a/src/config/registerRulesConfig.ts
+++ b/src/config/registerRulesConfig.ts
@@ -8,6 +8,7 @@ import { ConditionImmunityRule } from '../models/rules/conditionImmunity.js';
 import { DamageBonusRule } from '../models/rules/damageBonus.js';
 import { DiceConsumerRule } from '../models/rules/diceConsumer.js';
 import { DicePoolRule } from '../models/rules/dicePool.js';
+import { DyingActionLimitRule } from '../models/rules/dyingActionLimit.js';
 import { ItemGrantRule } from '../models/rules/grantItem.js';
 import { GrantMovementRule } from '../models/rules/grantMovement.js';
 import { GrantProficiencyRule } from '../models/rules/grantProficiencies.ts';
@@ -40,6 +41,7 @@ export default function registerRulesConfig() {
 		combatMana: 'NIMBLE.ruleTypes.combatMana',
 		conditionImmunity: 'NIMBLE.ruleTypes.conditionImmunity',
 		damageBonus: 'NIMBLE.ruleTypes.damageBonus',
+		dyingActionLimit: 'NIMBLE.ruleTypes.dyingActionLimit',
 		grantMovement: 'NIMBLE.ruleTypes.grantMovement',
 		diceConsumer: 'NIMBLE.ruleTypes.diceConsumer',
 		dicePool: 'NIMBLE.ruleTypes.dicePool',
@@ -74,6 +76,7 @@ export default function registerRulesConfig() {
 		combatMana: CombatManaRule,
 		conditionImmunity: ConditionImmunityRule,
 		damageBonus: DamageBonusRule,
+		dyingActionLimit: DyingActionLimitRule,
 		grantMovement: GrantMovementRule,
 		diceConsumer: DiceConsumerRule,
 		dicePool: DicePoolRule,

--- a/src/documents/combat/combat.svelte.ts
+++ b/src/documents/combat/combat.svelte.ts
@@ -17,7 +17,7 @@ import { initiativeRollLock } from '#utils/initiativeRollLock.js';
 import { isCombatantDead } from '#utils/isCombatantDead.js';
 import { getMinionGroupId, getMinionGroupSummaries } from '#utils/minionGrouping.js';
 import { queueCombatantMutationWithFreshDocument } from '#utils/queueCombatantMutationWithFreshDocument.js';
-import { getCombatantBaseActionMax, getCombatantManualSortValue } from './combatantSystem.js';
+import { getCombatantManualSortValue, getCombatantResetActions } from './combatantSystem.js';
 import { getCombatantCurrentActions, logMinionGroupingCombat } from './combatCommon.js';
 import { rollInitiativeForCombatant } from './combatInitiative.js';
 import { performMinionGroupAttack } from './combatMinionAttacks.js';
@@ -483,7 +483,7 @@ class NimbleCombat extends Combat {
 			const combatantId = targetCombatant.id ?? null;
 			if (!combatantId) return accumulator;
 
-			const nextActions = getCombatantBaseActionMax(targetCombatant);
+			const nextActions = getCombatantResetActions(targetCombatant);
 			if (getCombatantCurrentActions(targetCombatant) === nextActions) return accumulator;
 
 			accumulator.push({
@@ -573,7 +573,7 @@ class NimbleCombat extends Combat {
 			.map((combatant) => {
 				return {
 					_id: combatant.id,
-					'system.actions.base.current': getCombatantBaseActionMax(combatant),
+					'system.actions.base.current': getCombatantResetActions(combatant),
 				};
 			});
 		if (updates.length < 1) return;
@@ -696,7 +696,7 @@ class NimbleCombat extends Combat {
 
 		if (combatant.type === 'character') {
 			await combatant.update({
-				'system.actions.base.current': getCombatantBaseActionMax(combatant),
+				'system.actions.base.current': getCombatantResetActions(combatant),
 				'system.actions.base.additional': 0,
 				...this.#buildHeroicReactionAvailabilityUpdate(true),
 			} as Record<string, unknown>);

--- a/src/documents/combat/combatantSystem.test.ts
+++ b/src/documents/combat/combatantSystem.test.ts
@@ -3,14 +3,10 @@ import {
 	createCombatActorFixture,
 	createCombatantFixture,
 } from '../../../tests/fixtures/combat.js';
-import {
-	getCombatantEffectiveMax,
-	getCombatantResetActions,
-	isCombatantDying,
-} from './combatantSystem.js';
+import { getCombatantResetActions, isCombatantDying } from './combatantSystem.js';
 
-function createDyingActor() {
-	return Object.assign(createCombatActorFixture({ type: 'character' }), {
+function createDyingActor(dyingActionLimit?: number) {
+	return Object.assign(createCombatActorFixture({ type: 'character', dyingActionLimit }), {
 		statuses: new Set(['dying']),
 	}) as Actor.Implementation;
 }
@@ -47,31 +43,14 @@ describe('getCombatantResetActions', () => {
 		const combatant = createCombatantFixture({ actionsMax: 3, actor: createDyingActor() });
 		expect(getCombatantResetActions(combatant)).toBe(1);
 	});
-});
 
-describe('getCombatantEffectiveMax', () => {
-	it('caps the base max at 1 when dying but still includes additional actions', () => {
-		const combatant = createCombatantFixture({ actionsMax: 3, actor: createDyingActor() });
-		(
-			combatant.system as unknown as { actions: { base: { additional: number } } }
-		).actions.base.additional = 2;
-		// Dying base max (1) + additional (2) = 3.
-		expect(getCombatantEffectiveMax(combatant)).toBe(3);
+	it('respects a raised dying action limit (e.g. Enduring Rage)', () => {
+		const combatant = createCombatantFixture({ actionsMax: 3, actor: createDyingActor(2) });
+		expect(getCombatantResetActions(combatant)).toBe(2);
 	});
 
-	it('returns the dying base max when there are no additional actions', () => {
-		const combatant = createCombatantFixture({ actionsMax: 3, actor: createDyingActor() });
-		expect(getCombatantEffectiveMax(combatant)).toBe(1);
-	});
-
-	it('includes additional actions when not dying', () => {
-		const combatant = createCombatantFixture({
-			actionsMax: 3,
-			actor: createCombatActorFixture({ type: 'character' }),
-		});
-		(
-			combatant.system as unknown as { actions: { base: { additional: number } } }
-		).actions.base.additional = 2;
-		expect(getCombatantEffectiveMax(combatant)).toBe(5);
+	it('never resets above the combatant base max even with a higher dying limit', () => {
+		const combatant = createCombatantFixture({ actionsMax: 1, actor: createDyingActor(2) });
+		expect(getCombatantResetActions(combatant)).toBe(1);
 	});
 });

--- a/src/documents/combat/combatantSystem.test.ts
+++ b/src/documents/combat/combatantSystem.test.ts
@@ -50,12 +50,17 @@ describe('getCombatantResetActions', () => {
 });
 
 describe('getCombatantEffectiveMax', () => {
-	it('caps the effective max at 1 when dying, ignoring additional actions', () => {
+	it('caps the base max at 1 when dying but still includes additional actions', () => {
 		const combatant = createCombatantFixture({ actionsMax: 3, actor: createDyingActor() });
-		// Simulate a stale additional action that should not raise the dying cap.
 		(
 			combatant.system as unknown as { actions: { base: { additional: number } } }
 		).actions.base.additional = 2;
+		// Dying base max (1) + additional (2) = 3.
+		expect(getCombatantEffectiveMax(combatant)).toBe(3);
+	});
+
+	it('returns the dying base max when there are no additional actions', () => {
+		const combatant = createCombatantFixture({ actionsMax: 3, actor: createDyingActor() });
 		expect(getCombatantEffectiveMax(combatant)).toBe(1);
 	});
 

--- a/src/documents/combat/combatantSystem.test.ts
+++ b/src/documents/combat/combatantSystem.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import {
+	createCombatActorFixture,
+	createCombatantFixture,
+} from '../../../tests/fixtures/combat.js';
+import {
+	getCombatantEffectiveMax,
+	getCombatantResetActions,
+	isCombatantDying,
+} from './combatantSystem.js';
+
+function createDyingActor() {
+	return Object.assign(createCombatActorFixture({ type: 'character' }), {
+		statuses: new Set(['dying']),
+	}) as Actor.Implementation;
+}
+
+describe('isCombatantDying', () => {
+	it('is true when the combatant actor has the dying status', () => {
+		const combatant = createCombatantFixture({ actor: createDyingActor() });
+		expect(isCombatantDying(combatant)).toBe(true);
+	});
+
+	it('is false when the combatant actor is not dying', () => {
+		const combatant = createCombatantFixture({
+			actor: createCombatActorFixture({ type: 'character' }),
+		});
+		expect(isCombatantDying(combatant)).toBe(false);
+	});
+
+	it('is false when the combatant has no actor', () => {
+		const combatant = createCombatantFixture({ actor: null });
+		expect(isCombatantDying(combatant)).toBe(false);
+	});
+});
+
+describe('getCombatantResetActions', () => {
+	it('resets to the base max when not dying', () => {
+		const combatant = createCombatantFixture({
+			actionsMax: 3,
+			actor: createCombatActorFixture({ type: 'character' }),
+		});
+		expect(getCombatantResetActions(combatant)).toBe(3);
+	});
+
+	it('resets to 1 when dying', () => {
+		const combatant = createCombatantFixture({ actionsMax: 3, actor: createDyingActor() });
+		expect(getCombatantResetActions(combatant)).toBe(1);
+	});
+});
+
+describe('getCombatantEffectiveMax', () => {
+	it('caps the effective max at 1 when dying, ignoring additional actions', () => {
+		const combatant = createCombatantFixture({ actionsMax: 3, actor: createDyingActor() });
+		// Simulate a stale additional action that should not raise the dying cap.
+		(
+			combatant.system as unknown as { actions: { base: { additional: number } } }
+		).actions.base.additional = 2;
+		expect(getCombatantEffectiveMax(combatant)).toBe(1);
+	});
+
+	it('includes additional actions when not dying', () => {
+		const combatant = createCombatantFixture({
+			actionsMax: 3,
+			actor: createCombatActorFixture({ type: 'character' }),
+		});
+		(
+			combatant.system as unknown as { actions: { base: { additional: number } } }
+		).actions.base.additional = 2;
+		expect(getCombatantEffectiveMax(combatant)).toBe(5);
+	});
+});

--- a/src/documents/combat/combatantSystem.ts
+++ b/src/documents/combat/combatantSystem.ts
@@ -1,4 +1,4 @@
-import { DYING_MAX_ACTIONS, isActorDying } from '#utils/actorHealthState.js';
+import { getActorDyingActionLimit, isActorDying } from '#utils/actorHealthState.js';
 import type { CombatantBaseActions, NimbleCombatantSystem } from './combatTypes.js';
 
 function getCombatantSystem(combatant: Combatant.Implementation): NimbleCombatantSystem | null {
@@ -31,18 +31,16 @@ export function isCombatantDying(combatant: Combatant.Implementation): boolean {
 }
 
 /**
- * Base action max to reset `current` to at the start of a turn, capped at
- * {@link DYING_MAX_ACTIONS} while the combatant is Dying.
+ * Base action max to reset `current` to at the start of a turn, capped at the
+ * actor's Dying action limit (baseline 1, raised by features such as Enduring
+ * Rage) while the combatant is Dying.
  */
 export function getCombatantResetActions(combatant: Combatant.Implementation): number {
 	const baseMax = getCombatantBaseActionMax(combatant);
-	if (isCombatantDying(combatant)) return Math.min(baseMax, DYING_MAX_ACTIONS);
+	if (isCombatantDying(combatant)) {
+		return Math.min(baseMax, getActorDyingActionLimit(combatant.actor));
+	}
 	return baseMax;
-}
-
-export function getCombatantEffectiveMax(combatant: Combatant.Implementation): number {
-	// While Dying the base action max is limited to 1, but additional actions still apply.
-	return getCombatantResetActions(combatant) + getCombatantAdditionalActions(combatant);
 }
 
 export function getCombatantBaseActionCurrent(combatant: Combatant.Implementation): number {

--- a/src/documents/combat/combatantSystem.ts
+++ b/src/documents/combat/combatantSystem.ts
@@ -1,3 +1,4 @@
+import { DYING_MAX_ACTIONS, isActorDying } from '#utils/actorHealthState.js';
 import type { CombatantBaseActions, NimbleCombatantSystem } from './combatTypes.js';
 
 function getCombatantSystem(combatant: Combatant.Implementation): NimbleCombatantSystem | null {
@@ -25,7 +26,24 @@ export function getCombatantAdditionalActions(combatant: Combatant.Implementatio
 	return normalizeNonNegativeInteger((actions as { additional?: unknown } | undefined)?.additional);
 }
 
+export function isCombatantDying(combatant: Combatant.Implementation): boolean {
+	return isActorDying(combatant.actor);
+}
+
+/**
+ * Base action max to reset `current` to at the start of a turn, capped at
+ * {@link DYING_MAX_ACTIONS} while the combatant is Dying.
+ */
+export function getCombatantResetActions(combatant: Combatant.Implementation): number {
+	const baseMax = getCombatantBaseActionMax(combatant);
+	if (isCombatantDying(combatant)) return Math.min(baseMax, DYING_MAX_ACTIONS);
+	return baseMax;
+}
+
 export function getCombatantEffectiveMax(combatant: Combatant.Implementation): number {
+	if (isCombatantDying(combatant)) {
+		return Math.min(getCombatantBaseActionMax(combatant), DYING_MAX_ACTIONS);
+	}
 	return getCombatantBaseActionMax(combatant) + getCombatantAdditionalActions(combatant);
 }
 

--- a/src/documents/combat/combatantSystem.ts
+++ b/src/documents/combat/combatantSystem.ts
@@ -41,10 +41,8 @@ export function getCombatantResetActions(combatant: Combatant.Implementation): n
 }
 
 export function getCombatantEffectiveMax(combatant: Combatant.Implementation): number {
-	if (isCombatantDying(combatant)) {
-		return Math.min(getCombatantBaseActionMax(combatant), DYING_MAX_ACTIONS);
-	}
-	return getCombatantBaseActionMax(combatant) + getCombatantAdditionalActions(combatant);
+	// While Dying the base action max is limited to 1, but additional actions still apply.
+	return getCombatantResetActions(combatant) + getCombatantAdditionalActions(combatant);
 }
 
 export function getCombatantBaseActionCurrent(combatant: Combatant.Implementation): number {

--- a/src/hooks/combatantHooks/dyingActionLimitSync.test.ts
+++ b/src/hooks/combatantHooks/dyingActionLimitSync.test.ts
@@ -27,12 +27,39 @@ describe('registerDyingActionLimitSync', () => {
 		globals().game.combats = { contents: [] };
 	});
 
-	it('clamps current actions to 1 and clears additional actions when an actor becomes Dying', async () => {
+	it('clamps current actions to the dying base limit when an actor becomes Dying', async () => {
 		const callbacks = createHookCapture(globals().Hooks.on);
 		const register = (await import('./dyingActionLimitSync.js')).default;
 		register();
 
 		const combatant = createMockCombatant({ id: 'c1', actorId: 'actor-1', actionsCurrent: 3 });
+		const combat = createMockCombat({
+			id: 'combat-1',
+			combatants: [combatant],
+			turns: [combatant],
+			activeCombatant: combatant,
+			round: 1,
+		});
+		globals().game.combats = { contents: [combat] };
+
+		const createActiveEffect = callbacks.get('createActiveEffect');
+		createActiveEffect?.(createDyingEffect('actor-1'));
+		await flushAsync();
+
+		expect(combat.updateEmbeddedDocuments).toHaveBeenCalledWith('Combatant', [
+			{
+				_id: 'c1',
+				'system.actions.base.current': 1,
+			},
+		]);
+	});
+
+	it('preserves additional actions, clamping current to 1 + additional', async () => {
+		const callbacks = createHookCapture(globals().Hooks.on);
+		const register = (await import('./dyingActionLimitSync.js')).default;
+		register();
+
+		const combatant = createMockCombatant({ id: 'c1', actorId: 'actor-1', actionsCurrent: 5 });
 		(
 			combatant.system as unknown as { actions: { base: { additional: number } } }
 		).actions.base.additional = 2;
@@ -52,8 +79,7 @@ describe('registerDyingActionLimitSync', () => {
 		expect(combat.updateEmbeddedDocuments).toHaveBeenCalledWith('Combatant', [
 			{
 				_id: 'c1',
-				'system.actions.base.current': 1,
-				'system.actions.base.additional': 0,
+				'system.actions.base.current': 3,
 			},
 		]);
 	});

--- a/src/hooks/combatantHooks/dyingActionLimitSync.test.ts
+++ b/src/hooks/combatantHooks/dyingActionLimitSync.test.ts
@@ -27,34 +27,7 @@ describe('registerDyingActionLimitSync', () => {
 		globals().game.combats = { contents: [] };
 	});
 
-	it('clamps current actions to the dying base limit when an actor becomes Dying', async () => {
-		const callbacks = createHookCapture(globals().Hooks.on);
-		const register = (await import('./dyingActionLimitSync.js')).default;
-		register();
-
-		const combatant = createMockCombatant({ id: 'c1', actorId: 'actor-1', actionsCurrent: 3 });
-		const combat = createMockCombat({
-			id: 'combat-1',
-			combatants: [combatant],
-			turns: [combatant],
-			activeCombatant: combatant,
-			round: 1,
-		});
-		globals().game.combats = { contents: [combat] };
-
-		const createActiveEffect = callbacks.get('createActiveEffect');
-		createActiveEffect?.(createDyingEffect('actor-1'));
-		await flushAsync();
-
-		expect(combat.updateEmbeddedDocuments).toHaveBeenCalledWith('Combatant', [
-			{
-				_id: 'c1',
-				'system.actions.base.current': 1,
-			},
-		]);
-	});
-
-	it('preserves additional actions, clamping current to 1 + additional', async () => {
+	it('clamps current to 1 and clears carried-over additional actions when an actor becomes Dying', async () => {
 		const callbacks = createHookCapture(globals().Hooks.on);
 		const register = (await import('./dyingActionLimitSync.js')).default;
 		register();
@@ -79,7 +52,39 @@ describe('registerDyingActionLimitSync', () => {
 		expect(combat.updateEmbeddedDocuments).toHaveBeenCalledWith('Combatant', [
 			{
 				_id: 'c1',
-				'system.actions.base.current': 3,
+				'system.actions.base.current': 1,
+				'system.actions.base.additional': 0,
+			},
+		]);
+	});
+
+	it('clears carried-over additional actions even when current is already within the limit', async () => {
+		const callbacks = createHookCapture(globals().Hooks.on);
+		const register = (await import('./dyingActionLimitSync.js')).default;
+		register();
+
+		const combatant = createMockCombatant({ id: 'c1', actorId: 'actor-1', actionsCurrent: 1 });
+		(
+			combatant.system as unknown as { actions: { base: { additional: number } } }
+		).actions.base.additional = 2;
+		const combat = createMockCombat({
+			id: 'combat-1',
+			combatants: [combatant],
+			turns: [combatant],
+			activeCombatant: combatant,
+			round: 1,
+		});
+		globals().game.combats = { contents: [combat] };
+
+		const createActiveEffect = callbacks.get('createActiveEffect');
+		createActiveEffect?.(createDyingEffect('actor-1'));
+		await flushAsync();
+
+		expect(combat.updateEmbeddedDocuments).toHaveBeenCalledWith('Combatant', [
+			{
+				_id: 'c1',
+				'system.actions.base.current': 1,
+				'system.actions.base.additional': 0,
 			},
 		]);
 	});

--- a/src/hooks/combatantHooks/dyingActionLimitSync.test.ts
+++ b/src/hooks/combatantHooks/dyingActionLimitSync.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushAsync, getTestGlobals } from '../../../tests/helpers.js';
+import {
+	type CombatDefeatSyncTestGlobals,
+	createHookCapture,
+	createMockCombat,
+	createMockCombatant,
+} from '../../../tests/mocks/combat.js';
+
+function globals() {
+	return getTestGlobals<CombatDefeatSyncTestGlobals>();
+}
+
+function createDyingEffect(actorId: string) {
+	return {
+		parent: { documentName: 'Actor', id: actorId },
+		statuses: new Set(['dying']),
+	} as unknown as ActiveEffect.Implementation;
+}
+
+describe('registerDyingActionLimitSync', () => {
+	beforeEach(() => {
+		vi.resetModules();
+		vi.clearAllMocks();
+
+		globals().game.user = { isGM: true };
+		globals().game.combats = { contents: [] };
+	});
+
+	it('clamps current actions to 1 and clears additional actions when an actor becomes Dying', async () => {
+		const callbacks = createHookCapture(globals().Hooks.on);
+		const register = (await import('./dyingActionLimitSync.js')).default;
+		register();
+
+		const combatant = createMockCombatant({ id: 'c1', actorId: 'actor-1', actionsCurrent: 3 });
+		(
+			combatant.system as unknown as { actions: { base: { additional: number } } }
+		).actions.base.additional = 2;
+		const combat = createMockCombat({
+			id: 'combat-1',
+			combatants: [combatant],
+			turns: [combatant],
+			activeCombatant: combatant,
+			round: 1,
+		});
+		globals().game.combats = { contents: [combat] };
+
+		const createActiveEffect = callbacks.get('createActiveEffect');
+		createActiveEffect?.(createDyingEffect('actor-1'));
+		await flushAsync();
+
+		expect(combat.updateEmbeddedDocuments).toHaveBeenCalledWith('Combatant', [
+			{
+				_id: 'c1',
+				'system.actions.base.current': 1,
+				'system.actions.base.additional': 0,
+			},
+		]);
+	});
+
+	it('does not update when the combatant is already within the Dying limit', async () => {
+		const callbacks = createHookCapture(globals().Hooks.on);
+		const register = (await import('./dyingActionLimitSync.js')).default;
+		register();
+
+		const combatant = createMockCombatant({ id: 'c1', actorId: 'actor-1', actionsCurrent: 1 });
+		const combat = createMockCombat({
+			id: 'combat-1',
+			combatants: [combatant],
+			turns: [combatant],
+			activeCombatant: combatant,
+			round: 1,
+		});
+		globals().game.combats = { contents: [combat] };
+
+		const createActiveEffect = callbacks.get('createActiveEffect');
+		createActiveEffect?.(createDyingEffect('actor-1'));
+		await flushAsync();
+
+		expect(combat.updateEmbeddedDocuments).not.toHaveBeenCalled();
+	});
+
+	it('ignores active effects that are not the Dying status', async () => {
+		const callbacks = createHookCapture(globals().Hooks.on);
+		const register = (await import('./dyingActionLimitSync.js')).default;
+		register();
+
+		const combatant = createMockCombatant({ id: 'c1', actorId: 'actor-1', actionsCurrent: 3 });
+		const combat = createMockCombat({
+			id: 'combat-1',
+			combatants: [combatant],
+			turns: [combatant],
+			activeCombatant: combatant,
+			round: 1,
+		});
+		globals().game.combats = { contents: [combat] };
+
+		const createActiveEffect = callbacks.get('createActiveEffect');
+		createActiveEffect?.({
+			parent: { documentName: 'Actor', id: 'actor-1' },
+			statuses: new Set(['bloodied']),
+		} as unknown as ActiveEffect.Implementation);
+		await flushAsync();
+
+		expect(combat.updateEmbeddedDocuments).not.toHaveBeenCalled();
+	});
+
+	it('does nothing for non-GM users', async () => {
+		globals().game.user = { isGM: false };
+		const callbacks = createHookCapture(globals().Hooks.on);
+		const register = (await import('./dyingActionLimitSync.js')).default;
+		register();
+
+		const combatant = createMockCombatant({ id: 'c1', actorId: 'actor-1', actionsCurrent: 3 });
+		const combat = createMockCombat({
+			id: 'combat-1',
+			combatants: [combatant],
+			turns: [combatant],
+			activeCombatant: combatant,
+			round: 1,
+		});
+		globals().game.combats = { contents: [combat] };
+
+		const createActiveEffect = callbacks.get('createActiveEffect');
+		createActiveEffect?.(createDyingEffect('actor-1'));
+		await flushAsync();
+
+		expect(combat.updateEmbeddedDocuments).not.toHaveBeenCalled();
+	});
+});

--- a/src/hooks/combatantHooks/dyingActionLimitSync.ts
+++ b/src/hooks/combatantHooks/dyingActionLimitSync.ts
@@ -22,10 +22,11 @@ function getCombatantsForActor(
 
 /**
  * When an actor gains the Dying condition mid-turn, its combatants may still have
- * more actions available than the Dying limit allows. The base action max is limited
- * to {@link DYING_MAX_ACTIONS} while Dying, but already-granted additional actions
- * still apply — so clamp `current` down to `DYING_MAX_ACTIONS + additional` so the
- * action tracker and any action-spend checks immediately reflect the rule.
+ * more actions available — and additional actions carried over from before Dying —
+ * than the Dying limit allows. Clamp `current` down to {@link DYING_MAX_ACTIONS} and
+ * clear those carried-over additional actions so the action tracker and any
+ * action-spend checks immediately reflect the rule. The player can still add fresh
+ * additional actions afterward while Dying.
  */
 async function clampDyingActorActions(actor: Actor.Implementation): Promise<void> {
 	if (!game.user?.isGM) return;
@@ -36,13 +37,13 @@ async function clampDyingActorActions(actor: Actor.Implementation): Promise<void
 
 		const current = getCombatantCurrentActions(combatant);
 		const additional = getCombatantAdditionalActions(combatant);
-		const cappedActions = DYING_MAX_ACTIONS + additional;
-		if (current <= cappedActions) continue;
+		if (current <= DYING_MAX_ACTIONS && additional === 0) continue;
 
 		await combat.updateEmbeddedDocuments('Combatant', [
 			{
 				_id: combatant.id,
-				'system.actions.base.current': cappedActions,
+				'system.actions.base.current': Math.min(current, DYING_MAX_ACTIONS),
+				'system.actions.base.additional': 0,
 			} as Record<string, unknown>,
 		]);
 	}

--- a/src/hooks/combatantHooks/dyingActionLimitSync.ts
+++ b/src/hooks/combatantHooks/dyingActionLimitSync.ts
@@ -1,0 +1,60 @@
+import { STATUS_EFFECT_IDS } from '../../config/registerConditionsConfig.js';
+import { getCombatantAdditionalActions } from '../../documents/combat/combatantSystem.js';
+import { DYING_MAX_ACTIONS } from '../../utils/actorHealthState.js';
+import { getCombatantCurrentActions } from '../../utils/combatTurnActions.js';
+
+let didRegisterDyingActionLimitSync = false;
+
+function getCombatantsForActor(
+	actorId: string,
+): Array<{ combat: Combat; combatant: Combatant.Implementation }> {
+	const entries: Array<{ combat: Combat; combatant: Combatant.Implementation }> = [];
+
+	for (const combat of game.combats?.contents ?? []) {
+		for (const combatant of combat.combatants.contents) {
+			if (combatant.actorId !== actorId) continue;
+			entries.push({ combat, combatant });
+		}
+	}
+
+	return entries;
+}
+
+/**
+ * When an actor gains the Dying condition mid-turn, its combatants may still have
+ * more actions available (and additional actions) than the Dying limit allows.
+ * Clamp `current` down to {@link DYING_MAX_ACTIONS} and clear additional actions so
+ * the action tracker and any action-spend checks immediately reflect the rule.
+ */
+async function clampDyingActorActions(actor: Actor.Implementation): Promise<void> {
+	if (!game.user?.isGM) return;
+	if (!actor.id) return;
+
+	for (const { combat, combatant } of getCombatantsForActor(actor.id)) {
+		if (!combat.id || !combatant.id) continue;
+
+		const current = getCombatantCurrentActions(combatant);
+		const additional = getCombatantAdditionalActions(combatant);
+		if (current <= DYING_MAX_ACTIONS && additional === 0) continue;
+
+		await combat.updateEmbeddedDocuments('Combatant', [
+			{
+				_id: combatant.id,
+				'system.actions.base.current': Math.min(current, DYING_MAX_ACTIONS),
+				'system.actions.base.additional': 0,
+			} as Record<string, unknown>,
+		]);
+	}
+}
+
+export default function registerDyingActionLimitSync() {
+	if (didRegisterDyingActionLimitSync) return;
+	didRegisterDyingActionLimitSync = true;
+
+	Hooks.on('createActiveEffect', (effect: ActiveEffect.Implementation) => {
+		if (!effect?.parent || effect.parent.documentName !== 'Actor') return;
+		if (!(effect.statuses instanceof Set) || !effect.statuses.has(STATUS_EFFECT_IDS.dying)) return;
+
+		void clampDyingActorActions(effect.parent as Actor.Implementation);
+	});
+}

--- a/src/hooks/combatantHooks/dyingActionLimitSync.ts
+++ b/src/hooks/combatantHooks/dyingActionLimitSync.ts
@@ -1,6 +1,6 @@
 import { STATUS_EFFECT_IDS } from '../../config/registerConditionsConfig.js';
 import { getCombatantAdditionalActions } from '../../documents/combat/combatantSystem.js';
-import { DYING_MAX_ACTIONS } from '../../utils/actorHealthState.js';
+import { getActorDyingActionLimit } from '../../utils/actorHealthState.js';
 import { getCombatantCurrentActions } from '../../utils/combatTurnActions.js';
 
 let didRegisterDyingActionLimitSync = false;
@@ -23,26 +23,29 @@ function getCombatantsForActor(
 /**
  * When an actor gains the Dying condition mid-turn, its combatants may still have
  * more actions available — and additional actions carried over from before Dying —
- * than the Dying limit allows. Clamp `current` down to {@link DYING_MAX_ACTIONS} and
- * clear those carried-over additional actions so the action tracker and any
- * action-spend checks immediately reflect the rule. The player can still add fresh
- * additional actions afterward while Dying.
+ * than the Dying limit allows. Clamp `current` down to the actor's Dying action
+ * limit (baseline 1, raised by features such as Enduring Rage) and clear those
+ * carried-over additional actions so the action tracker and any action-spend checks
+ * immediately reflect the rule. The player can still add fresh additional actions
+ * afterward while Dying.
  */
 async function clampDyingActorActions(actor: Actor.Implementation): Promise<void> {
 	if (!game.user?.isGM) return;
 	if (!actor.id) return;
+
+	const dyingActionLimit = getActorDyingActionLimit(actor);
 
 	for (const { combat, combatant } of getCombatantsForActor(actor.id)) {
 		if (!combat.id || !combatant.id) continue;
 
 		const current = getCombatantCurrentActions(combatant);
 		const additional = getCombatantAdditionalActions(combatant);
-		if (current <= DYING_MAX_ACTIONS && additional === 0) continue;
+		if (current <= dyingActionLimit && additional === 0) continue;
 
 		await combat.updateEmbeddedDocuments('Combatant', [
 			{
 				_id: combatant.id,
-				'system.actions.base.current': Math.min(current, DYING_MAX_ACTIONS),
+				'system.actions.base.current': Math.min(current, dyingActionLimit),
 				'system.actions.base.additional': 0,
 			} as Record<string, unknown>,
 		]);

--- a/src/hooks/combatantHooks/dyingActionLimitSync.ts
+++ b/src/hooks/combatantHooks/dyingActionLimitSync.ts
@@ -22,9 +22,10 @@ function getCombatantsForActor(
 
 /**
  * When an actor gains the Dying condition mid-turn, its combatants may still have
- * more actions available (and additional actions) than the Dying limit allows.
- * Clamp `current` down to {@link DYING_MAX_ACTIONS} and clear additional actions so
- * the action tracker and any action-spend checks immediately reflect the rule.
+ * more actions available than the Dying limit allows. The base action max is limited
+ * to {@link DYING_MAX_ACTIONS} while Dying, but already-granted additional actions
+ * still apply — so clamp `current` down to `DYING_MAX_ACTIONS + additional` so the
+ * action tracker and any action-spend checks immediately reflect the rule.
  */
 async function clampDyingActorActions(actor: Actor.Implementation): Promise<void> {
 	if (!game.user?.isGM) return;
@@ -35,13 +36,13 @@ async function clampDyingActorActions(actor: Actor.Implementation): Promise<void
 
 		const current = getCombatantCurrentActions(combatant);
 		const additional = getCombatantAdditionalActions(combatant);
-		if (current <= DYING_MAX_ACTIONS && additional === 0) continue;
+		const cappedActions = DYING_MAX_ACTIONS + additional;
+		if (current <= cappedActions) continue;
 
 		await combat.updateEmbeddedDocuments('Combatant', [
 			{
 				_id: combatant.id,
-				'system.actions.base.current': Math.min(current, DYING_MAX_ACTIONS),
-				'system.actions.base.additional': 0,
+				'system.actions.base.current': cappedActions,
 			} as Record<string, unknown>,
 		]);
 	}

--- a/src/models/actor/CharacterDataModel.ts
+++ b/src/models/actor/CharacterDataModel.ts
@@ -2,6 +2,7 @@ import type { AbilityKeyType } from '#types/abilityKey.js';
 import type { SaveKeyType } from '#types/saveKey.js';
 import type { SkillKeyType } from '#types/skillKey.js';
 
+import { DYING_MAX_ACTIONS } from '#utils/actorHealthState.js';
 import { RecordField } from '../fields/RecordField.js';
 import { abilities, savingThrows } from './common.js';
 
@@ -78,6 +79,16 @@ const characterSchema = () => ({
 			}),
 			{ required: true, nullable: false, initial: () => [] },
 		),
+		// Effective action cap while Dying. Defaults to the engine baseline and is
+		// raised in-place during data prep by the `dyingActionLimit` rule (e.g. the
+		// Berserker's Enduring Rage). Read via `getActorDyingActionLimit`.
+		dyingActionLimit: new fields.NumberField({
+			required: true,
+			nullable: false,
+			initial: DYING_MAX_ACTIONS,
+			integer: true,
+			min: 0,
+		}),
 		armor: new fields.SchemaField({
 			baseValue: new fields.StringField({
 				required: true,

--- a/src/models/rules/dyingActionLimit.test.ts
+++ b/src/models/rules/dyingActionLimit.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DyingActionLimitRule } from './dyingActionLimit.js';
+
+interface MockActor {
+	system: {
+		attributes: { dyingActionLimit?: number };
+	};
+	getRollData: ReturnType<typeof vi.fn>;
+	getDomain: ReturnType<typeof vi.fn>;
+}
+
+interface MockItem {
+	isEmbedded: boolean;
+	actor: MockActor;
+	name: string;
+	uuid: string;
+	getDomain: ReturnType<typeof vi.fn>;
+}
+
+function createMockActor(dyingActionLimit = 1): MockActor {
+	return {
+		system: { attributes: { dyingActionLimit } },
+		getRollData: vi.fn(() => ({})),
+		getDomain: vi.fn(() => new Set<string>()),
+	};
+}
+
+function createDyingActionLimitRule(
+	config: {
+		value?: string;
+		disabled?: boolean;
+		predicatePasses?: boolean;
+	},
+	actor: MockActor,
+	itemOptions?: { isEmbedded?: boolean },
+): DyingActionLimitRule {
+	const item: MockItem = {
+		isEmbedded: itemOptions?.isEmbedded ?? true,
+		actor,
+		name: 'Test Item',
+		uuid: 'test-item-uuid',
+		getDomain: vi.fn(() => new Set<string>()),
+	};
+
+	const sourceData = {
+		value: config.value ?? '2',
+		disabled: config.disabled ?? false,
+		label: 'Test Rule',
+		id: 'test-rule-id',
+		identifier: '',
+		priority: 1,
+		predicate: {},
+		type: 'dyingActionLimit',
+	};
+
+	const rule = new DyingActionLimitRule(
+		sourceData as foundry.data.fields.SchemaField.CreateData<
+			DyingActionLimitRule['schema']['fields']
+		>,
+		{ parent: item as unknown as foundry.abstract.DataModel.Any, strict: false },
+	);
+
+	(rule as any).value = config.value ?? '2';
+	(rule as any).disabled = config.disabled ?? false;
+
+	Object.defineProperty(rule, 'item', {
+		get: () => item,
+		configurable: true,
+	});
+
+	const predicatePasses = config.predicatePasses ?? true;
+	Object.defineProperty(rule, '_predicate', {
+		get: () => ({ size: predicatePasses ? 0 : 1, test: () => predicatePasses }),
+		configurable: true,
+	});
+
+	return rule;
+}
+
+describe('DyingActionLimitRule', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe('afterPrepareData', () => {
+		it('raises the dying action limit when the predicate passes', () => {
+			const actor = createMockActor(1);
+			const rule = createDyingActionLimitRule({ value: '2' }, actor);
+
+			rule.afterPrepareData();
+
+			expect(actor.system.attributes.dyingActionLimit).toBe(2);
+		});
+
+		it('keeps the highest limit when stacking features (never lowers it)', () => {
+			const actor = createMockActor(3);
+			const rule = createDyingActionLimitRule({ value: '2' }, actor);
+
+			rule.afterPrepareData();
+
+			expect(actor.system.attributes.dyingActionLimit).toBe(3);
+		});
+
+		it('does not change the limit when the predicate fails', () => {
+			const actor = createMockActor(1);
+			const rule = createDyingActionLimitRule({ value: '2', predicatePasses: false }, actor);
+
+			rule.afterPrepareData();
+
+			expect(actor.system.attributes.dyingActionLimit).toBe(1);
+		});
+
+		it('does nothing when the rule is disabled', () => {
+			const actor = createMockActor(1);
+			const rule = createDyingActionLimitRule({ value: '2', disabled: true }, actor);
+
+			rule.afterPrepareData();
+
+			expect(actor.system.attributes.dyingActionLimit).toBe(1);
+		});
+
+		it('does nothing when the item is not embedded', () => {
+			const actor = createMockActor(1);
+			const rule = createDyingActionLimitRule({ value: '2' }, actor, { isEmbedded: false });
+
+			rule.afterPrepareData();
+
+			expect(actor.system.attributes.dyingActionLimit).toBe(1);
+		});
+	});
+
+	describe('schema', () => {
+		it('defines the expected fields', () => {
+			const schema = DyingActionLimitRule.defineSchema();
+			expect(schema).toHaveProperty('type');
+			expect(schema).toHaveProperty('value');
+		});
+	});
+
+	describe('class metadata', () => {
+		it('exposes the picker group and i18n description key', () => {
+			expect(DyingActionLimitRule.group).toBe('bonuses');
+			expect(DyingActionLimitRule.description).toBe('NIMBLE.rules.dyingActionLimit.description');
+		});
+	});
+});

--- a/src/models/rules/dyingActionLimit.ts
+++ b/src/models/rules/dyingActionLimit.ts
@@ -1,0 +1,69 @@
+import { DYING_ACTION_LIMIT_PATH, DYING_MAX_ACTIONS } from '#utils/actorHealthState.js';
+import { withWidget } from './_widgetOption.js';
+import { NimbleBaseRule } from './base.js';
+
+function schema() {
+	const { fields } = foundry.data;
+
+	return {
+		value: new fields.StringField(
+			withWidget({
+				required: true,
+				nullable: false,
+				initial: String(DYING_MAX_ACTIONS),
+				label: 'NIMBLE.rules.dyingActionLimit.value.label',
+				widget: 'formula',
+			}),
+		),
+		type: new fields.StringField({
+			required: true,
+			nullable: false,
+			initial: 'dyingActionLimit',
+		}),
+	};
+}
+
+declare namespace DyingActionLimitRule {
+	type Schema = NimbleBaseRule.Schema & ReturnType<typeof schema>;
+}
+
+/**
+ * Raises the actor's Dying action limit while the rule's predicate holds (e.g.
+ * `self:dying`). The highest applicable limit wins, so the engine baseline of
+ * {@link DYING_MAX_ACTIONS} is never lowered. The combat system reads the result
+ * via {@link DYING_ACTION_LIMIT_PATH} when capping actions for a Dying combatant.
+ */
+class DyingActionLimitRule extends NimbleBaseRule<DyingActionLimitRule.Schema> {
+	static override group = 'bonuses';
+	static override description = 'NIMBLE.rules.dyingActionLimit.description';
+
+	declare value: string;
+
+	static override defineSchema(): DyingActionLimitRule.Schema {
+		return {
+			...NimbleBaseRule.defineSchema(),
+			...schema(),
+		};
+	}
+
+	override tooltipInfo(): string {
+		return super.tooltipInfo(new Map([['value', 'string']]));
+	}
+
+	override afterPrepareData(): void {
+		const { item } = this;
+		if (!item.isEmbedded) return;
+		if (!this.test()) return;
+
+		const { actor } = item;
+		const limit = this.resolveFormula(this.value) ?? DYING_MAX_ACTIONS;
+		const current =
+			(foundry.utils.getProperty(actor.system, DYING_ACTION_LIMIT_PATH) as number | undefined) ??
+			DYING_MAX_ACTIONS;
+
+		// Highest limit wins so stacking features never reduce the cap.
+		foundry.utils.setProperty(actor.system, DYING_ACTION_LIMIT_PATH, Math.max(current, limit));
+	}
+}
+
+export { DyingActionLimitRule };

--- a/src/nimble.ts
+++ b/src/nimble.ts
@@ -8,6 +8,7 @@ import { registerWoundTriggerHooks } from './hooks/chargePoolTriggers/woundTrigg
 import registerChargeSystemHooks from './hooks/chargeSystem.js';
 import registerCombatantDefeatSync from './hooks/combatantHooks/combatantDefeatSync.js';
 import registerCombatantHealthStateSync from './hooks/combatantHooks/combatantHealthStateSync.js';
+import registerDyingActionLimitSync from './hooks/combatantHooks/dyingActionLimitSync.js';
 import registerTokenCombatantSync from './hooks/combatantHooks/tokenCombatantSync.js';
 import { conditionImmunityGuard } from './hooks/conditionImmunityGuard.js';
 import registerDicePoolSystemHooks from './hooks/dicePoolSystem.js';
@@ -111,6 +112,7 @@ type HookFn = (...args: object[]) => undefined | boolean | Promise<undefined | b
 Hooks.on('hotbarDrop', onHotbarDrop);
 registerCombatantDefeatSync();
 registerCombatantHealthStateSync();
+registerDyingActionLimitSync();
 registerChargeSystemHooks();
 registerDicePoolSystemHooks();
 registerWoundTriggerHooks();

--- a/src/utils/actorHealthState.test.ts
+++ b/src/utils/actorHealthState.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { createCombatActorFixture } from '../../tests/fixtures/combat.js';
-import { getActorHealthState, isActorAtOrBelowHalfHp } from './actorHealthState.js';
+import { getActorHealthState, isActorAtOrBelowHalfHp, isActorDying } from './actorHealthState.js';
 
 describe('getActorHealthState', () => {
 	it('returns bloodied for non-solo actors at half HP or lower', () => {
@@ -121,5 +121,31 @@ describe('isActorAtOrBelowHalfHp', () => {
 			{ statuses: new Set(['lastStand']) },
 		);
 		expect(isActorAtOrBelowHalfHp(actor as Actor.Implementation)).toBe(true);
+	});
+});
+
+describe('isActorDying', () => {
+	it('returns true when the actor has the dying status', () => {
+		const actor = Object.assign(createCombatActorFixture({ type: 'character', hp: 0 }), {
+			statuses: new Set(['dying']),
+		});
+		expect(isActorDying(actor as Actor.Implementation)).toBe(true);
+	});
+
+	it('returns false when the actor lacks the dying status', () => {
+		const actor = Object.assign(createCombatActorFixture({ type: 'character', hp: 10 }), {
+			statuses: new Set(['bloodied']),
+		});
+		expect(isActorDying(actor as Actor.Implementation)).toBe(false);
+	});
+
+	it('returns false when statuses are absent', () => {
+		const actor = createCombatActorFixture({ type: 'character', hp: 10 });
+		expect(isActorDying(actor)).toBe(false);
+	});
+
+	it('returns false for null/undefined actors', () => {
+		expect(isActorDying(null)).toBe(false);
+		expect(isActorDying(undefined)).toBe(false);
 	});
 });

--- a/src/utils/actorHealthState.test.ts
+++ b/src/utils/actorHealthState.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import { createCombatActorFixture } from '../../tests/fixtures/combat.js';
-import { getActorHealthState, isActorAtOrBelowHalfHp, isActorDying } from './actorHealthState.js';
+import {
+	DYING_MAX_ACTIONS,
+	getActorDyingActionLimit,
+	getActorHealthState,
+	isActorAtOrBelowHalfHp,
+	isActorDying,
+} from './actorHealthState.js';
 
 describe('getActorHealthState', () => {
 	it('returns bloodied for non-solo actors at half HP or lower', () => {
@@ -147,5 +153,30 @@ describe('isActorDying', () => {
 	it('returns false for null/undefined actors', () => {
 		expect(isActorDying(null)).toBe(false);
 		expect(isActorDying(undefined)).toBe(false);
+	});
+});
+
+describe('getActorDyingActionLimit', () => {
+	it('falls back to the baseline when the attribute is absent (e.g. NPCs)', () => {
+		const actor = createCombatActorFixture({ type: 'npc' });
+		expect(getActorDyingActionLimit(actor)).toBe(DYING_MAX_ACTIONS);
+	});
+
+	it('reads a raised limit from the actor attribute (e.g. Enduring Rage)', () => {
+		const actor = createCombatActorFixture({ type: 'character', dyingActionLimit: 2 });
+		expect(getActorDyingActionLimit(actor)).toBe(2);
+	});
+
+	it('falls back to the baseline for null/undefined actors', () => {
+		expect(getActorDyingActionLimit(null)).toBe(DYING_MAX_ACTIONS);
+		expect(getActorDyingActionLimit(undefined)).toBe(DYING_MAX_ACTIONS);
+	});
+
+	it('falls back to the baseline when the attribute is non-numeric', () => {
+		const actor = createCombatActorFixture({ type: 'character' });
+		(
+			actor.system as unknown as { attributes: { dyingActionLimit: unknown } }
+		).attributes.dyingActionLimit = 'not-a-number';
+		expect(getActorDyingActionLimit(actor)).toBe(DYING_MAX_ACTIONS);
 	});
 });

--- a/src/utils/actorHealthState.ts
+++ b/src/utils/actorHealthState.ts
@@ -4,10 +4,30 @@ import { getActorHpMaxValue, getActorHpValue } from './actorResources.js';
 export type ActorHealthState = 'normal' | 'bloodied' | 'lastStand' | 'unknown';
 
 /**
- * Maximum number of actions a combatant may take while suffering the Dying condition.
- * Per the Nimble rules, "while Dying, actions are limited to 1".
+ * Engine baseline for the maximum number of actions a combatant may take while
+ * suffering the Dying condition. Per the Nimble rules, "while Dying, actions are
+ * limited to 1". Features can raise this per-actor (e.g. the Berserker's Enduring
+ * Rage allows 2) via the `dyingActionLimit` rule, surfaced on
+ * {@link DYING_ACTION_LIMIT_PATH}.
  */
 export const DYING_MAX_ACTIONS = 1;
+
+/** System-relative path holding an actor's effective Dying action limit. */
+export const DYING_ACTION_LIMIT_PATH = 'attributes.dyingActionLimit';
+
+/**
+ * The actor's effective Dying action limit. Reads the derived
+ * {@link DYING_ACTION_LIMIT_PATH} (raised by features such as Enduring Rage),
+ * falling back to {@link DYING_MAX_ACTIONS} when the actor has no such attribute
+ * (e.g. NPCs/solo monsters, whose data model omits the field).
+ */
+export function getActorDyingActionLimit(actor: Actor.Implementation | null | undefined): number {
+	if (!actor) return DYING_MAX_ACTIONS;
+	const raw = foundry.utils.getProperty(actor.system, DYING_ACTION_LIMIT_PATH);
+	const value = Number(raw);
+	if (!Number.isFinite(value)) return DYING_MAX_ACTIONS;
+	return Math.max(0, Math.trunc(value));
+}
 
 export function hasLastStandStatus(actor: Actor.Implementation | null | undefined): boolean {
 	if (!actor) return false;

--- a/src/utils/actorHealthState.ts
+++ b/src/utils/actorHealthState.ts
@@ -3,9 +3,20 @@ import { getActorHpMaxValue, getActorHpValue } from './actorResources.js';
 
 export type ActorHealthState = 'normal' | 'bloodied' | 'lastStand' | 'unknown';
 
+/**
+ * Maximum number of actions a combatant may take while suffering the Dying condition.
+ * Per the Nimble rules, "while Dying, actions are limited to 1".
+ */
+export const DYING_MAX_ACTIONS = 1;
+
 export function hasLastStandStatus(actor: Actor.Implementation | null | undefined): boolean {
 	if (!actor) return false;
 	return actor.statuses instanceof Set && actor.statuses.has(STATUS_EFFECT_IDS.lastStand);
+}
+
+export function isActorDying(actor: Actor.Implementation | null | undefined): boolean {
+	if (!actor) return false;
+	return actor.statuses instanceof Set && actor.statuses.has(STATUS_EFFECT_IDS.dying);
 }
 
 /**

--- a/src/utils/combatTurnActions.test.ts
+++ b/src/utils/combatTurnActions.test.ts
@@ -7,10 +7,28 @@ import { createMockCombatant } from '../../tests/mocks/combat.js';
 import { combatantActionMutationQueue } from './combatantActionMutationQueue.js';
 import {
 	consumeCombatantAction,
+	getCombatantMaxActions,
 	registerCombatTurnSocketListener,
 	requestAdvanceCombatTurn,
 	resolveCombatantCurrentActionsAfterDelta,
 } from './combatTurnActions.js';
+
+describe('getCombatantMaxActions', () => {
+	it('returns the base max for a non-dying combatant', () => {
+		const combatant = createMockCombatant({ actionsMax: 3 });
+		expect(getCombatantMaxActions(combatant)).toBe(3);
+	});
+
+	it('caps the max at 1 when the combatant is Dying', () => {
+		const combatant = createMockCombatant({
+			actionsMax: 3,
+			actor: Object.assign(createCombatActorFixture({ type: 'character' }), {
+				statuses: new Set(['dying']),
+			}) as Actor.Implementation,
+		});
+		expect(getCombatantMaxActions(combatant)).toBe(1);
+	});
+});
 
 describe('resolveCombatantCurrentActionsAfterDelta', () => {
 	it('clamps increases at max actions', () => {

--- a/src/utils/combatTurnActions.ts
+++ b/src/utils/combatTurnActions.ts
@@ -1,4 +1,4 @@
-import { DYING_MAX_ACTIONS, isActorDying } from './actorHealthState.js';
+import { getActorDyingActionLimit, isActorDying } from './actorHealthState.js';
 import { combatantActionMutationQueue } from './combatantActionMutationQueue.js';
 
 export const COMBATANT_ACTIONS_CURRENT_PATH = 'system.actions.base.current';
@@ -29,7 +29,9 @@ export function getCombatantMaxActions(combatant: Combatant.Implementation): num
 	const baseMax = toFiniteNonNegativeNumber(
 		foundry.utils.getProperty(combatant, COMBATANT_ACTIONS_MAX_PATH),
 	);
-	if (isActorDying(combatant.actor)) return Math.min(baseMax, DYING_MAX_ACTIONS);
+	if (isActorDying(combatant.actor)) {
+		return Math.min(baseMax, getActorDyingActionLimit(combatant.actor));
+	}
 	return baseMax;
 }
 

--- a/src/utils/combatTurnActions.ts
+++ b/src/utils/combatTurnActions.ts
@@ -1,3 +1,4 @@
+import { DYING_MAX_ACTIONS, isActorDying } from './actorHealthState.js';
 import { combatantActionMutationQueue } from './combatantActionMutationQueue.js';
 
 export const COMBATANT_ACTIONS_CURRENT_PATH = 'system.actions.base.current';
@@ -25,9 +26,11 @@ export function getCombatantCurrentActions(combatant: Combatant.Implementation):
 }
 
 export function getCombatantMaxActions(combatant: Combatant.Implementation): number {
-	return toFiniteNonNegativeNumber(
+	const baseMax = toFiniteNonNegativeNumber(
 		foundry.utils.getProperty(combatant, COMBATANT_ACTIONS_MAX_PATH),
 	);
+	if (isActorDying(combatant.actor)) return Math.min(baseMax, DYING_MAX_ACTIONS);
+	return baseMax;
 }
 
 export function resolveCombatantCurrentActionsAfterDelta(params: {

--- a/src/view/rulesBuilder/components/RuleTypePicker.svelte.ts
+++ b/src/view/rulesBuilder/components/RuleTypePicker.svelte.ts
@@ -18,6 +18,7 @@ const RULE_ICONS: Record<string, string> = {
 	combatMana: 'fa-solid fa-droplet',
 	conditionImmunity: 'fa-solid fa-shield-virus',
 	damageBonus: 'fa-solid fa-explosion',
+	dyingActionLimit: 'fa-solid fa-skull',
 	grantItem: 'fa-solid fa-gift',
 	grantProficiency: 'fa-solid fa-graduation-cap',
 	grantSpells: 'fa-solid fa-wand-magic-sparkles',

--- a/src/view/sheets/components/ActionTracker.svelte
+++ b/src/view/sheets/components/ActionTracker.svelte
@@ -61,7 +61,7 @@
 						</button>
 					{/each}
 
-					{#if !state.actionsData.isDying && state.actionsData.effectiveMax < 10}
+					{#if state.actionsData.effectiveMax < 10}
 						<button
 							class="action-tracker__add-additional"
 							type="button"

--- a/src/view/sheets/components/ActionTracker.svelte
+++ b/src/view/sheets/components/ActionTracker.svelte
@@ -61,7 +61,7 @@
 						</button>
 					{/each}
 
-					{#if state.actionsData.effectiveMax < 10}
+					{#if !state.actionsData.isDying && state.actionsData.effectiveMax < 10}
 						<button
 							class="action-tracker__add-additional"
 							type="button"

--- a/src/view/sheets/components/ActionTracker.svelte.ts
+++ b/src/view/sheets/components/ActionTracker.svelte.ts
@@ -4,8 +4,10 @@ import type { NimbleCharacter } from '#documents/actor/character.js';
 import {
 	getCombatantAdditionalActions,
 	getCombatantBaseActions,
+	isCombatantDying,
 } from '#documents/combat/combatantSystem.js';
 import type { PromptedInitiativeOptions } from '#types/combat.js';
+import { DYING_MAX_ACTIONS } from '#utils/actorHealthState.js';
 import { getActiveCombatForCurrentScene, registerCombatStateHooks } from '#utils/combatState.js';
 import { requestAdvanceCombatTurn } from '#utils/combatTurnActions.js';
 import { getActiveCombatant } from '#utils/combatTurnSync.js';
@@ -22,6 +24,7 @@ interface ActionsData {
 	max: number;
 	additional: number;
 	effectiveMax: number;
+	isDying: boolean;
 }
 
 // ============================================================================
@@ -86,16 +89,20 @@ export function createActionTrackerState(getActor: () => NimbleCharacter) {
 
 	function getActionsData(): ActionsData {
 		const combatant = getCombatantInCombat();
-		if (!combatant) return { current: 0, max: 3, additional: 0, effectiveMax: 3 };
+		if (!combatant) return { current: 0, max: 3, additional: 0, effectiveMax: 3, isDying: false };
 
 		const actions = getCombatantBaseActions(combatant);
 		const additional = getCombatantAdditionalActions(combatant);
-		const max = actions.max || 3;
+		const isDying = isCombatantDying(combatant);
+		// While Dying, actions are limited to 1 and additional actions do not apply.
+		const max = isDying ? Math.min(actions.max || 3, DYING_MAX_ACTIONS) : actions.max || 3;
+		const effectiveMax = isDying ? max : max + additional;
 		return {
 			current: actions.current,
 			max,
 			additional,
-			effectiveMax: max + additional,
+			effectiveMax,
+			isDying,
 		};
 	}
 

--- a/src/view/sheets/components/ActionTracker.svelte.ts
+++ b/src/view/sheets/components/ActionTracker.svelte.ts
@@ -24,7 +24,6 @@ interface ActionsData {
 	max: number;
 	additional: number;
 	effectiveMax: number;
-	isDying: boolean;
 }
 
 // ============================================================================
@@ -89,20 +88,19 @@ export function createActionTrackerState(getActor: () => NimbleCharacter) {
 
 	function getActionsData(): ActionsData {
 		const combatant = getCombatantInCombat();
-		if (!combatant) return { current: 0, max: 3, additional: 0, effectiveMax: 3, isDying: false };
+		if (!combatant) return { current: 0, max: 3, additional: 0, effectiveMax: 3 };
 
 		const actions = getCombatantBaseActions(combatant);
 		const additional = getCombatantAdditionalActions(combatant);
-		const isDying = isCombatantDying(combatant);
-		// While Dying, actions are limited to 1 and additional actions do not apply.
-		const max = isDying ? Math.min(actions.max || 3, DYING_MAX_ACTIONS) : actions.max || 3;
-		const effectiveMax = isDying ? max : max + additional;
+		// While Dying the base action max is limited to 1, but additional actions still apply.
+		const max = isCombatantDying(combatant)
+			? Math.min(actions.max || 3, DYING_MAX_ACTIONS)
+			: actions.max || 3;
 		return {
 			current: actions.current,
 			max,
 			additional,
-			effectiveMax,
-			isDying,
+			effectiveMax: max + additional,
 		};
 	}
 

--- a/src/view/sheets/components/ActionTracker.svelte.ts
+++ b/src/view/sheets/components/ActionTracker.svelte.ts
@@ -7,7 +7,7 @@ import {
 	isCombatantDying,
 } from '#documents/combat/combatantSystem.js';
 import type { PromptedInitiativeOptions } from '#types/combat.js';
-import { DYING_MAX_ACTIONS } from '#utils/actorHealthState.js';
+import { getActorDyingActionLimit } from '#utils/actorHealthState.js';
 import { getActiveCombatForCurrentScene, registerCombatStateHooks } from '#utils/combatState.js';
 import { requestAdvanceCombatTurn } from '#utils/combatTurnActions.js';
 import { getActiveCombatant } from '#utils/combatTurnSync.js';
@@ -92,9 +92,11 @@ export function createActionTrackerState(getActor: () => NimbleCharacter) {
 
 		const actions = getCombatantBaseActions(combatant);
 		const additional = getCombatantAdditionalActions(combatant);
-		// While Dying the base action max is limited to 1, but additional actions still apply.
+		// While Dying the base action max is capped at the actor's Dying action limit
+		// (baseline 1, raised by features such as Enduring Rage), but additional
+		// actions still apply.
 		const max = isCombatantDying(combatant)
-			? Math.min(actions.max || 3, DYING_MAX_ACTIONS)
+			? Math.min(actions.max || 3, getActorDyingActionLimit(combatant.actor))
 			: actions.max || 3;
 		return {
 			current: actions.current,

--- a/src/view/ui/ctTopTracker/resources.utils.ts
+++ b/src/view/ui/ctTopTracker/resources.utils.ts
@@ -3,11 +3,7 @@ import type {
 	CombatTrackerNonPlayerHpBarTextMode,
 	CombatTrackerPlayerHpBarTextMode,
 } from '../../../settings/combatTrackerSettings.js';
-import {
-	type ActorHealthState,
-	getActorHealthState,
-	isActorDying,
-} from '../../../utils/actorHealthState.js';
+import { type ActorHealthState, getActorHealthState } from '../../../utils/actorHealthState.js';
 import {
 	getActorHpMaxValue,
 	getActorHpValue,
@@ -453,16 +449,14 @@ export function getActionState(combatant: Combatant.Implementation): {
 	effectiveMax: number;
 } {
 	const normalizedCurrent = getCombatantCurrentActions(combatant);
+	// `normalizedMax` is the base action max, already capped to the Dying limit when applicable.
 	const normalizedMax = getCombatantMaxActions(combatant);
 	const additional = getCombatantAdditionalActions(combatant);
-	// While Dying, total actions are capped at the (already dying-limited) base max;
-	// additional actions do not apply.
-	const effectiveMax = isActorDying(combatant.actor) ? normalizedMax : normalizedMax + additional;
 	return {
 		current: normalizedCurrent,
 		max: normalizedMax,
 		additional,
-		effectiveMax,
+		effectiveMax: normalizedMax + additional,
 	};
 }
 

--- a/src/view/ui/ctTopTracker/resources.utils.ts
+++ b/src/view/ui/ctTopTracker/resources.utils.ts
@@ -3,7 +3,11 @@ import type {
 	CombatTrackerNonPlayerHpBarTextMode,
 	CombatTrackerPlayerHpBarTextMode,
 } from '../../../settings/combatTrackerSettings.js';
-import { type ActorHealthState, getActorHealthState } from '../../../utils/actorHealthState.js';
+import {
+	type ActorHealthState,
+	getActorHealthState,
+	isActorDying,
+} from '../../../utils/actorHealthState.js';
 import {
 	getActorHpMaxValue,
 	getActorHpValue,
@@ -451,11 +455,14 @@ export function getActionState(combatant: Combatant.Implementation): {
 	const normalizedCurrent = getCombatantCurrentActions(combatant);
 	const normalizedMax = getCombatantMaxActions(combatant);
 	const additional = getCombatantAdditionalActions(combatant);
+	// While Dying, total actions are capped at the (already dying-limited) base max;
+	// additional actions do not apply.
+	const effectiveMax = isActorDying(combatant.actor) ? normalizedMax : normalizedMax + additional;
 	return {
 		current: normalizedCurrent,
 		max: normalizedMax,
 		additional,
-		effectiveMax: normalizedMax + additional,
+		effectiveMax,
 	};
 }
 

--- a/tests/fixtures/combat.ts
+++ b/tests/fixtures/combat.ts
@@ -9,6 +9,7 @@ export type CombatActorFixtureOptions = {
 	woundsMax?: number;
 	manaValue?: number;
 	manaMax?: number;
+	dyingActionLimit?: number;
 };
 
 export type CombatantFixtureOptions = {
@@ -44,6 +45,7 @@ export function createCombatActorFixture({
 	woundsMax,
 	manaValue,
 	manaMax,
+	dyingActionLimit,
 }: CombatActorFixtureOptions = {}): Actor.Implementation {
 	const items =
 		typeof lastStandHp === 'number'
@@ -67,6 +69,7 @@ export function createCombatActorFixture({
 					max: hpMax ?? Math.max(hp, 1),
 				},
 				wounds: { value: woundsValue, max: woundsMax },
+				...(typeof dyingActionLimit === 'number' ? { dyingActionLimit } : {}),
 			},
 			resources: {
 				mana: {


### PR DESCRIPTION
## Summary

Implements the Nimble rule that **while Dying, a creature's actions are limited to 1** (requested by a user in Discord).

> When reduced to 0 HP … you gain the Dying condition until you regain HP. **While Dying, actions are limited to 1**, Concentration is broken, and you are at risk of further serious harm.

This PR scopes strictly to the **action limit**. The other Dying clauses (Wound on attack without a DC 10 STR save, extra Wounds on damage, broken Concentration) are out of scope here.

## Approach

A single dying-aware source of truth, wired through every place actions are read, reset, or spent:

- **`actorHealthState.ts`** — `isActorDying(actor)` + `DYING_MAX_ACTIONS = 1`.
- **`combatantSystem.ts`** — `isCombatantDying()`, `getCombatantResetActions()` (turn-start refill value, capped at 1 while dying), and `getCombatantEffectiveMax()` collapses to 1 while dying (additional actions don't apply).
- **Turn resets** (`combat.svelte.ts`) — end-of-turn, NPC/round reset, and non-character turn restore refill to the dying-capped value.
- **Both action trackers** — character-sheet `ActionTracker` and the top combat tracker (`getCombatantMaxActions`, `getActionState`) render 1 pip and clamp restoration while dying; the sheet hides the "+additional action" button.
- **Mid-turn application** — new hook `dyingActionLimitSync.ts` listens for the `dying` status being applied and immediately clamps the combatant's stored `current` to 1 and clears additional actions, so pre-dying actions can't still be spent (e.g. via `consumeCombatantAction`).

### Why the clamp hook is needed
Capping the *display* max alone isn't enough — `current` persists and is checked when attacking/casting. Without the clamp, a character who drops to Dying with 3 actions left could keep spending them.

## Scope / non-regressions
- **NPCs and solo monsters are unaffected** — their base max is already 1, so the cap is a no-op even for a Last Stand monster that also carries the `dying` status. Only characters (base 3) change.

## Tests
- 41 new tests (`isActorDying`, `isCombatantDying`, `getCombatantResetActions`, `getCombatantEffectiveMax`, dying-capped `getCombatantMaxActions`, and the clamp hook: clamps when over limit, no-ops when within, ignores non-dying effects, GM-only).
- Full suite: **1470 passing**. `type-check`, `biome lint`/`format`, `eslint` (svelte), and `circular-deps` all pass.
