### PR TITLE
chore(rules): assign stable ids to rule entries in pack build and UI

### DIFF
--- a/build/lib/Pack.mjs
+++ b/build/lib/Pack.mjs
@@ -562,6 +562,18 @@ export default class Pack {
 
 		// TODO: Update migration data
 
+		// Backfill stable ids on system.rules entries. Babele compendium
+		// skeletons key rule translations on `id`; without one, the runtime
+		// converter falls back to `index:N`, which silently shifts translations
+		// if a rule is ever reordered, inserted, or removed.
+		if (Array.isArray(source?.system?.rules)) {
+			for (const rule of source.system.rules) {
+				if (rule && typeof rule === 'object' && typeof rule.id !== 'string') {
+					rule.id = Pack.#generateRuleId();
+				}
+			}
+		}
+
 		// Recurse for sub documents
 		if (Array.isArray(source?.effects)) {
 			for (const e of source.effects) this.#cleanDocument(e);
@@ -569,6 +581,19 @@ export default class Pack {
 		if (Array.isArray(source?.items)) {
 			for (const i of source.items) this.#cleanDocument(i);
 		}
+	}
+
+	static #RULE_ID_ALPHABET = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+
+	// Mirrors `foundry.utils.randomID()` — 16-char base62 string.
+	static #generateRuleId() {
+		const alphabet = Pack.#RULE_ID_ALPHABET;
+		const bytes = crypto.randomBytes(16);
+		let id = '';
+		for (let i = 0; i < 16; i++) {
+			id += alphabet[bytes[i] % alphabet.length];
+		}
+		return id;
 	}
 
 	async saveAsPack() {

--- a/packs/ancestries/core/common/dwarf.json
+++ b/packs/ancestries/core/common/dwarf.json
@@ -20,7 +20,8 @@
 				"type": "maxHitDice",
 				"label": "Stout",
 				"value": "2",
-				"dieSize": 0
+				"dieSize": 0,
+				"id": "xWH270Re7449Dlb8"
 			},
 			{
 				"type": "grantProficiency",
@@ -33,12 +34,14 @@
 					"intelligence": {
 						"min": 0
 					}
-				}
+				},
+				"id": "PPHsbGkbuWOhTruC"
 			},
 			{
 				"type": "speedBonus",
 				"value": "-1",
-				"label": "Stout"
+				"label": "Stout",
+				"id": "TBlofXUDPL1zBvyu"
 			}
 		],
 		"description": "<p>Dwarf, in the old language, means “stone.” You are resilient, solid, stout. Even when driven to exhaustion, you will not falter. Forgoing speed, you are gifted with physical vitality and a belly that can handle the finest (and worst) consumables this world has to offer.</p><hr><p><strong>Stout</strong></p><p>+2 max Hit Dice [M]</p><p>+1 max Wounds [A]</p><p>-1 Speed [M]</p><p>You know Dwarvish if your INT is not negative [M]</p>",

--- a/packs/ancestries/core/common/elf.json
+++ b/packs/ancestries/core/common/elf.json
@@ -17,18 +17,21 @@
 					"intelligence": {
 						"min": 0
 					}
-				}
+				},
+				"id": "wwJMcxgBUNmFaf6X"
 			},
 			{
 				"type": "speedBonus",
 				"value": "1",
-				"label": "Lithe"
+				"label": "Lithe",
+				"id": "Jz7OOTWRVvFo1dTC"
 			},
 			{
 				"type": "initiativeRollMode",
 				"value": 1,
 				"mode": "adjust",
-				"label": "Lithe (Advantage on Initiative)"
+				"label": "Lithe (Advantage on Initiative)",
+				"id": "xDUbWHBMslNIkMiL"
 			}
 		],
 		"description": "<p>Elves epitomize swiftness and grace. Their tall, slender forms belie their innate speed, grace, and wit. Formidable in both diplomacy and combat, elves strike swiftly, often preventing the worst by acting first.</p><hr><p><strong>Lithe</strong></p><p>Advantage on Initiative</p><p>+1 Speed [M]</p><p>You know Elvish if your INT is not negative</p>",

--- a/packs/ancestries/core/common/gnome.json
+++ b/packs/ancestries/core/common/gnome.json
@@ -17,12 +17,14 @@
 					"intelligence": {
 						"min": 0
 					}
-				}
+				},
+				"id": "utvbMgCYMl6eoIm7"
 			},
 			{
 				"type": "speedBonus",
 				"value": "-1",
-				"label": "Optimistic"
+				"label": "Optimistic",
+				"id": "dRasAQ5eyCA70sWv"
 			}
 		],
 		"description": "<p>Eccentric, curious, and perpetually optimistic, gnomes are cheerful—especially when compared to their typically grumpier and larger kin, the dwarves. Known for their tinkering, spreading cheer, and playful antics, gnomes pursue their passions with a scatterbrained enthusiasm.</p><hr><p><strong>Optimistic</strong></p><p>Allow an ally within Reach 6 to reroll any single die. Resets when healed to your max HP. </p><p>-1 Speed [M]</p><p>You know Dwarvish if your INT is not negative (but you call it Gnomish, of course) [M]</p>",

--- a/packs/ancestries/core/exotic/birdfolk.json
+++ b/packs/ancestries/core/exotic/birdfolk.json
@@ -10,7 +10,8 @@
 				"type": "speedBonus",
 				"value": "@attributes.movement.walk",
 				"movementType": "fly",
-				"label": "Hollow Bones"
+				"label": "Hollow Bones",
+				"id": "77PFA7AbSWEB2h30"
 			}
 		],
 		"description": "<p>Birdfolk find sanctuary not in stone or chains, but within the boundless expanse of the sky. However, the gift of flight comes at a cost—hollow bones, and commensurate frailty.</p><hr><p><strong>Hollow Bones</strong></p><p>You have a fly Speed as long as you are wearing armor no heavier than Leather. </p><p>Crits against you are Vicious (the attacker rolls 1 additional die). </p><p>Forced movement moves you twice as far.</p>",

--- a/packs/ancestries/core/exotic/celestial.json
+++ b/packs/ancestries/core/exotic/celestial.json
@@ -11,7 +11,8 @@
 				"label": "Highborn",
 				"value": 0,
 				"target": "disadvantaged",
-				"mode": "set"
+				"mode": "set",
+				"id": "QwL4D7Zl3D1S1sbj"
 			},
 			{
 				"type": "grantProficiency",
@@ -24,7 +25,8 @@
 					"intelligence": {
 						"min": 0
 					}
-				}
+				},
+				"id": "mbCpzjDXY6k0ZZFV"
 			}
 		],
 		"description": "<p>Descendants of divine beings, Celestials carry an aura of nobility and grace. Their innate connection to the higher planes allows them to resist the effects of misfortune, standing strong where others may falter.</p><hr><p><strong>Highborn</strong> </p><p>Your disadvantaged save is Neutral instead. [M]</p><p>You know Celestial if your INT isn't negative. [M]</p>",

--- a/packs/ancestries/core/exotic/dragonborn.json
+++ b/packs/ancestries/core/exotic/dragonborn.json
@@ -28,7 +28,8 @@
 					"intelligence": {
 						"min": 0
 					}
-				}
+				},
+				"id": "ONMVoM2545DOr6Ib"
 			}
 		],
 		"description": "<p>The soul of a dragon burns within you, the scales of your body are like forged steel. You are a kiln and your heritage the coals that stoke your flames. Call upon your wrath, to speak in the tongue of your ancestors and imbue unbridled fury into your attacks.</p><hr><p><strong>Draconic Heritage</strong></p><p>+1 Armor. [A]</p><p>When you attack: deal an additional LVL+KEY damage (ignoring armor) divided as you choose among any of your targets; recharges whenever you Safe Rest or gain a Wound.</p><p>You know Draconic if your INT is not negative. [M]</p>",

--- a/packs/ancestries/core/exotic/dryadshroomling.json
+++ b/packs/ancestries/core/exotic/dryadshroomling.json
@@ -17,7 +17,8 @@
 					"intelligence": {
 						"min": 0
 					}
-				}
+				},
+				"id": "93J1JO4w6KUqXpqo"
 			}
 		],
 		"description": "<p>Tied to the natural world, Dryads and Shroomlings embody the balance between flora and fauna. Their unique physiology releases toxic spores when harmed, providing a natural defense against those who dare to harm them.</p><hr><p><strong>Danger Pollen/Spores</strong> </p><p>Whenever an enemy causes you one or more Wounds, you excrete soporific spores: all adjacent enemies are Dazed. </p><p>You know Elvish if your INT is not negative. [M]</p>",

--- a/packs/ancestries/core/exotic/fiendkin.json
+++ b/packs/ancestries/core/exotic/fiendkin.json
@@ -12,7 +12,8 @@
 				"value": 1,
 				"target": "neutral",
 				"mode": "set",
-				"requiresChoice": true
+				"requiresChoice": true,
+				"id": "Ps5OpAcOStWfekWe"
 			},
 			{
 				"type": "grantProficiency",
@@ -25,7 +26,8 @@
 					"intelligence": {
 						"min": 0
 					}
-				}
+				},
+				"id": "Jg42GZD7ParxVgSz"
 			}
 		],
 		"description": "<p>Said to have been born from the union of man and fiend, or from a cursed bloodline, Fiendkin often find themselves outcasts in society. Yet, they embody determination in the face of adversity. Their ancestors didn't emerge from the depths of the Everflame to succumb to minor setbacks!</p><hr><p><strong>Flameborn</strong> </p><p>1 of your neutral saves is advantaged instead. [M]</p><p>You know Infernal if your INT is not negative. [M]</p>",

--- a/packs/ancestries/core/exotic/goblin.json
+++ b/packs/ancestries/core/exotic/goblin.json
@@ -17,7 +17,8 @@
 					"intelligence": {
 						"min": 0
 					}
-				}
+				},
+				"id": "UON7rnMCdp2jx0iy"
 			}
 		],
 		"description": "<p>Green, cunning, and perpetually vilified, Goblins thrive on the edge of chaos. For a Goblin, vanishing into the shadows is not just a skill—it's an identity. After all, what kind of Goblin would you be if you couldn't slip away unnoticed?</p><hr><p><strong>Skedaddle</strong> </p><p>Can move 2 spaces for free after you become the target of an attack or negative effect (after damage, ignoring difficult terrain). </p><p>You know Goblin if your INT is not negative. [M]</p>",

--- a/packs/ancestries/core/exotic/half-giant.json
+++ b/packs/ancestries/core/exotic/half-giant.json
@@ -30,7 +30,8 @@
 					"intelligence": {
 						"min": 0
 					}
-				}
+				},
+				"id": "AvwGjGVx5mDqgBHu"
 			}
 		],
 		"description": "<p>Towering beings whose strength is as immovable as the mountains they call home. Their sheer size and resilience make them fearsome opponents, capable of surviving even devastating blows.</p><hr><p><strong>Strength of Stone</strong> </p><p>Force an enemy to reroll a crit against you, 1/encounter. </p><p>+2 Might. [A]</p><p>You know Dwarvish if your INT is not negative. [M]</p>",

--- a/packs/ancestries/core/exotic/kobold.json
+++ b/packs/ancestries/core/exotic/kobold.json
@@ -17,7 +17,8 @@
 					"intelligence": {
 						"min": 0
 					}
-				}
+				},
+				"id": "KMR4cBnh3wKJMTpr"
 			}
 		],
 		"description": "<p>Small, often maniacal, and dragon–obsessed. Kobolds thrive in the shadows, finding ingenious ways to survive despite their diminutive size. Underestimated by many, Kobolds prove time and again that even the smallest among us can wield great power.</p><hr><p><strong>Wily</strong> </p><p>Force an enemy to reroll a non-critical attack against you, 1/encounter. </p><p>+3 to Influence friendly characters. [M]</p><p>Advantage on skill checks related to dragons. [M]</p><p> You know Draconic if your INT is not negative. [M]</p>",

--- a/packs/ancestries/core/exotic/oozelingconstruct.json
+++ b/packs/ancestries/core/exotic/oozelingconstruct.json
@@ -9,11 +9,13 @@
 			{
 				"type": "incrementHitDice",
 				"label": "Odd Constitution",
-				"value": "1"
+				"value": "1",
+				"id": "E3LTczDN5sCHW2QV"
 			},
 			{
 				"type": "maximizeHitDice",
-				"label": "Odd Constitution"
+				"label": "Odd Constitution",
+				"id": "GUqHRh644HlQ11lU"
 			}
 		],
 		"description": "<p>What even is a “PeOpLe“ anyway? So what if your heart pumps oil instead of blood, so what if you don't even have a heart!? If you can squish yourself into a pair of pants, or swing a sword like everyone else, who's to say you can't be a pEOpLe, too?!</p><hr><p><strong>Odd Constitution</strong> </p><p>Increment your Hit Dice one step (d6 » d8 » d10 » d12 » d20); they always heal you for the maximum amount. Magical healing always heals you for the minimum amount.</p>",

--- a/packs/ancestries/core/exotic/orc.json
+++ b/packs/ancestries/core/exotic/orc.json
@@ -30,7 +30,8 @@
 					"intelligence": {
 						"min": 0
 					}
-				}
+				},
+				"id": "ehGVxOF7pLnbpDsk"
 			}
 		],
 		"description": "<p>Just when you think you've bested a mighty Orc, you've merely succeeded in rousing their anger. Engaging in combat with an Orc is no endeavor for the weak-willed. While others may cower before death's approach, Orcs boldly defy its grasp.</p><hr><p><strong>Relentless</strong> </p><p>When you would drop to 0 HP, you may set your HP to LVL instead, 1/Safe Rest. </p><p>+1 Might. [A]</p><p>You know Goblin if your INT is not negative (but you call it Orcish, of course). [M]</p>",

--- a/packs/backgrounds/core/survivalist.json
+++ b/packs/backgrounds/core/survivalist.json
@@ -11,7 +11,8 @@
 				"type": "maxHitDice",
 				"label": "Survivalist",
 				"value": "1",
-				"dieSize": 0
+				"dieSize": 0,
+				"id": "1C7GnDgBamsrGvjI"
 			}
 		],
 		"description": "<p>You never run out of your own personal rations. Anything can be food if you try hard enough! Advantage against poison saves. +1 max Hit Die.</p><hr><p>+1 max Hit Die [M]</p>"

--- a/packs/backgrounds/core/wild-one.json
+++ b/packs/backgrounds/core/wild-one.json
@@ -23,7 +23,8 @@
 			{
 				"type": "hitDiceAdvantage",
 				"label": "Wild One",
-				"condition": "in the wild"
+				"condition": "in the wild",
+				"id": "VeZT7ntScHXwdEm0"
 			}
 		],
 		"description": "<p>Whether it is the sticks or flowers in your hair, your smell, or the way you carry yourself, wild creatures are less frightened of you and more willing to aid you. +1 Naturecraft. While Field Resting, roll your Hit Dice with advantage while in the wild.</p><hr><p>+1 Naturecraft [A]</p>"

--- a/packs/boons/core/epic/epic-speed.json
+++ b/packs/boons/core/epic/epic-speed.json
@@ -20,7 +20,8 @@
 			{
 				"type": "speedBonus",
 				"value": "4",
-				"label": "Epic Speed"
+				"label": "Epic Speed",
+				"id": "C7maLpA1q4TnENvQ"
 			}
 		],
 		"description": "<p><span class=\"dig-1hicw9p1_4-2-0 dig-1hicw9p0_4-2-0 dig-ekabin0_4-2-0 dig-Theme-vis2023 dig-Theme-vis2023--dark dig-Mode--dark In-Theme-Provider\" style=\"display: contents;\">+4 Speed [M]<br>+4 Initiative [A]</span></p>",

--- a/packs/boons/core/lodging/plus-1-speed.json
+++ b/packs/boons/core/lodging/plus-1-speed.json
@@ -9,7 +9,8 @@
 			{
 				"type": "speedBonus",
 				"value": "1",
-				"label": "+1 Speed"
+				"label": "+1 Speed",
+				"id": "wczhdygtYEAnNUS0"
 			}
 		],
 		"description": "<p>+1 Speed.</p>",

--- a/packs/boons/core/major/stalwart.json
+++ b/packs/boons/core/major/stalwart.json
@@ -24,7 +24,8 @@
 				"type": "maxHitDice",
 				"label": "Stalwart",
 				"value": "1",
-				"dieSize": 0
+				"dieSize": 0,
+				"id": "i7arJ8qAqOVRtpXG"
 			}
 		],
 		"description": "<p><span class=\"dig-1hicw9p1_4-2-0 dig-1hicw9p0_4-2-0 dig-ekabin0_4-2-0 dig-Theme-vis2023 dig-Theme-vis2023--dark dig-Mode--dark In-Theme-Provider\" style=\"display: contents;\">+1 max Hit Die. [M]</span></p><p><span class=\"dig-1hicw9p1_4-2-0 dig-1hicw9p0_4-2-0 dig-ekabin0_4-2-0 dig-Theme-vis2023 dig-Theme-vis2023--dark dig-Mode--dark In-Theme-Provider\" style=\"display: contents;\">+2 Might. [A]</span></p>",

--- a/packs/boons/core/major/tenacious.json
+++ b/packs/boons/core/major/tenacious.json
@@ -11,7 +11,8 @@
 				"type": "maxHitDice",
 				"label": "Tenacious",
 				"value": "2",
-				"dieSize": 0
+				"dieSize": 0,
+				"id": "3Lgy6EQ3HyPW4D27"
 			}
 		],
 		"description": "<p><span class=\"dig-1hicw9p1_4-2-0 dig-1hicw9p0_4-2-0 dig-ekabin0_4-2-0 dig-Theme-vis2023 dig-Theme-vis2023--dark dig-Mode--dark In-Theme-Provider\" style=\"display: contents;\">+2 max Hit Dice. [M]</span></p>",

--- a/packs/boons/core/minor/feisty.json
+++ b/packs/boons/core/minor/feisty.json
@@ -10,7 +10,8 @@
 				"type": "maxHitDice",
 				"label": "Feisty",
 				"value": "1",
-				"dieSize": 0
+				"dieSize": 0,
+				"id": "2lMztAia47L6iT1s"
 			}
 		],
 		"description": "<p>+1 max Hit Die. [M]</p>",

--- a/packs/boons/core/minor/intrepid.json
+++ b/packs/boons/core/minor/intrepid.json
@@ -9,7 +9,8 @@
 			{
 				"type": "speedBonus",
 				"value": "1",
-				"label": "Intrepid"
+				"label": "Intrepid",
+				"id": "lApcrxi3FeR92dow"
 			}
 		],
 		"description": "<p>+1 Speed. [M]</p>",

--- a/packs/classFeatures/core/berserker/savage-arsenal/eager-for-battle.json
+++ b/packs/classFeatures/core/berserker/savage-arsenal/eager-for-battle.json
@@ -12,13 +12,15 @@
 				"type": "initiativeRollMode",
 				"value": 1,
 				"mode": "adjust",
-				"label": "Eager for Battle (Advantage on Initiative)"
+				"label": "Eager for Battle (Advantage on Initiative)",
+				"id": "uIU5puSybZptEtcS"
 			},
 			{
 				"type": "initiativeMessage",
 				"formula": "2 * @dexterity",
 				"label": "Eager for Battle",
-				"message": "You can move {value} spaces for free on your first turn!"
+				"message": "You can move {value} spaces for free on your first turn!",
+				"id": "I6AZz9ni9tkA3rsp"
 			}
 		],
 		"activation": {

--- a/packs/classFeatures/core/commander/commanders-order/i-can-do-this-all-day.json
+++ b/packs/classFeatures/core/commander/commanders-order/i-can-do-this-all-day.json
@@ -8,7 +8,8 @@
 		"rules": [
 			{
 				"type": "maxHitDice",
-				"name": "New Rule 1"
+				"name": "New Rule 1",
+				"id": "75GQq1kNmfQR1JzG"
 			}
 		],
 		"activation": {

--- a/packs/classFeatures/core/hunter/hunter-progression/explorer-of-the-wilds.json
+++ b/packs/classFeatures/core/hunter/hunter-progression/explorer-of-the-wilds.json
@@ -10,13 +10,15 @@
 			{
 				"type": "speedBonus",
 				"value": "2",
-				"label": "Explorer of the Wilds"
+				"label": "Explorer of the Wilds",
+				"id": "t78A5cp7E9AcmEoD"
 			},
 			{
 				"type": "grantMovement",
 				"mode": "climb",
 				"speed": "@attributes.movement.walk",
-				"label": "Explorer of the Wilds"
+				"label": "Explorer of the Wilds",
+				"id": "J3Y32rSs9EXuKrin"
 			}
 		],
 		"activation": {

--- a/packs/classFeatures/core/oathsworn/sacred-decree/unstoppable-protector.json
+++ b/packs/classFeatures/core/oathsworn/sacred-decree/unstoppable-protector.json
@@ -10,7 +10,8 @@
 			{
 				"type": "speedBonus",
 				"value": "1",
-				"label": "Unstoppable Protector"
+				"label": "Unstoppable Protector",
+				"id": "x5UWrJw1yREILyHx"
 			}
 		],
 		"activation": {

--- a/packs/classFeatures/core/stormshifter/chimeric-boon/fleet-footed.json
+++ b/packs/classFeatures/core/stormshifter/chimeric-boon/fleet-footed.json
@@ -10,7 +10,8 @@
 			{
 				"type": "speedBonus",
 				"value": "2",
-				"label": "Fleet Footed"
+				"label": "Fleet Footed",
+				"id": "EcMJKDIwbT3q5cP3"
 			}
 		],
 		"activation": {

--- a/packs/classFeatures/core/stormshifter/chimeric-boon/winged.json
+++ b/packs/classFeatures/core/stormshifter/chimeric-boon/winged.json
@@ -11,7 +11,8 @@
 				"type": "speedBonus",
 				"value": "@attributes.movement.walk",
 				"movementType": "fly",
-				"label": "Winged"
+				"label": "Winged",
+				"id": "RivdlU4xcZIxnZQt"
 			}
 		],
 		"activation": {

--- a/packs/classFeatures/core/the-cheat/the-cheat-subclasses/tools-of-the-silent-blade/professional-skulker.json
+++ b/packs/classFeatures/core/the-cheat/the-cheat-subclasses/tools-of-the-silent-blade/professional-skulker.json
@@ -11,7 +11,8 @@
 				"type": "grantMovement",
 				"mode": "climb",
 				"speed": "@attributes.movement.walk",
-				"label": "Professional Skulker"
+				"label": "Professional Skulker",
+				"id": "CbCCuwJX0Tt1vxPk"
 			}
 		],
 		"activation": {

--- a/packs/classFeatures/core/zephyr/zephyr-progression/swift-feet.json
+++ b/packs/classFeatures/core/zephyr/zephyr-progression/swift-feet.json
@@ -13,7 +13,8 @@
 				"label": "Swift Feet (2)",
 				"predicate": {
 					"armor": "unarmored"
-				}
+				},
+				"id": "N6AjtypNnAog0Yxe"
 			},
 			{
 				"type": "initiativeBonus",
@@ -21,7 +22,8 @@
 				"label": "Swift Feet Initiative Bonus",
 				"predicate": {
 					"armor": "unarmored"
-				}
+				},
+				"id": "lax2tm9WANtF27kW"
 			},
 			{
 				"type": "speedBonus",
@@ -32,7 +34,8 @@
 					"level": {
 						"min": 9
 					}
-				}
+				},
+				"id": "JflZ8p8jDbfUKhtr"
 			}
 		],
 		"activation": {

--- a/packs/magicItems/core/coreRules/trinket-of-ill-omen.json
+++ b/packs/magicItems/core/coreRules/trinket-of-ill-omen.json
@@ -13,7 +13,8 @@
 				"value": "-1",
 				"savingThrows": [
 					"all"
-				]
+				],
+				"id": "5RwFO4nRifW448FN"
 			}
 		],
 		"activation": {

--- a/packs/monsters/core/cultists/doomsayer.json
+++ b/packs/monsters/core/cultists/doomsayer.json
@@ -149,7 +149,8 @@
 						"type": "applyCondition",
 						"condition": "despair",
 						"trigger": "onCrit",
-						"label": "Fanatical Zeal: Despair on crit"
+						"label": "Fanatical Zeal: Despair on crit",
+						"id": "wLc3rqnZrrkHI1FC"
 					}
 				],
 				"activation": {

--- a/src/managers/RulesManager.ts
+++ b/src/managers/RulesManager.ts
@@ -186,18 +186,22 @@ class RulesManager extends Map<string, InstanceType<typeof NimbleBaseRule>> {
 
 		// TODO: Add validation for new data
 
+		// Assign a stable id at creation so the rule has the same identity in
+		// persisted JSON, in-memory data model, and Babele translation skeletons.
+		const ruleData =
+			typeof data.id === 'string' && data.id ? data : { ...data, id: foundry.utils.randomID() };
+
 		if (options.update) {
 			await item.update({
-				'system.rules': [...existingRules, data],
+				'system.rules': [...existingRules, ruleData],
 			} as Record<string, unknown>);
 
-			const existingIds = existingRules.map((r) => r.id);
 			const updatedSystem = getSystemWithRules(item);
-			return updatedSystem.rules.filter((r) => !existingIds.includes(r.id))?.[0];
+			return updatedSystem.rules.find((r) => r.id === ruleData.id);
 		}
 
 		const dataModels = CONFIG.NIMBLE.ruleDataModels;
-		const type = data.type;
+		const type = ruleData.type;
 		if (!type || typeof type !== 'string') {
 			// eslint-disable-next-line no-console
 			console.error('Nimble | Rule does not have a type.');
@@ -211,7 +215,7 @@ class RulesManager extends Map<string, InstanceType<typeof NimbleBaseRule>> {
 			return undefined;
 		}
 
-		const rule = new Cls(data, { parent: item });
+		const rule = new Cls(ruleData, { parent: item });
 		return rule;
 	}
 }


### PR DESCRIPTION
## Summary

Closes #822.

- **Pack build (`build/lib/Pack.mjs`):** `#cleanDocument` now walks `source.system.rules[]` and assigns a fresh 16-char base62 id (mirroring `foundry.utils.randomID()`) to any rule lacking one. Idempotent — existing ids are preserved, and embedded items' rules are covered via the existing recursion.
- **Rules builder UI (`src/managers/RulesManager.ts`):** `addRule` assigns an id at creation time when one isn't provided, so newly-added UI rules never persist without an id.
- **Pack source backfill:** 43 missing rule ids populated across 31 source pack files (audit went from 43 missing → 0).

Resolves the `index:N` fallback drift risk in Babele compendium translation skeletons flagged during #821 review. The runtime converter already tries `id` first; once every rule has a stable id, translations land deterministically regardless of pack ordering changes.

## Test plan

- [x] `pnpm build:compendia` populates ids on first run, generates 0 new ids on second run (idempotent)
- [x] Audit script confirms 0/264 rules missing an `id` after backfill
- [x] `pnpm check` — formatting, lint, circular-deps, types, all 1492 tests pass
- [x] Smoke test in Foundry: add a new rule via the rules builder, verify the persisted JSON has an `id`
- [x] Smoke test in Foundry: confirm existing compendium content (with backfilled ids) loads and rules still apply

## Out of scope

- Babele skeleton/translation backfill — deferred to a follow-up after #821 lands; `public/lang/babele/` does not yet exist on `dev`.