### PR TITLE
feat(character-sheet): show color-coded associated stat for each skill (#509)

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -451,6 +451,7 @@
 			"rollSavingThrowSpecific": "Roll {save} Save",
 			"rollSkillCheck": "Roll Skill Check",
 			"rollSkillCheckSpecific": "Roll {skill} Check",
+			"rollSkillCheckSpecificWithAbility": "Roll {skill} Check (Uses {ability})",
 			"fieldRest": "Field Rest",
 			"hideRoll": "Hide From Players?"
 		},

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -451,7 +451,7 @@
 			"rollSavingThrowSpecific": "Roll {save} Save",
 			"rollSkillCheck": "Roll Skill Check",
 			"rollSkillCheckSpecific": "Roll {skill} Check",
-			"rollSkillCheckSpecificWithAbility": "Roll {skill} Check (Uses {ability})",
+			"rollSkillCheckSpecificWithAbility": "Roll {skill} Check ({ability})",
 			"fieldRest": "Field Rest",
 			"hideRoll": "Hide From Players?"
 		},

--- a/src/config.ts
+++ b/src/config.ts
@@ -41,6 +41,14 @@ const abilityScoreAbbreviations: Record<AbilityKeyType, string> = {
 	will: 'NIMBLE.abilityScoreAbbreviations.will',
 };
 
+// Used to color- and icon-code each skill by the ability score it is tied to.
+const abilityScoreIcons: Record<AbilityKeyType, string> = {
+	strength: 'fa-solid fa-dumbbell',
+	dexterity: 'fa-solid fa-bolt',
+	intelligence: 'fa-solid fa-scroll',
+	will: 'fa-solid fa-fire',
+};
+
 const abilityScoreTooltips = {
 	advantageOnSave: 'NIMBLE.abilityScoreTooltips.advantageOnSave',
 	disadvantageOnSave: 'NIMBLE.abilityScoreTooltips.disadvantageOnSave',
@@ -902,6 +910,7 @@ const NIMBLE = {
 	abilities,
 	abilityScoreAbbreviations,
 	abilityScoreControls,
+	abilityScoreIcons,
 	abilityScores,
 	abilityScoreTooltips,
 	activationCostTypes,

--- a/src/scss/base/_theme.scss
+++ b/src/scss/base/_theme.scss
@@ -107,8 +107,8 @@
 	// Used to color-code each skill by the ability score it is tied to.
 	--nimble-ability-strength-color: hsl(0, 70%, 66%);
 	--nimble-ability-dexterity-color: hsl(140, 50%, 58%);
-	--nimble-ability-intelligence-color: hsl(210, 72%, 68%);
-	--nimble-ability-will-color: hsl(280, 58%, 72%);
+	--nimble-ability-intelligence-color: hsl(270, 60%, 62%);
+	--nimble-ability-will-color: hsl(30, 85%, 60%);
 
 	/** SPELL EFFECT COLORS **/
 	--nimble-spell-damage-color: hsl(0, 65%, 60%);

--- a/src/scss/base/_theme.scss
+++ b/src/scss/base/_theme.scss
@@ -103,6 +103,13 @@
 	--nimble-additional-action-color: hsl(210, 60%, 60%);
 	--nimble-additional-action-color-hover: hsl(210, 60%, 70%);
 
+	/** ABILITY / STAT COLORS **/
+	// Used to color-code each skill by the ability score it is tied to.
+	--nimble-ability-strength-color: hsl(0, 70%, 66%);
+	--nimble-ability-dexterity-color: hsl(140, 50%, 58%);
+	--nimble-ability-intelligence-color: hsl(210, 72%, 68%);
+	--nimble-ability-will-color: hsl(280, 58%, 72%);
+
 	/** SPELL EFFECT COLORS **/
 	--nimble-spell-damage-color: hsl(0, 65%, 60%);
 	--nimble-spell-healing-color: hsl(139, 55%, 50%);

--- a/src/scss/base/_variables.scss
+++ b/src/scss/base/_variables.scss
@@ -182,6 +182,13 @@
 	--nimble-reaction-move-text: hsl(185, 60%, 25%);
 	--nimble-reaction-move-accent: hsl(185, 60%, 40%);
 
+	/** ABILITY / STAT COLORS **/
+	// Used to color-code each skill by the ability score it is tied to.
+	--nimble-ability-strength-color: hsl(0, 70%, 48%);
+	--nimble-ability-dexterity-color: hsl(140, 60%, 33%);
+	--nimble-ability-intelligence-color: hsl(270, 60%, 50%);
+	--nimble-ability-will-color: hsl(30, 90%, 42%);
+
 	/** SPELL EFFECT COLORS **/
 	--nimble-spell-damage-color: hsl(0, 60%, 50%);
 	--nimble-spell-healing-color: hsl(139, 50%, 40%);

--- a/src/scss/components/_skill.scss
+++ b/src/scss/components/_skill.scss
@@ -27,7 +27,8 @@
   }
 
   &--compact {
-    grid-template-columns: 1fr 4ch;
+    gap: 0.5rem;
+    grid-template-columns: 3ch 1fr 4ch;
   }
 
   &--show-passive {
@@ -36,7 +37,7 @@
 
   &--compact.nimble-skill--show-passive {
     gap: 0.25rem;
-    grid-template-columns: 1fr 3ch 3ch;
+    grid-template-columns: 3ch 1fr 3ch 3ch;
     padding-inline: 0.25rem;
   }
 
@@ -57,7 +58,24 @@
   &__ability {
     text-transform: uppercase;
     font-weight: 900;
-    color: var(--nimble-medium-text-color);
+    text-align: start;
+    color: var(--nimble-skill-ability-color, var(--nimble-medium-text-color));
+
+    &[data-ability="strength"] {
+      --nimble-skill-ability-color: var(--nimble-ability-strength-color);
+    }
+
+    &[data-ability="dexterity"] {
+      --nimble-skill-ability-color: var(--nimble-ability-dexterity-color);
+    }
+
+    &[data-ability="intelligence"] {
+      --nimble-skill-ability-color: var(--nimble-ability-intelligence-color);
+    }
+
+    &[data-ability="will"] {
+      --nimble-skill-ability-color: var(--nimble-ability-will-color);
+    }
   }
 
   &__name {

--- a/src/view/dialogs/components/characterCreator/SkillPointAssignment.svelte
+++ b/src/view/dialogs/components/characterCreator/SkillPointAssignment.svelte
@@ -42,7 +42,8 @@
 	}
 
 	const {
-		abilityScoreAbbreviations,
+		abilityScores,
+		abilityScoreIcons,
 		characterCreationStages,
 		defaultSkillAbilities,
 		hints,
@@ -98,7 +99,8 @@
 {/snippet}
 
 {#snippet skill(abilityKey, skillKey, skillLabel)}
-	{@const abilityLabel = abilityScoreAbbreviations[abilityKey]}
+	{@const abilityLabel = abilityScores[abilityKey]}
+	{@const abilityIcon = abilityScoreIcons[abilityKey]}
 	{@const abilityModifier = getAbilityModifier(abilityKey)}
 	{@const skillPoints = active ? tempAssignedSkillPoints : assignedSkillPoints}
 	{@const baseSkillScore = Number.parseInt(skillPoints[skillKey] ?? 0, 10)}
@@ -107,7 +109,14 @@
 
 	<li class="nimble-skills__item nimble-skills__item--compact">
 		<div class="nimble-skill nimble-skill--character-creator">
-			<span class="nimble-skill__ability" data-ability={abilityKey}>{abilityLabel}</span>
+			<span
+				class="nimble-skill__ability"
+				data-ability={abilityKey}
+				aria-label={abilityLabel}
+				data-tooltip={abilityLabel}
+			>
+				<i class={abilityIcon}></i>
+			</span>
 			<span class="nimble-skill__name">{skillLabel}</span>
 
 			<ol class="nimble-skill-point-assignment-list">

--- a/src/view/dialogs/components/characterCreator/SkillPointAssignment.svelte
+++ b/src/view/dialogs/components/characterCreator/SkillPointAssignment.svelte
@@ -107,7 +107,7 @@
 
 	<li class="nimble-skills__item nimble-skills__item--compact">
 		<div class="nimble-skill nimble-skill--character-creator">
-			<span class="nimble-skill__ability">{abilityLabel}</span>
+			<span class="nimble-skill__ability" data-ability={abilityKey}>{abilityLabel}</span>
 			<span class="nimble-skill__name">{skillLabel}</span>
 
 			<ol class="nimble-skill-point-assignment-list">

--- a/src/view/sheets/components/Skills.svelte
+++ b/src/view/sheets/components/Skills.svelte
@@ -20,7 +20,7 @@
 
 	const {
 		abilityScores,
-		abilityScoreAbbreviations,
+		abilityScoreIcons,
 		defaultSkillAbilities,
 		skills: skillNames,
 	} = CONFIG.NIMBLE;
@@ -39,11 +39,12 @@
 	);
 </script>
 
-{#snippet skillSnippet(skill, skillKey, skillName, abilityKey, abilityAbbreviation, abilityName)}
+{#snippet skillSnippet(skill, skillKey, skillName, abilityKey, abilityName)}
 	{@const tooltip = localize('NIMBLE.prompts.rollSkillCheckSpecificWithAbility', {
 		skill: skillName,
 		ability: abilityName,
 	})}
+	{@const abilityIcon = abilityScoreIcons[abilityKey]}
 
 	<li
 		class="nimble-skills__item"
@@ -59,7 +60,14 @@
 			data-tooltip={tooltip}
 			onclick={() => actor.rollSkillCheckToChat(skillKey)}
 		>
-			<span class="nimble-skill__ability" data-ability={abilityKey}>{abilityAbbreviation}</span>
+			<span
+				class="nimble-skill__ability"
+				data-ability={abilityKey}
+				aria-label={abilityName}
+				data-tooltip={abilityName}
+			>
+				<i class={abilityIcon}></i>
+			</span>
 
 			<span class="nimble-skill__name">{skillName}</span>
 			<span class="nimble-skill__value">{getSkillValueLabel(skill.mod)}</span>
@@ -93,17 +101,9 @@
 		{#each sortedSkills as [skillKey, skill]}
 			{@const skillName = skillNames[skillKey]}
 			{@const defaultAbilityKey = defaultSkillAbilities[skillKey]}
-			{@const abilityScoreAbbreviation = abilityScoreAbbreviations[defaultAbilityKey]}
 			{@const abilityName = abilityScores[defaultAbilityKey]}
 
-			{@render skillSnippet(
-				skill,
-				skillKey,
-				skillName,
-				defaultAbilityKey,
-				abilityScoreAbbreviation,
-				abilityName,
-			)}
+			{@render skillSnippet(skill, skillKey, skillName, defaultAbilityKey, abilityName)}
 		{/each}
 	</ul>
 </section>

--- a/src/view/sheets/components/Skills.svelte
+++ b/src/view/sheets/components/Skills.svelte
@@ -18,7 +18,12 @@
 
 	let { skills } = $props();
 
-	const { abilityScoreAbbreviations, defaultSkillAbilities, skills: skillNames } = CONFIG.NIMBLE;
+	const {
+		abilityScores,
+		abilityScoreAbbreviations,
+		defaultSkillAbilities,
+		skills: skillNames,
+	} = CONFIG.NIMBLE;
 
 	const actor = getContext('actor');
 
@@ -34,9 +39,10 @@
 	);
 </script>
 
-{#snippet skillSnippet(skill, skillKey, skillName, defaultAbility)}
-	{@const tooltip = localize('NIMBLE.prompts.rollSkillCheckSpecific', {
+{#snippet skillSnippet(skill, skillKey, skillName, abilityKey, abilityAbbreviation, abilityName)}
+	{@const tooltip = localize('NIMBLE.prompts.rollSkillCheckSpecificWithAbility', {
 		skill: skillName,
+		ability: abilityName,
 	})}
 
 	<li
@@ -49,13 +55,11 @@
 			class:nimble-skill--compact={compactSkillsView}
 			class:nimble-skill--show-passive={showPassiveSkillScores}
 			type="button"
-			aria-label={localize(tooltip)}
+			aria-label={tooltip}
 			data-tooltip={tooltip}
 			onclick={() => actor.rollSkillCheckToChat(skillKey)}
 		>
-			{#if !compactSkillsView}
-				<span class="nimble-skill__ability">{defaultAbility}</span>
-			{/if}
+			<span class="nimble-skill__ability" data-ability={abilityKey}>{abilityAbbreviation}</span>
 
 			<span class="nimble-skill__name">{skillName}</span>
 			<span class="nimble-skill__value">{getSkillValueLabel(skill.mod)}</span>
@@ -90,8 +94,16 @@
 			{@const skillName = skillNames[skillKey]}
 			{@const defaultAbilityKey = defaultSkillAbilities[skillKey]}
 			{@const abilityScoreAbbreviation = abilityScoreAbbreviations[defaultAbilityKey]}
+			{@const abilityName = abilityScores[defaultAbilityKey]}
 
-			{@render skillSnippet(skill, skillKey, skillName, abilityScoreAbbreviation)}
+			{@render skillSnippet(
+				skill,
+				skillKey,
+				skillName,
+				defaultAbilityKey,
+				abilityScoreAbbreviation,
+				abilityName,
+			)}
 		{/each}
 	</ul>
 </section>


### PR DESCRIPTION
## Summary

Resolves #509 — character sheets now make it clear which ability score each skill is tied to.

Each skill always displays its associated stat as a **color-coded icon**, in both the compact (default) and expanded views. Previously the stat only appeared in the rarely-used expanded view.

### Changes
- **Always-visible, color-coded stat icon** next to every skill, so skills can be grouped by stat at a glance:
  - Str — 🏋️ dumbbell (`fa-dumbbell`), red
  - Dex — ⚡ lightning bolt (`fa-bolt`), green
  - Int — 📜 scroll (`fa-scroll`), royal purple
  - Wil — 🔥 flame (`fa-fire`), orange
  - All icons are FontAwesome **Free** (Solid), so they render with Foundry's bundled font — no extra assets.
- New themeable CSS variables `--nimble-ability-*-color`, defined for **both light and dark themes** (light-mode values tuned darker for contrast on light backgrounds). Colors applied via a `data-ability` attribute; icons inherit the stat color.
- New `abilityScoreIcons` config map driving the per-stat icon.
- **Hover tooltip**: "Roll _Skill_ Check (_Ability_)" on the skill, plus the localized ability name as the icon's `aria-label`/tooltip for accessibility.
- Same icon + color coding applied in the character-creator skill-point assignment for consistency.
- Compact-grid columns adjusted to fit the stat column without overflow at the 367px sheet width.

### Acceptance criteria (#509)
- [x] Each skill clearly indicates its associated stat
- [x] Easy to discover and understand
- [x] Works for quick reference during play
- [x] UI stays clean and uncluttered

### Verification
- `pnpm check` passes (format, lint, circular-deps, type-check, 1596 tests).
- Layout verified at the narrow 367px character-sheet width (compact, expanded, and compact + passive-scores) with no text overflow.
- Stat colors verified in both light and dark themes.

> ⚠️ **i18n note (per AGENTS.md):** updates one English source string `NIMBLE.prompts.rollSkillCheckSpecificWithAbility`. No other locale files were modified — flagging for human review.
