### PR TITLE
fix(conditions): only active GM applies automatic conditions (Hampered)

### DIFF
--- a/src/hooks/automaticConditions.test.ts
+++ b/src/hooks/automaticConditions.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Hampered (and other triggered conditions) are applied/removed automatically
+// in reaction to Dazed/Grappled/etc. Foundry fires create/deleteActiveEffect
+// hooks on EVERY connected client, so these follow-up writes must be gated to
+// the single active GM — otherwise players hit "lacks permission" errors and
+// the effect stacks once per connected user with permission.
+
+vi.mock('./conditionImmunityGuard.js', () => ({
+	isConditionImmune: vi.fn(() => false),
+}));
+
+import { handleAutomaticConditionApplication } from './automaticConditions.js';
+
+interface MockActor {
+	documentName: 'Actor';
+	statuses: Set<string>;
+	toggleStatusEffect: ReturnType<typeof vi.fn>;
+}
+
+function createActor(): MockActor {
+	return {
+		documentName: 'Actor',
+		statuses: new Set<string>(),
+		toggleStatusEffect: vi.fn().mockResolvedValue(undefined),
+	};
+}
+
+function createDocument(actor: MockActor, statuses: string[] = ['dazed']) {
+	return {
+		id: 'effect-1',
+		parent: actor,
+		statuses: new Set(statuses),
+	};
+}
+
+/** Stub the global `game` for a given current user / active GM pairing. */
+function stubGame(opts: {
+	currentUserId: string;
+	currentUserIsGM: boolean;
+	activeGmId: string | null;
+}): void {
+	vi.stubGlobal('game', {
+		user: { id: opts.currentUserId, isGM: opts.currentUserIsGM },
+		users: { activeGM: opts.activeGmId ? { id: opts.activeGmId } : null },
+		nimble: {
+			conditions: {
+				getConditionsToRemove: vi.fn(() => ['hampered']),
+				shouldRemoveTriggeredCondition: vi.fn(() => true),
+			},
+		},
+	});
+}
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	vi.clearAllMocks();
+});
+
+describe('handleAutomaticConditionApplication.postCreate', () => {
+	let actor: MockActor;
+
+	beforeEach(() => {
+		actor = createActor();
+	});
+
+	it('applies the automatic condition when run on the active GM client', async () => {
+		stubGame({ currentUserId: 'gm-1', currentUserIsGM: true, activeGmId: 'gm-1' });
+		const document = createDocument(actor);
+
+		await handleAutomaticConditionApplication.postCreate(
+			document as never,
+			{ automaticConditionsToApply: ['hampered'] } as never,
+			'gm-1',
+		);
+
+		expect(actor.toggleStatusEffect).toHaveBeenCalledTimes(1);
+		expect(actor.toggleStatusEffect).toHaveBeenCalledWith(
+			'hampered',
+			expect.objectContaining({ automaticConditionSource: 'effect-1' }),
+		);
+	});
+
+	it('does NOT apply the condition on a non-GM player client', async () => {
+		stubGame({ currentUserId: 'player-1', currentUserIsGM: false, activeGmId: 'gm-1' });
+		const document = createDocument(actor);
+
+		await handleAutomaticConditionApplication.postCreate(
+			document as never,
+			{ automaticConditionsToApply: ['hampered'] } as never,
+			'gm-1',
+		);
+
+		expect(actor.toggleStatusEffect).not.toHaveBeenCalled();
+	});
+
+	it('does NOT apply the condition on a second, non-active GM client', async () => {
+		stubGame({ currentUserId: 'gm-2', currentUserIsGM: true, activeGmId: 'gm-1' });
+		const document = createDocument(actor);
+
+		await handleAutomaticConditionApplication.postCreate(
+			document as never,
+			{ automaticConditionsToApply: ['hampered'] } as never,
+			'gm-1',
+		);
+
+		expect(actor.toggleStatusEffect).not.toHaveBeenCalled();
+	});
+
+	it('falls back to any connected GM when no active GM is designated', async () => {
+		stubGame({ currentUserId: 'gm-1', currentUserIsGM: true, activeGmId: null });
+		const document = createDocument(actor);
+
+		await handleAutomaticConditionApplication.postCreate(
+			document as never,
+			{ automaticConditionsToApply: ['hampered'] } as never,
+			'gm-1',
+		);
+
+		expect(actor.toggleStatusEffect).toHaveBeenCalledTimes(1);
+	});
+
+	it('does nothing when there are no conditions to apply', async () => {
+		stubGame({ currentUserId: 'gm-1', currentUserIsGM: true, activeGmId: 'gm-1' });
+		const document = createDocument(actor);
+
+		await handleAutomaticConditionApplication.postCreate(document as never, {} as never, 'gm-1');
+
+		expect(actor.toggleStatusEffect).not.toHaveBeenCalled();
+	});
+});
+
+describe('handleAutomaticConditionApplication.postDelete', () => {
+	let actor: MockActor;
+
+	beforeEach(() => {
+		actor = createActor();
+	});
+
+	it('removes the automatic condition when run on the active GM client', async () => {
+		stubGame({ currentUserId: 'gm-1', currentUserIsGM: true, activeGmId: 'gm-1' });
+		const document = createDocument(actor);
+
+		await handleAutomaticConditionApplication.postDelete(document as never, {} as never, 'gm-1');
+
+		expect(actor.toggleStatusEffect).toHaveBeenCalledWith(
+			'hampered',
+			expect.objectContaining({ active: false }),
+		);
+	});
+
+	it('does NOT remove the condition on a non-GM player client', async () => {
+		stubGame({ currentUserId: 'player-1', currentUserIsGM: false, activeGmId: 'gm-1' });
+		const document = createDocument(actor);
+
+		await handleAutomaticConditionApplication.postDelete(document as never, {} as never, 'gm-1');
+
+		expect(actor.toggleStatusEffect).not.toHaveBeenCalled();
+	});
+});

--- a/src/hooks/automaticConditions.ts
+++ b/src/hooks/automaticConditions.ts
@@ -8,6 +8,25 @@ interface AutomaticConditionContext {
 	automaticConditionsActor?: NimbleBaseActor; // Actor reference for postDelete operations
 }
 
+/**
+ * Applying/removing automatic conditions (e.g. Hampered) mutates the actor's
+ * effects, but Foundry fires create/deleteActiveEffect hooks on *every*
+ * connected client. Without a guard, each client runs the follow-up write:
+ * players hit "User lacks permission to create/delete effect on actor" errors,
+ * and one duplicate effect is created per connected user with permission.
+ *
+ * Restrict execution to the single designated active GM so the write happens
+ * exactly once.
+ */
+function isActiveGM(): boolean {
+	const users = game.users as unknown as { activeGM?: { id?: string | null } | null };
+	const activeGmId = users?.activeGM?.id ?? null;
+	// If an active GM is designated, only that user proceeds.
+	if (activeGmId) return activeGmId === game.user?.id;
+	// Fallback (no active GM designated): allow any connected GM.
+	return Boolean(game.user?.isGM);
+}
+
 export const handleAutomaticConditionApplication = {
 	/**
 	 * Before creating an ActiveEffect, check if it should trigger automatic conditions
@@ -46,6 +65,7 @@ export const handleAutomaticConditionApplication = {
 		_userId: string,
 	): Promise<void> => {
 		if (!options.automaticConditionsToApply) return;
+		if (!isActiveGM()) return;
 
 		try {
 			const actor = document.parent as NimbleBaseActor;
@@ -83,6 +103,8 @@ export const handleAutomaticConditionApplication = {
 		_options: ActiveEffect.Database.DeleteOptions & AutomaticConditionContext,
 		_userId: string,
 	): Promise<void> => {
+		if (!isActiveGM()) return;
+
 		try {
 			const actor = document.parent as NimbleBaseActor;
 			const conditionIds = Array.from(document.statuses);


### PR DESCRIPTION
## Problem

When the GM applies any condition that auto-applies **Hampered** (Dazed, Grappled, Restrained, Slowed, Prone), every connected player sees errors:

- `User <name> lacks permission to create ActiveEffect … in parent`
- `User <name> lacks permission to delete ActiveEffect … in parent`
- `ActiveEffect … does not exist`

Worse, if multiple users have permission on the token, Hampered stacks **once per connected user**.

Applying **Hampered directly** never triggers this — only conditions that *trigger* Hampered do.

## Root cause

Foundry fires `createActiveEffect` / `deleteActiveEffect` hooks on **every connected client**. The automatic-condition handler in `src/hooks/automaticConditions.ts` responded to those hooks by calling `actor.toggleStatusEffect('hampered', …)` with **no guard on which client runs it**. So:

- Each player's client tried to perform a privileged effect write → permission error (they don't own the token).
- Each client *with* permission succeeded → one duplicate Hampered stack per user.
- The delete path raced the same way → `ActiveEffect … does not exist`.

## Fix

Gate the `postCreate` / `postDelete` follow-up writes on the single designated **active GM** (`game.users.activeGM`) via a new `isActiveGM()` helper, so the bookkeeping write runs exactly once.

Note: this gates on `activeGM`, **not** a plain `game.user.isGM` check — a bare `isGM` check would still let *every connected GM* run the write, which is exactly the per-user stacking behavior reported.

Applying the underlying conditions themselves is **unchanged** — players who own a token can still apply Dazed/etc.; the active GM's client (which also receives the hook) performs the Hampered write on their behalf.

## Testing

- `pnpm type-check` — passes
- Biome format/lint — clean
- `pnpm test` — 1453/1453 pass
