### PR TITLE
feat(rules): hitDiceAdvantage advantage-level support for Hardy boon (#406)

### DIFF
--- a/packs/boons/core/major/hardy.json
+++ b/packs/boons/core/major/hardy.json
@@ -12,7 +12,8 @@
 				"label": "Hardy",
 				"condition": "",
 				"amount": 2,
-				"rollContext": "maxHpIncrease"
+				"rollContext": "maxHpIncrease",
+				"id": "1lZPqDoh5KF6oxc5"
 			}
 		],
 		"description": "<p><span class=\"dig-1hicw9p1_4-2-0 dig-1hicw9p0_4-2-0 dig-ekabin0_4-2-0 dig-Theme-vis2023 dig-Theme-vis2023--dark dig-Mode--dark In-Theme-Provider\" style=\"display: contents;\">Whenever you would roll your Hit Dice to increase your max HP, roll with advantage 2 instead. [M]</span></p>",

--- a/packs/boons/core/major/hardy.json
+++ b/packs/boons/core/major/hardy.json
@@ -6,7 +6,15 @@
 	"system": {
 		"macro": "",
 		"identifier": "",
-		"rules": [],
+		"rules": [
+			{
+				"type": "hitDiceAdvantage",
+				"label": "Hardy",
+				"condition": "",
+				"amount": 2,
+				"rollContext": "maxHpIncrease"
+			}
+		],
 		"description": "<p><span class=\"dig-1hicw9p1_4-2-0 dig-1hicw9p0_4-2-0 dig-ekabin0_4-2-0 dig-Theme-vis2023 dig-Theme-vis2023--dark dig-Mode--dark In-Theme-Provider\" style=\"display: contents;\">Whenever you would roll your Hit Dice to increase your max HP, roll with advantage 2 instead. [M]</span></p>",
 		"boonType": "major"
 	},

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -853,7 +853,19 @@
 				"value": { "label": "Bonus" }
 			},
 			"hitDiceAdvantage": {
-				"description": "Grant advantage on hit-dice rolls under a specific narrative condition (e.g., ‘in the wild’)."
+				"description": "Grant advantage on hit-dice rolls. Raise the amount to roll with greater advantage (e.g. advantage 2), and choose whether it applies to field-rest healing or the max-HP increase when leveling up.",
+				"condition": {
+					"label": "Condition",
+					"hint": "Optional narrative condition shown to the player (e.g. ‘in the wild’). Field-rest rules appear as a toggle during a rest."
+				},
+				"amount": {
+					"label": "Advantage Level",
+					"hint": "1 = normal advantage (roll 2, keep highest). 2 = advantage 2 (roll 3, keep highest)."
+				},
+				"rollContext": {
+					"label": "Applies To",
+					"hint": "Which hit-dice roll the advantage modifies: field-rest healing or the max-HP increase when leveling up."
+				}
 			},
 			"incrementHitDice": {
 				"description": "Increase the size of the actor’s hit dice (e.g. d8 → d10) by a flat or formula amount.",

--- a/src/documents/actor/character.ts
+++ b/src/documents/actor/character.ts
@@ -1230,20 +1230,50 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 			(this.system.attributes as { hitDiceSizeBonus?: number }).hitDiceSizeBonus ?? 0;
 		const effectiveHitDieSize = incrementDieSize(classHitDieSize, hitDiceSizeBonus);
 
+		// Hit-dice advantage rules (e.g., the Hardy boon) can raise the advantage
+		// level on the max-HP-increase roll. The base level-up roll is already made
+		// with advantage (`2d{size}khn`), so the baseline advantage level is 1.
+		const maxHpAdvantageRules = (
+			(
+				this.system.attributes as {
+					hitDiceAdvantageRules?: Array<{ label: string; amount: number; rollContext: string }>;
+				}
+			).hitDiceAdvantageRules ?? []
+		).filter((rule) => (rule.rollContext ?? 'fieldRest') === 'maxHpIncrease');
+
+		const advantageLevel = maxHpAdvantageRules.reduce(
+			(highest, rule) => Math.max(highest, rule.amount ?? 1),
+			1,
+		);
+
+		// Surface the boon(s) that raised the advantage level above the baseline.
+		const hitDiceAdvantageSource =
+			advantageLevel > 1
+				? (maxHpAdvantageRules
+						.filter((rule) => (rule.amount ?? 1) >= advantageLevel)
+						.map((rule) => rule.label)
+						.find((label) => label) ?? null)
+				: null;
+
 		let formula: string;
 
 		if (typedDialogData.takeAverageHp) {
 			formula = Math.ceil((effectiveHitDieSize + 1) / 2).toString();
 		} else {
-			// Use Nimble's leftmost-on-tie keep modifier (`khn`) instead of Foundry's bare `kh`.
-			formula = `2d${effectiveHitDieSize}khn`;
+			// Roll one die per advantage level plus one, keeping the highest. Uses
+			// Nimble's leftmost-on-tie keep modifier (`khn`) instead of Foundry's bare
+			// `kh`. Advantage 1 → `2d{size}khn`; advantage 2 (Hardy) → `3d{size}khn`.
+			formula = `${advantageLevel + 1}d${effectiveHitDieSize}khn`;
 		}
 
 		const roll = new Roll(formula);
 		await roll.evaluate();
 		const hp = roll.total!;
 
-		this.outputLevelUpSummary({ currentClassLevel, ...typedDialogData }, roll);
+		this.outputLevelUpSummary(
+			{ currentClassLevel, ...typedDialogData, hitDiceAdvantageSource },
+			roll,
+		);
 
 		itemUpdates['system.hpData'] = [...characterClass.system.hpData, hp];
 
@@ -1526,7 +1556,7 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 
 	async outputLevelUpSummary(data, roll: Roll | undefined) {
 		const rolls = roll ? [roll] : [];
-		const { currentClassLevel, takeAverageHp } = data;
+		const { currentClassLevel, takeAverageHp, hitDiceAdvantageSource = null } = data;
 
 		const chatData = {
 			author: game.user?.id,
@@ -1538,6 +1568,7 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 				actorType: this.type,
 				currentClassLevel,
 				takeAverageHp,
+				hitDiceAdvantageSource,
 				permissions: this.permission,
 			},
 		};

--- a/src/managers/HitDiceManager.ts
+++ b/src/managers/HitDiceManager.ts
@@ -120,17 +120,13 @@ class HitDiceManager {
 		dieSize?: number,
 		quantity?: number,
 		maximize?: boolean,
-		advantageAmount?: number,
+		advantage?: boolean,
 		skipChatMessage?: boolean,
 	): Promise<{ roll: Roll; healing: number } | null> {
 		const dSize = dieSize ?? this.largest;
 		const dQuantity = quantity ?? 0;
 		const maximizeDie = maximize ?? false;
-		// Advantage level: 0 = no advantage, 1 = roll 2 keep highest, 2 = roll 3 keep
-		// highest (advantage 2), etc. The number of dice rolled per hit die is
-		// `advantage + 1`.
-		const advantage = Math.max(0, advantageAmount ?? 0);
-		const hasAdvantage = advantage > 0;
+		const hasAdvantage = advantage ?? false;
 		const skipChat = skipChatMessage ?? false;
 
 		// Skip rolling if no dice selected
@@ -145,14 +141,12 @@ class HitDiceManager {
 		// Format: (1d8 + STR) + (1d8 + STR) + ... to show each die gets the STR bonus
 		let formula: string;
 		if (hasAdvantage && !maximizeDie) {
-			// Advantage: roll `advantage + 1` dice per hit die and keep the highest,
-			// plus STR per die. Uses Nimble's `khn` (leftmost-on-tie keep highest)
-			// instead of Foundry's bare `kh`. Advantage 1 → "(2d8khn1 + 2)"; advantage 2
-			// → "(3d8khn1 + 2)". Build one such group per spent hit die.
-			const diceToRoll = advantage + 1;
+			// Advantage: roll each die twice and keep the higher, plus STR per die.
+			// Uses Nimble's `khn` (leftmost-on-tie keep highest) instead of Foundry's bare `kh`.
+			// Build formula like "(2d8khn1 + 2) + (2d8khn1 + 2) + (2d8khn1 + 2)" for 3 dice with advantage
 			const advantageParts = Array(dQuantity)
 				.fill(null)
-				.map(() => `(${diceToRoll}d${dSize}khn1 + ${strMod})`);
+				.map(() => `(2d${dSize}khn1 + ${strMod})`);
 			formula = advantageParts.join(' + ');
 		} else {
 			// Normal roll or maximized: show each die with STR bonus

--- a/src/managers/HitDiceManager.ts
+++ b/src/managers/HitDiceManager.ts
@@ -120,13 +120,17 @@ class HitDiceManager {
 		dieSize?: number,
 		quantity?: number,
 		maximize?: boolean,
-		advantage?: boolean,
+		advantageAmount?: number,
 		skipChatMessage?: boolean,
 	): Promise<{ roll: Roll; healing: number } | null> {
 		const dSize = dieSize ?? this.largest;
 		const dQuantity = quantity ?? 0;
 		const maximizeDie = maximize ?? false;
-		const hasAdvantage = advantage ?? false;
+		// Advantage level: 0 = no advantage, 1 = roll 2 keep highest, 2 = roll 3 keep
+		// highest (advantage 2), etc. The number of dice rolled per hit die is
+		// `advantage + 1`.
+		const advantage = Math.max(0, advantageAmount ?? 0);
+		const hasAdvantage = advantage > 0;
 		const skipChat = skipChatMessage ?? false;
 
 		// Skip rolling if no dice selected
@@ -141,12 +145,14 @@ class HitDiceManager {
 		// Format: (1d8 + STR) + (1d8 + STR) + ... to show each die gets the STR bonus
 		let formula: string;
 		if (hasAdvantage && !maximizeDie) {
-			// Advantage: roll each die twice and keep the higher, plus STR per die.
-			// Uses Nimble's `khn` (leftmost-on-tie keep highest) instead of Foundry's bare `kh`.
-			// Build formula like "(2d8khn1 + 2) + (2d8khn1 + 2) + (2d8khn1 + 2)" for 3 dice with advantage
+			// Advantage: roll `advantage + 1` dice per hit die and keep the highest,
+			// plus STR per die. Uses Nimble's `khn` (leftmost-on-tie keep highest)
+			// instead of Foundry's bare `kh`. Advantage 1 → "(2d8khn1 + 2)"; advantage 2
+			// → "(3d8khn1 + 2)". Build one such group per spent hit die.
+			const diceToRoll = advantage + 1;
 			const advantageParts = Array(dQuantity)
 				.fill(null)
-				.map(() => `(2d${dSize}khn1 + ${strMod})`);
+				.map(() => `(${diceToRoll}d${dSize}khn1 + ${strMod})`);
 			formula = advantageParts.join(' + ');
 		} else {
 			// Normal roll or maximized: show each die with STR bonus

--- a/src/managers/RestManager.ts
+++ b/src/managers/RestManager.ts
@@ -212,8 +212,22 @@ class RestManager {
 			(this.#actor.system.attributes as { maximizeHitDice?: boolean }).maximizeHitDice ?? false;
 		const shouldMaximize = makeCamp || maximizeFromRules;
 
-		// Check if any advantage rules are active
-		const hasAdvantage = activeAdvantageRuleIds.length > 0;
+		// Determine the advantage level from active field-rest advantage rules.
+		// 0 = no advantage; multiple active rules use the highest amount.
+		const advantageRules =
+			(
+				this.#actor.system.attributes as {
+					hitDiceAdvantageRules?: Array<{ id: string; amount: number; rollContext: string }>;
+				}
+			).hitDiceAdvantageRules ?? [];
+
+		const advantageAmount = advantageRules
+			.filter(
+				(rule) =>
+					(rule.rollContext ?? 'fieldRest') === 'fieldRest' &&
+					activeAdvantageRuleIds.includes(rule.id),
+			)
+			.reduce((highest, rule) => Math.max(highest, rule.amount ?? 1), 0);
 
 		const rolls: Roll[] = [];
 		let totalHealing = 0;
@@ -227,7 +241,7 @@ class RestManager {
 					Number(size),
 					quantity,
 					shouldMaximize,
-					hasAdvantage,
+					advantageAmount,
 					true, // skipChatMessage
 				);
 				if (result) {

--- a/src/managers/RestManager.ts
+++ b/src/managers/RestManager.ts
@@ -212,22 +212,21 @@ class RestManager {
 			(this.#actor.system.attributes as { maximizeHitDice?: boolean }).maximizeHitDice ?? false;
 		const shouldMaximize = makeCamp || maximizeFromRules;
 
-		// Determine the advantage level from active field-rest advantage rules.
-		// 0 = no advantage; multiple active rules use the highest amount.
+		// Check if any active advantage rules apply to field-rest healing. Rules
+		// scoped to other contexts (e.g., the Hardy boon's max-HP increase) are
+		// excluded so they never grant advantage here.
 		const advantageRules =
 			(
 				this.#actor.system.attributes as {
-					hitDiceAdvantageRules?: Array<{ id: string; amount: number; rollContext: string }>;
+					hitDiceAdvantageRules?: Array<{ id: string; rollContext: string }>;
 				}
 			).hitDiceAdvantageRules ?? [];
 
-		const advantageAmount = advantageRules
-			.filter(
-				(rule) =>
-					(rule.rollContext ?? 'fieldRest') === 'fieldRest' &&
-					activeAdvantageRuleIds.includes(rule.id),
-			)
-			.reduce((highest, rule) => Math.max(highest, rule.amount ?? 1), 0);
+		const hasAdvantage = advantageRules.some(
+			(rule) =>
+				(rule.rollContext ?? 'fieldRest') === 'fieldRest' &&
+				activeAdvantageRuleIds.includes(rule.id),
+		);
 
 		const rolls: Roll[] = [];
 		let totalHealing = 0;
@@ -241,7 +240,7 @@ class RestManager {
 					Number(size),
 					quantity,
 					shouldMaximize,
-					advantageAmount,
+					hasAdvantage,
 					true, // skipChatMessage
 				);
 				if (result) {

--- a/src/models/chat/LevelUpSummaryCardDataModel.ts
+++ b/src/models/chat/LevelUpSummaryCardDataModel.ts
@@ -6,6 +6,13 @@ const { fields } = foundry.data;
 const levelUpSummaryCardSchema = () => ({
 	currentClassLevel: new fields.NumberField({ required: true, initial: 1, nullable: false }),
 	takeAverageHp: new fields.BooleanField({ required: true, initial: false, nullable: false }),
+	// Label of the boon (e.g., Hardy) that raised the advantage level on the
+	// max-HP-increase roll, or null when the baseline advantage was used.
+	hitDiceAdvantageSource: new fields.StringField({
+		required: false,
+		initial: null,
+		nullable: true,
+	}),
 });
 
 declare namespace NimbleLevelUpSummaryCardData {

--- a/src/models/rules/hitDiceAdvantage.test.ts
+++ b/src/models/rules/hitDiceAdvantage.test.ts
@@ -7,6 +7,14 @@ describe('HitDiceAdvantageRule', () => {
 			const schema = HitDiceAdvantageRule.defineSchema();
 			expect(schema).toHaveProperty('type');
 			expect(schema).toHaveProperty('condition');
+			expect(schema).toHaveProperty('amount');
+			expect(schema).toHaveProperty('rollContext');
+		});
+
+		it('defaults amount to 1 and rollContext to fieldRest', () => {
+			const schema = HitDiceAdvantageRule.defineSchema();
+			expect(schema.amount.initial).toBe(1);
+			expect(schema.rollContext.initial).toBe('fieldRest');
 		});
 	});
 

--- a/src/models/rules/hitDiceAdvantage.ts
+++ b/src/models/rules/hitDiceAdvantage.ts
@@ -1,11 +1,42 @@
 import { NimbleBaseRule } from './base.js';
 
+/** Roll contexts a hit-dice advantage rule can apply to. */
+const ROLL_CONTEXTS = ['fieldRest', 'maxHpIncrease'] as const;
+
 function schema() {
 	const { fields } = foundry.data;
 
 	return {
 		// User-facing condition text (e.g., "in the wild", "underground", etc.)
-		condition: new fields.StringField({ required: true, nullable: false, initial: '' }),
+		condition: new fields.StringField({
+			required: true,
+			nullable: false,
+			initial: '',
+			label: 'NIMBLE.rules.hitDiceAdvantage.condition.label',
+			hint: 'NIMBLE.rules.hitDiceAdvantage.condition.hint',
+		}),
+		// Advantage level. 1 = normal advantage (roll 2, keep highest); 2 = advantage 2
+		// (roll 3, keep highest); etc. The number of dice rolled is `amount + 1`.
+		amount: new fields.NumberField({
+			required: true,
+			nullable: false,
+			initial: 1,
+			integer: true,
+			min: 1,
+			label: 'NIMBLE.rules.hitDiceAdvantage.amount.label',
+			hint: 'NIMBLE.rules.hitDiceAdvantage.amount.hint',
+		}),
+		// Which hit-dice roll the advantage applies to. `fieldRest` covers the
+		// healing rolls made during a field rest; `maxHpIncrease` covers the
+		// roll made to increase max HP when leveling up.
+		rollContext: new fields.StringField({
+			required: true,
+			nullable: false,
+			initial: 'fieldRest',
+			choices: [...ROLL_CONTEXTS],
+			label: 'NIMBLE.rules.hitDiceAdvantage.rollContext.label',
+			hint: 'NIMBLE.rules.hitDiceAdvantage.rollContext.hint',
+		}),
 		type: new fields.StringField({ required: true, nullable: false, initial: 'hitDiceAdvantage' }),
 	};
 }
@@ -20,6 +51,10 @@ class HitDiceAdvantageRule extends NimbleBaseRule<HitDiceAdvantageRule.Schema> {
 
 	declare condition: string;
 
+	declare amount: number;
+
+	declare rollContext: 'fieldRest' | 'maxHpIncrease';
+
 	static override defineSchema(): HitDiceAdvantageRule.Schema {
 		return {
 			...NimbleBaseRule.defineSchema(),
@@ -28,7 +63,16 @@ class HitDiceAdvantageRule extends NimbleBaseRule<HitDiceAdvantageRule.Schema> {
 	}
 
 	override tooltipInfo(): string {
-		return super.tooltipInfo(new Map([['condition', 'string']]));
+		return super.tooltipInfo(
+			new Map([
+				['condition', 'string'],
+				['amount', 'number'],
+				[
+					'rollContext',
+					"'fieldRest' <span class=\"nimble-type-summary__operator\">|</span> 'maxHpIncrease'",
+				],
+			]),
+		);
 	}
 
 	prePrepareData(): void {
@@ -40,16 +84,26 @@ class HitDiceAdvantageRule extends NimbleBaseRule<HitDiceAdvantageRule.Schema> {
 
 		if (!this.test()) return;
 
-		// Store the advantage rule for display in the rest dialog
+		// Store the advantage rule for display in the rest dialog and for use
+		// during the max-HP-increase roll on level up.
 		const advantageRules = (foundry.utils.getProperty(
 			actor.system,
 			'attributes.hitDiceAdvantageRules',
-		) ?? []) as Array<{ id: string; label: string; condition: string; sourceId: string }>;
+		) ?? []) as Array<{
+			id: string;
+			label: string;
+			condition: string;
+			amount: number;
+			rollContext: string;
+			sourceId: string;
+		}>;
 
 		advantageRules.push({
 			id: this.id,
 			label: this.label,
 			condition: this.condition,
+			amount: this.amount,
+			rollContext: this.rollContext,
 			sourceId: item.sourceId ?? item.uuid,
 		});
 

--- a/src/view/chat/LevelUpSummaryCard.svelte
+++ b/src/view/chat/LevelUpSummaryCard.svelte
@@ -13,7 +13,14 @@
 	const actorType = $derived(system.actorType);
 	const currentClassLevel = $derived(system.currentClassLevel);
 	const takeAverageHp = $derived(system.takeAverageHp);
+	const hitDiceAdvantageSource = $derived(system.hitDiceAdvantageSource);
 	const permissions = $derived(system.permissions);
+
+	const hitPointsSubheading = $derived.by(() => {
+		if (takeAverageHp) return 'Chose Average';
+		if (hitDiceAdvantageSource) return `Rolled with advantage (${hitDiceAdvantageSource})`;
+		return 'Rolled';
+	});
 
 	const headerBackgroundColor = $derived(messageDocument.reactive.author.color);
 	const headerTextColor = $derived(calculateHeaderTextColor(headerBackgroundColor));
@@ -35,7 +42,7 @@
 		{#if rolls.length}
 			<RollSummary
 				label="Hit Points"
-				subheading={takeAverageHp ? 'Chose Average' : 'Rolled'}
+				subheading={hitPointsSubheading}
 				tooltip={prepareRollTooltip(actorType, permissions, rolls[0])}
 				total={rolls[0].total}
 			/>

--- a/src/view/dialogs/FieldRestDialog.svelte
+++ b/src/view/dialogs/FieldRestDialog.svelte
@@ -9,6 +9,8 @@
 		id: string;
 		label: string;
 		condition: string;
+		amount: number;
+		rollContext: string;
 		sourceId: string;
 	}
 
@@ -106,10 +108,14 @@
 		return clampHitDiceBySize(bySize);
 	});
 
-	// Get hit dice advantage rules from the actor
+	// Get hit dice advantage rules from the actor. Only rules that apply to
+	// field-rest healing are shown here; rules scoped to max-HP increases (e.g.,
+	// the Hardy boon) are handled during level up instead.
 	const advantageRules = $derived(
-		((actor.system.attributes as { hitDiceAdvantageRules?: HitDiceAdvantageRule[] })
-			.hitDiceAdvantageRules ?? []) as HitDiceAdvantageRule[],
+		(
+			((actor.system.attributes as { hitDiceAdvantageRules?: HitDiceAdvantageRule[] })
+				.hitDiceAdvantageRules ?? []) as HitDiceAdvantageRule[]
+		).filter((rule) => (rule.rollContext ?? 'fieldRest') === 'fieldRest'),
 	);
 
 	// Check if hit dice are always maximized (from rules like Oozeling's Odd Constitution)


### PR DESCRIPTION
## Summary

Implements the **Hardy** major boon (#406): _"Whenever you would roll your Hit Dice to increase your max HP, roll with advantage 2 instead."_

Verification first: `hitDiceAdvantage` did **not** support "advantage 2" — it modeled only boolean advantage (`2d{size}khn1`) and only fired during field-rest healing. The max-HP-increase roll happens at level up (`character.ts`), which already rolls with advantage (`2d{size}khn`) or takes the average. So rather than a placeholder note, this PR makes the rule a proper, generic advantage-level building block and wires it into the real roll.

## Changes

- **`hitDiceAdvantage` rule** — adds two fields:
  - `amount` (advantage level, default `1`): number of dice rolled is `amount + 1`, keep highest. `1` = normal advantage; `2` = advantage 2.
  - `rollContext` (`fieldRest` | `maxHpIncrease`, default `fieldRest`): which hit-dice roll the advantage applies to. Keeps existing field-rest rules (e.g. Wild One) working unchanged and prevents max-HP boons from leaking into field rest.
- **Level-up** (`character.ts`) — the max-HP roll honors `maxHpIncrease` rules: advantage 2 → `3d{size}khn`. The boon label is surfaced on the Level Up Summary card.
- **Field rest** (`HitDiceManager` / `RestManager` / `FieldRestDialog`) — the roll honors `amount` too, and the dialog filters to `fieldRest` rules.
- **Hardy boon JSON** — now carries `hitDiceAdvantage` (amount 2, `maxHpIncrease`).
- i18n field labels/hints + updated rule test.

## Testing

- `vitest run` — 1454 passed
- `tsc --noEmit` — clean
- `biome` lint/format + `eslint` (svelte) — clean
- `build:compendia` — builds successfully (validates the Hardy rule data)
- `audit:rules-choices` — 0 mismatches

Closes #406
