### PR TITLE
feat(settings): custom and aliased in-game languages

### DIFF
--- a/packs/ancestries/core/common/gnome.json
+++ b/packs/ancestries/core/common/gnome.json
@@ -18,7 +18,8 @@
 						"min": 0
 					}
 				},
-				"id": "utvbMgCYMl6eoIm7"
+				"id": "utvbMgCYMl6eoIm7",
+				"displayAs": "Gnomish"
 			},
 			{
 				"type": "speedBonus",

--- a/packs/ancestries/core/exotic/orc.json
+++ b/packs/ancestries/core/exotic/orc.json
@@ -31,7 +31,8 @@
 						"min": 0
 					}
 				},
-				"id": "ehGVxOF7pLnbpDsk"
+				"id": "ehGVxOF7pLnbpDsk",
+				"displayAs": "Orcish"
 			}
 		],
 		"description": "<p>Just when you think you've bested a mighty Orc, you've merely succeeded in rousing their anger. Engaging in combat with an Orc is no endeavor for the weak-willed. While others may cower before death's approach, Orcs boldly defy its grasp.</p><hr><p><strong>Relentless</strong> </p><p>When you would drop to 0 HP, you may set your HP to LVL instead, 1/Safe Rest. </p><p>+1 Might. [A]</p><p>You know Goblin if your INT is not negative (but you call it Orcish, of course). [M]</p>",

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -2077,6 +2077,25 @@
 			"filterAll": "All"
 		},
 		"settings": {
+			"languageCustomization": {
+				"name": "In-Game Languages",
+				"hint": "Rename built-in languages, give them alternate names, and add your own custom languages.",
+				"button": "Configure Languages",
+				"title": "Configure In-Game Languages",
+				"intro": "Rename built-in languages or add alternate names, and create custom languages. Leave a field blank to keep the built-in default.",
+				"builtinSection": "Built-In Languages",
+				"customSection": "Custom Languages",
+				"label": "Name",
+				"aliases": "Alternate Names",
+				"aliasesPlaceholder": "Comma-separated, e.g. Orcish, Goblin Tongue",
+				"tooltip": "Tooltip",
+				"icon": "Icon Path",
+				"reset": "Reset to default",
+				"remove": "Remove language",
+				"newLanguage": "New Language",
+				"addLanguage": "Add Custom Language",
+				"save": "Save Changes"
+			},
 			"autoExpandRolls": {
 				"name": "Auto-Expand Rolls",
 				"hint": "When enabled, dice roll details are shown inline below each roll in chat messages, without needing to hover."

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -829,7 +829,11 @@
 				"uuid": { "label": "Item" }
 			},
 			"grantProficiency": {
-				"description": "Grant proficiency in armor, weapons, or languages. Use ‘all’ to grant every value of the chosen type."
+				"description": "Grant proficiency in armor, weapons, or languages. Use ‘all’ to grant every value of the chosen type.",
+				"displayAs": {
+					"label": "Display As",
+					"hint": "Languages only: the name this item's ancestry uses for the granted language (e.g. a Gnome calls Dwarvish \"Gnomish\"). Leave blank to use the language's normal name."
+				}
 			},
 			"grantSpells": {
 				"description": "Grant spells by school + tier filter, by UUID, or by user choice.",
@@ -2079,17 +2083,23 @@
 		"settings": {
 			"languageCustomization": {
 				"name": "In-Game Languages",
-				"hint": "Rename built-in languages, give them alternate names, and add your own custom languages.",
+				"hint": "Rename built-in languages, give them ancestry-specific alternate names, and add your own custom languages.",
 				"button": "Configure Languages",
 				"title": "Configure In-Game Languages",
-				"intro": "Rename built-in languages or add alternate names, and create custom languages. Leave a field blank to keep the built-in default.",
+				"intro": "Rename a built-in language, change which ancestries speak it, or add your own languages. These start from the Nimble ancestry rules and override them at runtime — they never change the compendium itself, and Reset restores the rule defaults.",
 				"builtinSection": "Built-In Languages",
 				"customSection": "Custom Languages",
 				"label": "Name",
-				"aliases": "Alternate Names",
-				"aliasesPlaceholder": "Comma-separated, e.g. Orcish, Goblin Tongue",
+				"rename": "Rename",
 				"tooltip": "Tooltip",
-				"icon": "Icon Path",
+				"spokenBy": "Spoken by",
+				"spokenByHint": "Each ancestry below knows this language if its INT isn't negative. Add or remove ancestries to change who speaks it, and type what an ancestry calls it (leave blank to use the language's own name).",
+				"enableAlternateNames": "Show ancestry names for languages",
+				"alternateNamesHint": "When on, a language shows the name its ancestry uses for it (e.g. a Gnome sees \"Dwarvish (Gnomish)\"). Turn off to always show the plain language name.",
+				"selectAncestry": "Add an ancestry…",
+				"removeAncestry": "Remove ancestry",
+				"noAncestries": "No ancestry items found in your world or compendiums.",
+				"conflictError": "Two languages can't share the same name. Resolve the highlighted names before saving.",
 				"reset": "Reset to default",
 				"remove": "Remove language",
 				"newLanguage": "New Language",

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -2093,6 +2093,7 @@
 				"rename": "Rename",
 				"tooltip": "Tooltip",
 				"spokenBy": "Spoken by",
+				"spokenByEveryone": "Spoken by every ancestry — Common is always known.",
 				"spokenByHint": "Each ancestry below knows this language if its INT isn't negative. Add or remove ancestries to change who speaks it, and type what an ancestry calls it (leave blank to use the language's own name).",
 				"enableAlternateNames": "Show ancestry names for languages",
 				"alternateNamesHint": "When on, a language shows the name its ancestry uses for it (e.g. a Gnome sees \"Dwarvish (Gnomish)\"). Turn off to always show the plain language name.",

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -2094,7 +2094,7 @@
 				"tooltip": "Tooltip",
 				"spokenBy": "Spoken by",
 				"spokenByEveryone": "Spoken by every ancestry — Common is always known.",
-				"spokenByHint": "Each ancestry below knows this language if its INT isn't negative. Add or remove ancestries to change who speaks it, and type what an ancestry calls it (leave blank to use the language's own name).",
+				"spokenByHint": "Each ancestry selected for a language learns that language if its Intelligence isn't negative.",
 				"enableAlternateNames": "Show ancestry names for languages",
 				"alternateNamesHint": "When on, a language shows the name its ancestry uses for it (e.g. a Gnome sees \"Dwarvish (Gnomish)\"). Turn off to always show the plain language name.",
 				"selectAncestry": "Add an ancestry…",

--- a/src/config.ts
+++ b/src/config.ts
@@ -397,22 +397,16 @@ const languageHints = {
 	deepSpeak: 'NIMBLE.languageHints.deepSpeak',
 };
 
-const languageImages = {
-	common: 'icons/environment/people/group.webp',
-	dwarvish: 'icons/tools/smithing/crucible.webp',
-	elvish: 'icons/weapons/swords/sword-hilt-steel-green.webp',
-	goblin: 'icons/creatures/magical/humanoid-silhouette-green.webp',
-	infernal: 'icons/creatures/unholy/demon-horned-winged-laughing.webp',
-	thievesCant: 'icons/magic/perception/shadow-stealth-eyes-purple.webp',
-	celestial: 'icons/magic/holy/angel-winged-humanoid-blue.webp',
-	draconic: 'icons/creatures/reptiles/dragon-horned-blue.webp',
-	primordial: 'icons/creatures/magical/spirit-fire-orange.webp',
-	deepSpeak: 'icons/creatures/slimes/slime-giant-face-eyes.webp',
-};
+// Ancestry-scoped alternate display names for languages, keyed by language key.
+// Empty by default; populated at runtime from the GM's language customizations
+// setting. Each entry binds an alternate name to the ancestry identifiers that
+// use it (e.g. a Gnome calls `dwarvish` "Gnomish").
+const languageAlternateNames: Record<string, { name: string; ancestries: string[] }[]> = {};
 
-// Alternate display names for languages, keyed by language key. Empty by
-// default; populated at runtime from the GM's language customizations setting.
-const languageAliases: Record<string, string[]> = {};
+// GM-added ancestry→language grants beyond the ancestry rules, keyed by language
+// key with the ancestry identifiers that gain it (if INT is not negative).
+// Empty by default; populated at runtime from the language customizations setting.
+const languageSpeakers: Record<string, string[]> = {};
 
 const manaRecoveryTypes = {
 	fieldRest: 'NIMBLE.manaRecoveryTypes.fieldRest',
@@ -941,9 +935,9 @@ const NIMBLE = {
 	hitDice,
 	hitPoints,
 	jsonExport,
-	languageAliases,
+	languageAlternateNames,
 	languageHints,
-	languageImages,
+	languageSpeakers,
 	languages,
 	skillCheckDialog,
 	levelDownDialog,

--- a/src/config.ts
+++ b/src/config.ts
@@ -410,6 +410,10 @@ const languageImages = {
 	deepSpeak: 'icons/creatures/slimes/slime-giant-face-eyes.webp',
 };
 
+// Alternate display names for languages, keyed by language key. Empty by
+// default; populated at runtime from the GM's language customizations setting.
+const languageAliases: Record<string, string[]> = {};
+
 const manaRecoveryTypes = {
 	fieldRest: 'NIMBLE.manaRecoveryTypes.fieldRest',
 	safeRest: 'NIMBLE.manaRecoveryTypes.safeRest',
@@ -937,6 +941,7 @@ const NIMBLE = {
 	hitDice,
 	hitPoints,
 	jsonExport,
+	languageAliases,
 	languageHints,
 	languageImages,
 	languages,

--- a/src/documents/actor/character.ts
+++ b/src/documents/actor/character.ts
@@ -145,7 +145,32 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 
 		super.prepareData();
 
+		this._applyConfiguredLanguageGrants();
 		this._prepareArmorClass();
+	}
+
+	/**
+	 * Apply GM-configured ancestry→language grants from the language-customization
+	 * setting, on top of the ancestry items' own grants. Mirrors the ancestry rule:
+	 * "You know {Language} if your INT is not negative."
+	 */
+	private _applyConfiguredLanguageGrants(): void {
+		const speakers = (CONFIG.NIMBLE as unknown as { languageSpeakers?: Record<string, string[]> })
+			.languageSpeakers;
+		if (!speakers) return;
+
+		const ancestryIdentifier = this.ancestry?.identifier;
+		if (!ancestryIdentifier) return;
+
+		const intelligenceMod = this.system.abilities?.intelligence?.mod ?? 0;
+		const known = this.system.proficiencies.languages;
+		for (const [languageKey, ancestries] of Object.entries(speakers)) {
+			if (!ancestries.includes(ancestryIdentifier)) continue;
+			// Common is known by everyone regardless of INT; other ancestry languages
+			// require a non-negative INT ("You know {Language} if your INT is not negative").
+			if (languageKey !== 'common' && intelligenceMod < 0) continue;
+			known.add(languageKey);
+		}
 	}
 
 	override prepareBaseData(): void {

--- a/src/documents/actor/character.ts
+++ b/src/documents/actor/character.ts
@@ -150,11 +150,15 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 	}
 
 	/**
-	 * Apply GM-configured ancestry→language grants from the language-customization
-	 * setting, on top of the ancestry items' own grants. Mirrors the ancestry rule:
-	 * "You know {Language} if your INT is not negative."
+	 * Apply language grants beyond the items on the actor:
+	 *  - Common is universal — every character speaks it, regardless of ancestry or INT.
+	 *  - GM-configured ancestry→language grants from the language-customization setting,
+	 *    mirroring the ancestry rule: "You know {Language} if your INT is not negative."
 	 */
 	private _applyConfiguredLanguageGrants(): void {
+		const known = this.system.proficiencies.languages;
+		if ('common' in CONFIG.NIMBLE.languages) known.add('common');
+
 		const speakers = (CONFIG.NIMBLE as unknown as { languageSpeakers?: Record<string, string[]> })
 			.languageSpeakers;
 		if (!speakers) return;
@@ -162,14 +166,11 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 		const ancestryIdentifier = this.ancestry?.identifier;
 		if (!ancestryIdentifier) return;
 
-		const intelligenceMod = this.system.abilities?.intelligence?.mod ?? 0;
-		const known = this.system.proficiencies.languages;
+		// "...if your INT is not negative."
+		if ((this.system.abilities?.intelligence?.mod ?? 0) < 0) return;
+
 		for (const [languageKey, ancestries] of Object.entries(speakers)) {
-			if (!ancestries.includes(ancestryIdentifier)) continue;
-			// Common is known by everyone regardless of INT; other ancestry languages
-			// require a non-negative INT ("You know {Language} if your INT is not negative").
-			if (languageKey !== 'common' && intelligenceMod < 0) continue;
-			known.add(languageKey);
+			if (ancestries.includes(ancestryIdentifier)) known.add(languageKey);
 		}
 	}
 

--- a/src/documents/dialogs/CharacterCreationDialog.svelte.ts
+++ b/src/documents/dialogs/CharacterCreationDialog.svelte.ts
@@ -525,14 +525,17 @@ export default class CharacterCreationDialog extends SvelteApplicationMixin(Appl
 	}
 
 	prepareBonusLanguageOptions() {
-		const { languages, languageHints } = CONFIG.NIMBLE;
+		const { languages, languageHints, languageAliases } = CONFIG.NIMBLE;
 		const { common: _, ...languageOptions } = languages;
 
-		return Object.entries(languageOptions).map(([value, label]) => ({
-			value,
-			label,
-			tooltip: languageHints[value],
-		}));
+		return Object.entries(languageOptions).map(([value, label]) => {
+			const aliases = languageAliases?.[value] ?? [];
+			return {
+				value,
+				label: aliases.length ? `${label} (${aliases.join(', ')})` : label,
+				tooltip: languageHints[value],
+			};
+		});
 	}
 
 	async prepareClassOptions(): Promise<NimbleClassItem[]> {

--- a/src/documents/dialogs/CharacterCreationDialog.svelte.ts
+++ b/src/documents/dialogs/CharacterCreationDialog.svelte.ts
@@ -525,17 +525,14 @@ export default class CharacterCreationDialog extends SvelteApplicationMixin(Appl
 	}
 
 	prepareBonusLanguageOptions() {
-		const { languages, languageHints, languageAliases } = CONFIG.NIMBLE;
+		const { languages, languageHints } = CONFIG.NIMBLE;
 		const { common: _, ...languageOptions } = languages;
 
-		return Object.entries(languageOptions).map(([value, label]) => {
-			const aliases = languageAliases?.[value] ?? [];
-			return {
-				value,
-				label: aliases.length ? `${label} (${aliases.join(', ')})` : label,
-				tooltip: languageHints[value],
-			};
-		});
+		return Object.entries(languageOptions).map(([value, label]) => ({
+			value,
+			label,
+			tooltip: languageHints[value],
+		}));
 	}
 
 	async prepareClassOptions(): Promise<NimbleClassItem[]> {

--- a/src/hooks/ready.ts
+++ b/src/hooks/ready.ts
@@ -5,7 +5,10 @@ import { MigrationList } from '../migration/MigrationList.js';
 import { MigrationRunner } from '../migration/MigrationRunner.js';
 import { MigrationRunnerBase } from '../migration/MigrationRunnerBase.js';
 import { getAdjacencySyncEnabled } from '../settings/adjacencySettings.js';
-import { applyLanguageCustomizations } from '../settings/languageSettings.js';
+import {
+	applyLanguageCustomizations,
+	loadAncestryLanguageDefaults,
+} from '../settings/languageSettings.js';
 import { registerCombatTurnSocketListener } from '../utils/combatTurnActions.js';
 import CanvasConditionsPanel from '../view/ui/CanvasConditionsPanel.svelte';
 import CtTopTracker from '../view/ui/CtTopTracker.svelte';
@@ -45,7 +48,13 @@ export default async function ready() {
 	}
 
 	game.nimble.conditions.configureStatusEffects();
+	await loadAncestryLanguageDefaults();
 	applyLanguageCustomizations();
+	// Actors were prepared during world init before language grants became managed,
+	// so re-prepare characters once so any GM language overrides take effect.
+	for (const actor of game.actors ?? []) {
+		if (actor?.type === 'character') actor.prepareData?.();
+	}
 	registerCombatTurnSocketListener();
 
 	const target = document.body;

--- a/src/hooks/ready.ts
+++ b/src/hooks/ready.ts
@@ -5,6 +5,7 @@ import { MigrationList } from '../migration/MigrationList.js';
 import { MigrationRunner } from '../migration/MigrationRunner.js';
 import { MigrationRunnerBase } from '../migration/MigrationRunnerBase.js';
 import { getAdjacencySyncEnabled } from '../settings/adjacencySettings.js';
+import { applyLanguageCustomizations } from '../settings/languageSettings.js';
 import { registerCombatTurnSocketListener } from '../utils/combatTurnActions.js';
 import CanvasConditionsPanel from '../view/ui/CanvasConditionsPanel.svelte';
 import CtTopTracker from '../view/ui/CtTopTracker.svelte';
@@ -44,6 +45,7 @@ export default async function ready() {
 	}
 
 	game.nimble.conditions.configureStatusEffects();
+	applyLanguageCustomizations();
 	registerCombatTurnSocketListener();
 
 	const target = document.body;

--- a/src/models/rules/grantProficiencies.ts
+++ b/src/models/rules/grantProficiencies.ts
@@ -25,6 +25,17 @@ function schema() {
 			}),
 			{ required: true, nullable: false },
 		),
+		// For language grants only: the name the granting item's ancestry uses for
+		// the language (e.g. a Gnome "calls Dwarvish Gnomish"). Drives the
+		// ancestry-scoped alternate name shown on sheets. Empty = use the default.
+		displayAs: new fields.StringField({
+			required: false,
+			nullable: false,
+			initial: '',
+			label: 'NIMBLE.rules.grantProficiency.displayAs.label',
+			hint: 'NIMBLE.rules.grantProficiency.displayAs.hint',
+			showWhen: (data) => data.proficiencyType === 'languages',
+		} as unknown as never),
 		type: new fields.StringField({ required: true, nullable: false, initial: 'grantProficiency' }),
 	};
 }
@@ -53,6 +64,7 @@ class GrantProficiencyRule extends NimbleBaseRule<GrantProficiencyRule.Schema> {
 			new Map([
 				['values', 'string[]'],
 				['propertyType', 'armor | languages | weapons'],
+				['displayAs', 'string'],
 			]),
 		);
 	}
@@ -64,6 +76,19 @@ class GrantProficiencyRule extends NimbleBaseRule<GrantProficiencyRule.Schema> {
 
 		const actor = item.actor as NimbleCharacter;
 		const { proficiencyType } = this;
+
+		// Ancestry language grants are governed by the In-Game Languages settings
+		// (seeded from these same rules, then editable and authoritative at runtime).
+		// Once that layer is active the character applies them itself, so skip here
+		// to honor GM edits/removals. Falls through normally until then (e.g. tests,
+		// initial load) so languages are never silently dropped.
+		if (
+			proficiencyType === 'languages' &&
+			item.type === 'ancestry' &&
+			(CONFIG.NIMBLE as unknown as { languageGrantsManaged?: boolean }).languageGrantsManaged
+		) {
+			return;
+		}
 		let { values } = this;
 		const property = foundry.utils.getProperty(
 			actor,

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -2,10 +2,12 @@ import type { Component } from 'svelte';
 import GenericDialog from '#documents/dialogs/GenericDialog.svelte.js';
 import { SYSTEM_ID } from '#system';
 import DiceTestbench from '#view/debug/DiceTestbench.svelte';
+import LanguageCustomizationDialog from '#view/dialogs/LanguageCustomizationDialog.svelte';
 import { MigrationRunnerBase } from '../migration/MigrationRunnerBase.js';
 import { registerAdjacencySettings } from './adjacencySettings.js';
 import { registerCombatTrackerSettings } from './combatTrackerSettings.js';
 import { AUTO_ADD_CHARACTER_TO_COMBAT_ON_INITIATIVE_ROLL_SETTING_KEY } from './initiativeSettings.js';
+import { registerLanguageSettings } from './languageSettings.js';
 import { registerNcswSettings } from './ncswSettings.js';
 
 export const DEBUG_MODE_SETTING_KEY = 'debugMode';
@@ -98,6 +100,7 @@ export default function registerSystemSettings() {
 
 	registerCombatTrackerSettings();
 	registerNcswSettings();
+	registerLanguageSettings();
 
 	game.settings.register(
 		SYSTEM_ID as 'core',
@@ -165,6 +168,62 @@ export default function registerSystemSettings() {
 		if (systemTab.querySelector('.nimble-attribution')) return;
 
 		systemTab.appendChild(createAttributionElement());
+	});
+
+	Hooks.on('renderSettingsConfig', (_app: unknown, html: HTMLElement | JQuery) => {
+		if (!game.user?.isGM) return;
+
+		const element = html instanceof HTMLElement ? html : html[0];
+		if (!element) return;
+
+		const systemTab =
+			element.querySelector('section[data-tab="system"]') ||
+			element.querySelector('section[data-category="system"]');
+		if (!systemTab) return;
+
+		if (systemTab.querySelector('.nimble-language-customization-launch')) return;
+
+		const wrapper = document.createElement('div');
+		wrapper.className = 'form-group nimble-language-customization-launch';
+
+		const label = document.createElement('label');
+		label.textContent = game.i18n.localize('NIMBLE.settings.languageCustomization.name');
+
+		const fields = document.createElement('div');
+		fields.className = 'form-fields';
+
+		const button = document.createElement('button');
+		button.type = 'button';
+		button.innerHTML = `<i class="fa-solid fa-language"></i> ${game.i18n.localize(
+			'NIMBLE.settings.languageCustomization.button',
+		)}`;
+		button.addEventListener('click', (ev) => {
+			ev.preventDefault();
+			const dialog = GenericDialog.getOrCreate(
+				game.i18n.localize('NIMBLE.settings.languageCustomization.title'),
+				LanguageCustomizationDialog as unknown as Component<Record<string, never>>,
+				{},
+				{
+					uniqueId: 'nimble-language-customization',
+					icon: 'fa-solid fa-language',
+					width: 640,
+					resizable: true,
+				},
+			);
+			dialog.render(true);
+		});
+
+		fields.appendChild(button);
+
+		const hint = document.createElement('p');
+		hint.className = 'hint';
+		hint.textContent = game.i18n.localize('NIMBLE.settings.languageCustomization.hint');
+
+		wrapper.appendChild(label);
+		wrapper.appendChild(fields);
+		wrapper.appendChild(hint);
+
+		systemTab.appendChild(wrapper);
 	});
 
 	Hooks.on('renderSettingsConfig', (_app: unknown, html: HTMLElement | JQuery) => {

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -223,7 +223,8 @@ export default function registerSystemSettings() {
 		wrapper.appendChild(fields);
 		wrapper.appendChild(hint);
 
-		systemTab.appendChild(wrapper);
+		// Surface the launcher at the top of the system tab so it's easy to find.
+		systemTab.prepend(wrapper);
 	});
 
 	Hooks.on('renderSettingsConfig', (_app: unknown, html: HTMLElement | JQuery) => {

--- a/src/settings/languageSettings.test.ts
+++ b/src/settings/languageSettings.test.ts
@@ -222,7 +222,7 @@ describe('ancestry language defaults', () => {
 		]);
 	});
 
-	it('marks Common as spoken by every ancestry (even non-language ones)', async () => {
+	it('does not enumerate ancestries for Common (it is universal, granted on the actor)', async () => {
 		const {
 			applyLanguageCustomizations,
 			loadAncestryLanguageDefaults,
@@ -234,11 +234,8 @@ describe('ancestry language defaults', () => {
 		await loadAncestryLanguageDefaults();
 		applyLanguageCustomizations();
 
-		expect(getAncestryLanguageDefaults().common).toEqual([
-			{ ancestry: 'gnome', alias: '' },
-			{ ancestry: 'human', alias: '' },
-		]);
-		expect(nimble().languageSpeakers.common).toEqual(['gnome', 'human']);
+		expect(getAncestryLanguageDefaults().common).toBeUndefined();
+		expect(nimble().languageSpeakers.common).toBeUndefined();
 	});
 
 	it('lets a GM override the rule defaults (and removals stick)', async () => {

--- a/src/settings/languageSettings.test.ts
+++ b/src/settings/languageSettings.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { LanguageCustomizations } from './languageSettings.js';
+import getLanguageName from '../utils/getLanguageName.js';
+import { findLanguageNameConflicts, type LanguageCustomizations } from './languageSettings.js';
 
 type LanguageSettingsModule = typeof import('./languageSettings.js');
 
@@ -7,15 +8,28 @@ type LanguageSettingsModule = typeof import('./languageSettings.js');
 // pristine built-in language maps before any customization is applied.
 const PRISTINE_LANGUAGES = { ...CONFIG.NIMBLE.languages };
 const PRISTINE_HINTS = { ...CONFIG.NIMBLE.languageHints };
-const PRISTINE_IMAGES = { ...CONFIG.NIMBLE.languageImages };
 
 let customizations: LanguageCustomizations;
 
+type NimbleConfig = {
+	languages: Record<string, string>;
+	languageHints: Record<string, string>;
+	languageAlternateNames: Record<string, unknown>;
+	languageSpeakers: Record<string, string[]>;
+	languageGrantsManaged?: boolean;
+};
+
+function nimble(): NimbleConfig {
+	return CONFIG.NIMBLE as unknown as NimbleConfig;
+}
+
 function restorePristineConfig(): void {
-	CONFIG.NIMBLE.languages = { ...PRISTINE_LANGUAGES } as typeof CONFIG.NIMBLE.languages;
-	CONFIG.NIMBLE.languageHints = { ...PRISTINE_HINTS } as typeof CONFIG.NIMBLE.languageHints;
-	CONFIG.NIMBLE.languageImages = { ...PRISTINE_IMAGES } as typeof CONFIG.NIMBLE.languageImages;
-	CONFIG.NIMBLE.languageAliases = {};
+	const config = nimble();
+	config.languages = { ...PRISTINE_LANGUAGES };
+	config.languageHints = { ...PRISTINE_HINTS };
+	config.languageAlternateNames = {};
+	config.languageSpeakers = {};
+	config.languageGrantsManaged = false;
 }
 
 async function loadModule(): Promise<LanguageSettingsModule> {
@@ -26,7 +40,7 @@ async function loadModule(): Promise<LanguageSettingsModule> {
 
 beforeEach(() => {
 	restorePristineConfig();
-	customizations = { overrides: {}, custom: [] };
+	customizations = { overrides: {}, custom: [], alternateNamesEnabled: true };
 	(game as unknown as { settings: Record<string, ReturnType<typeof vi.fn>> }).settings = {
 		get: vi.fn(() => customizations),
 		set: vi.fn().mockResolvedValue(undefined),
@@ -45,36 +59,56 @@ describe('applyLanguageCustomizations', () => {
 		expect(CONFIG.NIMBLE.languages.common).toBe(PRISTINE_LANGUAGES.common);
 	});
 
-	it('stores alternate names in languageAliases', async () => {
-		const { applyLanguageCustomizations } = await loadModule();
-		customizations.overrides = { common: { aliases: ['Trade Tongue', 'Lingua'] } };
-
-		applyLanguageCustomizations();
-
-		expect(CONFIG.NIMBLE.languageAliases.common).toEqual(['Trade Tongue', 'Lingua']);
-	});
-
-	it('overrides hint and image for a built-in language', async () => {
+	it('publishes ancestry aliases and speakers from a GM override', async () => {
 		const { applyLanguageCustomizations } = await loadModule();
 		customizations.overrides = {
-			elvish: { hint: 'Custom hint', image: 'icons/custom.webp' },
+			dwarvish: {
+				speakers: [
+					{ ancestry: 'dwarf', alias: '' },
+					{ ancestry: 'gnome', alias: 'Gnomish' },
+				],
+			},
 		};
 
 		applyLanguageCustomizations();
 
-		expect(CONFIG.NIMBLE.languageHints.elvish).toBe('Custom hint');
-		expect(CONFIG.NIMBLE.languageImages.elvish).toBe('icons/custom.webp');
+		expect(nimble().languageAlternateNames.dwarvish).toEqual([
+			{ name: 'Gnomish', ancestries: ['gnome'] },
+		]);
+		expect(nimble().languageSpeakers.dwarvish).toEqual(['dwarf', 'gnome']);
+		expect(nimble().languageGrantsManaged).toBe(true);
 	});
 
-	it('adds custom languages with their hint, image, and aliases', async () => {
+	it('omits aliases when alternate names are disabled (grants still publish)', async () => {
+		const { applyLanguageCustomizations } = await loadModule();
+		customizations.alternateNamesEnabled = false;
+		customizations.overrides = {
+			dwarvish: { speakers: [{ ancestry: 'gnome', alias: 'Gnomish' }] },
+		};
+
+		applyLanguageCustomizations();
+
+		expect(nimble().languageAlternateNames).toEqual({});
+		expect(nimble().languageSpeakers.dwarvish).toEqual(['gnome']);
+	});
+
+	it('overrides the hint for a built-in language', async () => {
+		const { applyLanguageCustomizations } = await loadModule();
+		customizations.overrides = { elvish: { hint: 'Custom hint' } };
+
+		applyLanguageCustomizations();
+
+		expect(CONFIG.NIMBLE.languageHints.elvish).toBe('Custom hint');
+	});
+
+	it('adds custom languages with their hint and speakers', async () => {
 		const { applyLanguageCustomizations } = await loadModule();
 		customizations.custom = [
 			{
 				key: 'sylvanCant',
 				label: 'Sylvan Cant',
-				aliases: ['Fey Speech'],
 				hint: 'Spoken by the fey.',
-				image: 'icons/sylvan.webp',
+				speakers: [{ ancestry: 'dryadshroomling', alias: 'Fey Speech' }],
 			},
 		];
 
@@ -82,11 +116,12 @@ describe('applyLanguageCustomizations', () => {
 
 		const languages = CONFIG.NIMBLE.languages as Record<string, string>;
 		const hints = CONFIG.NIMBLE.languageHints as Record<string, string>;
-		const images = CONFIG.NIMBLE.languageImages as Record<string, string>;
 		expect(languages.sylvanCant).toBe('Sylvan Cant');
 		expect(hints.sylvanCant).toBe('Spoken by the fey.');
-		expect(images.sylvanCant).toBe('icons/sylvan.webp');
-		expect(CONFIG.NIMBLE.languageAliases.sylvanCant).toEqual(['Fey Speech']);
+		expect(nimble().languageAlternateNames.sylvanCant).toEqual([
+			{ name: 'Fey Speech', ancestries: ['dryadshroomling'] },
+		]);
+		expect(nimble().languageSpeakers.sylvanCant).toEqual(['dryadshroomling']);
 	});
 
 	it('ignores overrides for unknown built-in keys', async () => {
@@ -108,20 +143,143 @@ describe('applyLanguageCustomizations', () => {
 		applyLanguageCustomizations();
 
 		expect(CONFIG.NIMBLE.languages.goblin).toBe(PRISTINE_LANGUAGES.goblin);
-		expect(CONFIG.NIMBLE.languageAliases).toEqual({});
 	});
 });
 
-describe('registerLanguageSettings', () => {
-	it('registers a world-scoped, non-config object setting', async () => {
-		const { registerLanguageSettings } = await loadModule();
-		const settingsMock = (game as unknown as { settings: { register: ReturnType<typeof vi.fn> } })
-			.settings;
+describe('findLanguageNameConflicts', () => {
+	it('flags entries that share a name (case-insensitive)', () => {
+		const conflicts = findLanguageNameConflicts([
+			{ id: 'builtin:dwarvish', name: 'Celestial' },
+			{ id: 'builtin:celestial', name: 'celestial' },
+			{ id: 'builtin:common', name: 'Common' },
+		]);
 
-		registerLanguageSettings();
+		expect(conflicts).toEqual(new Set(['builtin:dwarvish', 'builtin:celestial']));
+	});
 
-		const [, key, options] = settingsMock.register.mock.calls[0];
-		expect(key).toBe('languageCustomizations');
-		expect(options).toMatchObject({ scope: 'world', config: false });
+	it('returns an empty set when all names are unique', () => {
+		const conflicts = findLanguageNameConflicts([
+			{ id: 'a', name: 'Dwarvish' },
+			{ id: 'b', name: 'Elvish' },
+		]);
+
+		expect(conflicts.size).toBe(0);
+	});
+
+	it('ignores blank names', () => {
+		const conflicts = findLanguageNameConflicts([
+			{ id: 'a', name: '   ' },
+			{ id: 'b', name: '' },
+		]);
+
+		expect(conflicts.size).toBe(0);
+	});
+});
+
+describe('ancestry language defaults', () => {
+	const gnomeAncestry = {
+		type: 'ancestry',
+		name: 'Gnome',
+		identifier: 'gnome',
+		system: {
+			rules: [
+				{
+					type: 'grantProficiency',
+					proficiencyType: 'languages',
+					values: ['dwarvish'],
+					displayAs: 'Gnomish',
+				},
+			],
+		},
+	};
+
+	function mockAncestrySources(items: unknown[]): void {
+		(game as unknown as { items: unknown[]; packs: unknown[] }).items = items;
+		(game as unknown as { items: unknown[]; packs: unknown[] }).packs = [];
+	}
+
+	it('seeds aliases and speakers from ancestry rules with zero GM setup', async () => {
+		const { applyLanguageCustomizations, loadAncestryLanguageDefaults } = await loadModule();
+		mockAncestrySources([gnomeAncestry]);
+
+		await loadAncestryLanguageDefaults();
+		applyLanguageCustomizations();
+
+		expect(nimble().languageAlternateNames.dwarvish).toEqual([
+			{ name: 'Gnomish', ancestries: ['gnome'] },
+		]);
+		expect(nimble().languageSpeakers.dwarvish).toEqual(['gnome']);
+	});
+
+	it('exposes the defaults to the editor', async () => {
+		const { loadAncestryLanguageDefaults, getAncestryLanguageDefaults } = await loadModule();
+		mockAncestrySources([gnomeAncestry]);
+
+		await loadAncestryLanguageDefaults();
+
+		expect(getAncestryLanguageDefaults().dwarvish).toEqual([
+			{ ancestry: 'gnome', alias: 'Gnomish' },
+		]);
+	});
+
+	it('marks Common as spoken by every ancestry (even non-language ones)', async () => {
+		const {
+			applyLanguageCustomizations,
+			loadAncestryLanguageDefaults,
+			getAncestryLanguageDefaults,
+		} = await loadModule();
+		const human = { type: 'ancestry', name: 'Human', identifier: 'human', system: { rules: [] } };
+		mockAncestrySources([gnomeAncestry, human]);
+
+		await loadAncestryLanguageDefaults();
+		applyLanguageCustomizations();
+
+		expect(getAncestryLanguageDefaults().common).toEqual([
+			{ ancestry: 'gnome', alias: '' },
+			{ ancestry: 'human', alias: '' },
+		]);
+		expect(nimble().languageSpeakers.common).toEqual(['gnome', 'human']);
+	});
+
+	it('lets a GM override the rule defaults (and removals stick)', async () => {
+		const { applyLanguageCustomizations, loadAncestryLanguageDefaults } = await loadModule();
+		mockAncestrySources([gnomeAncestry]);
+		// GM removed the gnome speaker entirely.
+		customizations.overrides = { dwarvish: { speakers: [] } };
+
+		await loadAncestryLanguageDefaults();
+		applyLanguageCustomizations();
+
+		expect(nimble().languageSpeakers.dwarvish).toBeUndefined();
+		expect(nimble().languageAlternateNames.dwarvish).toBeUndefined();
+	});
+});
+
+describe('getLanguageName', () => {
+	beforeEach(() => {
+		nimble().languages = { ...PRISTINE_LANGUAGES };
+		nimble().languageAlternateNames = {
+			dwarvish: [{ name: 'Gnomish', ancestries: ['gnome'] }],
+		};
+	});
+
+	it('annotates the canonical label with the alternate name for a matching ancestry', () => {
+		expect(getLanguageName('dwarvish', { ancestryIdentifier: 'gnome' })).toBe(
+			`${PRISTINE_LANGUAGES.dwarvish} (Gnomish)`,
+		);
+	});
+
+	it('returns the canonical label for a non-matching ancestry', () => {
+		expect(getLanguageName('dwarvish', { ancestryIdentifier: 'dwarf' })).toBe(
+			PRISTINE_LANGUAGES.dwarvish,
+		);
+	});
+
+	it('returns the canonical label when no ancestry is provided', () => {
+		expect(getLanguageName('dwarvish')).toBe(PRISTINE_LANGUAGES.dwarvish);
+	});
+
+	it('falls back to the key for unknown languages', () => {
+		expect(getLanguageName('madeUpKey', { ancestryIdentifier: 'gnome' })).toBe('madeUpKey');
 	});
 });

--- a/src/settings/languageSettings.test.ts
+++ b/src/settings/languageSettings.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { LanguageCustomizations } from './languageSettings.js';
+
+type LanguageSettingsModule = typeof import('./languageSettings.js');
+
+// CONFIG.NIMBLE is initialized + localized by tests/setup.ts, so these are the
+// pristine built-in language maps before any customization is applied.
+const PRISTINE_LANGUAGES = { ...CONFIG.NIMBLE.languages };
+const PRISTINE_HINTS = { ...CONFIG.NIMBLE.languageHints };
+const PRISTINE_IMAGES = { ...CONFIG.NIMBLE.languageImages };
+
+let customizations: LanguageCustomizations;
+
+function restorePristineConfig(): void {
+	CONFIG.NIMBLE.languages = { ...PRISTINE_LANGUAGES } as typeof CONFIG.NIMBLE.languages;
+	CONFIG.NIMBLE.languageHints = { ...PRISTINE_HINTS } as typeof CONFIG.NIMBLE.languageHints;
+	CONFIG.NIMBLE.languageImages = { ...PRISTINE_IMAGES } as typeof CONFIG.NIMBLE.languageImages;
+	CONFIG.NIMBLE.languageAliases = {};
+}
+
+async function loadModule(): Promise<LanguageSettingsModule> {
+	// Fresh module so the captured baseline re-derives from the restored config.
+	vi.resetModules();
+	return import('./languageSettings.js');
+}
+
+beforeEach(() => {
+	restorePristineConfig();
+	customizations = { overrides: {}, custom: [] };
+	(game as unknown as { settings: Record<string, ReturnType<typeof vi.fn>> }).settings = {
+		get: vi.fn(() => customizations),
+		set: vi.fn().mockResolvedValue(undefined),
+		register: vi.fn(),
+	};
+});
+
+describe('applyLanguageCustomizations', () => {
+	it('renames a built-in language label without touching others', async () => {
+		const { applyLanguageCustomizations } = await loadModule();
+		customizations.overrides = { goblin: { label: 'Orcish' } };
+
+		applyLanguageCustomizations();
+
+		expect(CONFIG.NIMBLE.languages.goblin).toBe('Orcish');
+		expect(CONFIG.NIMBLE.languages.common).toBe(PRISTINE_LANGUAGES.common);
+	});
+
+	it('stores alternate names in languageAliases', async () => {
+		const { applyLanguageCustomizations } = await loadModule();
+		customizations.overrides = { common: { aliases: ['Trade Tongue', 'Lingua'] } };
+
+		applyLanguageCustomizations();
+
+		expect(CONFIG.NIMBLE.languageAliases.common).toEqual(['Trade Tongue', 'Lingua']);
+	});
+
+	it('overrides hint and image for a built-in language', async () => {
+		const { applyLanguageCustomizations } = await loadModule();
+		customizations.overrides = {
+			elvish: { hint: 'Custom hint', image: 'icons/custom.webp' },
+		};
+
+		applyLanguageCustomizations();
+
+		expect(CONFIG.NIMBLE.languageHints.elvish).toBe('Custom hint');
+		expect(CONFIG.NIMBLE.languageImages.elvish).toBe('icons/custom.webp');
+	});
+
+	it('adds custom languages with their hint, image, and aliases', async () => {
+		const { applyLanguageCustomizations } = await loadModule();
+		customizations.custom = [
+			{
+				key: 'sylvanCant',
+				label: 'Sylvan Cant',
+				aliases: ['Fey Speech'],
+				hint: 'Spoken by the fey.',
+				image: 'icons/sylvan.webp',
+			},
+		];
+
+		applyLanguageCustomizations();
+
+		const languages = CONFIG.NIMBLE.languages as Record<string, string>;
+		const hints = CONFIG.NIMBLE.languageHints as Record<string, string>;
+		const images = CONFIG.NIMBLE.languageImages as Record<string, string>;
+		expect(languages.sylvanCant).toBe('Sylvan Cant');
+		expect(hints.sylvanCant).toBe('Spoken by the fey.');
+		expect(images.sylvanCant).toBe('icons/sylvan.webp');
+		expect(CONFIG.NIMBLE.languageAliases.sylvanCant).toEqual(['Fey Speech']);
+	});
+
+	it('ignores overrides for unknown built-in keys', async () => {
+		const { applyLanguageCustomizations } = await loadModule();
+		customizations.overrides = { notALanguage: { label: 'Nope' } };
+
+		applyLanguageCustomizations();
+
+		expect((CONFIG.NIMBLE.languages as Record<string, string>).notALanguage).toBeUndefined();
+	});
+
+	it('restores built-in defaults when an override is removed (idempotent)', async () => {
+		const { applyLanguageCustomizations } = await loadModule();
+		customizations.overrides = { goblin: { label: 'Orcish' } };
+		applyLanguageCustomizations();
+		expect(CONFIG.NIMBLE.languages.goblin).toBe('Orcish');
+
+		customizations.overrides = {};
+		applyLanguageCustomizations();
+
+		expect(CONFIG.NIMBLE.languages.goblin).toBe(PRISTINE_LANGUAGES.goblin);
+		expect(CONFIG.NIMBLE.languageAliases).toEqual({});
+	});
+});
+
+describe('registerLanguageSettings', () => {
+	it('registers a world-scoped, non-config object setting', async () => {
+		const { registerLanguageSettings } = await loadModule();
+		const settingsMock = (game as unknown as { settings: { register: ReturnType<typeof vi.fn> } })
+			.settings;
+
+		registerLanguageSettings();
+
+		const [, key, options] = settingsMock.register.mock.calls[0];
+		expect(key).toBe('languageCustomizations');
+		expect(options).toMatchObject({ scope: 'world', config: false });
+	});
+});

--- a/src/settings/languageSettings.ts
+++ b/src/settings/languageSettings.ts
@@ -2,16 +2,37 @@ import { SYSTEM_ID } from '#system';
 
 export const LANGUAGE_CUSTOMIZATIONS_SETTING_KEY = 'languageCustomizations';
 
+/**
+ * One ancestry that speaks a language, plus the name that ancestry uses for it.
+ * `alias` empty means the ancestry calls the language by its normal name; a
+ * non-empty alias is shown instead (e.g. a Gnome calls `dwarvish` "Gnomish").
+ */
+export interface LanguageSpeaker {
+	/** Ancestry identifier (slugified name, e.g. "gnome"). */
+	ancestry: string;
+	/** The ancestry's name for this language ('' = the language's normal name). */
+	alias: string;
+}
+
+/**
+ * Display-time alternate-name binding consumed by `getLanguageName`. Built into
+ * `CONFIG.NIMBLE.languageAlternateNames` by {@link applyLanguageCustomizations}.
+ */
+export interface LanguageAlternateName {
+	/** The display name shown to matching ancestries (e.g. "Gnomish"). */
+	name: string;
+	/** Ancestry identifiers that use this name. */
+	ancestries: string[];
+}
+
 /** Sparse override applied on top of a built-in language. */
 export interface LanguageOverride {
-	/** Renamed display label (falls back to the built-in label when omitted). */
+	/** World-wide renamed display label (falls back to the built-in label). */
 	label?: string;
-	/** Alternate display names shown alongside the label. */
-	aliases?: string[];
 	/** Replacement tooltip hint. */
 	hint?: string;
-	/** Replacement icon path. */
-	image?: string;
+	/** Full "spoken by" list when the GM has changed it from the ancestry defaults. */
+	speakers?: LanguageSpeaker[];
 }
 
 /** A fully GM-authored language. */
@@ -19,9 +40,8 @@ export interface CustomLanguage {
 	/** Stable key, generated from the label and unique across all languages. */
 	key: string;
 	label: string;
-	aliases: string[];
 	hint: string;
-	image: string;
+	speakers: LanguageSpeaker[];
 }
 
 export interface LanguageCustomizations {
@@ -29,9 +49,15 @@ export interface LanguageCustomizations {
 	overrides: Record<string, LanguageOverride>;
 	/** Languages added by the GM. */
 	custom: CustomLanguage[];
+	/** When false, ancestry alias names are ignored for display (grants still apply). */
+	alternateNamesEnabled: boolean;
 }
 
-const DEFAULT_CUSTOMIZATIONS: LanguageCustomizations = { overrides: {}, custom: [] };
+const DEFAULT_CUSTOMIZATIONS: LanguageCustomizations = {
+	overrides: {},
+	custom: [],
+	alternateNamesEnabled: true,
+};
 
 /**
  * Localized snapshot of the built-in language maps, captured the first time
@@ -42,7 +68,6 @@ const DEFAULT_CUSTOMIZATIONS: LanguageCustomizations = { overrides: {}, custom: 
 let baseline: {
 	languages: Record<string, string>;
 	languageHints: Record<string, string>;
-	languageImages: Record<string, string>;
 } | null = null;
 
 function captureBaseline(): void {
@@ -51,7 +76,6 @@ function captureBaseline(): void {
 	baseline = {
 		languages: { ...CONFIG.NIMBLE.languages },
 		languageHints: { ...CONFIG.NIMBLE.languageHints },
-		languageImages: { ...CONFIG.NIMBLE.languageImages },
 	};
 }
 
@@ -62,14 +86,12 @@ function captureBaseline(): void {
 export function getBuiltinLanguageBaseline(): {
 	languages: Record<string, string>;
 	languageHints: Record<string, string>;
-	languageImages: Record<string, string>;
 } {
 	captureBaseline();
 	return (
 		baseline ?? {
 			languages: { ...CONFIG.NIMBLE.languages },
 			languageHints: { ...CONFIG.NIMBLE.languageHints },
-			languageImages: { ...CONFIG.NIMBLE.languageImages },
 		}
 	);
 }
@@ -83,6 +105,7 @@ export function getLanguageCustomizations(): LanguageCustomizations {
 	return {
 		overrides: stored?.overrides ?? {},
 		custom: stored?.custom ?? [],
+		alternateNamesEnabled: stored?.alternateNamesEnabled ?? true,
 	};
 }
 
@@ -95,44 +118,209 @@ export async function setLanguageCustomizations(value: LanguageCustomizations): 
 }
 
 /**
- * Rebuild `CONFIG.NIMBLE.languages`, `languageHints`, `languageImages`, and
- * `languageAliases` from the immutable baseline plus the stored customizations.
- * Idempotent: always derives from `baseline`, so removing an override restores
- * the built-in default.
+ * Default "spoken by" list per language, derived from ancestry items (their
+ * `grantProficiency` language rules; `displayAs` becomes the alias). Built once
+ * at startup by scanning world + compendium ancestries. These ship with the
+ * Nimble rules so the right speakers and names appear with zero GM setup.
+ */
+let ancestryLanguageDefaults: Record<string, LanguageSpeaker[]> = {};
+
+interface AncestryLike {
+	type?: string;
+	name?: string;
+	identifier?: string;
+	system?: { rules?: Array<Record<string, unknown>> };
+}
+
+/** Resolve an ancestry's stable identifier (slugified name fallback). */
+function ancestryIdentifierOf(ancestry: AncestryLike): string {
+	if (ancestry.identifier) return ancestry.identifier;
+	const name = ancestry.name ?? '';
+	return (
+		(name as unknown as { slugify?: (o: { strict: boolean }) => string }).slugify?.({
+			strict: true,
+		}) ?? ''
+	);
+}
+
+/** Group an ancestryId→name map into `{ name, ancestries }[]` bindings. */
+function groupBindingsByName(byAncestry: Map<string, string>): LanguageAlternateName[] {
+	const byName = new Map<string, string[]>();
+	for (const [ancestryId, name] of byAncestry) {
+		const ancestries = byName.get(name) ?? [];
+		ancestries.push(ancestryId);
+		byName.set(name, ancestries);
+	}
+	return [...byName.entries()].map(([name, ancestries]) => ({ name, ancestries }));
+}
+
+/**
+ * Scan world + compendium ancestry items for language grants, and cache them as
+ * the built-in "spoken by" defaults (ancestry + any `displayAs` alias). Async
+ * because compendium rules live on full documents (not the index). Call once on
+ * `ready` before {@link applyLanguageCustomizations}.
+ */
+export async function loadAncestryLanguageDefaults(): Promise<void> {
+	// language key -> (ancestry identifier -> alias)
+	const byKey = new Map<string, Map<string, string>>();
+	// Every ancestry seen — Common is spoken by all of them.
+	const allAncestries = new Set<string>();
+
+	const collect = (items: Iterable<AncestryLike>): void => {
+		for (const item of items) {
+			if (item?.type !== 'ancestry') continue;
+			const identifier = ancestryIdentifierOf(item);
+			if (!identifier) continue;
+			allAncestries.add(identifier);
+
+			for (const rule of item.system?.rules ?? []) {
+				if (rule.type !== 'grantProficiency' || rule.proficiencyType !== 'languages') continue;
+				const alias = String(rule.displayAs ?? '').trim();
+
+				for (const langKey of (rule.values as string[] | undefined) ?? []) {
+					const byAncestry = byKey.get(langKey) ?? new Map<string, string>();
+					// Don't clobber an alias with a later empty one.
+					if (alias || !byAncestry.has(identifier)) byAncestry.set(identifier, alias);
+					byKey.set(langKey, byAncestry);
+				}
+			}
+		}
+	};
+
+	collect((game.items ?? []) as unknown as Iterable<AncestryLike>);
+
+	for (const pack of (game.packs ?? []) as unknown as Iterable<{
+		documentName?: string;
+		index?: Iterable<{ type?: string }>;
+		getDocuments: (query?: object) => Promise<unknown[]>;
+	}>) {
+		if (pack.documentName !== 'Item') continue;
+		const hasAncestry = [...(pack.index ?? [])].some((entry) => entry.type === 'ancestry');
+		if (!hasAncestry) continue;
+
+		const docs = await pack
+			.getDocuments({ type: 'ancestry' })
+			.catch(() => pack.getDocuments())
+			.catch(() => []);
+		collect(docs as Iterable<AncestryLike>);
+	}
+
+	// Common is spoken by every ancestry (preserve any alias an ancestry sets).
+	if ('common' in CONFIG.NIMBLE.languages && allAncestries.size) {
+		const commonByAncestry = byKey.get('common') ?? new Map<string, string>();
+		for (const identifier of allAncestries) {
+			if (!commonByAncestry.has(identifier)) commonByAncestry.set(identifier, '');
+		}
+		byKey.set('common', commonByAncestry);
+	}
+
+	const defaults: Record<string, LanguageSpeaker[]> = {};
+	for (const [key, byAncestry] of byKey) {
+		defaults[key] = [...byAncestry.entries()].map(([ancestry, alias]) => ({ ancestry, alias }));
+	}
+	ancestryLanguageDefaults = defaults;
+}
+
+/** The cached ancestry-derived "spoken by" defaults (see loader above). */
+export function getAncestryLanguageDefaults(): Record<string, LanguageSpeaker[]> {
+	return ancestryLanguageDefaults;
+}
+
+/** Normalize a display name for case-insensitive conflict comparison. */
+function normalizeName(name: string): string {
+	return name.trim().toLowerCase();
+}
+
+/**
+ * Detect languages that would share the same effective primary display name.
+ * `entries` is the full set of effective names (renamed built-ins, untouched
+ * built-ins, and custom languages), each tagged with a stable `id`. Returns the
+ * ids of every entry that collides with at least one other. Pure + side-effect
+ * free so the editor and tests can share it.
+ */
+export function findLanguageNameConflicts(entries: { id: string; name: string }[]): Set<string> {
+	const byName = new Map<string, string[]>();
+	for (const entry of entries) {
+		const key = normalizeName(entry.name);
+		if (!key) continue;
+		const ids = byName.get(key) ?? [];
+		ids.push(entry.id);
+		byName.set(key, ids);
+	}
+
+	const conflicting = new Set<string>();
+	for (const ids of byName.values()) {
+		if (ids.length > 1) for (const id of ids) conflicting.add(id);
+	}
+	return conflicting;
+}
+
+/**
+ * Rebuild the language config from the immutable baseline + ancestry defaults +
+ * stored GM customizations:
+ *  - `CONFIG.NIMBLE.languages` / `languageHints` — renamed labels and tooltips.
+ *  - `CONFIG.NIMBLE.languageAlternateNames` — display aliases per ancestry (used
+ *    by `getLanguageName`); skipped when `alternateNamesEnabled` is false.
+ *  - `CONFIG.NIMBLE.languageSpeakers` — ancestry→language grants the GM ADDED
+ *    beyond the ancestry rules (applied to characters at data-prep time). The
+ *    built-in ancestry grants still come from the ancestry items themselves.
+ * Idempotent: derives entirely from the baseline + defaults each call.
  */
 export function applyLanguageCustomizations(): void {
 	captureBaseline();
 	if (!baseline) return;
 
-	const { overrides, custom } = getLanguageCustomizations();
+	const { overrides, custom, alternateNamesEnabled } = getLanguageCustomizations();
 
 	const languages: Record<string, string> = { ...baseline.languages };
 	const languageHints: Record<string, string> = { ...baseline.languageHints };
-	const languageImages: Record<string, string> = { ...baseline.languageImages };
-	const languageAliases: Record<string, string[]> = {};
+	const languageAlternateNames: Record<string, LanguageAlternateName[]> = {};
+	const languageSpeakers: Record<string, string[]> = {};
 
-	// Apply overrides to built-in languages.
-	for (const [key, override] of Object.entries(overrides)) {
-		if (!(key in baseline.languages)) continue;
-		if (override.label) languages[key] = override.label;
-		if (override.hint !== undefined) languageHints[key] = override.hint;
-		if (override.image) languageImages[key] = override.image;
-		if (override.aliases?.length) languageAliases[key] = [...override.aliases];
+	const recordSpeakers = (key: string, speakers: LanguageSpeaker[]) => {
+		// Display aliases (ancestry -> alias) for this language.
+		if (alternateNamesEnabled) {
+			const byAncestry = new Map<string, string>();
+			for (const speaker of speakers) {
+				const alias = speaker.alias?.trim();
+				if (alias && speaker.ancestry) byAncestry.set(speaker.ancestry, alias);
+			}
+			if (byAncestry.size) languageAlternateNames[key] = groupBindingsByName(byAncestry);
+		}
+
+		// Full effective grant list: every ancestry that speaks the language. This
+		// is authoritative — the ancestry items' own language grants defer to it.
+		const ancestries = [...new Set(speakers.map((s) => s.ancestry).filter(Boolean))];
+		if (ancestries.length) languageSpeakers[key] = ancestries;
+	};
+
+	// Built-in languages: effective speakers = GM override, else ancestry defaults.
+	for (const key of Object.keys(baseline.languages)) {
+		const override = overrides[key];
+		if (override?.label) languages[key] = override.label;
+		if (override?.hint !== undefined) languageHints[key] = override.hint;
+
+		recordSpeakers(key, override?.speakers ?? ancestryLanguageDefaults[key] ?? []);
 	}
 
-	// Add custom languages.
+	// GM custom languages.
 	for (const language of custom) {
 		if (!language.key || !language.label) continue;
 		languages[language.key] = language.label;
 		languageHints[language.key] = language.hint ?? '';
-		languageImages[language.key] = language.image ?? '';
-		if (language.aliases?.length) languageAliases[language.key] = [...language.aliases];
+		recordSpeakers(language.key, language.speakers ?? []);
 	}
 
 	CONFIG.NIMBLE.languages = languages as typeof CONFIG.NIMBLE.languages;
 	CONFIG.NIMBLE.languageHints = languageHints as typeof CONFIG.NIMBLE.languageHints;
-	CONFIG.NIMBLE.languageImages = languageImages as typeof CONFIG.NIMBLE.languageImages;
-	CONFIG.NIMBLE.languageAliases = languageAliases;
+	CONFIG.NIMBLE.languageAlternateNames = languageAlternateNames;
+	const nimble = CONFIG.NIMBLE as unknown as {
+		languageSpeakers: Record<string, string[]>;
+		languageGrantsManaged: boolean;
+	};
+	nimble.languageSpeakers = languageSpeakers;
+	// Signals the grant rule that ancestry language grants are now governed here.
+	nimble.languageGrantsManaged = true;
 }
 
 /**
@@ -176,6 +364,10 @@ export function registerLanguageSettings(): void {
 			default: DEFAULT_CUSTOMIZATIONS,
 			onChange: () => {
 				applyLanguageCustomizations();
+				// Re-prepare characters so added/removed language grants take effect live.
+				for (const actor of game.actors ?? []) {
+					if (actor?.type === 'character') actor.prepareData?.();
+				}
 				rerenderLanguageConsumers();
 			},
 		} as unknown as Parameters<typeof game.settings.register>[2],

--- a/src/settings/languageSettings.ts
+++ b/src/settings/languageSettings.ts
@@ -163,15 +163,12 @@ function groupBindingsByName(byAncestry: Map<string, string>): LanguageAlternate
 export async function loadAncestryLanguageDefaults(): Promise<void> {
 	// language key -> (ancestry identifier -> alias)
 	const byKey = new Map<string, Map<string, string>>();
-	// Every ancestry seen — Common is spoken by all of them.
-	const allAncestries = new Set<string>();
 
 	const collect = (items: Iterable<AncestryLike>): void => {
 		for (const item of items) {
 			if (item?.type !== 'ancestry') continue;
 			const identifier = ancestryIdentifierOf(item);
 			if (!identifier) continue;
-			allAncestries.add(identifier);
 
 			for (const rule of item.system?.rules ?? []) {
 				if (rule.type !== 'grantProficiency' || rule.proficiencyType !== 'languages') continue;
@@ -203,15 +200,6 @@ export async function loadAncestryLanguageDefaults(): Promise<void> {
 			.catch(() => pack.getDocuments())
 			.catch(() => []);
 		collect(docs as Iterable<AncestryLike>);
-	}
-
-	// Common is spoken by every ancestry (preserve any alias an ancestry sets).
-	if ('common' in CONFIG.NIMBLE.languages && allAncestries.size) {
-		const commonByAncestry = byKey.get('common') ?? new Map<string, string>();
-		for (const identifier of allAncestries) {
-			if (!commonByAncestry.has(identifier)) commonByAncestry.set(identifier, '');
-		}
-		byKey.set('common', commonByAncestry);
 	}
 
 	const defaults: Record<string, LanguageSpeaker[]> = {};

--- a/src/settings/languageSettings.ts
+++ b/src/settings/languageSettings.ts
@@ -1,0 +1,183 @@
+import { SYSTEM_ID } from '#system';
+
+export const LANGUAGE_CUSTOMIZATIONS_SETTING_KEY = 'languageCustomizations';
+
+/** Sparse override applied on top of a built-in language. */
+export interface LanguageOverride {
+	/** Renamed display label (falls back to the built-in label when omitted). */
+	label?: string;
+	/** Alternate display names shown alongside the label. */
+	aliases?: string[];
+	/** Replacement tooltip hint. */
+	hint?: string;
+	/** Replacement icon path. */
+	image?: string;
+}
+
+/** A fully GM-authored language. */
+export interface CustomLanguage {
+	/** Stable key, generated from the label and unique across all languages. */
+	key: string;
+	label: string;
+	aliases: string[];
+	hint: string;
+	image: string;
+}
+
+export interface LanguageCustomizations {
+	/** Overrides for built-in languages, keyed by built-in language key. */
+	overrides: Record<string, LanguageOverride>;
+	/** Languages added by the GM. */
+	custom: CustomLanguage[];
+}
+
+const DEFAULT_CUSTOMIZATIONS: LanguageCustomizations = { overrides: {}, custom: [] };
+
+/**
+ * Localized snapshot of the built-in language maps, captured the first time
+ * customizations are applied (after `i18nInit` has localized them). Used as the
+ * immutable baseline so every re-apply starts from the shipped defaults rather
+ * than from previously-merged values.
+ */
+let baseline: {
+	languages: Record<string, string>;
+	languageHints: Record<string, string>;
+	languageImages: Record<string, string>;
+} | null = null;
+
+function captureBaseline(): void {
+	if (baseline) return;
+
+	baseline = {
+		languages: { ...CONFIG.NIMBLE.languages },
+		languageHints: { ...CONFIG.NIMBLE.languageHints },
+		languageImages: { ...CONFIG.NIMBLE.languageImages },
+	};
+}
+
+/**
+ * The localized, un-customized built-in language maps. Used by the editor UI to
+ * show defaults and detect which fields the GM has actually overridden.
+ */
+export function getBuiltinLanguageBaseline(): {
+	languages: Record<string, string>;
+	languageHints: Record<string, string>;
+	languageImages: Record<string, string>;
+} {
+	captureBaseline();
+	return (
+		baseline ?? {
+			languages: { ...CONFIG.NIMBLE.languages },
+			languageHints: { ...CONFIG.NIMBLE.languageHints },
+			languageImages: { ...CONFIG.NIMBLE.languageImages },
+		}
+	);
+}
+
+export function getLanguageCustomizations(): LanguageCustomizations {
+	const stored = game.settings.get(
+		SYSTEM_ID as 'core',
+		LANGUAGE_CUSTOMIZATIONS_SETTING_KEY as 'rollMode',
+	) as unknown as Partial<LanguageCustomizations> | undefined;
+
+	return {
+		overrides: stored?.overrides ?? {},
+		custom: stored?.custom ?? [],
+	};
+}
+
+export async function setLanguageCustomizations(value: LanguageCustomizations): Promise<void> {
+	await game.settings.set(
+		SYSTEM_ID as 'core',
+		LANGUAGE_CUSTOMIZATIONS_SETTING_KEY as 'rollMode',
+		value as unknown as never,
+	);
+}
+
+/**
+ * Rebuild `CONFIG.NIMBLE.languages`, `languageHints`, `languageImages`, and
+ * `languageAliases` from the immutable baseline plus the stored customizations.
+ * Idempotent: always derives from `baseline`, so removing an override restores
+ * the built-in default.
+ */
+export function applyLanguageCustomizations(): void {
+	captureBaseline();
+	if (!baseline) return;
+
+	const { overrides, custom } = getLanguageCustomizations();
+
+	const languages: Record<string, string> = { ...baseline.languages };
+	const languageHints: Record<string, string> = { ...baseline.languageHints };
+	const languageImages: Record<string, string> = { ...baseline.languageImages };
+	const languageAliases: Record<string, string[]> = {};
+
+	// Apply overrides to built-in languages.
+	for (const [key, override] of Object.entries(overrides)) {
+		if (!(key in baseline.languages)) continue;
+		if (override.label) languages[key] = override.label;
+		if (override.hint !== undefined) languageHints[key] = override.hint;
+		if (override.image) languageImages[key] = override.image;
+		if (override.aliases?.length) languageAliases[key] = [...override.aliases];
+	}
+
+	// Add custom languages.
+	for (const language of custom) {
+		if (!language.key || !language.label) continue;
+		languages[language.key] = language.label;
+		languageHints[language.key] = language.hint ?? '';
+		languageImages[language.key] = language.image ?? '';
+		if (language.aliases?.length) languageAliases[language.key] = [...language.aliases];
+	}
+
+	CONFIG.NIMBLE.languages = languages as typeof CONFIG.NIMBLE.languages;
+	CONFIG.NIMBLE.languageHints = languageHints as typeof CONFIG.NIMBLE.languageHints;
+	CONFIG.NIMBLE.languageImages = languageImages as typeof CONFIG.NIMBLE.languageImages;
+	CONFIG.NIMBLE.languageAliases = languageAliases;
+}
+
+/**
+ * Re-render the sheets and dialogs that read language config at render time, so
+ * customization edits appear without a reload. Svelte components capture
+ * `CONFIG.NIMBLE` at script init, so re-rendering the host re-instantiates them.
+ */
+function rerenderLanguageConsumers(): void {
+	const shouldRerender = (name: string | undefined): boolean =>
+		name === 'PlayerCharacterSheet' ||
+		name === 'CharacterCreationDialog' ||
+		name === 'GenericDialog';
+
+	const v1 = Object.values(ui.windows ?? {}) as Array<{
+		render?: (force?: boolean) => void;
+		constructor: { name: string };
+	}>;
+	for (const app of v1) {
+		if (shouldRerender(app.constructor?.name)) app.render?.(false);
+	}
+
+	const v2 = (foundry.applications?.instances ?? new Map()) as Map<
+		string,
+		{ render?: (force?: boolean) => void; constructor: { name: string } }
+	>;
+	v2.forEach((app) => {
+		if (shouldRerender(app.constructor?.name)) app.render?.(false);
+	});
+}
+
+export function registerLanguageSettings(): void {
+	game.settings.register(
+		SYSTEM_ID as 'core',
+		LANGUAGE_CUSTOMIZATIONS_SETTING_KEY as 'rollMode',
+		{
+			name: 'NIMBLE.settings.languageCustomization.name',
+			hint: 'NIMBLE.settings.languageCustomization.hint',
+			scope: 'world',
+			config: false,
+			type: Object,
+			default: DEFAULT_CUSTOMIZATIONS,
+			onChange: () => {
+				applyLanguageCustomizations();
+				rerenderLanguageConsumers();
+			},
+		} as unknown as Parameters<typeof game.settings.register>[2],
+	);
+}

--- a/src/utils/getLanguageName.ts
+++ b/src/utils/getLanguageName.ts
@@ -1,0 +1,44 @@
+import type { LanguageAlternateName } from '../settings/languageSettings.js';
+
+interface GetLanguageNameOptions {
+	/**
+	 * Identifier of the speaking character's ancestry (e.g. "gnome"). When it
+	 * matches an alternate-name binding for the language, that name is returned
+	 * instead of the canonical/renamed label.
+	 */
+	ancestryIdentifier?: string | null;
+}
+
+/**
+ * Resolve the display name for a language key. Returns the renamed/canonical
+ * label by default. When the speaker's ancestry matches an alternate-name
+ * binding, the canonical label is annotated with the ancestry's term for it —
+ * e.g. a Gnome speaking `dwarvish` sees "Dwarvish (Gnomish)".
+ *
+ * The stored proficiency key is never changed — this only affects display, so
+ * every place that prints a language name stays consistent.
+ */
+export default function getLanguageName(key: string, options?: GetLanguageNameOptions): string {
+	const languages = CONFIG.NIMBLE.languages as Record<string, string>;
+	const label = languages[key] ?? key;
+
+	const ancestryIdentifier = options?.ancestryIdentifier;
+	if (!ancestryIdentifier) return label;
+
+	const bindings = (
+		CONFIG.NIMBLE as unknown as {
+			languageAlternateNames?: Record<string, LanguageAlternateName[]>;
+		}
+	).languageAlternateNames?.[key];
+	if (!bindings?.length) return label;
+
+	const match = bindings.find(
+		(binding) => binding.name?.trim() && binding.ancestries?.includes(ancestryIdentifier),
+	);
+	if (!match) return label;
+
+	// The alternate name is the ancestry's term; the canonical label stays so the
+	// underlying language is never ambiguous (e.g. "Dwarvish (Gnomish)").
+	const alternate = match.name.trim();
+	return alternate === label ? label : `${label} (${alternate})`;
+}

--- a/src/view/dialogs/CharacterCreationDialog.svelte
+++ b/src/view/dialogs/CharacterCreationDialog.svelte
@@ -188,6 +188,7 @@
 
 	<BonusLanguageSelection
 		active={state.stage === CHARACTER_CREATION_STAGES.LANGUAGES}
+		ancestryIdentifier={state.selectedAncestry?.identifier ?? null}
 		bind:bonusLanguages={state.bonusLanguages}
 		{bonusLanguageOptions}
 		grantedLanguages={state.grantedLanguages}

--- a/src/view/dialogs/CharacterLanguageProficienciesConfigDialog.svelte
+++ b/src/view/dialogs/CharacterLanguageProficienciesConfigDialog.svelte
@@ -1,6 +1,11 @@
 <script>
+	import getLanguageName from '../../utils/getLanguageName.js';
+
 	function prepareLanguageOptions() {
-		return Object.entries(languages).sort((a, b) => a[1].localeCompare(b[1]));
+		const ancestryIdentifier = document.ancestry?.identifier ?? null;
+		return Object.keys(languages)
+			.map((key) => [key, getLanguageName(key, { ancestryIdentifier })])
+			.sort((a, b) => a[1].localeCompare(b[1]));
 	}
 
 	function toggleLanguageProficiency(language) {
@@ -14,10 +19,11 @@
 		});
 	}
 
-	const { languages, languageAliases } = CONFIG.NIMBLE;
-	const languageOptions = prepareLanguageOptions();
+	const { languages } = CONFIG.NIMBLE;
 
 	let { document } = $props();
+
+	const languageOptions = prepareLanguageOptions();
 
 	let knownLanguages = $derived(document.reactive?.system?.proficiencies?.languages);
 </script>
@@ -35,20 +41,7 @@
 				onclick={() => toggleLanguageProficiency(key)}
 			/>
 
-			<span class="nimble-field__label">
-				{label}
-				{#if languageAliases?.[key]?.length}
-					<span class="nimble-field__aliases">({languageAliases[key].join(', ')})</span>
-				{/if}
-			</span>
+			<span class="nimble-field__label">{label}</span>
 		</label>
 	{/each}
 </section>
-
-<style lang="scss">
-	.nimble-field__aliases {
-		margin-inline-start: 0.25rem;
-		font-style: italic;
-		opacity: 0.7;
-	}
-</style>

--- a/src/view/dialogs/CharacterLanguageProficienciesConfigDialog.svelte
+++ b/src/view/dialogs/CharacterLanguageProficienciesConfigDialog.svelte
@@ -14,7 +14,7 @@
 		});
 	}
 
-	const { languages } = CONFIG.NIMBLE;
+	const { languages, languageAliases } = CONFIG.NIMBLE;
 	const languageOptions = prepareLanguageOptions();
 
 	let { document } = $props();
@@ -35,7 +35,20 @@
 				onclick={() => toggleLanguageProficiency(key)}
 			/>
 
-			<span class="nimble-field__label">{label}</span>
+			<span class="nimble-field__label">
+				{label}
+				{#if languageAliases?.[key]?.length}
+					<span class="nimble-field__aliases">({languageAliases[key].join(', ')})</span>
+				{/if}
+			</span>
 		</label>
 	{/each}
 </section>
+
+<style lang="scss">
+	.nimble-field__aliases {
+		margin-inline-start: 0.25rem;
+		font-style: italic;
+		opacity: 0.7;
+	}
+</style>

--- a/src/view/dialogs/LanguageCustomizationDialog.svelte
+++ b/src/view/dialogs/LanguageCustomizationDialog.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
 	import localize from '../../utils/localize.js';
-	import { LanguageCustomizationDialogState } from './languageCustomization/state.svelte.js';
+	import {
+		type BuiltinLanguageRow,
+		type CustomLanguageRow,
+		LanguageCustomizationDialogState,
+	} from './languageCustomization/state.svelte.js';
 
 	let {
 		dialog,
@@ -11,15 +15,98 @@
 	const state = new LanguageCustomizationDialogState();
 
 	async function handleSave() {
+		if (state.hasConflicts) return;
 		await state.save();
 		dialog?.submit?.({ saved: true });
 	}
 </script>
 
+{#snippet spokenBy(row: BuiltinLanguageRow | CustomLanguageRow)}
+	{@const languageName = 'defaultLabel' in row ? row.defaultLabel : row.label.trim()}
+	{@const available = state.ancestryOptions.filter(
+		(option) => !row.speakers.some((speaker) => speaker.ancestry === option.value),
+	)}
+	<div class="nimble-language-customization__speakers">
+		<span class="nimble-language-customization__speakers-title">
+			{localize('NIMBLE.settings.languageCustomization.spokenBy')}
+		</span>
+
+		{#if row.speakers.length}
+			<ul class="nimble-language-customization__speaker-list">
+				{#each row.speakers as speaker (speaker.ancestry)}
+					<li class="nimble-language-customization__speaker">
+						<span class="nimble-language-customization__speaker-name"
+							>{state.ancestryLabel(speaker.ancestry)}</span
+						>
+						<input
+							type="text"
+							class="nimble-language-customization__speaker-alias"
+							placeholder={languageName}
+							bind:value={speaker.alias}
+						/>
+						<button
+							type="button"
+							class="nimble-language-customization__icon-button"
+							data-tooltip={localize('NIMBLE.settings.languageCustomization.removeAncestry')}
+							aria-label={localize('NIMBLE.settings.languageCustomization.removeAncestry')}
+							onclick={() => state.removeSpeaker(row, speaker.ancestry)}
+						>
+							<i class="fa-solid fa-xmark"></i>
+						</button>
+					</li>
+				{/each}
+			</ul>
+		{/if}
+
+		{#if available.length}
+			<select
+				class="nimble-language-customization__ancestry-select"
+				value=""
+				onchange={(event) => {
+					const select = event.currentTarget;
+					if (select.value) state.addSpeaker(row, select.value);
+					select.value = '';
+				}}
+			>
+				<option value="" disabled selected>
+					{localize('NIMBLE.settings.languageCustomization.selectAncestry')}
+				</option>
+				{#each available as option (option.value)}
+					<option value={option.value}>{option.label}</option>
+				{/each}
+			</select>
+		{:else if !state.ancestryOptions.length}
+			<p class="hint">{localize('NIMBLE.settings.languageCustomization.noAncestries')}</p>
+		{/if}
+	</div>
+{/snippet}
+
 <section class="nimble-sheet__body nimble-language-customization standard-form">
 	<p class="nimble-language-customization__intro">
 		{localize('NIMBLE.settings.languageCustomization.intro')}
 	</p>
+
+	<p class="hint nimble-language-customization__speakers-hint">
+		{localize('NIMBLE.settings.languageCustomization.spokenByHint')}
+	</p>
+
+	<label class="nimble-language-customization__toggle">
+		<input type="checkbox" bind:checked={state.alternateNamesEnabled} />
+		<span>{localize('NIMBLE.settings.languageCustomization.enableAlternateNames')}</span>
+	</label>
+
+	{#if state.alternateNamesEnabled}
+		<p class="hint nimble-language-customization__speakers-hint">
+			{localize('NIMBLE.settings.languageCustomization.alternateNamesHint')}
+		</p>
+	{/if}
+
+	{#if state.hasConflicts}
+		<p class="nimble-language-customization__error" role="alert">
+			<i class="fa-solid fa-triangle-exclamation"></i>
+			{localize('NIMBLE.settings.languageCustomization.conflictError')}
+		</p>
+	{/if}
 
 	<fieldset class="nimble-language-customization__section">
 		<legend class="nimble-language-customization__section-title">
@@ -28,31 +115,30 @@
 
 		<div class="nimble-language-customization__rows">
 			{#each state.builtinRows as row, index (row.key)}
+				{@const conflicted = state.conflicts.has(state.conflictIdForBuiltin(row))}
 				<div class="nimble-language-customization__card">
 					<header class="nimble-language-customization__card-header">
 						<span class="nimble-language-customization__default-name">{row.defaultLabel}</span>
-						<button
-							type="button"
-							class="nimble-language-customization__reset"
-							data-tooltip={localize('NIMBLE.settings.languageCustomization.reset')}
-							aria-label={localize('NIMBLE.settings.languageCustomization.reset')}
-							onclick={() => state.resetBuiltin(index)}
-						>
-							<i class="fa-solid fa-rotate-left"></i>
-						</button>
+						{#if state.isBuiltinCustomized(row)}
+							<button
+								type="button"
+								class="nimble-language-customization__icon-button"
+								data-tooltip={localize('NIMBLE.settings.languageCustomization.reset')}
+								aria-label={localize('NIMBLE.settings.languageCustomization.reset')}
+								onclick={() => state.resetBuiltin(index)}
+							>
+								<i class="fa-solid fa-rotate-left"></i>
+							</button>
+						{/if}
 					</header>
 
 					<label class="nimble-language-customization__field">
-						<span>{localize('NIMBLE.settings.languageCustomization.label')}</span>
-						<input type="text" placeholder={row.defaultLabel} bind:value={row.label} />
-					</label>
-
-					<label class="nimble-language-customization__field">
-						<span>{localize('NIMBLE.settings.languageCustomization.aliases')}</span>
+						<span>{localize('NIMBLE.settings.languageCustomization.rename')}</span>
 						<input
 							type="text"
-							placeholder={localize('NIMBLE.settings.languageCustomization.aliasesPlaceholder')}
-							bind:value={row.aliases}
+							class:nimble-language-customization__input--error={conflicted}
+							placeholder={row.defaultLabel}
+							bind:value={row.label}
 						/>
 					</label>
 
@@ -61,10 +147,7 @@
 						<input type="text" placeholder={row.defaultHint} bind:value={row.hint} />
 					</label>
 
-					<label class="nimble-language-customization__field">
-						<span>{localize('NIMBLE.settings.languageCustomization.icon')}</span>
-						<input type="text" placeholder={row.defaultImage} bind:value={row.image} />
-					</label>
+					{@render spokenBy(row)}
 				</div>
 			{/each}
 		</div>
@@ -77,6 +160,7 @@
 
 		<div class="nimble-language-customization__rows">
 			{#each state.customRows as row, index (index)}
+				{@const conflicted = state.conflicts.has(state.conflictIdForCustom(index))}
 				<div class="nimble-language-customization__card">
 					<header class="nimble-language-customization__card-header">
 						<span class="nimble-language-customization__default-name">
@@ -84,7 +168,7 @@
 						</span>
 						<button
 							type="button"
-							class="nimble-language-customization__reset"
+							class="nimble-language-customization__icon-button"
 							data-tooltip={localize('NIMBLE.settings.languageCustomization.remove')}
 							aria-label={localize('NIMBLE.settings.languageCustomization.remove')}
 							onclick={() => state.removeCustomLanguage(index)}
@@ -97,17 +181,9 @@
 						<span>{localize('NIMBLE.settings.languageCustomization.label')}</span>
 						<input
 							type="text"
+							class:nimble-language-customization__input--error={conflicted}
 							placeholder={localize('NIMBLE.settings.languageCustomization.label')}
 							bind:value={row.label}
-						/>
-					</label>
-
-					<label class="nimble-language-customization__field">
-						<span>{localize('NIMBLE.settings.languageCustomization.aliases')}</span>
-						<input
-							type="text"
-							placeholder={localize('NIMBLE.settings.languageCustomization.aliasesPlaceholder')}
-							bind:value={row.aliases}
 						/>
 					</label>
 
@@ -116,10 +192,7 @@
 						<input type="text" bind:value={row.hint} />
 					</label>
 
-					<label class="nimble-language-customization__field">
-						<span>{localize('NIMBLE.settings.languageCustomization.icon')}</span>
-						<input type="text" placeholder="icons/..." bind:value={row.image} />
-					</label>
+					{@render spokenBy(row)}
 				</div>
 			{/each}
 		</div>
@@ -138,7 +211,7 @@
 		<button
 			type="button"
 			class="nimble-language-customization__save"
-			disabled={state.saving}
+			disabled={state.saving || state.hasConflicts}
 			onclick={handleSave}
 		>
 			<i class="fa-solid fa-floppy-disk"></i>
@@ -159,6 +232,26 @@
 		margin: 0;
 		font-size: var(--font-size-13, 0.8125rem);
 		opacity: 0.85;
+	}
+
+	.nimble-language-customization__toggle {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		font-weight: 600;
+	}
+
+	.nimble-language-customization__error {
+		display: flex;
+		align-items: center;
+		gap: 0.4rem;
+		margin: 0;
+		padding: 0.4rem 0.6rem;
+		border-radius: 0.3rem;
+		background: rgba(180, 40, 40, 0.12);
+		color: var(--color-level-error, #b42828);
+		font-size: var(--font-size-12, 0.75rem);
+		font-weight: 600;
 	}
 
 	.nimble-language-customization__section {
@@ -215,7 +308,62 @@
 		}
 	}
 
-	.nimble-language-customization__reset,
+	.nimble-language-customization__input--error {
+		border-color: var(--color-level-error, #b42828);
+		outline: 1px solid var(--color-level-error, #b42828);
+	}
+
+	.nimble-language-customization__speakers {
+		grid-column: 1 / -1;
+		display: flex;
+		flex-direction: column;
+		gap: 0.35rem;
+		padding-top: 0.35rem;
+		border-top: 1px dashed var(--color-border-light-tertiary, rgba(0, 0, 0, 0.15));
+	}
+
+	.nimble-language-customization__speakers-title {
+		font-size: var(--font-size-12, 0.75rem);
+		font-weight: 700;
+	}
+
+	.nimble-language-customization__speakers-hint {
+		margin: 0;
+	}
+
+	.nimble-language-customization__speaker-list {
+		display: flex;
+		flex-direction: column;
+		gap: 0.3rem;
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	.nimble-language-customization__speaker {
+		display: flex;
+		align-items: center;
+		gap: 0.4rem;
+	}
+
+	.nimble-language-customization__speaker-name {
+		flex: 0 0 8rem;
+		font-size: var(--font-size-12, 0.75rem);
+		font-weight: 600;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.nimble-language-customization__speaker-alias {
+		flex: 1 1 auto;
+	}
+
+	.nimble-language-customization__ancestry-select {
+		width: 100%;
+	}
+
+	.nimble-language-customization__icon-button,
 	.nimble-language-customization__add,
 	.nimble-language-customization__save {
 		display: inline-flex;
@@ -224,7 +372,7 @@
 		width: auto;
 	}
 
-	.nimble-language-customization__reset {
+	.nimble-language-customization__icon-button {
 		flex: 0 0 auto;
 		padding-inline: 0.4rem;
 	}
@@ -232,5 +380,21 @@
 	.nimble-language-customization__footer {
 		display: flex;
 		justify-content: flex-end;
+	}
+
+	// Dark mode: the translucent black backgrounds/borders above disappear against
+	// a dark sheet, so each language reads as one flat panel. Give the cards a
+	// lighter surface and visible borders so they read as distinct boxes.
+	:global(.theme-dark) .nimble-language-customization__section {
+		border-color: hsl(220, 10%, 34%);
+	}
+
+	:global(.theme-dark) .nimble-language-customization__card {
+		background: hsl(220, 15%, 19%);
+		border-color: hsl(220, 12%, 40%);
+	}
+
+	:global(.theme-dark) .nimble-language-customization__speakers {
+		border-top-color: hsl(220, 10%, 38%);
 	}
 </style>

--- a/src/view/dialogs/LanguageCustomizationDialog.svelte
+++ b/src/view/dialogs/LanguageCustomizationDialog.svelte
@@ -1,0 +1,236 @@
+<script lang="ts">
+	import localize from '../../utils/localize.js';
+	import { LanguageCustomizationDialogState } from './languageCustomization/state.svelte.js';
+
+	let {
+		dialog,
+	}: {
+		dialog?: { submit?: (results?: unknown) => void; close?: () => void };
+	} = $props();
+
+	const state = new LanguageCustomizationDialogState();
+
+	async function handleSave() {
+		await state.save();
+		dialog?.submit?.({ saved: true });
+	}
+</script>
+
+<section class="nimble-sheet__body nimble-language-customization standard-form">
+	<p class="nimble-language-customization__intro">
+		{localize('NIMBLE.settings.languageCustomization.intro')}
+	</p>
+
+	<fieldset class="nimble-language-customization__section">
+		<legend class="nimble-language-customization__section-title">
+			{localize('NIMBLE.settings.languageCustomization.builtinSection')}
+		</legend>
+
+		<div class="nimble-language-customization__rows">
+			{#each state.builtinRows as row, index (row.key)}
+				<div class="nimble-language-customization__card">
+					<header class="nimble-language-customization__card-header">
+						<span class="nimble-language-customization__default-name">{row.defaultLabel}</span>
+						<button
+							type="button"
+							class="nimble-language-customization__reset"
+							data-tooltip={localize('NIMBLE.settings.languageCustomization.reset')}
+							aria-label={localize('NIMBLE.settings.languageCustomization.reset')}
+							onclick={() => state.resetBuiltin(index)}
+						>
+							<i class="fa-solid fa-rotate-left"></i>
+						</button>
+					</header>
+
+					<label class="nimble-language-customization__field">
+						<span>{localize('NIMBLE.settings.languageCustomization.label')}</span>
+						<input type="text" placeholder={row.defaultLabel} bind:value={row.label} />
+					</label>
+
+					<label class="nimble-language-customization__field">
+						<span>{localize('NIMBLE.settings.languageCustomization.aliases')}</span>
+						<input
+							type="text"
+							placeholder={localize('NIMBLE.settings.languageCustomization.aliasesPlaceholder')}
+							bind:value={row.aliases}
+						/>
+					</label>
+
+					<label class="nimble-language-customization__field">
+						<span>{localize('NIMBLE.settings.languageCustomization.tooltip')}</span>
+						<input type="text" placeholder={row.defaultHint} bind:value={row.hint} />
+					</label>
+
+					<label class="nimble-language-customization__field">
+						<span>{localize('NIMBLE.settings.languageCustomization.icon')}</span>
+						<input type="text" placeholder={row.defaultImage} bind:value={row.image} />
+					</label>
+				</div>
+			{/each}
+		</div>
+	</fieldset>
+
+	<fieldset class="nimble-language-customization__section">
+		<legend class="nimble-language-customization__section-title">
+			{localize('NIMBLE.settings.languageCustomization.customSection')}
+		</legend>
+
+		<div class="nimble-language-customization__rows">
+			{#each state.customRows as row, index (index)}
+				<div class="nimble-language-customization__card">
+					<header class="nimble-language-customization__card-header">
+						<span class="nimble-language-customization__default-name">
+							{row.label.trim() || localize('NIMBLE.settings.languageCustomization.newLanguage')}
+						</span>
+						<button
+							type="button"
+							class="nimble-language-customization__reset"
+							data-tooltip={localize('NIMBLE.settings.languageCustomization.remove')}
+							aria-label={localize('NIMBLE.settings.languageCustomization.remove')}
+							onclick={() => state.removeCustomLanguage(index)}
+						>
+							<i class="fa-solid fa-trash"></i>
+						</button>
+					</header>
+
+					<label class="nimble-language-customization__field">
+						<span>{localize('NIMBLE.settings.languageCustomization.label')}</span>
+						<input
+							type="text"
+							placeholder={localize('NIMBLE.settings.languageCustomization.label')}
+							bind:value={row.label}
+						/>
+					</label>
+
+					<label class="nimble-language-customization__field">
+						<span>{localize('NIMBLE.settings.languageCustomization.aliases')}</span>
+						<input
+							type="text"
+							placeholder={localize('NIMBLE.settings.languageCustomization.aliasesPlaceholder')}
+							bind:value={row.aliases}
+						/>
+					</label>
+
+					<label class="nimble-language-customization__field">
+						<span>{localize('NIMBLE.settings.languageCustomization.tooltip')}</span>
+						<input type="text" bind:value={row.hint} />
+					</label>
+
+					<label class="nimble-language-customization__field">
+						<span>{localize('NIMBLE.settings.languageCustomization.icon')}</span>
+						<input type="text" placeholder="icons/..." bind:value={row.image} />
+					</label>
+				</div>
+			{/each}
+		</div>
+
+		<button
+			type="button"
+			class="nimble-language-customization__add"
+			onclick={state.addCustomLanguage}
+		>
+			<i class="fa-solid fa-plus"></i>
+			{localize('NIMBLE.settings.languageCustomization.addLanguage')}
+		</button>
+	</fieldset>
+
+	<footer class="nimble-language-customization__footer">
+		<button
+			type="button"
+			class="nimble-language-customization__save"
+			disabled={state.saving}
+			onclick={handleSave}
+		>
+			<i class="fa-solid fa-floppy-disk"></i>
+			{localize('NIMBLE.settings.languageCustomization.save')}
+		</button>
+	</footer>
+</section>
+
+<style lang="scss">
+	.nimble-language-customization {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+		padding: 0.75rem;
+	}
+
+	.nimble-language-customization__intro {
+		margin: 0;
+		font-size: var(--font-size-13, 0.8125rem);
+		opacity: 0.85;
+	}
+
+	.nimble-language-customization__section {
+		margin: 0;
+		border: 1px solid var(--color-border-light-secondary, rgba(0, 0, 0, 0.25));
+		border-radius: 0.375rem;
+		padding: 0.6rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+
+	.nimble-language-customization__section-title {
+		padding-inline: 0.3rem;
+		font-weight: 700;
+	}
+
+	.nimble-language-customization__rows {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+
+	.nimble-language-customization__card {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: 0.4rem 0.6rem;
+		padding: 0.5rem;
+		border: 1px solid var(--color-border-light-tertiary, rgba(0, 0, 0, 0.15));
+		border-radius: 0.3rem;
+		background: rgba(0, 0, 0, 0.05);
+	}
+
+	.nimble-language-customization__card-header {
+		grid-column: 1 / -1;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.5rem;
+	}
+
+	.nimble-language-customization__default-name {
+		font-weight: 700;
+	}
+
+	.nimble-language-customization__field {
+		display: flex;
+		flex-direction: column;
+		gap: 0.2rem;
+		font-size: var(--font-size-12, 0.75rem);
+
+		input {
+			width: 100%;
+		}
+	}
+
+	.nimble-language-customization__reset,
+	.nimble-language-customization__add,
+	.nimble-language-customization__save {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.35rem;
+		width: auto;
+	}
+
+	.nimble-language-customization__reset {
+		flex: 0 0 auto;
+		padding-inline: 0.4rem;
+	}
+
+	.nimble-language-customization__footer {
+		display: flex;
+		justify-content: flex-end;
+	}
+</style>

--- a/src/view/dialogs/LanguageCustomizationDialog.svelte
+++ b/src/view/dialogs/LanguageCustomizationDialog.svelte
@@ -31,52 +31,58 @@
 			{localize('NIMBLE.settings.languageCustomization.spokenBy')}
 		</span>
 
-		{#if row.speakers.length}
-			<ul class="nimble-language-customization__speaker-list">
-				{#each row.speakers as speaker (speaker.ancestry)}
-					<li class="nimble-language-customization__speaker">
-						<span class="nimble-language-customization__speaker-name"
-							>{state.ancestryLabel(speaker.ancestry)}</span
-						>
-						<input
-							type="text"
-							class="nimble-language-customization__speaker-alias"
-							placeholder={languageName}
-							bind:value={speaker.alias}
-						/>
-						<button
-							type="button"
-							class="nimble-language-customization__icon-button"
-							data-tooltip={localize('NIMBLE.settings.languageCustomization.removeAncestry')}
-							aria-label={localize('NIMBLE.settings.languageCustomization.removeAncestry')}
-							onclick={() => state.removeSpeaker(row, speaker.ancestry)}
-						>
-							<i class="fa-solid fa-xmark"></i>
-						</button>
-					</li>
-				{/each}
-			</ul>
-		{/if}
+		{#if row.key === 'common'}
+			<p class="hint nimble-language-customization__speakers-hint">
+				{localize('NIMBLE.settings.languageCustomization.spokenByEveryone')}
+			</p>
+		{:else}
+			{#if row.speakers.length}
+				<ul class="nimble-language-customization__speaker-list">
+					{#each row.speakers as speaker (speaker.ancestry)}
+						<li class="nimble-language-customization__speaker">
+							<span class="nimble-language-customization__speaker-name"
+								>{state.ancestryLabel(speaker.ancestry)}</span
+							>
+							<input
+								type="text"
+								class="nimble-language-customization__speaker-alias"
+								placeholder={languageName}
+								bind:value={speaker.alias}
+							/>
+							<button
+								type="button"
+								class="nimble-language-customization__icon-button"
+								data-tooltip={localize('NIMBLE.settings.languageCustomization.removeAncestry')}
+								aria-label={localize('NIMBLE.settings.languageCustomization.removeAncestry')}
+								onclick={() => state.removeSpeaker(row, speaker.ancestry)}
+							>
+								<i class="fa-solid fa-xmark"></i>
+							</button>
+						</li>
+					{/each}
+				</ul>
+			{/if}
 
-		{#if available.length}
-			<select
-				class="nimble-language-customization__ancestry-select"
-				value=""
-				onchange={(event) => {
-					const select = event.currentTarget;
-					if (select.value) state.addSpeaker(row, select.value);
-					select.value = '';
-				}}
-			>
-				<option value="" disabled selected>
-					{localize('NIMBLE.settings.languageCustomization.selectAncestry')}
-				</option>
-				{#each available as option (option.value)}
-					<option value={option.value}>{option.label}</option>
-				{/each}
-			</select>
-		{:else if !state.ancestryOptions.length}
-			<p class="hint">{localize('NIMBLE.settings.languageCustomization.noAncestries')}</p>
+			{#if available.length}
+				<select
+					class="nimble-language-customization__ancestry-select"
+					value=""
+					onchange={(event) => {
+						const select = event.currentTarget;
+						if (select.value) state.addSpeaker(row, select.value);
+						select.value = '';
+					}}
+				>
+					<option value="" disabled selected>
+						{localize('NIMBLE.settings.languageCustomization.selectAncestry')}
+					</option>
+					{#each available as option (option.value)}
+						<option value={option.value}>{option.label}</option>
+					{/each}
+				</select>
+			{:else if !state.ancestryOptions.length}
+				<p class="hint">{localize('NIMBLE.settings.languageCustomization.noAncestries')}</p>
+			{/if}
 		{/if}
 	</div>
 {/snippet}

--- a/src/view/dialogs/characterCreation/state.svelte.ts
+++ b/src/view/dialogs/characterCreation/state.svelte.ts
@@ -156,26 +156,6 @@ function hasClassFeatures(features: ClassFeatureResult | null): boolean {
 	return features.autoGrant.length > 0 || features.selectionGroups.size > 0;
 }
 
-function getLanguageGrantsFromRules(
-	rules: NimbleBaseRule[],
-	intMod: number,
-	source: 'ancestry' | 'background',
-): GrantedLanguage[] {
-	if (!rules?.length) return [];
-
-	const grantRules = rules.filter(
-		(r) => r.type === 'grantProficiency' && r.proficiencyType === 'languages',
-	);
-
-	return grantRules.flatMap((r) => {
-		const intPredicate = r.predicate?.intelligence;
-		if (intPredicate?.min !== undefined && intMod < intPredicate.min) {
-			return [];
-		}
-		return (r.values ?? []).map((v) => ({ key: v.toLowerCase(), source }));
-	});
-}
-
 interface GetCurrentStageParams {
 	selectedClass: NimbleClassItem | null;
 	selectedAncestry: NimbleAncestryItem | null;
@@ -383,14 +363,23 @@ export function createCharacterCreationState(params: CharacterCreationStateParam
 		Object.values(selectedAbilityScores).every((mod) => mod !== null),
 	);
 
-	// Languages granted by ancestry (based on rules with INT predicate)
+	// Languages granted by ancestry. Sourced from the In-Game Languages settings
+	// (authoritative, seeded from the ancestry rules) so custom or GM-edited ancestry
+	// languages appear here too — same INT rule: known if Intelligence isn't negative.
 	const ancestryGrantedLanguages = $derived.by((): GrantedLanguage[] => {
 		if (!selectedAncestry || !selectedArray || selectedAbilityScores.intelligence === null)
 			return [];
 		const intMod = selectedArray.array?.[selectedAbilityScores.intelligence] ?? 0;
+		if (intMod < 0) return [];
 
-		const rules = [...(selectedAncestry?.system?.rules ?? [])];
-		return getLanguageGrantsFromRules(rules, intMod, 'ancestry');
+		const identifier = selectedAncestry.identifier;
+		const speakers =
+			(CONFIG.NIMBLE as unknown as { languageSpeakers?: Record<string, string[]> })
+				.languageSpeakers ?? {};
+
+		return Object.entries(speakers)
+			.filter(([, ancestries]) => ancestries.includes(identifier))
+			.map(([key]) => ({ key, source: 'ancestry' as const }));
 	});
 
 	// Languages granted by background

--- a/src/view/dialogs/components/characterCreator/BonusLanguageSelection.svelte
+++ b/src/view/dialogs/components/characterCreator/BonusLanguageSelection.svelte
@@ -1,33 +1,10 @@
-<script>
+<script lang="ts">
 	import { getContext } from 'svelte';
-	import getLanguageName from '../../../../utils/getLanguageName.js';
-
+	import getLanguageName from '#utils/getLanguageName.js';
 	import Hint from '../../../components/Hint.svelte';
 	import TagGroup from '../../../components/TagGroup.svelte';
-
-	function lockInBonusLanguages() {
-		bonusLanguages = tempBonusLanguages;
-	}
-
-	function toggleBonusLanguages(selection) {
-		const index = tempBonusLanguages.indexOf(selection);
-
-		if (index === -1) {
-			if (remainingLanguagePicks > 0) {
-				tempBonusLanguages.push(selection);
-			}
-		} else {
-			tempBonusLanguages.splice(index, 1);
-		}
-
-		setTimeout(() => {
-			const element = dialog.element.querySelector(
-				`#${dialog.id}-stage-${CHARACTER_CREATION_STAGES.LANGUAGES}`,
-			);
-
-			element.scrollIntoView({ behavior: 'smooth' });
-		}, 0);
-	}
+	import { createBonusLanguageSelectionState } from './BonusLanguageSelection.svelte.js';
+	import type { BonusLanguageSelectionProps } from './BonusLanguageSelection.types.js';
 
 	let {
 		active,
@@ -38,41 +15,43 @@
 		remainingSkillPoints,
 		selectedAbilityScores,
 		selectedArray,
-	} = $props();
+	}: BonusLanguageSelectionProps = $props();
 
-	const CHARACTER_CREATION_STAGES = getContext('CHARACTER_CREATION_STAGES');
-	const dialog = getContext('dialog');
+	const CHARACTER_CREATION_STAGES = getContext('CHARACTER_CREATION_STAGES') as Record<
+		string,
+		number | string
+	>;
+	const dialog = getContext('dialog') as { id: string; element: HTMLElement };
 
 	const { languageHints, bonusLanguageSelection } = CONFIG.NIMBLE;
 
-	let tempBonusLanguages = $state([]);
+	function scrollToLanguagesStage(): void {
+		setTimeout(() => {
+			dialog.element
+				.querySelector(`#${dialog.id}-stage-${CHARACTER_CREATION_STAGES.LANGUAGES}`)
+				?.scrollIntoView({ behavior: 'smooth' });
+		}, 0);
+	}
 
-	let hasUnassignedAbilityScores = $derived(
-		Object.values(selectedAbilityScores).some((mod) => mod === null),
-	);
-
-	let intelligenceModifier = $derived(
-		selectedArray?.array?.[selectedAbilityScores.intelligence] ?? 0,
-	);
-
-	let remainingLanguagePicks = $derived(intelligenceModifier - bonusLanguages.length);
-
-	let remainingTempLanguagePicks = $derived(intelligenceModifier - tempBonusLanguages.length);
-
-	let grantedLanguageKeys = $derived(grantedLanguages.map((l) => l.key));
-
-	let selectableOptions = $derived(
-		bonusLanguageOptions.filter((opt) => !grantedLanguageKeys.includes(opt.value)),
-	);
-
-	// Reset temp selections when INT drops below current temp selection count
-	// Only run after ability scores are fully assigned (not during drag operations)
-	$effect(() => {
-		if (hasUnassignedAbilityScores) return;
-		if (tempBonusLanguages.length > 0 && intelligenceModifier < tempBonusLanguages.length) {
-			tempBonusLanguages = [];
-		}
+	const state = createBonusLanguageSelectionState({
+		getBonusLanguages: () => bonusLanguages,
+		setBonusLanguages: (languages) => {
+			bonusLanguages = languages;
+		},
+		getBonusLanguageOptions: () => bonusLanguageOptions,
+		getGrantedLanguages: () => grantedLanguages,
+		getSelectedAbilityScores: () => selectedAbilityScores,
+		getSelectedArray: () => selectedArray,
+		scrollToLanguagesStage,
 	});
+
+	const hasUnassignedAbilityScores = $derived(state.hasUnassignedAbilityScores);
+	const intelligenceModifier = $derived(state.intelligenceModifier);
+	const remainingLanguagePicks = $derived(state.remainingLanguagePicks);
+	const remainingTempLanguagePicks = $derived(state.remainingTempLanguagePicks);
+	const selectableOptions = $derived(state.selectableOptions);
+	const tempBonusLanguages = $derived(state.tempBonusLanguages);
+	const { toggleBonusLanguages, lockInBonusLanguages } = state;
 </script>
 
 <section
@@ -129,14 +108,14 @@
 				<div class="nimble-language-group">
 					<span class="nimble-language-group__label"
 						>{game.i18n.format(bonusLanguageSelection.choose, {
-							count: intelligenceModifier,
+							count: String(intelligenceModifier),
 						})}</span
 					>
 					<TagGroup
 						disabled={remainingTempLanguagePicks < 1}
 						options={selectableOptions}
 						selectedOptions={tempBonusLanguages}
-						toggleOption={toggleBonusLanguages}
+						toggleOption={async (value) => toggleBonusLanguages(value)}
 					/>
 				</div>
 

--- a/src/view/dialogs/components/characterCreator/BonusLanguageSelection.svelte
+++ b/src/view/dialogs/components/characterCreator/BonusLanguageSelection.svelte
@@ -1,6 +1,6 @@
 <script>
 	import { getContext } from 'svelte';
-	import localize from '../../../../utils/localize.js';
+	import getLanguageName from '../../../../utils/getLanguageName.js';
 
 	import Hint from '../../../components/Hint.svelte';
 	import TagGroup from '../../../components/TagGroup.svelte';
@@ -31,6 +31,7 @@
 
 	let {
 		active,
+		ancestryIdentifier = null,
 		bonusLanguages = $bindable(),
 		bonusLanguageOptions,
 		grantedLanguages = [],
@@ -42,7 +43,7 @@
 	const CHARACTER_CREATION_STAGES = getContext('CHARACTER_CREATION_STAGES');
 	const dialog = getContext('dialog');
 
-	const { languages, languageHints, bonusLanguageSelection } = CONFIG.NIMBLE;
+	const { languageHints, bonusLanguageSelection } = CONFIG.NIMBLE;
 
 	let tempBonusLanguages = $state([]);
 
@@ -114,7 +115,7 @@
 								data-tooltip-direction="UP"
 							>
 								<span class="nimble-language-tag__name"
-									>{localize(languages[lang.key] ?? lang.key)}</span
+									>{getLanguageName(lang.key, { ancestryIdentifier })}</span
 								>
 								<span class="nimble-language-tag__source">({lang.source})</span>
 							</li>
@@ -154,7 +155,9 @@
 				data-tooltip={languageHints.common}
 				data-tooltip-direction="UP"
 			>
-				<span class="nimble-language-tag__name">{localize(languages.common)}</span>
+				<span class="nimble-language-tag__name"
+					>{getLanguageName('common', { ancestryIdentifier })}</span
+				>
 			</li>
 
 			{#each grantedLanguages as lang}
@@ -163,7 +166,9 @@
 					data-tooltip={languageHints[lang.key]}
 					data-tooltip-direction="UP"
 				>
-					<span class="nimble-language-tag__name">{localize(languages[lang.key] ?? lang.key)}</span>
+					<span class="nimble-language-tag__name"
+						>{getLanguageName(lang.key, { ancestryIdentifier })}</span
+					>
 					<span class="nimble-language-tag__source">({lang.source})</span>
 				</li>
 			{/each}
@@ -174,7 +179,9 @@
 					data-tooltip={languageHints[language]}
 					data-tooltip-direction="UP"
 				>
-					<span class="nimble-language-tag__name">{localize(languages[language] ?? language)}</span>
+					<span class="nimble-language-tag__name"
+						>{getLanguageName(language, { ancestryIdentifier })}</span
+					>
 				</li>
 			{/each}
 		</ul>

--- a/src/view/dialogs/components/characterCreator/BonusLanguageSelection.svelte.ts
+++ b/src/view/dialogs/components/characterCreator/BonusLanguageSelection.svelte.ts
@@ -1,0 +1,108 @@
+import type {
+	AbilityScoreAssignment,
+	GrantedLanguage,
+	StatArrayOption,
+} from '../../characterCreation/types.js';
+
+// `TagGroupOption` is a global ambient type (types/tagGroupOption.d.ts).
+
+interface BonusLanguageSelectionStateParams {
+	getBonusLanguages: () => string[];
+	setBonusLanguages: (languages: string[]) => void;
+	getBonusLanguageOptions: () => TagGroupOption[];
+	getGrantedLanguages: () => GrantedLanguage[];
+	getSelectedAbilityScores: () => AbilityScoreAssignment;
+	getSelectedArray: () => StatArrayOption | null;
+	/** Smooth-scrolls the languages stage back into view after a selection change. */
+	scrollToLanguagesStage: () => void;
+}
+
+/**
+ * Reactive state for the bonus-language step: tracks the in-progress selection,
+ * derives the Intelligence-driven pick budget, and exposes the toggle/lock-in
+ * actions. Lives in `.svelte.ts` because it uses runes; called once during
+ * component init.
+ */
+export function createBonusLanguageSelectionState(params: BonusLanguageSelectionStateParams) {
+	const {
+		getBonusLanguages,
+		setBonusLanguages,
+		getBonusLanguageOptions,
+		getGrantedLanguages,
+		getSelectedAbilityScores,
+		getSelectedArray,
+		scrollToLanguagesStage,
+	} = params;
+
+	let tempBonusLanguages = $state<string[]>([]);
+
+	const hasUnassignedAbilityScores = $derived(
+		Object.values(getSelectedAbilityScores()).some((mod) => mod === null),
+	);
+
+	const intelligenceModifier = $derived.by(() => {
+		const index = getSelectedAbilityScores().intelligence;
+		if (index == null) return 0;
+		return getSelectedArray()?.array?.[index] ?? 0;
+	});
+
+	const remainingLanguagePicks = $derived(intelligenceModifier - getBonusLanguages().length);
+
+	const remainingTempLanguagePicks = $derived(intelligenceModifier - tempBonusLanguages.length);
+
+	const selectableOptions = $derived.by(() => {
+		const grantedKeys = getGrantedLanguages().map((language) => language.key);
+		return getBonusLanguageOptions().filter(
+			(option) => !grantedKeys.includes(option.value as string),
+		);
+	});
+
+	function toggleBonusLanguages(selection: string | number): void {
+		const value = String(selection);
+		const index = tempBonusLanguages.indexOf(value);
+
+		if (index === -1) {
+			if (remainingLanguagePicks > 0) tempBonusLanguages.push(value);
+		} else {
+			tempBonusLanguages.splice(index, 1);
+		}
+
+		scrollToLanguagesStage();
+	}
+
+	function lockInBonusLanguages(): void {
+		setBonusLanguages([...tempBonusLanguages]);
+	}
+
+	// Reset the in-progress selection if Intelligence drops below the count, but
+	// only once ability scores are fully assigned (not mid-drag).
+	$effect(() => {
+		if (hasUnassignedAbilityScores) return;
+		if (tempBonusLanguages.length > 0 && intelligenceModifier < tempBonusLanguages.length) {
+			tempBonusLanguages = [];
+		}
+	});
+
+	return {
+		get hasUnassignedAbilityScores() {
+			return hasUnassignedAbilityScores;
+		},
+		get intelligenceModifier() {
+			return intelligenceModifier;
+		},
+		get remainingLanguagePicks() {
+			return remainingLanguagePicks;
+		},
+		get remainingTempLanguagePicks() {
+			return remainingTempLanguagePicks;
+		},
+		get tempBonusLanguages() {
+			return tempBonusLanguages;
+		},
+		get selectableOptions() {
+			return selectableOptions;
+		},
+		toggleBonusLanguages,
+		lockInBonusLanguages,
+	};
+}

--- a/src/view/dialogs/components/characterCreator/BonusLanguageSelection.types.ts
+++ b/src/view/dialogs/components/characterCreator/BonusLanguageSelection.types.ts
@@ -1,0 +1,23 @@
+import type {
+	AbilityScoreAssignment,
+	GrantedLanguage,
+	StatArrayOption,
+} from '../../characterCreation/types.js';
+
+// `TagGroupOption` is a global ambient type (types/tagGroupOption.d.ts).
+
+/** Props for the bonus-language character-creation step. */
+export interface BonusLanguageSelectionProps {
+	active: boolean;
+	/** Identifier of the selected ancestry, used to resolve ancestry-specific names. */
+	ancestryIdentifier?: string | null;
+	/** Player-chosen bonus languages (two-way bound). */
+	bonusLanguages: string[];
+	/** Selectable bonus-language options. */
+	bonusLanguageOptions: TagGroupOption[];
+	/** Languages already granted by ancestry/background. */
+	grantedLanguages?: GrantedLanguage[];
+	remainingSkillPoints: number;
+	selectedAbilityScores: AbilityScoreAssignment;
+	selectedArray: StatArrayOption | null;
+}

--- a/src/view/dialogs/languageCustomization/state.svelte.ts
+++ b/src/view/dialogs/languageCustomization/state.svelte.ts
@@ -1,21 +1,31 @@
 import {
 	type CustomLanguage,
+	findLanguageNameConflicts,
+	getAncestryLanguageDefaults,
 	getBuiltinLanguageBaseline,
 	getLanguageCustomizations,
 	type LanguageCustomizations,
+	type LanguageSpeaker,
 	setLanguageCustomizations,
 } from '../../../settings/languageSettings.js';
+import getChoicesFromCompendium from '../../../utils/getChoicesFromCompendium.js';
+
+/** Editable "spoken by" row: an ancestry and the name it uses for the language. */
+export interface SpeakerRow {
+	ancestry: string;
+	alias: string;
+}
 
 /** Editable row for a built-in language's overrides. */
 export interface BuiltinLanguageRow {
 	key: string;
 	defaultLabel: string;
 	defaultHint: string;
-	defaultImage: string;
+	/** Ancestry "spoken by" list shipped with the Nimble rules (the reset target). */
+	defaultSpeakers: SpeakerRow[];
 	label: string;
-	aliases: string;
 	hint: string;
-	image: string;
+	speakers: SpeakerRow[];
 }
 
 /** Editable row for a GM-authored custom language. */
@@ -23,22 +33,14 @@ export interface CustomLanguageRow {
 	/** Stable key once saved; empty for newly-added rows (generated on save). */
 	key: string;
 	label: string;
-	aliases: string;
 	hint: string;
-	image: string;
+	speakers: SpeakerRow[];
 }
 
-const ALIAS_SEPARATOR = ', ';
-
-function parseAliases(text: string): string[] {
-	return text
-		.split(',')
-		.map((alias) => alias.trim())
-		.filter((alias) => alias.length > 0);
-}
-
-function formatAliases(aliases: string[] | undefined): string {
-	return (aliases ?? []).join(ALIAS_SEPARATOR);
+/** Option for the ancestry picker, keyed by stable identifier. */
+export interface AncestryOption {
+	value: string;
+	label: string;
 }
 
 /** Slug-derive a stable, unique language key from a label. */
@@ -62,45 +64,122 @@ function generateLanguageKey(label: string, taken: Set<string>): string {
 	return candidate;
 }
 
+function cloneSpeakers(speakers: Array<LanguageSpeaker | SpeakerRow> | undefined): SpeakerRow[] {
+	return (speakers ?? []).map((speaker) => ({
+		ancestry: speaker.ancestry,
+		alias: speaker.alias ?? '',
+	}));
+}
+
+function serializeSpeakers(rows: SpeakerRow[]): LanguageSpeaker[] {
+	return rows
+		.filter((row) => row.ancestry)
+		.map((row) => ({ ancestry: row.ancestry, alias: row.alias.trim() }));
+}
+
+/** Order-insensitive canonical form for comparing "spoken by" lists. */
+function canonicalSpeakers(rows: SpeakerRow[]): string {
+	const normalized = serializeSpeakers(rows).sort((a, b) => a.ancestry.localeCompare(b.ancestry));
+	return JSON.stringify(normalized);
+}
+
+function speakersEqual(a: SpeakerRow[], b: SpeakerRow[]): boolean {
+	return canonicalSpeakers(a) === canonicalSpeakers(b);
+}
+
 export class LanguageCustomizationDialogState {
 	builtinRows = $state<BuiltinLanguageRow[]>([]);
 
 	customRows = $state<CustomLanguageRow[]>([]);
 
+	alternateNamesEnabled = $state(true);
+
+	ancestryOptions = $state<AncestryOption[]>([]);
+
 	saving = $state(false);
+
+	/** Ids of entries whose primary name collides with another (live, reactive). */
+	conflicts = $derived.by(() => findLanguageNameConflicts(this.effectiveNames()));
+
+	get hasConflicts(): boolean {
+		return this.conflicts.size > 0;
+	}
 
 	constructor() {
 		const baseline = getBuiltinLanguageBaseline();
-		const { overrides, custom } = getLanguageCustomizations();
+		const { overrides, custom, alternateNamesEnabled } = getLanguageCustomizations();
+
+		this.alternateNamesEnabled = alternateNamesEnabled;
+
+		const defaults = getAncestryLanguageDefaults();
 
 		this.builtinRows = Object.entries(baseline.languages).map(([key, defaultLabel]) => {
 			const override = overrides[key] ?? {};
+			const defaultSpeakers = cloneSpeakers(defaults[key]);
 			return {
 				key,
 				defaultLabel,
 				defaultHint: baseline.languageHints[key] ?? '',
-				defaultImage: baseline.languageImages[key] ?? '',
+				defaultSpeakers,
 				label: override.label ?? '',
-				aliases: formatAliases(override.aliases),
 				hint: override.hint ?? '',
-				image: override.image ?? '',
+				// Show the GM's saved "spoken by" list if they have one, otherwise the
+				// rule defaults so they're visible and editable.
+				speakers: override.speakers
+					? cloneSpeakers(override.speakers)
+					: cloneSpeakers(defaultSpeakers),
 			};
 		});
 
 		this.customRows = custom.map((language) => ({
 			key: language.key,
 			label: language.label,
-			aliases: formatAliases(language.aliases),
 			hint: language.hint ?? '',
-			image: language.image ?? '',
+			speakers: cloneSpeakers(language.speakers),
 		}));
+
+		void this.loadAncestryOptions();
+	}
+
+	async loadAncestryOptions(): Promise<void> {
+		const uuids = getChoicesFromCompendium('ancestry');
+		const docs = await Promise.all(
+			uuids.map((uuid) => fromUuid(uuid as `Item.${string}`).catch(() => null)),
+		);
+
+		const byIdentifier = new Map<string, string>();
+		for (const doc of docs) {
+			if (!doc) continue;
+			const ancestry = doc as unknown as { identifier?: string; name?: string };
+			const identifier =
+				ancestry.identifier ?? (ancestry.name ?? '').slugify?.({ strict: true }) ?? '';
+			if (!identifier) continue;
+			if (!byIdentifier.has(identifier)) byIdentifier.set(identifier, ancestry.name ?? identifier);
+		}
+
+		this.ancestryOptions = [...byIdentifier.entries()]
+			.map(([value, label]) => ({ value, label }))
+			.sort((a, b) => a.label.localeCompare(b.label));
+	}
+
+	/** Display name for an ancestry identifier (falls back to the id). */
+	ancestryLabel(identifier: string): string {
+		return this.ancestryOptions.find((option) => option.value === identifier)?.label ?? identifier;
+	}
+
+	/**
+	 * Whether a built-in language diverges from its rule defaults (name, tooltip, or
+	 * the "spoken by" ancestries + their names). Controls reset-button visibility.
+	 */
+	isBuiltinCustomized(row: BuiltinLanguageRow): boolean {
+		const labelChanged = row.label.trim() !== '' && row.label.trim() !== row.defaultLabel;
+		const hintChanged = row.hint.trim() !== '' && row.hint.trim() !== row.defaultHint.trim();
+		const speakersChanged = !speakersEqual(row.speakers, row.defaultSpeakers);
+		return labelChanged || hintChanged || speakersChanged;
 	}
 
 	addCustomLanguage = (): void => {
-		this.customRows = [
-			...this.customRows,
-			{ key: '', label: '', aliases: '', hint: '', image: '' },
-		];
+		this.customRows = [...this.customRows, { key: '', label: '', hint: '', speakers: [] }];
 	};
 
 	removeCustomLanguage = (index: number): void => {
@@ -109,11 +188,45 @@ export class LanguageCustomizationDialogState {
 
 	resetBuiltin = (index: number): void => {
 		this.builtinRows = this.builtinRows.map((row, i) =>
-			i === index ? { ...row, label: '', aliases: '', hint: '', image: '' } : row,
+			i === index
+				? { ...row, label: '', hint: '', speakers: cloneSpeakers(row.defaultSpeakers) }
+				: row,
 		);
 	};
 
+	addSpeaker = (row: BuiltinLanguageRow | CustomLanguageRow, ancestry: string): void => {
+		if (!ancestry || row.speakers.some((speaker) => speaker.ancestry === ancestry)) return;
+		row.speakers = [...row.speakers, { ancestry, alias: '' }];
+	};
+
+	removeSpeaker = (row: BuiltinLanguageRow | CustomLanguageRow, ancestry: string): void => {
+		row.speakers = row.speakers.filter((speaker) => speaker.ancestry !== ancestry);
+	};
+
+	/** Effective primary display names tagged with a stable conflict id. */
+	effectiveNames(): { id: string; name: string }[] {
+		const entries: { id: string; name: string }[] = [];
+		for (const row of this.builtinRows) {
+			entries.push({ id: `builtin:${row.key}`, name: row.label.trim() || row.defaultLabel });
+		}
+		this.customRows.forEach((row, index) => {
+			const name = row.label.trim();
+			if (name) entries.push({ id: `custom:${index}`, name });
+		});
+		return entries;
+	}
+
+	conflictIdForBuiltin(row: BuiltinLanguageRow): string {
+		return `builtin:${row.key}`;
+	}
+
+	conflictIdForCustom(index: number): string {
+		return `custom:${index}`;
+	}
+
 	save = async (): Promise<void> => {
+		if (this.hasConflicts) return;
+
 		this.saving = true;
 
 		try {
@@ -122,13 +235,14 @@ export class LanguageCustomizationDialogState {
 				const override: LanguageCustomizations['overrides'][string] = {};
 				const label = row.label.trim();
 				const hint = row.hint.trim();
-				const image = row.image.trim();
-				const aliases = parseAliases(row.aliases);
 
 				if (label && label !== row.defaultLabel) override.label = label;
 				if (hint && hint !== row.defaultHint) override.hint = hint;
-				if (image && image !== row.defaultImage) override.image = image;
-				if (aliases.length) override.aliases = aliases;
+				// Only persist "spoken by" when it differs from the rule defaults, so
+				// untouched languages keep tracking the shipped Nimble rules.
+				if (!speakersEqual(row.speakers, row.defaultSpeakers)) {
+					override.speakers = serializeSpeakers(row.speakers);
+				}
 
 				if (Object.keys(override).length > 0) overrides[row.key] = override;
 			}
@@ -145,13 +259,16 @@ export class LanguageCustomizationDialogState {
 				custom.push({
 					key,
 					label,
-					aliases: parseAliases(row.aliases),
 					hint: row.hint.trim(),
-					image: row.image.trim(),
+					speakers: serializeSpeakers(row.speakers),
 				});
 			}
 
-			await setLanguageCustomizations({ overrides, custom });
+			await setLanguageCustomizations({
+				overrides,
+				custom,
+				alternateNamesEnabled: this.alternateNamesEnabled,
+			});
 		} finally {
 			this.saving = false;
 		}

--- a/src/view/dialogs/languageCustomization/state.svelte.ts
+++ b/src/view/dialogs/languageCustomization/state.svelte.ts
@@ -1,0 +1,159 @@
+import {
+	type CustomLanguage,
+	getBuiltinLanguageBaseline,
+	getLanguageCustomizations,
+	type LanguageCustomizations,
+	setLanguageCustomizations,
+} from '../../../settings/languageSettings.js';
+
+/** Editable row for a built-in language's overrides. */
+export interface BuiltinLanguageRow {
+	key: string;
+	defaultLabel: string;
+	defaultHint: string;
+	defaultImage: string;
+	label: string;
+	aliases: string;
+	hint: string;
+	image: string;
+}
+
+/** Editable row for a GM-authored custom language. */
+export interface CustomLanguageRow {
+	/** Stable key once saved; empty for newly-added rows (generated on save). */
+	key: string;
+	label: string;
+	aliases: string;
+	hint: string;
+	image: string;
+}
+
+const ALIAS_SEPARATOR = ', ';
+
+function parseAliases(text: string): string[] {
+	return text
+		.split(',')
+		.map((alias) => alias.trim())
+		.filter((alias) => alias.length > 0);
+}
+
+function formatAliases(aliases: string[] | undefined): string {
+	return (aliases ?? []).join(ALIAS_SEPARATOR);
+}
+
+/** Slug-derive a stable, unique language key from a label. */
+function generateLanguageKey(label: string, taken: Set<string>): string {
+	const slug = label
+		.trim()
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, ' ')
+		.trim()
+		.split(' ')
+		.map((word, index) => (index === 0 ? word : word.charAt(0).toUpperCase() + word.slice(1)))
+		.join('');
+
+	const base = slug.length > 0 ? slug : 'language';
+	let candidate = base;
+	let suffix = 2;
+	while (taken.has(candidate)) {
+		candidate = `${base}${suffix}`;
+		suffix += 1;
+	}
+	return candidate;
+}
+
+export class LanguageCustomizationDialogState {
+	builtinRows = $state<BuiltinLanguageRow[]>([]);
+
+	customRows = $state<CustomLanguageRow[]>([]);
+
+	saving = $state(false);
+
+	constructor() {
+		const baseline = getBuiltinLanguageBaseline();
+		const { overrides, custom } = getLanguageCustomizations();
+
+		this.builtinRows = Object.entries(baseline.languages).map(([key, defaultLabel]) => {
+			const override = overrides[key] ?? {};
+			return {
+				key,
+				defaultLabel,
+				defaultHint: baseline.languageHints[key] ?? '',
+				defaultImage: baseline.languageImages[key] ?? '',
+				label: override.label ?? '',
+				aliases: formatAliases(override.aliases),
+				hint: override.hint ?? '',
+				image: override.image ?? '',
+			};
+		});
+
+		this.customRows = custom.map((language) => ({
+			key: language.key,
+			label: language.label,
+			aliases: formatAliases(language.aliases),
+			hint: language.hint ?? '',
+			image: language.image ?? '',
+		}));
+	}
+
+	addCustomLanguage = (): void => {
+		this.customRows = [
+			...this.customRows,
+			{ key: '', label: '', aliases: '', hint: '', image: '' },
+		];
+	};
+
+	removeCustomLanguage = (index: number): void => {
+		this.customRows = this.customRows.filter((_, i) => i !== index);
+	};
+
+	resetBuiltin = (index: number): void => {
+		this.builtinRows = this.builtinRows.map((row, i) =>
+			i === index ? { ...row, label: '', aliases: '', hint: '', image: '' } : row,
+		);
+	};
+
+	save = async (): Promise<void> => {
+		this.saving = true;
+
+		try {
+			const overrides: LanguageCustomizations['overrides'] = {};
+			for (const row of this.builtinRows) {
+				const override: LanguageCustomizations['overrides'][string] = {};
+				const label = row.label.trim();
+				const hint = row.hint.trim();
+				const image = row.image.trim();
+				const aliases = parseAliases(row.aliases);
+
+				if (label && label !== row.defaultLabel) override.label = label;
+				if (hint && hint !== row.defaultHint) override.hint = hint;
+				if (image && image !== row.defaultImage) override.image = image;
+				if (aliases.length) override.aliases = aliases;
+
+				if (Object.keys(override).length > 0) overrides[row.key] = override;
+			}
+
+			const taken = new Set<string>(this.builtinRows.map((row) => row.key));
+			const custom: CustomLanguage[] = [];
+			for (const row of this.customRows) {
+				const label = row.label.trim();
+				if (!label) continue;
+
+				const key = row.key || generateLanguageKey(label, taken);
+				taken.add(key);
+
+				custom.push({
+					key,
+					label,
+					aliases: parseAliases(row.aliases),
+					hint: row.hint.trim(),
+					image: row.image.trim(),
+				});
+			}
+
+			await setLanguageCustomizations({ overrides, custom });
+		} finally {
+			this.saving = false;
+		}
+	};
+}

--- a/src/view/sheets/pages/PlayerCharacterCoreTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterCoreTab.svelte
@@ -7,6 +7,7 @@
 	import { createSubscriber } from 'svelte/reactivity';
 	import type { NimbleCharacter } from '../../../documents/actor/character.js';
 	import { registerCombatStateHooks } from '../../../utils/combatState.js';
+	import getLanguageName from '../../../utils/getLanguageName.js';
 	import { initiativeRollLock } from '../../../utils/initiativeRollLock.js';
 	import localize from '../../../utils/localize.js';
 	import { SYSTEM_ID } from '#system';
@@ -32,8 +33,9 @@
 	}
 
 	function getLanguageProficiencies(proficiencies: Iterable<string>) {
+		const ancestryIdentifier = actor.ancestry?.identifier ?? null;
 		return [...proficiencies]
-			.map((key): string => languages[key] ?? key)
+			.map((key): string => getLanguageName(key, { ancestryIdentifier }))
 			.sort((a, b) => a.localeCompare(b));
 	}
 
@@ -94,7 +96,7 @@
 		}
 	}
 
-	const { armorTypesPlural, languages } = CONFIG.NIMBLE;
+	const { armorTypesPlural } = CONFIG.NIMBLE;
 	let actor: NimbleCharacter = getContext('actor');
 	const subscribeCombatState = createSubscriber(registerCombatStateHooks);
 	let initiativeRequestPending = $state(false);


### PR DESCRIPTION
## Summary

Implements #85 — a GM-facing system to **rename built-in languages, add alternate names to any language, and create custom languages**, surfaced live everywhere languages are selected.

A single world setting (`languageCustomizations`) is the source of truth. At `ready` and on every edit, `applyLanguageCustomizations()` rebuilds `CONFIG.NIMBLE.languages` / `languageHints` / `languageImages` / `languageAliases` from an immutable baseline of the shipped built-ins plus the GM's overrides and custom entries. Because every consumer already reads from `CONFIG.NIMBLE`, customizations flow automatically into the character-sheet proficiencies dialog, the character-creation bonus-language step, and the `grantProficiency` rule — with no reload (open sheets/dialogs re-render via the setting's `onChange`).

## Changes
- **New** `src/settings/languageSettings.ts` — setting registration, get/set helpers, merge engine, live re-render
- **New** `src/view/dialogs/LanguageCustomizationDialog.svelte` + `languageCustomization/state.svelte.ts` — GM editor UI (built-in overrides with reset, custom-language CRUD, slug-generated stable keys)
- **New** `src/settings/languageSettings.test.ts` — 7 unit tests
- `src/config.ts` — add `languageAliases` to `NIMBLE`
- `src/settings/index.ts` — register setting + inject a GM-only **Configure Languages** button into the system settings tab
- `src/hooks/ready.ts` — apply customizations on load
- `CharacterLanguageProficienciesConfigDialog.svelte` & `CharacterCreationDialog.svelte.ts` — surface alternate names
- `public/lang/en.json` — new `NIMBLE.settings.languageCustomization.*` strings

## Reviewer notes
- ⚠️ **en.json**: English source strings only added; `es.json`/`fr.json` untouched and need translation through the normal process.
- `pnpm check` passes (format, lint, circular-deps, type-check, 1603 tests).

## How to test
Settings → System → **Configure Languages**. Rename a built-in (e.g. Goblin → Orcish), add an alternate name, add a custom language with hint + icon, Save → confirm an open character's Language Proficiencies dialog updates live with no reload prompt, and the custom language appears in character creation's bonus-language step.

Closes #85