### PR TITLE
feat(actor): convert monsters between standard, minion, and solo subtypes

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -1653,6 +1653,7 @@
 			"level": "Level",
 			"creatureType": "Creature Type",
 			"sizeCategory": "Size Category",
+			"monsterType": "Monster Type",
 			"flunky": "Flunky"
 		},
 		"featureSheet": {

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -1654,6 +1654,10 @@
 			"creatureType": "Creature Type",
 			"sizeCategory": "Size Category",
 			"monsterType": "Monster Type",
+			"confirmMonsterTypeChange": {
+				"title": "Change Monster Type",
+				"message": "Convert this monster from {current} to {target}? Fields that don't exist on the new type will be discarded, and the open sheet will be closed."
+			},
 			"flunky": "Flunky"
 		},
 		"featureSheet": {

--- a/src/documents/actor/base.svelte.ts
+++ b/src/documents/actor/base.svelte.ts
@@ -197,6 +197,10 @@ class NimbleBaseActor<ActorType extends SystemActorTypes = SystemActorTypes> ext
 			throw new Error(`Cannot convert actor of type "${this.type}" to a monster subtype.`);
 		}
 
+		if (!MONSTER_ACTOR_TYPES.includes(targetType)) {
+			throw new Error(`Cannot convert a monster to invalid target type "${targetType}".`);
+		}
+
 		if (this.type === targetType) return this;
 
 		// Changing a Document's type requires force-replacing the system field —

--- a/src/documents/actor/base.svelte.ts
+++ b/src/documents/actor/base.svelte.ts
@@ -72,6 +72,10 @@ interface InitiativeRollData {
 
 type HpScrollingEffectType = keyof typeof HP_SCROLLING_TEXT_COLORS;
 
+/** Actor subtypes that share the monster sheet and can be converted between each other. */
+const MONSTER_ACTOR_TYPES = ['npc', 'minion', 'soloMonster'] as const;
+type MonsterActorType = (typeof MONSTER_ACTOR_TYPES)[number];
+
 function toFiniteInteger(value: unknown): number {
 	const numericValue = Number(value);
 	if (!Number.isFinite(numericValue)) return 0;
@@ -180,6 +184,22 @@ class NimbleBaseActor<ActorType extends SystemActorTypes = SystemActorTypes> ext
 	/** ------------------------------------------------------ */
 	isType<TypeName extends SystemActorTypes>(type: TypeName): this is NimbleBaseActor<TypeName> {
 		return type === (this.type as SystemActorTypes);
+	}
+
+	/**
+	 * Convert this monster between the standard (`npc`), `minion`, and `soloMonster`
+	 * subtypes, preserving its name, items, and shared system data. Fields that don't
+	 * exist on the target subtype (e.g. an NPC's flunky flag) are dropped by the data
+	 * model when the type changes.
+	 */
+	async convertMonsterType(targetType: MonsterActorType): Promise<this | undefined> {
+		if (!MONSTER_ACTOR_TYPES.includes(this.type as MonsterActorType)) {
+			throw new Error(`Cannot convert actor of type "${this.type}" to a monster subtype.`);
+		}
+
+		if (this.type === targetType) return this;
+
+		return this.update({ type: targetType }) as Promise<this | undefined>;
 	}
 
 	/** ------------------------------------------------------ */

--- a/src/documents/actor/base.svelte.ts
+++ b/src/documents/actor/base.svelte.ts
@@ -199,7 +199,25 @@ class NimbleBaseActor<ActorType extends SystemActorTypes = SystemActorTypes> ext
 
 		if (this.type === targetType) return this;
 
-		return this.update({ type: targetType }) as Promise<this | undefined>;
+		// Changing a Document's type requires force-replacing the system field —
+		// Foundry refuses to recursively diff system data across a schema change
+		// ("...can be changed only if the system field is force-replaced..."). Passing
+		// the current system source with diff/recursion disabled lets the target data
+		// model keep shared fields and drop any that don't exist on the new subtype.
+		const updateData = {
+			type: targetType,
+			system: (this.system as { toObject(): object }).toObject(),
+		} as unknown as Parameters<this['update']>[0];
+
+		const updated = (await this.update(updateData, { diff: false, recursive: false })) as
+			| this
+			| undefined;
+
+		// The monster sheet renders different markup per subtype, so close any open
+		// sheet to force a clean re-render the next time it's opened.
+		await this.sheet?.close();
+
+		return updated;
 	}
 
 	/** ------------------------------------------------------ */

--- a/src/documents/actor/convertMonsterType.test.ts
+++ b/src/documents/actor/convertMonsterType.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+import { NimbleBaseActor } from './base.svelte.js';
+
+interface ActorStub {
+	type: string;
+	update: ReturnType<typeof vi.fn>;
+}
+
+function makeStub(type: string): ActorStub {
+	return {
+		type,
+		update: vi.fn().mockResolvedValue(undefined),
+	};
+}
+
+function convert(stub: ActorStub, targetType: string): Promise<unknown> {
+	const fn = NimbleBaseActor.prototype.convertMonsterType;
+	return fn.call(
+		stub as unknown as InstanceType<typeof NimbleBaseActor>,
+		targetType as Parameters<typeof fn>[0],
+	);
+}
+
+describe('convertMonsterType', () => {
+	it('changes the actor type via update when converting npc → minion', async () => {
+		const stub = makeStub('npc');
+
+		await convert(stub, 'minion');
+
+		expect(stub.update).toHaveBeenCalledTimes(1);
+		expect(stub.update).toHaveBeenCalledWith({ type: 'minion' });
+	});
+
+	it('supports converting between any monster subtypes', async () => {
+		const stub = makeStub('minion');
+
+		await convert(stub, 'soloMonster');
+
+		expect(stub.update).toHaveBeenCalledWith({ type: 'soloMonster' });
+	});
+
+	it('is a no-op (no update) when the target type matches the current type', async () => {
+		const stub = makeStub('minion');
+
+		const result = await convert(stub, 'minion');
+
+		expect(stub.update).not.toHaveBeenCalled();
+		expect(result).toBe(stub);
+	});
+
+	it('throws when the source actor is not a monster subtype', async () => {
+		const stub = makeStub('character');
+
+		await expect(convert(stub, 'minion')).rejects.toThrow(
+			'Cannot convert actor of type "character" to a monster subtype.',
+		);
+		expect(stub.update).not.toHaveBeenCalled();
+	});
+});

--- a/src/documents/actor/convertMonsterType.test.ts
+++ b/src/documents/actor/convertMonsterType.test.ts
@@ -3,12 +3,18 @@ import { NimbleBaseActor } from './base.svelte.js';
 
 interface ActorStub {
 	type: string;
+	system: { toObject: ReturnType<typeof vi.fn> };
+	sheet: { close: ReturnType<typeof vi.fn> };
 	update: ReturnType<typeof vi.fn>;
 }
+
+const SYSTEM_SOURCE = { details: { level: 3 } };
 
 function makeStub(type: string): ActorStub {
 	return {
 		type,
+		system: { toObject: vi.fn().mockReturnValue(SYSTEM_SOURCE) },
+		sheet: { close: vi.fn().mockResolvedValue(undefined) },
 		update: vi.fn().mockResolvedValue(undefined),
 	};
 }
@@ -22,13 +28,16 @@ function convert(stub: ActorStub, targetType: string): Promise<unknown> {
 }
 
 describe('convertMonsterType', () => {
-	it('changes the actor type via update when converting npc → minion', async () => {
+	it('force-replaces the system field when converting npc → minion', async () => {
 		const stub = makeStub('npc');
 
 		await convert(stub, 'minion');
 
 		expect(stub.update).toHaveBeenCalledTimes(1);
-		expect(stub.update).toHaveBeenCalledWith({ type: 'minion' });
+		expect(stub.update).toHaveBeenCalledWith(
+			{ type: 'minion', system: SYSTEM_SOURCE },
+			{ diff: false, recursive: false },
+		);
 	});
 
 	it('supports converting between any monster subtypes', async () => {
@@ -36,7 +45,18 @@ describe('convertMonsterType', () => {
 
 		await convert(stub, 'soloMonster');
 
-		expect(stub.update).toHaveBeenCalledWith({ type: 'soloMonster' });
+		expect(stub.update).toHaveBeenCalledWith(
+			{ type: 'soloMonster', system: SYSTEM_SOURCE },
+			{ diff: false, recursive: false },
+		);
+	});
+
+	it('closes the open sheet after converting so it re-renders for the new type', async () => {
+		const stub = makeStub('npc');
+
+		await convert(stub, 'minion');
+
+		expect(stub.sheet.close).toHaveBeenCalledTimes(1);
 	});
 
 	it('is a no-op (no update) when the target type matches the current type', async () => {
@@ -45,6 +65,7 @@ describe('convertMonsterType', () => {
 		const result = await convert(stub, 'minion');
 
 		expect(stub.update).not.toHaveBeenCalled();
+		expect(stub.sheet.close).not.toHaveBeenCalled();
 		expect(result).toBe(stub);
 	});
 

--- a/src/models/actor/actorDataModels.ts
+++ b/src/models/actor/actorDataModels.ts
@@ -1,6 +1,6 @@
 import { NimbleCharacterData } from './CharacterDataModel.js';
-import { NimbleNPCData } from './NPCDataModel.js';
 import { NimbleMinionData } from './MinionDataModel.js';
+import { NimbleNPCData } from './NPCDataModel.js';
 import { NimbleSoloMonsterData } from './SoloMonsterDataModel.js';
 
 const actorDataModels = {
@@ -18,6 +18,7 @@ declare global {
 		Actor: {
 			character: NimbleCharacterData;
 			npc: NimbleNPCData;
+			minion: NimbleMinionData;
 			soloMonster: NimbleSoloMonsterData;
 		};
 	}

--- a/src/view/dialogs/NPCMetaConfigDialog.svelte
+++ b/src/view/dialogs/NPCMetaConfigDialog.svelte
@@ -18,6 +18,24 @@
 		];
 	}
 
+	async function handleMonsterTypeChange(newValue: string) {
+		if (newValue === actor.type) return;
+
+		const confirmKey = 'NIMBLE.npcConfig.confirmMonsterTypeChange';
+		const confirmed = await foundry.applications.api.DialogV2.confirm({
+			window: { title: localize(`${confirmKey}.title`) },
+			content: `<p>${localize(`${confirmKey}.message`, {
+				current: localize(`TYPES.Actor.${actor.type}`),
+				target: localize(`TYPES.Actor.${newValue}`),
+			})}</p>`,
+			rejectClose: false,
+		});
+
+		if (confirmed !== true) return;
+
+		await actor.convertMonsterType(newValue);
+	}
+
 	const { sizeCategories } = CONFIG.NIMBLE;
 
 	let { actor } = $props();
@@ -68,7 +86,7 @@
 		<TagGroup
 			options={prepareMonsterTypeOptions()}
 			selectedOptions={[actor.reactive.type]}
-			toggleOption={(newValue) => actor.convertMonsterType(newValue)}
+			toggleOption={handleMonsterTypeChange}
 		/>
 	</div>
 

--- a/src/view/dialogs/NPCMetaConfigDialog.svelte
+++ b/src/view/dialogs/NPCMetaConfigDialog.svelte
@@ -10,6 +10,14 @@
 		}));
 	}
 
+	function prepareMonsterTypeOptions() {
+		return [
+			{ label: localize('TYPES.Actor.npc'), value: 'npc' },
+			{ label: localize('TYPES.Actor.minion'), value: 'minion' },
+			{ label: localize('TYPES.Actor.soloMonster'), value: 'soloMonster' },
+		];
+	}
+
 	const { sizeCategories } = CONFIG.NIMBLE;
 
 	let { actor } = $props();
@@ -52,7 +60,19 @@
 		/>
 	</div>
 
-	{#if actor.type === 'npc'}
+	<div class="nimble-field" data-field-variant="stacked">
+		<h3 class="nimble-heading" data-heading-variant="field">
+			{localize('NIMBLE.npcConfig.monsterType')}
+		</h3>
+
+		<TagGroup
+			options={prepareMonsterTypeOptions()}
+			selectedOptions={[actor.reactive.type]}
+			toggleOption={(newValue) => actor.convertMonsterType(newValue)}
+		/>
+	</div>
+
+	{#if actor.reactive.type === 'npc'}
 		<label class="nimble-field">
 			<input
 				type="checkbox"


### PR DESCRIPTION
## Summary

Resolves #127. Adds a way to convert a standard monster to a Minion (and between any monster subtypes) directly from the monster sheet, mirroring how the **Flunky** flag is toggled.

A new **Monster Type** selector (`Standard` / `Minion` / `Solo Monster`) appears in the NPC meta-config dialog — the gear/edit dialog opened from the monster sheet header, the same dialog that holds the Flunky toggle. Selecting a type prompts for confirmation, then converts the actor's subtype in place, preserving its name, items, and shared system data. Fields absent on the target subtype (e.g. an NPC's `isFlunky`) are dropped by the data model.

## Changes

- **`src/documents/actor/base.svelte.ts`** — new `convertMonsterType(targetType)` on `NimbleBaseActor`: guards against non-monster types (throws) and no-ops on same-type. Foundry refuses to recursively diff the `system` field across a schema change, so the conversion **force-replaces `system`** with the current source and passes `{ diff: false, recursive: false }`, letting the target data model keep shared fields and drop the rest. After updating it **closes the open sheet** so it re-renders cleanly for the new subtype (all three monster types share `NPCSheet`, which branches on type internally).
- **`src/view/dialogs/NPCMetaConfigDialog.svelte`** — added the `TagGroup` selector (reusing existing `TYPES.Actor.*` labels). Selecting a different type now routes through a handler that shows a **`DialogV2.confirm`** (naming the current → target type) before converting. The Flunky checkbox still reactively hides when converting away from `npc`.
- **`src/models/actor/actorDataModels.ts`** — fixed a pre-existing gap: `minion` was in the runtime registry but missing from the `DataModelConfig.Actor` type declaration, so TS rejected `'minion'` as a valid actor type. Required for the conversion to typecheck.
- **`public/lang/en.json`** — added `NIMBLE.npcConfig.monsterType` and `NIMBLE.npcConfig.confirmMonsterTypeChange.{title,message}` (English only; flagged for review).
- **`src/documents/actor/convertMonsterType.test.ts`** — unit tests for the force-replace payload, any-direction conversion, the sheet closing after conversion, the same-type no-op, and the non-monster guard.

## Caveat

Conversion uses Foundry's in-place `update()` (force-replacing `system`). Persisted data, sheet display, and minion crit logic (which falls back to `actor.type === 'minion'`) all update immediately, and the open sheet is closed so it re-renders against the new subtype. However, the live JS document keeps its original subclass (`NimbleNPC`, etc.) until the world reloads, because `actorProxy.ts` selects the per-type class only at construction. The only behaviors gated purely on the class (not on `actor.type`) are the `minion`/`solo-monster` derived tags and Solo Monster's bloodied/last-stand phase methods — these finalize on reload. In-place update was chosen over delete-and-recreate to preserve the actor ID (and thus token/reference links).

## Testing

- `pnpm type-check` — clean
- `pnpm test` — passing (5 tests for `convertMonsterType`)
- Biome clean on changed files
