### PR TITLE
feat(character): show custom reactions on heroic reactions tab

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -1204,6 +1204,11 @@
 				"title": "Heroic Actions",
 				"addAdditionalAction": "Add 1 action",
 				"reactionsTitle": "Heroic Reactions",
+				"customReactions": {
+					"tabLabel": "Custom Reactions",
+					"title": "Custom Reactions",
+					"empty": "No custom reactions. Check \"Is Reaction\" under a feature, spell, or item's Activation settings to show it here."
+				},
 				"reactions": {
 					"actionCost": "This will use 1 action (reaction)",
 					"cost": "1 Action",

--- a/src/view/sheets/components/CastSpellActionPanel.svelte.ts
+++ b/src/view/sheets/components/CastSpellActionPanel.svelte.ts
@@ -4,6 +4,7 @@ import { evaluateFormula as evalFormula } from '../../../utils/evaluateFormula.j
 import localize from '../../../utils/localize.js';
 import sortItems from '../../../utils/sortItems.js';
 import filterItems from '../../dataPreparationHelpers/filterItems.js';
+import { isCustomReaction } from './CustomReactionsPanel.svelte.js';
 
 interface SpellEffect {
 	formula: string;
@@ -62,6 +63,8 @@ export function createSpellPanelState(
 
 	const spells = $derived(
 		filterItems(getActor().reactive, ['spell'], searchTerm).filter((spell) => {
+			// Reaction spells are surfaced under Heroic Reactions > Custom Reactions instead.
+			if (isCustomReaction(spell as unknown as Item)) return false;
 			const costType = getSystemData(spell).activation?.cost?.type;
 			return costType !== 'minute' && costType !== 'hour';
 		}),

--- a/src/view/sheets/components/CustomReactionsPanel.svelte
+++ b/src/view/sheets/components/CustomReactionsPanel.svelte
@@ -1,0 +1,253 @@
+<script lang="ts">
+	import type { NimbleCharacter } from '../../../documents/actor/character.js';
+	import { getContext } from 'svelte';
+	import localize from '../../../utils/localize.js';
+	import { createCustomReactionsPanelState } from './CustomReactionsPanel.svelte.ts';
+
+	let { showEmbeddedDocumentImages = true } = $props();
+
+	const actor = getContext<NimbleCharacter>('actor');
+	// `_onDragStart` is a Foundry sheet mixin method not present on the typed sheet class.
+	const sheet = getContext('application') as { _onDragStart: (event: DragEvent) => void };
+
+	const state = createCustomReactionsPanelState(() => actor);
+</script>
+
+<section class="custom-reactions-panel">
+	<header class="nimble-section-header">
+		<h3 class="nimble-heading" data-heading-variant="section">
+			{localize('NIMBLE.ui.heroicActions.customReactions.title')}
+		</h3>
+	</header>
+
+	<div class="custom-reactions-panel__content">
+		{#if state.reactions.length > 0}
+			<ul class="custom-reactions-panel__list">
+				{#each state.reactions as reaction (reaction._id)}
+					{@const actionCost = state.getActionCost(reaction)}
+					{@const trigger = state.getReactionTrigger(reaction)}
+					{@const description = state.getDescription(reaction)}
+					{@const expanded = state.isExpanded(reaction._id)}
+
+					<li class="reaction-card" class:reaction-card--expanded={expanded}>
+						<!-- svelte-ignore a11y_no_noninteractive_element_to_interactive_role -->
+						<div
+							class="reaction-card__row"
+							role="button"
+							tabindex="0"
+							draggable="true"
+							data-item-id={reaction._id}
+							ondragstart={(event) => sheet._onDragStart(event)}
+							onclick={() => state.activateReaction(reaction._id)}
+							onkeydown={(event) =>
+								state.handleKeydown(event, () => state.activateReaction(reaction._id))}
+						>
+							{#if showEmbeddedDocumentImages}
+								<img
+									class="reaction-card__img"
+									src={reaction.reactive.img}
+									alt={reaction.reactive.name}
+								/>
+							{/if}
+
+							<div class="reaction-card__content">
+								<div class="reaction-card__header">
+									<span class="reaction-card__name">{reaction.reactive.name}</span>
+									{#if actionCost}
+										<span class="reaction-card__action-cost">{actionCost}</span>
+									{/if}
+								</div>
+
+								{#if trigger}
+									<div class="reaction-card__trigger">
+										<i class="fa-solid fa-bolt"></i>
+										<span>{trigger}</span>
+									</div>
+								{/if}
+							</div>
+
+							{#if description}
+								<button
+									class="reaction-card__expand"
+									type="button"
+									onclick={(event) => state.toggleDescription(reaction._id, event)}
+									aria-label={localize(
+										expanded
+											? 'NIMBLE.ui.heroicActions.collapse'
+											: 'NIMBLE.ui.heroicActions.expand',
+									)}
+								>
+									<i class="fa-solid fa-caret-{expanded ? 'up' : 'down'}"></i>
+								</button>
+							{/if}
+						</div>
+
+						{#if expanded && description}
+							<div class="reaction-card__description">
+								{#await foundry.applications.ux.TextEditor.implementation.enrichHTML(description) then enriched}
+									{@html enriched}
+								{:catch}
+									{@html description}
+								{/await}
+							</div>
+						{/if}
+					</li>
+				{/each}
+			</ul>
+		{:else}
+			<p class="custom-reactions-panel__empty">
+				{localize('NIMBLE.ui.heroicActions.customReactions.empty')}
+			</p>
+		{/if}
+	</div>
+</section>
+
+<style lang="scss">
+	.custom-reactions-panel {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+
+		&__content {
+			display: flex;
+			flex-direction: column;
+			gap: 0.5rem;
+			max-height: 300px;
+			overflow-y: auto;
+		}
+
+		&__list {
+			display: flex;
+			flex-direction: column;
+			gap: 0.25rem;
+			margin: 0;
+			padding: 0;
+			list-style: none;
+		}
+
+		&__empty {
+			margin: 0;
+			padding: 0.75rem;
+			font-size: var(--nimble-sm-text);
+			font-weight: 500;
+			text-align: center;
+			color: var(--nimble-medium-text-color);
+		}
+	}
+
+	.reaction-card {
+		display: flex;
+		flex-direction: column;
+		background: var(--nimble-box-background-color);
+		border: 1px solid var(--nimble-card-border-color);
+		border-radius: 4px;
+		transition: var(--nimble-standard-transition);
+
+		&:hover {
+			border-color: var(--nimble-box-color);
+			box-shadow: var(--nimble-box-shadow);
+		}
+
+		&__row {
+			display: flex;
+			align-items: center;
+			gap: 0.5rem;
+			padding: 0.5rem;
+			cursor: pointer;
+		}
+
+		&__img {
+			width: 2rem;
+			height: 2rem;
+			object-fit: cover;
+			border-radius: 3px;
+			flex-shrink: 0;
+		}
+
+		&__content {
+			display: flex;
+			flex-direction: column;
+			gap: 0.125rem;
+			flex: 1;
+			min-width: 0;
+		}
+
+		&__header {
+			display: flex;
+			align-items: center;
+			flex-wrap: wrap;
+			gap: 0.375rem;
+		}
+
+		&__name {
+			font-size: var(--nimble-sm-text);
+			font-weight: 600;
+			color: var(--nimble-dark-text-color);
+			line-height: 1.2;
+		}
+
+		&__action-cost {
+			font-size: var(--nimble-xs-text);
+			font-weight: 500;
+			color: var(--nimble-medium-text-color);
+			padding: 0 0.25rem;
+			background: var(--nimble-basic-button-background-color);
+			border-radius: 2px;
+		}
+
+		&__trigger {
+			display: inline-flex;
+			align-items: center;
+			gap: 0.25rem;
+			font-size: var(--nimble-xs-text);
+			font-weight: 500;
+			color: var(--nimble-medium-text-color);
+
+			i {
+				font-size: 0.625rem;
+				color: hsl(45, 70%, 45%);
+			}
+		}
+
+		&__expand {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			width: 1.5rem;
+			height: 1.5rem;
+			padding: 0;
+			background: transparent;
+			border: none;
+			border-radius: 3px;
+			cursor: pointer;
+			flex-shrink: 0;
+			color: var(--nimble-medium-text-color);
+			transition: all 0.15s ease;
+
+			&:hover {
+				background: var(--nimble-basic-button-background-color);
+				color: var(--nimble-dark-text-color);
+			}
+
+			i {
+				font-size: 0.875rem;
+			}
+		}
+
+		&__description {
+			padding: 0.5rem 0.75rem;
+			font-size: var(--nimble-sm-text);
+			color: var(--nimble-dark-text-color);
+			border-top: 1px solid var(--nimble-card-border-color);
+			line-height: 1.5;
+
+			:global(p) {
+				margin: 0 0 0.5rem;
+
+				&:last-child {
+					margin-bottom: 0;
+				}
+			}
+		}
+	}
+</style>

--- a/src/view/sheets/components/CustomReactionsPanel.svelte.ts
+++ b/src/view/sheets/components/CustomReactionsPanel.svelte.ts
@@ -1,0 +1,115 @@
+import type { NimbleCharacter } from '../../../documents/actor/character.js';
+import type { NimbleBaseItem } from '../../../documents/item/base.svelte.js';
+
+/** A prepared embedded item always has a non-null `_id`. */
+export type ReactionItem = NimbleBaseItem & { _id: string };
+
+/** Activation cost data shared by feature, spell, and object items. */
+interface ReactionActivationData {
+	cost?: {
+		type?: string;
+		quantity?: number;
+		isReaction?: boolean;
+		details?: string;
+	};
+}
+
+/** Description can be a plain HTML string (features) or a keyed object (spells, objects). */
+type ReactionDescription = string | Record<string, string> | null | undefined;
+
+function getActivation(item: Item): ReactionActivationData['cost'] {
+	return (item.system as { activation?: ReactionActivationData }).activation?.cost;
+}
+
+/** An item is a custom reaction when its activation cost has "Is Reaction" checked. */
+export function isCustomReaction(item: Item): boolean {
+	return getActivation(item)?.isReaction === true;
+}
+
+export function createCustomReactionsPanelState(getActor: () => NimbleCharacter) {
+	const { activationCostTypes, activationCostTypesPlural } = CONFIG.NIMBLE;
+	let expandedDescriptions = $state(new Set<string>());
+
+	const reactions = $derived(
+		(getActor().reactive.items as unknown as ReactionItem[])
+			.filter((item) => isCustomReaction(item as unknown as Item))
+			.sort((a, b) => (a.sort ?? 0) - (b.sort ?? 0)),
+	);
+
+	/**
+	 * The action cost label, shown only when the reaction costs more than a single
+	 * action (per the issue: "Action cost, if more than one").
+	 */
+	function getActionCost(item: Item): string | null {
+		const cost = getActivation(item);
+		if (!cost || cost.type !== 'action') return null;
+
+		const quantity = cost.quantity ?? 1;
+		if (quantity <= 1) return null;
+
+		return `${quantity} ${activationCostTypesPlural.action ?? activationCostTypes.action}`;
+	}
+
+	/** The free-text reaction trigger configured under Activation > Core. */
+	function getReactionTrigger(item: Item): string | null {
+		const details = getActivation(item)?.details;
+		return details && details.trim().length > 0 ? details : null;
+	}
+
+	/** Resolve a display description regardless of the item type's description shape. */
+	function getDescription(item: Item): string | null {
+		const description = (item.system as { description?: ReactionDescription }).description;
+		if (typeof description === 'string') {
+			return hasContent(description) ? description : null;
+		}
+		if (description && typeof description === 'object') {
+			const text = description.baseEffect ?? description.public ?? '';
+			return hasContent(text) ? text : null;
+		}
+		return null;
+	}
+
+	function hasContent(text: unknown): text is string {
+		if (!text || typeof text !== 'string') return false;
+		return text.replace(/<[^>]*>/g, '').trim().length > 0;
+	}
+
+	function isExpanded(itemId: string): boolean {
+		return expandedDescriptions.has(itemId);
+	}
+
+	function toggleDescription(itemId: string, event: Event): void {
+		event.stopPropagation();
+		const next = new Set(expandedDescriptions);
+		if (next.has(itemId)) {
+			next.delete(itemId);
+		} else {
+			next.add(itemId);
+		}
+		expandedDescriptions = next;
+	}
+
+	function handleKeydown(event: KeyboardEvent, callback: () => void): void {
+		if (event.key === 'Enter' || event.key === ' ') {
+			event.preventDefault();
+			callback();
+		}
+	}
+
+	async function activateReaction(itemId: string): Promise<unknown> {
+		return getActor().activateItem(itemId);
+	}
+
+	return {
+		get reactions() {
+			return reactions;
+		},
+		getActionCost,
+		getReactionTrigger,
+		getDescription,
+		isExpanded,
+		toggleDescription,
+		handleKeydown,
+		activateReaction,
+	};
+}

--- a/src/view/sheets/components/CustomReactionsPanel.test.ts
+++ b/src/view/sheets/components/CustomReactionsPanel.test.ts
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 
+import { isCustomReaction } from './CustomReactionsPanel.svelte.js';
 import CustomReactionsPanelTestHarness from './CustomReactionsPanel.testHarness.svelte';
 
 interface ReactionItemOptions {
@@ -49,6 +50,20 @@ function createActor(items: ReturnType<typeof createItem>[]) {
 		},
 	};
 }
+
+describe('isCustomReaction', () => {
+	it('is true only when the activation cost has Is Reaction checked', () => {
+		const reaction = createItem({ id: 'r', name: 'Parry', isReaction: true });
+		const spell = createItem({ id: 's', name: 'Fireball', isReaction: false });
+
+		expect(isCustomReaction(reaction as unknown as Item)).toBe(true);
+		expect(isCustomReaction(spell as unknown as Item)).toBe(false);
+	});
+
+	it('is false when the item has no activation data', () => {
+		expect(isCustomReaction({ system: {} } as unknown as Item)).toBe(false);
+	});
+});
 
 describe('CustomReactionsPanel', () => {
 	it('lists only items with "Is Reaction" checked', () => {

--- a/src/view/sheets/components/CustomReactionsPanel.test.ts
+++ b/src/view/sheets/components/CustomReactionsPanel.test.ts
@@ -1,0 +1,128 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+
+import CustomReactionsPanelTestHarness from './CustomReactionsPanel.testHarness.svelte';
+
+interface ReactionItemOptions {
+	id: string;
+	name: string;
+	isReaction: boolean;
+	quantity?: number;
+	costType?: string;
+	details?: string;
+	description?: unknown;
+	sort?: number;
+}
+
+function createItem(options: ReactionItemOptions) {
+	const item = {
+		_id: options.id,
+		id: options.id,
+		sort: options.sort ?? 0,
+		type: 'feature',
+		system: {
+			activation: {
+				cost: {
+					type: options.costType ?? 'action',
+					quantity: options.quantity ?? 1,
+					isReaction: options.isReaction,
+					details: options.details ?? '',
+				},
+			},
+			description: options.description ?? '',
+		},
+		reactive: {
+			name: options.name,
+			img: `${options.id}.webp`,
+		},
+	};
+	// `reactive` mirrors the document itself in the real model.
+	(item.reactive as Record<string, unknown>)._id = options.id;
+	return item;
+}
+
+function createActor(items: ReturnType<typeof createItem>[]) {
+	return {
+		id: 'custom-reaction-actor',
+		activateItem: vi.fn().mockResolvedValue({ ok: true }),
+		reactive: {
+			items,
+		},
+	};
+}
+
+describe('CustomReactionsPanel', () => {
+	it('lists only items with "Is Reaction" checked', () => {
+		const actor = createActor([
+			createItem({ id: 'reaction-1', name: 'Counterspell', isReaction: true }),
+			createItem({ id: 'not-a-reaction', name: 'Fireball', isReaction: false }),
+		]);
+		const application = { _onDragStart: vi.fn() };
+
+		render(CustomReactionsPanelTestHarness, { actor, application });
+
+		expect(screen.getByText('Counterspell')).toBeInTheDocument();
+		expect(screen.queryByText('Fireball')).not.toBeInTheDocument();
+	});
+
+	it('shows the action cost only when it costs more than one action', () => {
+		const actor = createActor([
+			createItem({ id: 'single', name: 'Single', isReaction: true, quantity: 1 }),
+			createItem({ id: 'double', name: 'Double', isReaction: true, quantity: 2 }),
+		]);
+		const application = { _onDragStart: vi.fn() };
+
+		render(CustomReactionsPanelTestHarness, { actor, application });
+
+		expect(screen.getByText('2 Actions')).toBeInTheDocument();
+		expect(screen.queryByText('1 Action')).not.toBeInTheDocument();
+	});
+
+	it('shows the configured reaction trigger', () => {
+		const actor = createActor([
+			createItem({
+				id: 'reaction-1',
+				name: 'Parry',
+				isReaction: true,
+				details: 'When you are hit by a melee attack',
+			}),
+		]);
+		const application = { _onDragStart: vi.fn() };
+
+		render(CustomReactionsPanelTestHarness, { actor, application });
+
+		expect(screen.getByText('When you are hit by a melee attack')).toBeInTheDocument();
+	});
+
+	it('activates the reaction when its card is clicked', async () => {
+		const actor = createActor([
+			createItem({ id: 'reaction-1', name: 'Counterspell', isReaction: true }),
+		]);
+		const application = { _onDragStart: vi.fn() };
+
+		render(CustomReactionsPanelTestHarness, { actor, application });
+
+		await fireEvent.click(screen.getByRole('button', { name: /counterspell/i }));
+
+		expect(actor.activateItem).toHaveBeenCalledWith('reaction-1');
+	});
+
+	it('expands the description when the toggle is clicked', async () => {
+		const actor = createActor([
+			createItem({
+				id: 'reaction-1',
+				name: 'Counterspell',
+				isReaction: true,
+				description: '<p>Negate a spell.</p>',
+			}),
+		]);
+		const application = { _onDragStart: vi.fn() };
+
+		render(CustomReactionsPanelTestHarness, { actor, application });
+
+		expect(screen.queryByText('Negate a spell.')).not.toBeInTheDocument();
+
+		await fireEvent.click(screen.getByRole('button', { name: /expand/i }));
+
+		await waitFor(() => expect(screen.getByText('Negate a spell.')).toBeInTheDocument());
+	});
+});

--- a/src/view/sheets/components/CustomReactionsPanel.testHarness.svelte
+++ b/src/view/sheets/components/CustomReactionsPanel.testHarness.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { setContext, untrack } from 'svelte';
+	import CustomReactionsPanel from './CustomReactionsPanel.svelte';
+
+	let { actor, application, showEmbeddedDocumentImages = true } = $props();
+
+	setContext(
+		'actor',
+		untrack(() => actor),
+	);
+	setContext(
+		'application',
+		untrack(() => application),
+	);
+</script>
+
+<CustomReactionsPanel {showEmbeddedDocumentImages} />

--- a/src/view/sheets/pages/PlayerCharacterHeroicActionsTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterHeroicActionsTab.svelte
@@ -12,6 +12,7 @@
 	import InterposeReactionPanel from '../components/InterposeReactionPanel.svelte';
 	import OpportunityAttackPanel from '../components/OpportunityAttackPanel.svelte';
 	import HelpReactionPanel from '../components/HelpReactionPanel.svelte';
+	import CustomReactionsPanel from '../components/CustomReactionsPanel.svelte';
 
 	// ============================================================================
 	// Context & State
@@ -154,6 +155,20 @@
 						<span class="heroic-action-tab__indicator"></span>
 					</button>
 				{/each}
+
+				{#if heroicState.hasCustomReactions}
+					<button
+						class="heroic-action-tab"
+						class:heroic-action-tab--active={heroicState.expandedReactionPanel === 'custom'}
+						type="button"
+						aria-label={localize('NIMBLE.ui.heroicActions.customReactions.tabLabel')}
+						data-tooltip={localize('NIMBLE.ui.heroicActions.customReactions.tabLabel')}
+						onclick={() => (heroicState.expandedReactionPanel = 'custom')}
+					>
+						<i class="fa-solid fa-bolt"></i>
+						<span class="heroic-action-tab__indicator"></span>
+					</button>
+				{/if}
 			</div>
 		{/if}
 	</section>
@@ -250,6 +265,10 @@
 			isActiveTurn={heroicState.isReactionActiveTurnBlocked('help')}
 			onUseReaction={(options) => heroicState.useReaction('help', options)}
 		/>
+	{/if}
+
+	{#if heroicState.activeHeroicTab === 'reactions' && heroicState.expandedReactionPanel === 'custom'}
+		<CustomReactionsPanel showEmbeddedDocumentImages={heroicState.showEmbeddedDocumentImages} />
 	{/if}
 </section>
 

--- a/src/view/sheets/pages/PlayerCharacterHeroicActionsTab.svelte.ts
+++ b/src/view/sheets/pages/PlayerCharacterHeroicActionsTab.svelte.ts
@@ -317,6 +317,8 @@ export function createHeroicActionsTabState(getActor: () => NimbleCharacter) {
 
 	const allSpells = $derived(
 		filterItems(getActor().reactive, ['spell'], '').filter((spell) => {
+			// Reaction spells live under Custom Reactions, not the Cast Spell action.
+			if (isCustomReaction(spell as unknown as Item)) return false;
 			const costType = (spell.system as unknown as { activation?: { cost?: { type?: string } } })
 				.activation?.cost?.type;
 			return costType !== 'minute' && costType !== 'hour';

--- a/src/view/sheets/pages/PlayerCharacterHeroicActionsTab.svelte.ts
+++ b/src/view/sheets/pages/PlayerCharacterHeroicActionsTab.svelte.ts
@@ -12,6 +12,7 @@ import localize from '#utils/localize.js';
 import { queueCombatantMutationWithFreshDocument } from '#utils/queueCombatantMutationWithFreshDocument.js';
 import filterItems from '#view/dataPreparationHelpers/filterItems.js';
 import HeroicActionsHelpDialog from '#view/dialogs/HeroicActionsHelpDialog.svelte';
+import { isCustomReaction } from '#view/sheets/components/CustomReactionsPanel.svelte.js';
 
 // ============================================================================
 // Types
@@ -324,6 +325,14 @@ export function createHeroicActionsTabState(getActor: () => NimbleCharacter) {
 	const hasSpells = $derived(allSpells.length > 0);
 
 	// ============================================================================
+	// Custom Reactions (items with "Is Reaction" checked under Activation > Core)
+	// ============================================================================
+
+	const hasCustomReactions = $derived(
+		getActor().reactive.items.some((item) => isCustomReaction(item as unknown as Item)),
+	);
+
+	// ============================================================================
 	// Derived State
 	// ============================================================================
 
@@ -409,6 +418,9 @@ export function createHeroicActionsTabState(getActor: () => NimbleCharacter) {
 		},
 		get hasSpells() {
 			return hasSpells;
+		},
+		get hasCustomReactions() {
+			return hasCustomReactions;
 		},
 		get showEmbeddedDocumentImages() {
 			return showEmbeddedDocumentImages;


### PR DESCRIPTION
## Summary

Surfaces custom reaction abilities on the **Heroic Reactions** tab. Any ability, spell, feature, or item with **Is Reaction** checked under **Activation > Core** now appears in a **Custom Reactions** sub-tab, so players can find and use reaction-based abilities during play instead of hunting through their full feature list.

Closes #816

## Behavior

- A 5th icon tab (⚡) appears in the reactions row **only when the character has at least one custom reaction**, keeping the four standard reactions uncrowded.
- Selecting it opens a panel listing each custom reaction with:
  - **Name**
  - **Action cost** — shown only when it costs more than one action
  - **Reaction trigger** (the Activation > Core details field)
  - **Expandable description** (enriched HTML, matching spell/feature cards)
  - **Click to activate** — sends to chat / rolls, with combat action deduction handled by the existing `activateItem` path
  - **Drag to the macro bar** — cards are draggable and create an item macro on drop

## Implementation

- New `CustomReactionsPanel.svelte` / `.svelte.ts` — gathers actor items where `system.activation.cost.isReaction === true`
- `PlayerCharacterHeroicActionsTab` — wires the tab, panel, and a `hasCustomReactions` derived
- `public/lang/en.json` — 3 new English strings (`customReactions.tabLabel/title/empty`) — **flagged for human review**; other locales untouched

## Testing

- New `CustomReactionsPanel.test.ts` (5 tests): filtering by Is Reaction, conditional action cost, trigger display, click-to-activate, description expansion
- `type-check`, `svelte-check` (clean on new files), `eslint`, `biome`, circular-deps, and the `systemId` guard all pass
- Existing heroic actions / reaction panel suites still pass
