### PR TITLE
feat(combat): hand the active turn to another combatant

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -1183,6 +1183,7 @@
 				"woundsValue": "Wounds {current}/{max}",
 				"removeFromCombat": "Remove from Combat",
 				"takeTurn": "Take the Turn",
+				"swapTurns": "Swap Turns",
 				"pingToken": "Ping Token"
 			},
 			"ctSettings": {

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -1181,7 +1181,9 @@
 				"wounds": "Wounds",
 				"woundsHidden": "Wounds hidden",
 				"woundsValue": "Wounds {current}/{max}",
-				"removeFromCombat": "Remove from Combat"
+				"removeFromCombat": "Remove from Combat",
+				"takeTurn": "Take the Turn",
+				"pingToken": "Ping Token"
 			},
 			"ctSettings": {
 				"sizeSection": "Size",

--- a/src/documents/combat/combat.svelte.test.ts
+++ b/src/documents/combat/combat.svelte.test.ts
@@ -32,6 +32,9 @@ describe('NimbleCombat', () => {
 		clearExpandedTurnIdentityHint('combat-legendary-previous-turn-occurrence');
 		clearExpandedTurnIdentityHint('combat-start-top-player');
 		clearExpandedTurnIdentityHint('combat-start-local-combatant-sync');
+		clearExpandedTurnIdentityHint('combat-set-active-turn');
+		clearExpandedTurnIdentityHint('combat-drop-take-turn');
+		clearExpandedTurnIdentityHint('combat-drop-keep-active');
 
 		globals().game.user = { isGM: true, role: 4 };
 		(
@@ -593,6 +596,127 @@ describe('NimbleCombat', () => {
 				occurrence: 0,
 			},
 		});
+	});
+
+	it('moves the active turn to the chosen combatant without advancing the round', async () => {
+		const combatId = 'combat-set-active-turn';
+		const playerOne = createMockCombatant({
+			id: 'player-one',
+			type: 'character',
+			sort: 1,
+			isOwner: true,
+			actor: createCombatActorFixture({ hp: 8, woundsValue: 0, woundsMax: 6 }),
+			combatId,
+		});
+		const playerTwo = createMockCombatant({
+			id: 'player-two',
+			type: 'character',
+			sort: 2,
+			isOwner: true,
+			actor: createCombatActorFixture({ hp: 8, woundsValue: 0, woundsMax: 6 }),
+			combatId,
+		});
+
+		const combat = new NimbleCombat({
+			id: combatId,
+			started: true,
+			round: 1,
+			combatants: createCombatantsCollectionFixture([playerOne, playerTwo]),
+			turns: [playerOne, playerTwo],
+			turn: 0,
+			combatant: playerOne,
+		} as unknown as Combat.CreateData);
+		const update = vi.fn().mockResolvedValue(combat);
+		(combat as NimbleCombat & { update: ReturnType<typeof vi.fn> }).update = update;
+
+		const changed = await combat.setActiveTurnToCombatant('player-two');
+
+		expect(changed).toBe(true);
+		expect(combat.turn).toBe(1);
+		expect(update).toHaveBeenCalledWith({
+			turn: 1,
+			'flags.nimble.expandedTurnIdentity': {
+				combatantId: 'player-two',
+				occurrence: 0,
+			},
+		});
+		// Round is never part of the persisted update.
+		expect(update).not.toHaveBeenCalledWith(expect.objectContaining({ round: expect.anything() }));
+	});
+
+	it('does not change the turn when the target is already active', async () => {
+		const combatId = 'combat-set-active-turn';
+		const playerOne = createMockCombatant({
+			id: 'player-one',
+			type: 'character',
+			sort: 1,
+			isOwner: true,
+			actor: createCombatActorFixture({ hp: 8, woundsValue: 0, woundsMax: 6 }),
+			combatId,
+		});
+		const playerTwo = createMockCombatant({
+			id: 'player-two',
+			type: 'character',
+			sort: 2,
+			isOwner: true,
+			actor: createCombatActorFixture({ hp: 8, woundsValue: 0, woundsMax: 6 }),
+			combatId,
+		});
+
+		const combat = new NimbleCombat({
+			id: combatId,
+			started: true,
+			round: 1,
+			combatants: createCombatantsCollectionFixture([playerOne, playerTwo]),
+			turns: [playerOne, playerTwo],
+			turn: 0,
+			combatant: playerOne,
+		} as unknown as Combat.CreateData);
+		const update = vi.fn().mockResolvedValue(combat);
+		(combat as NimbleCombat & { update: ReturnType<typeof vi.fn> }).update = update;
+
+		const changed = await combat.setActiveTurnToCombatant('player-one');
+
+		expect(changed).toBe(false);
+		expect(combat.turn).toBe(0);
+		expect(update).not.toHaveBeenCalled();
+	});
+
+	it('refuses to set the active turn before combat has started', async () => {
+		const combatId = 'combat-set-active-turn';
+		const playerOne = createMockCombatant({
+			id: 'player-one',
+			type: 'character',
+			sort: 1,
+			isOwner: true,
+			actor: createCombatActorFixture({ hp: 8, woundsValue: 0, woundsMax: 6 }),
+			combatId,
+		});
+		const playerTwo = createMockCombatant({
+			id: 'player-two',
+			type: 'character',
+			sort: 2,
+			isOwner: true,
+			actor: createCombatActorFixture({ hp: 8, woundsValue: 0, woundsMax: 6 }),
+			combatId,
+		});
+
+		const combat = new NimbleCombat({
+			id: combatId,
+			started: false,
+			round: 0,
+			combatants: createCombatantsCollectionFixture([playerOne, playerTwo]),
+			turns: [playerOne, playerTwo],
+			turn: 0,
+			combatant: playerOne,
+		} as unknown as Combat.CreateData);
+		const update = vi.fn().mockResolvedValue(combat);
+		(combat as NimbleCombat & { update: ReturnType<typeof vi.fn> }).update = update;
+
+		const changed = await combat.setActiveTurnToCombatant('player-two');
+
+		expect(changed).toBe(false);
+		expect(update).not.toHaveBeenCalled();
 	});
 
 	it('restores non-player actions to max when rewinding to a previous monster turn', async () => {
@@ -3476,6 +3600,112 @@ describe('NimbleCombat', () => {
 				'system.sort': 4,
 			},
 		]);
+	});
+
+	it('hands the active turn to a combatant dragged ahead of the active combatant', async () => {
+		globals().game.user.isGM = true;
+		const combatId = 'combat-drop-take-turn';
+		const source = createMockCombatant({
+			id: 'player-source',
+			type: 'character',
+			sort: 2,
+			isOwner: true,
+			actor: createCombatActorFixture({ hp: 8, woundsValue: 0, woundsMax: 6 }),
+			combatId,
+		});
+		const active = createMockCombatant({
+			id: 'player-active',
+			type: 'character',
+			sort: 1,
+			isOwner: true,
+			actor: createCombatActorFixture({ hp: 8, woundsValue: 0, woundsMax: 6 }),
+			combatId,
+		});
+		// Turn order after the reorder: source is now ahead of the previously active combatant.
+		const combat = new NimbleCombat({
+			id: combatId,
+			combatants: createCombatantsCollectionFixture([source, active]),
+			turns: [source, active],
+			turn: 1,
+			combatant: active,
+		} as unknown as Combat.CreateData) as NimbleCombat & {
+			update: ReturnType<typeof vi.fn>;
+			updateEmbeddedDocuments: ReturnType<typeof vi.fn>;
+		};
+
+		combat.update = vi.fn().mockResolvedValue(combat);
+		combat.updateEmbeddedDocuments = vi.fn().mockResolvedValue([]);
+		foundryUtils().performIntegerSort.mockReturnValue([
+			{ target: source, update: { 'system.sort': 1 } },
+			{ target: active, update: { 'system.sort': 2 } },
+		]);
+
+		const dropEvent = createCombatDropEvent({
+			sourceId: 'player-source',
+			targetId: 'player-active',
+			before: true,
+		});
+
+		await combat._onDrop(dropEvent);
+
+		expect(combat.turn).toBe(0);
+		expect(combat.update).toHaveBeenCalledWith({
+			turn: 0,
+			'flags.nimble.expandedTurnIdentity': {
+				combatantId: 'player-source',
+				occurrence: 0,
+			},
+		});
+	});
+
+	it('keeps the active combatant when a reorder does not move ahead of it', async () => {
+		globals().game.user.isGM = true;
+		const combatId = 'combat-drop-keep-active';
+		const active = createMockCombatant({
+			id: 'player-active',
+			type: 'character',
+			sort: 1,
+			isOwner: true,
+			actor: createCombatActorFixture({ hp: 8, woundsValue: 0, woundsMax: 6 }),
+			combatId,
+		});
+		const source = createMockCombatant({
+			id: 'player-source',
+			type: 'character',
+			sort: 2,
+			isOwner: true,
+			actor: createCombatActorFixture({ hp: 8, woundsValue: 0, woundsMax: 6 }),
+			combatId,
+		});
+		// Turn order after the reorder: source remains behind the active combatant.
+		const combat = new NimbleCombat({
+			id: combatId,
+			combatants: createCombatantsCollectionFixture([active, source]),
+			turns: [active, source],
+			turn: 0,
+			combatant: active,
+		} as unknown as Combat.CreateData) as NimbleCombat & {
+			update: ReturnType<typeof vi.fn>;
+			updateEmbeddedDocuments: ReturnType<typeof vi.fn>;
+		};
+
+		combat.update = vi.fn().mockResolvedValue(combat);
+		combat.updateEmbeddedDocuments = vi.fn().mockResolvedValue([]);
+		foundryUtils().performIntegerSort.mockReturnValue([
+			{ target: source, update: { 'system.sort': 2 } },
+			{ target: active, update: { 'system.sort': 1 } },
+		]);
+
+		const dropEvent = createCombatDropEvent({
+			sourceId: 'player-source',
+			targetId: 'player-active',
+			before: false,
+		});
+
+		await combat._onDrop(dropEvent);
+
+		expect(combat.turn).toBe(0);
+		expect(combat.update).not.toHaveBeenCalled();
 	});
 
 	it('uses distinct visible turn siblings for GM reorder sorting', async () => {

--- a/src/documents/combat/combat.svelte.test.ts
+++ b/src/documents/combat/combat.svelte.test.ts
@@ -719,6 +719,180 @@ describe('NimbleCombat', () => {
 		expect(update).not.toHaveBeenCalled();
 	});
 
+	it('swaps the active combatant and the target combatant in the turn order', async () => {
+		const combatId = 'combat-swap-turn';
+		const playerOne = createMockCombatant({
+			id: 'player-one',
+			type: 'character',
+			sort: 1,
+			isOwner: true,
+			actionsCurrent: 2,
+			actionsMax: 2,
+			actor: createCombatActorFixture({ hp: 8, woundsValue: 0, woundsMax: 6 }),
+			combatId,
+		});
+		const playerTwo = createMockCombatant({
+			id: 'player-two',
+			type: 'character',
+			sort: 2,
+			isOwner: true,
+			actionsCurrent: 2,
+			actionsMax: 2,
+			actor: createCombatActorFixture({ hp: 8, woundsValue: 0, woundsMax: 6 }),
+			combatId,
+		});
+
+		const combat = new NimbleCombat({
+			id: combatId,
+			started: true,
+			round: 1,
+			combatants: createCombatantsCollectionFixture([playerOne, playerTwo]),
+			turns: [playerOne, playerTwo],
+			turn: 0,
+			combatant: playerOne,
+		} as unknown as Combat.CreateData) as NimbleCombat & {
+			update: ReturnType<typeof vi.fn>;
+			updateEmbeddedDocuments: ReturnType<typeof vi.fn>;
+		};
+		combat.update = vi.fn().mockResolvedValue(combat);
+		combat.updateEmbeddedDocuments = vi
+			.fn()
+			.mockImplementation(
+				async (_documentName: string, updates: Array<Record<string, unknown>>) => {
+					for (const update of updates) {
+						const id = update._id as string | undefined;
+						if (!id) continue;
+						const target = combat.combatants.get(id);
+						if (!target) continue;
+						const nextSort = update['system.sort'];
+						if (typeof nextSort === 'number') {
+							foundry.utils.setProperty(target, 'system.sort', nextSort);
+						}
+					}
+					return updates as unknown as Combatant.Implementation[];
+				},
+			);
+		// Reflect the sort exchange in the turn order, mirroring the real setupTurns sort.
+		combat.setupTurns = vi.fn(() =>
+			[...combat.combatants.contents].sort(
+				(a, b) =>
+					(foundry.utils.getProperty(a, 'system.sort') as number) -
+					(foundry.utils.getProperty(b, 'system.sort') as number),
+			),
+		);
+
+		const changed = await combat.swapTurnWithActiveCombatant('player-two');
+
+		expect(changed).toBe(true);
+		// The two combatants exchanged positions in the order.
+		expect(foundry.utils.getProperty(playerOne, 'system.sort')).toBe(2);
+		expect(foundry.utils.getProperty(playerTwo, 'system.sort')).toBe(1);
+		expect(combat.updateEmbeddedDocuments).toHaveBeenCalledWith('Combatant', [
+			{ _id: 'player-one', 'system.sort': 2 },
+			{ _id: 'player-two', 'system.sort': 1 },
+		]);
+		// The target now holds the active turn at the front of the order.
+		expect(combat.turns[combat.turn ?? -1]?.id).toBe('player-two');
+	});
+
+	it('ends the handed-off turn and refills actions when the active combatant is out of actions', async () => {
+		const combatId = 'combat-handoff-end-turn';
+		const playerOne = createMockCombatant({
+			id: 'player-one',
+			type: 'character',
+			sort: 1,
+			isOwner: true,
+			actionsCurrent: 0,
+			actionsMax: 3,
+			actor: createCombatActorFixture({ hp: 8, woundsValue: 0, woundsMax: 6 }),
+			combatId,
+		});
+		const playerTwo = createMockCombatant({
+			id: 'player-two',
+			type: 'character',
+			sort: 2,
+			isOwner: true,
+			actionsCurrent: 3,
+			actionsMax: 3,
+			actor: createCombatActorFixture({ hp: 8, woundsValue: 0, woundsMax: 6 }),
+			combatId,
+		});
+
+		const combat = new NimbleCombat({
+			id: combatId,
+			started: true,
+			round: 1,
+			combatants: createCombatantsCollectionFixture([playerOne, playerTwo]),
+			turns: [playerOne, playerTwo],
+			turn: 0,
+			combatant: playerOne,
+		} as unknown as Combat.CreateData) as NimbleCombat & {
+			update: ReturnType<typeof vi.fn>;
+			updateEmbeddedDocuments: ReturnType<typeof vi.fn>;
+		};
+		combat.update = vi.fn().mockResolvedValue(combat);
+		combat.updateEmbeddedDocuments = vi.fn().mockResolvedValue([]);
+
+		const changed = await combat.setActiveTurnToCombatant('player-two');
+
+		expect(changed).toBe(true);
+		expect(combat.updateEmbeddedDocuments).toHaveBeenCalledWith('Combatant', [
+			expect.objectContaining({
+				_id: 'player-one',
+				'system.actions.base.current': 3,
+				'system.actions.base.additional': 0,
+				'system.actions.heroic.defendAvailable': true,
+				'system.actions.heroic.interposeAvailable': true,
+				'system.actions.heroic.opportunityAttackAvailable': true,
+				'system.actions.heroic.helpAvailable': true,
+			}),
+		]);
+	});
+
+	it('does not refill the handed-off combatant when they still have actions left', async () => {
+		const combatId = 'combat-handoff-keep-actions';
+		const playerOne = createMockCombatant({
+			id: 'player-one',
+			type: 'character',
+			sort: 1,
+			isOwner: true,
+			actionsCurrent: 1,
+			actionsMax: 3,
+			actor: createCombatActorFixture({ hp: 8, woundsValue: 0, woundsMax: 6 }),
+			combatId,
+		});
+		const playerTwo = createMockCombatant({
+			id: 'player-two',
+			type: 'character',
+			sort: 2,
+			isOwner: true,
+			actionsCurrent: 3,
+			actionsMax: 3,
+			actor: createCombatActorFixture({ hp: 8, woundsValue: 0, woundsMax: 6 }),
+			combatId,
+		});
+
+		const combat = new NimbleCombat({
+			id: combatId,
+			started: true,
+			round: 1,
+			combatants: createCombatantsCollectionFixture([playerOne, playerTwo]),
+			turns: [playerOne, playerTwo],
+			turn: 0,
+			combatant: playerOne,
+		} as unknown as Combat.CreateData) as NimbleCombat & {
+			update: ReturnType<typeof vi.fn>;
+			updateEmbeddedDocuments: ReturnType<typeof vi.fn>;
+		};
+		combat.update = vi.fn().mockResolvedValue(combat);
+		combat.updateEmbeddedDocuments = vi.fn().mockResolvedValue([]);
+
+		const changed = await combat.setActiveTurnToCombatant('player-two');
+
+		expect(changed).toBe(true);
+		expect(combat.updateEmbeddedDocuments).not.toHaveBeenCalled();
+	});
+
 	it('restores non-player actions to max when rewinding to a previous monster turn', async () => {
 		const combatId = 'combat-rewind-restore-monster-actions';
 		const monster = createMockCombatant({

--- a/src/documents/combat/combat.svelte.ts
+++ b/src/documents/combat/combat.svelte.ts
@@ -1094,8 +1094,15 @@ class NimbleCombat extends Combat {
 	 *
 	 * Returns whether the active turn actually changed.
 	 */
-	async setActiveTurnToCombatant(combatantId: string): Promise<boolean> {
+	async setActiveTurnToCombatant(
+		combatantId: string,
+		options: { previousActiveCombatant?: Combatant.Implementation | null } = {},
+	): Promise<boolean> {
 		if (!combatantId || !this.started) return false;
+		const previousActiveCombatant =
+			options.previousActiveCombatant !== undefined
+				? options.previousActiveCombatant
+				: (this.combatant ?? null);
 		this.#syncTurnIndexWithAliveTurns();
 		const targetIndex = this.turns.findIndex((turn) => (turn?.id ?? '') === combatantId);
 		if (targetIndex < 0) return false;
@@ -1103,7 +1110,79 @@ class NimbleCombat extends Combat {
 		if (!targetIdentity) return false;
 		const previousTurnIndex = Number.isInteger(this.turn) ? Number(this.turn) : -1;
 		await this.#syncTurnToCombatant(targetIdentity);
-		return this.turn !== previousTurnIndex;
+		const changed = this.turn !== previousTurnIndex;
+		if (changed) {
+			await this.#endHandedOffCombatantTurnIfDepleted(previousActiveCombatant, combatantId);
+		}
+		return changed;
+	}
+
+	/**
+	 * When the active turn is handed to a different combatant, the combatant losing the turn ends
+	 * theirs as if it had run to completion — but only if they had already spent all of their
+	 * actions. This refills their actions, clears additional actions, restores heroic reactions,
+	 * and fires the Nimble end-of-turn hook (charge-pool recovery, etc.). A combatant who still has
+	 * actions left is simply interrupted and keeps their remaining actions for when play returns.
+	 */
+	async #endHandedOffCombatantTurnIfDepleted(
+		combatant: Combatant.Implementation | null | undefined,
+		nextActiveCombatantId: string,
+	): Promise<void> {
+		if (!combatant || combatant.type !== 'character') return;
+		const combatantId = combatant.id ?? null;
+		if (!combatantId || combatantId === nextActiveCombatantId) return;
+		if (getCombatantCurrentActions(combatant) !== 0) return;
+
+		// @ts-expect-error Custom hook
+		Hooks.call('nimbleCombatTurnEnd', combatant);
+
+		await this.updateEmbeddedDocuments('Combatant', [
+			{
+				_id: combatantId,
+				'system.actions.base.current': getCombatantResetActions(combatant),
+				'system.actions.base.additional': 0,
+				...this.#buildHeroicReactionAvailabilityUpdate(true),
+			} as Record<string, unknown>,
+		]);
+	}
+
+	/**
+	 * Swap the active turn with another combatant: exchange the two combatants' positions in the
+	 * turn order and hand the active turn to the target. Unlike {@link setActiveTurnToCombatant} —
+	 * which leaves the order untouched and simply repoints the active turn — this trades the
+	 * target's slot with the active combatant's slot, so the previously active combatant lands
+	 * where the target used to be. Backs the "swap turns" control.
+	 *
+	 * Returns whether anything changed.
+	 */
+	async swapTurnWithActiveCombatant(combatantId: string): Promise<boolean> {
+		if (!combatantId || !this.started) return false;
+		this.#syncTurnIndexWithAliveTurns();
+
+		const activeCombatant = this.combatant ?? null;
+		const targetCombatant = this.combatants.get(combatantId) ?? null;
+		if (!activeCombatant || !targetCombatant) return false;
+
+		const activeCombatantId = activeCombatant.id ?? null;
+		if (!activeCombatantId || activeCombatantId === combatantId) return false;
+		if (isCombatantDead(activeCombatant) || isCombatantDead(targetCombatant)) return false;
+
+		const activeSort = getCombatantManualSortValue(activeCombatant);
+		const targetSort = getCombatantManualSortValue(targetCombatant);
+		const sortChanged = activeSort !== targetSort;
+
+		if (sortChanged) {
+			await this.updateEmbeddedDocuments('Combatant', [
+				{ _id: activeCombatantId, 'system.sort': targetSort } as Record<string, unknown>,
+				{ _id: combatantId, 'system.sort': activeSort } as Record<string, unknown>,
+			]);
+			this.turns = this.setupTurns();
+		}
+
+		const turnChanged = await this.setActiveTurnToCombatant(combatantId, {
+			previousActiveCombatant: activeCombatant,
+		});
+		return sortChanged || turnChanged;
 	}
 
 	override async nextTurn(): Promise<this> {

--- a/src/documents/combat/combat.svelte.ts
+++ b/src/documents/combat/combat.svelte.ts
@@ -2,6 +2,7 @@ import { createSubscriber } from 'svelte/reactivity';
 import type { ActorRollOptions } from '#documents/actor/actorInterfaces.ts';
 import type { NimbleCombatant } from '#documents/combatant/combatant.svelte.js';
 import { systemHookName } from '#system';
+import { requestSetActiveCombatTurn } from '#utils/combatTurnActions.js';
 import {
 	getHeroicReactionUsageState,
 	isSoftBlockedReason,
@@ -1086,6 +1087,25 @@ class NimbleCombat extends Combat {
 		return expandLegendaryTurns(minionNormalizedTurns);
 	}
 
+	/**
+	 * Repoint the active turn to a specific combatant within the current round, without advancing
+	 * the round or running turn-end cleanup. Backs the "take the turn" controls and drag-to-front
+	 * reordering, where a combatant is moved ahead of the active combatant and becomes active.
+	 *
+	 * Returns whether the active turn actually changed.
+	 */
+	async setActiveTurnToCombatant(combatantId: string): Promise<boolean> {
+		if (!combatantId || !this.started) return false;
+		this.#syncTurnIndexWithAliveTurns();
+		const targetIndex = this.turns.findIndex((turn) => (turn?.id ?? '') === combatantId);
+		if (targetIndex < 0) return false;
+		const targetIdentity = this.#resolveTurnIdentityAtIndex(this.turns, targetIndex);
+		if (!targetIdentity) return false;
+		const previousTurnIndex = Number.isInteger(this.turn) ? Number(this.turn) : -1;
+		await this.#syncTurnToCombatant(targetIdentity);
+		return this.turn !== previousTurnIndex;
+	}
+
 	override async nextTurn(): Promise<this> {
 		this.#syncTurnIndexWithAliveTurns();
 		const preferredNextTurnIdentity = this.#resolveNextTurnIdentity();
@@ -1197,6 +1217,9 @@ class NimbleCombat extends Combat {
 			dropResolution,
 			syncTurnToCombatant: (combatantIdOrIdentity, options) =>
 				this.#syncTurnToCombatant(combatantIdOrIdentity, options),
+			requestSetActiveTurn: async (combatantId) => {
+				await requestSetActiveCombatTurn({ combat: this, targetCombatantId: combatantId });
+			},
 		});
 	}
 }

--- a/src/documents/combat/combatSorting.ts
+++ b/src/documents/combat/combatSorting.ts
@@ -2,6 +2,7 @@ import {
 	canCurrentUserReorderCombatant,
 	getCombatantTypePriority,
 } from '../../utils/combatantOrdering.js';
+import { canUserTakeCombatTurn } from '../../utils/combatTurnActions.js';
 import { isCombatantDead } from '../../utils/isCombatantDead.js';
 import { getCombatantManualSortValue } from './combatantSystem.js';
 import { getSourceSortValueForDrop } from './combatCommon.js';
@@ -399,7 +400,14 @@ export async function applyOwnerSort(params: {
 	} as Record<string, unknown>);
 	params.combat.turns = params.combat.setupTurns();
 
-	if (shouldSourceTakeActiveTurn(params.combat, params.dropResolution)) {
+	// Only take the active turn when the GM relay would actually accept it. Otherwise the optimistic
+	// local sync below would repoint this client's turn pointer to a target the GM rejects (e.g. a
+	// monster holds the turn), leaving the owner's tracker desynced until the next combat update.
+	const sourceCanTakeActiveTurn =
+		shouldSourceTakeActiveTurn(params.combat, params.dropResolution) &&
+		canUserTakeCombatTurn(params.combat, params.dropResolution.source, game.user);
+
+	if (sourceCanTakeActiveTurn) {
 		// Owners cannot persist combat.turn directly; relay the active-turn change to the GM.
 		const sourceId = getCombatantId(params.dropResolution.source);
 		await params.syncTurnToCombatant(sourceId, { persist: false });

--- a/src/documents/combat/combatSorting.ts
+++ b/src/documents/combat/combatSorting.ts
@@ -266,6 +266,31 @@ function shouldUseBlockSort(dropResolution: DropResolution): boolean {
 	return dropResolution.sourceCombatants.length > 1 || dropResolution.targetCombatantIds.length > 1;
 }
 
+/**
+ * After a reorder, decide whether the dragged source should take over the active turn. The source
+ * becomes active only when it has been moved ahead of (before) the previously active combatant in
+ * the new turn order — i.e. dropped toward the front. Otherwise the previously active combatant
+ * keeps the turn, preserving the reorder-does-not-change-active behavior for everything else.
+ */
+function shouldSourceTakeActiveTurn(combat: Combat, dropResolution: DropResolution): boolean {
+	const previousActiveCombatantId = dropResolution.previousActiveTurnIdentity?.combatantId ?? '';
+	if (!previousActiveCombatantId) return false;
+
+	const sourceId = getCombatantId(dropResolution.source);
+	if (!sourceId || sourceId === previousActiveCombatantId) return false;
+
+	const turns = combat.turns;
+	const sourceIndex = turns.findIndex((combatant) => getCombatantId(combatant) === sourceId);
+	if (sourceIndex < 0) return false;
+
+	const activeIndex = turns.findIndex(
+		(combatant) => getCombatantId(combatant) === previousActiveCombatantId,
+	);
+	if (activeIndex < 0) return false;
+
+	return sourceIndex < activeIndex;
+}
+
 function buildBlockSortUpdateData(
 	dropResolution: DropResolution,
 ): Array<Record<string, unknown>> | null {
@@ -306,7 +331,9 @@ export async function applyGmSort(params: {
 
 		const updates = await params.combat.updateEmbeddedDocuments('Combatant', updateData);
 		params.combat.turns = params.combat.setupTurns();
-		await params.syncTurnToCombatant(params.dropResolution.previousActiveTurnIdentity);
+		await params.syncTurnToCombatant(
+			resolveTurnSyncTargetAfterSort(params.combat, params.dropResolution),
+		);
 		return updates;
 	}
 
@@ -332,14 +359,31 @@ export async function applyGmSort(params: {
 
 	const updates = await params.combat.updateEmbeddedDocuments('Combatant', updateData);
 	params.combat.turns = params.combat.setupTurns();
-	await params.syncTurnToCombatant(params.dropResolution.previousActiveTurnIdentity);
+	await params.syncTurnToCombatant(
+		resolveTurnSyncTargetAfterSort(params.combat, params.dropResolution),
+	);
 	return updates;
+}
+
+/**
+ * Resolve the combatant the active turn should point at after a GM reorder: the dragged source
+ * when it was moved to the front, otherwise the previously active combatant.
+ */
+function resolveTurnSyncTargetAfterSort(
+	combat: Combat,
+	dropResolution: DropResolution,
+): string | TurnIdentity | null {
+	if (shouldSourceTakeActiveTurn(combat, dropResolution)) {
+		return getCombatantId(dropResolution.source);
+	}
+	return dropResolution.previousActiveTurnIdentity;
 }
 
 export async function applyOwnerSort(params: {
 	combat: Combat;
 	dropResolution: DropResolution;
 	syncTurnToCombatant: SyncTurnToCombatant;
+	requestSetActiveTurn: (combatantId: string) => Promise<void>;
 }) {
 	// Non-GM owners can reorder their own character card by updating only their card's sort value.
 	const newSortValue = getSourceSortValueForDrop(
@@ -354,8 +398,16 @@ export async function applyOwnerSort(params: {
 		'system.sort': newSortValue,
 	} as Record<string, unknown>);
 	params.combat.turns = params.combat.setupTurns();
-	await params.syncTurnToCombatant(params.dropResolution.previousActiveTurnIdentity, {
-		persist: false,
-	});
+
+	if (shouldSourceTakeActiveTurn(params.combat, params.dropResolution)) {
+		// Owners cannot persist combat.turn directly; relay the active-turn change to the GM.
+		const sourceId = getCombatantId(params.dropResolution.source);
+		await params.syncTurnToCombatant(sourceId, { persist: false });
+		await params.requestSetActiveTurn(sourceId);
+	} else {
+		await params.syncTurnToCombatant(params.dropResolution.previousActiveTurnIdentity, {
+			persist: false,
+		});
+	}
 	return updated ? [updated] : [];
 }

--- a/src/utils/combatTurnActions.test.ts
+++ b/src/utils/combatTurnActions.test.ts
@@ -12,6 +12,7 @@ import {
 	registerCombatTurnSocketListener,
 	requestAdvanceCombatTurn,
 	requestSetActiveCombatTurn,
+	requestSwapCombatTurn,
 	resolveCombatantCurrentActionsAfterDelta,
 } from './combatTurnActions.js';
 
@@ -217,6 +218,67 @@ describe('requestAdvanceCombatTurn', () => {
 			userId: 'player-owner',
 			activeCombatantId: 'combatant-owner',
 		});
+	});
+});
+
+describe('requestSwapCombatTurn', () => {
+	it('swaps the active turn directly for a GM user', async () => {
+		const swapTurnWithActiveCombatant = vi.fn().mockResolvedValue(true);
+		const activeCombatant = createMockCombatant({
+			id: 'combatant-active',
+			type: 'character',
+			combatId: 'combat-gm-swap',
+		});
+		const targetCombatant = createMockCombatant({
+			id: 'combatant-target',
+			type: 'character',
+			combatId: 'combat-gm-swap',
+		});
+		const combat = {
+			id: 'combat-gm-swap',
+			started: true,
+			combatant: activeCombatant,
+			combatants: createCombatantsCollectionFixture([activeCombatant, targetCombatant]),
+			swapTurnWithActiveCombatant,
+		} as unknown as Combat;
+
+		(
+			globalThis as unknown as {
+				game: { user: { id: string; isGM: boolean } };
+			}
+		).game.user = { id: 'gm-user', isGM: true };
+
+		await expect(
+			requestSwapCombatTurn({ combat, targetCombatantId: 'combatant-target' }),
+		).resolves.toBe(true);
+		expect(swapTurnWithActiveCombatant).toHaveBeenCalledWith('combatant-target');
+	});
+
+	it('refuses to swap when the target is already the active combatant', async () => {
+		const swapTurnWithActiveCombatant = vi.fn().mockResolvedValue(true);
+		const activeCombatant = createMockCombatant({
+			id: 'combatant-active',
+			type: 'character',
+			combatId: 'combat-gm-swap-self',
+		});
+		const combat = {
+			id: 'combat-gm-swap-self',
+			started: true,
+			combatant: activeCombatant,
+			combatants: createCombatantsCollectionFixture([activeCombatant]),
+			swapTurnWithActiveCombatant,
+		} as unknown as Combat;
+
+		(
+			globalThis as unknown as {
+				game: { user: { id: string; isGM: boolean } };
+			}
+		).game.user = { id: 'gm-user', isGM: true };
+
+		await expect(
+			requestSwapCombatTurn({ combat, targetCombatantId: 'combatant-active' }),
+		).resolves.toBe(false);
+		expect(swapTurnWithActiveCombatant).not.toHaveBeenCalled();
 	});
 });
 

--- a/src/utils/combatTurnActions.test.ts
+++ b/src/utils/combatTurnActions.test.ts
@@ -6,10 +6,12 @@ import {
 import { createMockCombatant } from '../../tests/mocks/combat.js';
 import { combatantActionMutationQueue } from './combatantActionMutationQueue.js';
 import {
+	canUserTakeCombatTurn,
 	consumeCombatantAction,
 	getCombatantMaxActions,
 	registerCombatTurnSocketListener,
 	requestAdvanceCombatTurn,
+	requestSetActiveCombatTurn,
 	resolveCombatantCurrentActionsAfterDelta,
 } from './combatTurnActions.js';
 
@@ -401,5 +403,215 @@ describe('consumeCombatantAction', () => {
 		expect(updateEmbeddedDocuments).toHaveBeenCalledWith('Combatant', [
 			{ _id: 'c1', 'system.actions.base.current': 2 },
 		]);
+	});
+});
+
+describe('canUserTakeCombatTurn', () => {
+	function createCharacterCombatant(id: string, ownerId: string | null): Combatant.Implementation {
+		const actor = {
+			...createCombatActorFixture({
+				id: `actor-${id}`,
+				type: 'character',
+				woundsValue: 0,
+				woundsMax: 6,
+			}),
+			testUserPermission: vi.fn((user: { id?: string | null }) => user?.id === ownerId),
+		} as unknown as Actor.Implementation;
+		return createMockCombatant({ id, type: 'character', actor, combatId: 'combat-take-turn' });
+	}
+
+	function createMonsterCombatant(id: string): Combatant.Implementation {
+		return createMockCombatant({
+			id,
+			type: 'npc',
+			actor: createCombatActorFixture({ id: `actor-${id}`, hp: 20 }),
+			combatId: 'combat-take-turn',
+		});
+	}
+
+	function createCombat(
+		activeCombatant: Combatant.Implementation | null,
+		combatants: Combatant.Implementation[],
+	): Combat {
+		return {
+			id: 'combat-take-turn',
+			started: true,
+			combatant: activeCombatant,
+			combatants: createCombatantsCollectionFixture(combatants),
+		} as unknown as Combat;
+	}
+
+	it('lets a GM hand the turn to any living combatant, including a monster', () => {
+		const player = createCharacterCombatant('player-one', 'player-owner');
+		const monster = createMonsterCombatant('monster-one');
+		const combat = createCombat(player, [player, monster]);
+		const gm = { id: 'gm-user', isGM: true } as User.Implementation;
+
+		expect(canUserTakeCombatTurn(combat, monster, gm)).toBe(true);
+	});
+
+	it('lets an owner swap the turn to their character while a fellow player is active', () => {
+		const activePlayer = createCharacterCombatant('player-one', 'other-owner');
+		const ownedPlayer = createCharacterCombatant('player-two', 'player-owner');
+		const combat = createCombat(activePlayer, [activePlayer, ownedPlayer]);
+		const owner = { id: 'player-owner', isGM: false } as User.Implementation;
+
+		expect(canUserTakeCombatTurn(combat, ownedPlayer, owner)).toBe(true);
+	});
+
+	it('forbids an owner from pulling the turn away from an active monster', () => {
+		const activeMonster = createMonsterCombatant('monster-one');
+		const ownedPlayer = createCharacterCombatant('player-two', 'player-owner');
+		const combat = createCombat(activeMonster, [activeMonster, ownedPlayer]);
+		const owner = { id: 'player-owner', isGM: false } as User.Implementation;
+
+		expect(canUserTakeCombatTurn(combat, ownedPlayer, owner)).toBe(false);
+	});
+
+	it('forbids an owner from claiming the turn for a character they do not own', () => {
+		const activePlayer = createCharacterCombatant('player-one', 'other-owner');
+		const unownedPlayer = createCharacterCombatant('player-two', 'other-owner');
+		const combat = createCombat(activePlayer, [activePlayer, unownedPlayer]);
+		const owner = { id: 'player-owner', isGM: false } as User.Implementation;
+
+		expect(canUserTakeCombatTurn(combat, unownedPlayer, owner)).toBe(false);
+	});
+});
+
+describe('requestSetActiveCombatTurn', () => {
+	it('applies the change directly for a GM user', async () => {
+		const setActiveTurnToCombatant = vi.fn().mockResolvedValue(true);
+		const target = createMockCombatant({ id: 'target', type: 'character', combatId: 'combat-set' });
+		const active = createMockCombatant({ id: 'active', type: 'character', combatId: 'combat-set' });
+		const combat = {
+			id: 'combat-set',
+			started: true,
+			combatant: active,
+			combatants: createCombatantsCollectionFixture([active, target]),
+			setActiveTurnToCombatant,
+		} as unknown as Combat;
+
+		(globalThis as unknown as { game: { user: { id: string; isGM: boolean } } }).game.user = {
+			id: 'gm-user',
+			isGM: true,
+		};
+
+		await expect(requestSetActiveCombatTurn({ combat, targetCombatantId: 'target' })).resolves.toBe(
+			true,
+		);
+		expect(setActiveTurnToCombatant).toHaveBeenCalledWith('target');
+	});
+
+	it('returns false without acting when the target is already active', async () => {
+		const setActiveTurnToCombatant = vi.fn().mockResolvedValue(true);
+		const active = createMockCombatant({ id: 'active', type: 'character', combatId: 'combat-set' });
+		const combat = {
+			id: 'combat-set',
+			started: true,
+			combatant: active,
+			combatants: createCombatantsCollectionFixture([active]),
+			setActiveTurnToCombatant,
+		} as unknown as Combat;
+
+		(globalThis as unknown as { game: { user: { id: string; isGM: boolean } } }).game.user = {
+			id: 'gm-user',
+			isGM: true,
+		};
+
+		await expect(requestSetActiveCombatTurn({ combat, targetCombatantId: 'active' })).resolves.toBe(
+			false,
+		);
+		expect(setActiveTurnToCombatant).not.toHaveBeenCalled();
+	});
+
+	it('relays a socket request for an eligible owner swapping with a fellow player', async () => {
+		const socketEmit = vi.fn();
+		const activeActor = {
+			...createCombatActorFixture({
+				id: 'actor-active',
+				type: 'character',
+				woundsValue: 0,
+				woundsMax: 6,
+			}),
+			testUserPermission: vi.fn(() => false),
+		} as unknown as Actor.Implementation;
+		const active = createMockCombatant({
+			id: 'active',
+			type: 'character',
+			actor: activeActor,
+			combatId: 'combat-set',
+		});
+		const targetActor = {
+			...createCombatActorFixture({
+				id: 'actor-target',
+				type: 'character',
+				woundsValue: 0,
+				woundsMax: 6,
+			}),
+			testUserPermission: vi.fn((user: { id?: string | null }) => user?.id === 'player-owner'),
+		} as unknown as Actor.Implementation;
+		const target = createMockCombatant({
+			id: 'target',
+			type: 'character',
+			actor: targetActor,
+			combatId: 'combat-set',
+		});
+		const combat = {
+			id: 'combat-set',
+			started: true,
+			combatant: active,
+			combatants: createCombatantsCollectionFixture([active, target]),
+		} as unknown as Combat;
+
+		(
+			globalThis as unknown as {
+				game: {
+					socket: { emit: ReturnType<typeof vi.fn> };
+					user: { id: string; isGM: boolean };
+					users: {
+						activeGM: { id: string };
+						contents: Array<{ id: string; isGM: boolean; active: boolean }>;
+					};
+				};
+			}
+		).game.socket = { emit: socketEmit };
+		(
+			globalThis as unknown as {
+				game: {
+					socket: { emit: ReturnType<typeof vi.fn> };
+					user: { id: string; isGM: boolean };
+					users: {
+						activeGM: { id: string };
+						contents: Array<{ id: string; isGM: boolean; active: boolean }>;
+					};
+				};
+			}
+		).game.user = { id: 'player-owner', isGM: false };
+		(
+			globalThis as unknown as {
+				game: {
+					socket: { emit: ReturnType<typeof vi.fn> };
+					user: { id: string; isGM: boolean };
+					users: {
+						activeGM: { id: string };
+						contents: Array<{ id: string; isGM: boolean; active: boolean }>;
+					};
+				};
+			}
+		).game.users = {
+			activeGM: { id: 'gm-user' },
+			contents: [{ id: 'gm-user', isGM: true, active: true }],
+		};
+
+		await expect(requestSetActiveCombatTurn({ combat, targetCombatantId: 'target' })).resolves.toBe(
+			true,
+		);
+		expect(socketEmit).toHaveBeenCalledWith('system.nimble', {
+			type: 'setActiveCombatTurn',
+			combatId: 'combat-set',
+			userId: 'player-owner',
+			targetCombatantId: 'target',
+			expectedActiveCombatantId: 'active',
+		});
 	});
 });

--- a/src/utils/combatTurnActions.ts
+++ b/src/utils/combatTurnActions.ts
@@ -7,6 +7,7 @@ export const COMBATANT_ACTIONS_MAX_PATH = 'system.actions.base.max';
 const COMBAT_TURN_SOCKET_NAME = 'system.nimble';
 const ADVANCE_COMBAT_TURN_REQUEST_TYPE = 'advanceCombatTurn';
 const SET_ACTIVE_COMBAT_TURN_REQUEST_TYPE = 'setActiveCombatTurn';
+const SWAP_COMBAT_TURN_REQUEST_TYPE = 'swapCombatTurn';
 
 type AdvanceCombatTurnRequest = {
 	type: typeof ADVANCE_COMBAT_TURN_REQUEST_TYPE;
@@ -23,8 +24,17 @@ type SetActiveCombatTurnRequest = {
 	expectedActiveCombatantId: string | null;
 };
 
+type SwapCombatTurnRequest = {
+	type: typeof SWAP_COMBAT_TURN_REQUEST_TYPE;
+	combatId: string;
+	userId: string;
+	targetCombatantId: string;
+	expectedActiveCombatantId: string | null;
+};
+
 type CombatWithSetActiveTurn = Combat & {
 	setActiveTurnToCombatant?: (combatantId: string) => Promise<boolean>;
+	swapTurnWithActiveCombatant?: (combatantId: string) => Promise<boolean>;
 };
 
 function toFiniteNonNegativeNumber(value: unknown): number {
@@ -189,6 +199,30 @@ async function handleSetActiveCombatTurnRequest(payload: unknown): Promise<void>
 	await (combat as CombatWithSetActiveTurn).setActiveTurnToCombatant?.(request.targetCombatantId);
 }
 
+async function handleSwapCombatTurnRequest(payload: unknown): Promise<void> {
+	if (!game.user?.isGM) return;
+	if ((game.user.id ?? null) !== getPrimaryActiveGmId()) return;
+	if (!payload || typeof payload !== 'object') return;
+
+	const request = payload as Partial<SwapCombatTurnRequest>;
+	if (request.type !== SWAP_COMBAT_TURN_REQUEST_TYPE) return;
+	if (!request.targetCombatantId) return;
+
+	const combat = getCombatById(request.combatId);
+	if (!combat?.started) return;
+	// Guard against races: only honor the request if the active combatant is still what the
+	// requester saw when they initiated the swap.
+	if ((combat.combatant?.id ?? null) !== (request.expectedActiveCombatantId ?? null)) return;
+
+	const targetCombatant = combat.combatants.get(request.targetCombatantId) ?? null;
+	const requestingUser = getUserById(request.userId);
+	if (!canUserTakeCombatTurn(combat, targetCombatant, requestingUser)) return;
+
+	await (combat as CombatWithSetActiveTurn).swapTurnWithActiveCombatant?.(
+		request.targetCombatantId,
+	);
+}
+
 let hasRegisteredCombatTurnSocketListener = false;
 
 export function registerCombatTurnSocketListener(): void {
@@ -203,6 +237,7 @@ export function registerCombatTurnSocketListener(): void {
 	socket?.on?.(COMBAT_TURN_SOCKET_NAME, (payload) => {
 		void handleAdvanceCombatTurnRequest(payload);
 		void handleSetActiveCombatTurnRequest(payload);
+		void handleSwapCombatTurnRequest(payload);
 	});
 	Hooks.on('deleteCombat', (combat: Combat) => {
 		combatantActionMutationQueue.clearForCombat(combat.id ?? combat._id ?? null);
@@ -285,6 +320,52 @@ export async function requestSetActiveCombatTurn(params: {
 		userId: game.user.id,
 		targetCombatantId,
 		expectedActiveCombatantId: combat.combatant?.id ?? null,
+	});
+	return true;
+}
+
+/**
+ * Swap the active turn with a specific combatant within the current round, exchanging their
+ * positions in the turn order. GMs apply it directly; eligible players relay the request to the
+ * primary active GM (mirroring {@link requestSetActiveCombatTurn}).
+ *
+ * Returns whether the change was applied (GM) or successfully relayed (player).
+ */
+export async function requestSwapCombatTurn(params: {
+	combat: Combat;
+	targetCombatantId: string;
+}): Promise<boolean> {
+	const { combat, targetCombatantId } = params;
+	if (!targetCombatantId) return false;
+
+	const activeCombatantId = combat.combatant?.id ?? null;
+	if (!activeCombatantId || activeCombatantId === targetCombatantId) return false;
+
+	const targetCombatant = combat.combatants.get(targetCombatantId) ?? null;
+	if (!canUserTakeCombatTurn(combat, targetCombatant, game.user)) return false;
+
+	if (game.user?.isGM) {
+		return Boolean(
+			await (combat as CombatWithSetActiveTurn).swapTurnWithActiveCombatant?.(targetCombatantId),
+		);
+	}
+
+	if (!game.user?.id) return false;
+	if (!getPrimaryActiveGmId()) return false;
+
+	const socket = game.socket as
+		| {
+				emit?: (eventName: string, payload: SwapCombatTurnRequest) => void;
+		  }
+		| undefined;
+	if (!socket?.emit) return false;
+
+	socket.emit(COMBAT_TURN_SOCKET_NAME, {
+		type: SWAP_COMBAT_TURN_REQUEST_TYPE,
+		combatId: combat.id ?? combat._id ?? '',
+		userId: game.user.id,
+		targetCombatantId,
+		expectedActiveCombatantId: activeCombatantId,
 	});
 	return true;
 }

--- a/src/utils/combatTurnActions.ts
+++ b/src/utils/combatTurnActions.ts
@@ -1,16 +1,30 @@
 import { getActorDyingActionLimit, isActorDying } from './actorHealthState.js';
 import { combatantActionMutationQueue } from './combatantActionMutationQueue.js';
+import { isCombatantDead } from './isCombatantDead.js';
 
 export const COMBATANT_ACTIONS_CURRENT_PATH = 'system.actions.base.current';
 export const COMBATANT_ACTIONS_MAX_PATH = 'system.actions.base.max';
 const COMBAT_TURN_SOCKET_NAME = 'system.nimble';
 const ADVANCE_COMBAT_TURN_REQUEST_TYPE = 'advanceCombatTurn';
+const SET_ACTIVE_COMBAT_TURN_REQUEST_TYPE = 'setActiveCombatTurn';
 
 type AdvanceCombatTurnRequest = {
 	type: typeof ADVANCE_COMBAT_TURN_REQUEST_TYPE;
 	combatId: string;
 	userId: string;
 	activeCombatantId: string | null;
+};
+
+type SetActiveCombatTurnRequest = {
+	type: typeof SET_ACTIVE_COMBAT_TURN_REQUEST_TYPE;
+	combatId: string;
+	userId: string;
+	targetCombatantId: string;
+	expectedActiveCombatantId: string | null;
+};
+
+type CombatWithSetActiveTurn = Combat & {
+	setActiveTurnToCombatant?: (combatantId: string) => Promise<boolean>;
 };
 
 function toFiniteNonNegativeNumber(value: unknown): number {
@@ -57,6 +71,33 @@ export function canCurrentUserEndTurn(combatant: Combatant.Implementation | null
 	if (!combatant) return false;
 	if (game.user?.isGM) return true;
 	return Boolean(combatant.actor?.isOwner);
+}
+
+/**
+ * Whether `user` may hand the active turn to `targetCombatant` without advancing the round.
+ *
+ * GMs can target any living combatant. Non-GM owners may only swap the turn between fellow player
+ * characters they own — they can never pull the turn onto their character while a monster (or any
+ * non-character) holds it, since monster turns are GM-controlled.
+ */
+export function canUserTakeCombatTurn(
+	combat: Combat | null,
+	targetCombatant: Combatant.Implementation | null,
+	user: User.Implementation | null = game.user,
+): boolean {
+	if (!combat?.started || !targetCombatant || !user) return false;
+	if (targetCombatant.parent?.id !== combat.id) return false;
+	if (isCombatantDead(targetCombatant)) return false;
+	if (user.isGM) return true;
+
+	if (targetCombatant.type !== 'character') return false;
+	if (!targetCombatant.actor?.testUserPermission?.(user, CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER)) {
+		return false;
+	}
+
+	const activeCombatant = combat.combatant ?? null;
+	if (!activeCombatant || activeCombatant.type !== 'character') return false;
+	return !isCombatantDead(activeCombatant);
 }
 
 function getPrimaryActiveGmId(): string | null {
@@ -126,6 +167,28 @@ async function handleAdvanceCombatTurnRequest(payload: unknown): Promise<void> {
 	await combat.nextTurn();
 }
 
+async function handleSetActiveCombatTurnRequest(payload: unknown): Promise<void> {
+	if (!game.user?.isGM) return;
+	if ((game.user.id ?? null) !== getPrimaryActiveGmId()) return;
+	if (!payload || typeof payload !== 'object') return;
+
+	const request = payload as Partial<SetActiveCombatTurnRequest>;
+	if (request.type !== SET_ACTIVE_COMBAT_TURN_REQUEST_TYPE) return;
+	if (!request.targetCombatantId) return;
+
+	const combat = getCombatById(request.combatId);
+	if (!combat?.started) return;
+	// Guard against races: only honor the request if the active combatant is still what the
+	// requester saw when they initiated the swap.
+	if ((combat.combatant?.id ?? null) !== (request.expectedActiveCombatantId ?? null)) return;
+
+	const targetCombatant = combat.combatants.get(request.targetCombatantId) ?? null;
+	const requestingUser = getUserById(request.userId);
+	if (!canUserTakeCombatTurn(combat, targetCombatant, requestingUser)) return;
+
+	await (combat as CombatWithSetActiveTurn).setActiveTurnToCombatant?.(request.targetCombatantId);
+}
+
 let hasRegisteredCombatTurnSocketListener = false;
 
 export function registerCombatTurnSocketListener(): void {
@@ -139,6 +202,7 @@ export function registerCombatTurnSocketListener(): void {
 		| undefined;
 	socket?.on?.(COMBAT_TURN_SOCKET_NAME, (payload) => {
 		void handleAdvanceCombatTurnRequest(payload);
+		void handleSetActiveCombatTurnRequest(payload);
 	});
 	Hooks.on('deleteCombat', (combat: Combat) => {
 		combatantActionMutationQueue.clearForCombat(combat.id ?? combat._id ?? null);
@@ -178,6 +242,49 @@ export async function requestAdvanceCombatTurn(params: {
 		combatId: params.combat.id ?? params.combat._id ?? '',
 		userId: game.user.id,
 		activeCombatantId,
+	});
+	return true;
+}
+
+/**
+ * Hand the active turn to a specific combatant within the current round. GMs apply it directly;
+ * eligible players relay the request to the primary active GM (mirroring {@link requestAdvanceCombatTurn}).
+ *
+ * Returns whether the change was applied (GM) or successfully relayed (player).
+ */
+export async function requestSetActiveCombatTurn(params: {
+	combat: Combat;
+	targetCombatantId: string;
+}): Promise<boolean> {
+	const { combat, targetCombatantId } = params;
+	if (!targetCombatantId) return false;
+	if ((combat.combatant?.id ?? null) === targetCombatantId) return false;
+
+	const targetCombatant = combat.combatants.get(targetCombatantId) ?? null;
+	if (!canUserTakeCombatTurn(combat, targetCombatant, game.user)) return false;
+
+	if (game.user?.isGM) {
+		return Boolean(
+			await (combat as CombatWithSetActiveTurn).setActiveTurnToCombatant?.(targetCombatantId),
+		);
+	}
+
+	if (!game.user?.id) return false;
+	if (!getPrimaryActiveGmId()) return false;
+
+	const socket = game.socket as
+		| {
+				emit?: (eventName: string, payload: SetActiveCombatTurnRequest) => void;
+		  }
+		| undefined;
+	if (!socket?.emit) return false;
+
+	socket.emit(COMBAT_TURN_SOCKET_NAME, {
+		type: SET_ACTIVE_COMBAT_TURN_REQUEST_TYPE,
+		combatId: combat.id ?? combat._id ?? '',
+		userId: game.user.id,
+		targetCombatantId,
+		expectedActiveCombatantId: combat.combatant?.id ?? null,
 	});
 	return true;
 }

--- a/src/view/ui/CtTopTracker.state.svelte.ts
+++ b/src/view/ui/CtTopTracker.state.svelte.ts
@@ -4,9 +4,11 @@ import type { PromptedInitiativeOptions } from '#types/combat.js';
 import { canCurrentUserReorderCombatant } from '#utils/combatantOrdering.js';
 import {
 	COMBATANT_ACTIONS_CURRENT_PATH,
+	canUserTakeCombatTurn,
 	getCombatantCurrentActions,
 	getCombatantMaxActions,
 	requestAdvanceCombatTurn,
+	requestSetActiveCombatTurn,
 	resolveCombatantCurrentActionsAfterDelta,
 } from '#utils/combatTurnActions.js';
 import type { HeroicReactionKey } from '#utils/heroicActions.js';
@@ -491,7 +493,65 @@ export function createCtTopTrackerState() {
 	): void {
 		event.preventDefault();
 		event.stopPropagation();
-		void pingCombatantToken(combatant);
+
+		const combatantId = getCombatantId(combatant);
+		if (!combatantId) {
+			void pingCombatantToken(combatant);
+			return;
+		}
+
+		const combat = resolveActionCombat();
+		const canTakeTurn = Boolean(
+			combat &&
+				(combat.combatant?.id ?? null) !== combatantId &&
+				canUserTakeCombatTurn(combat, combatant, game.user),
+		);
+
+		combatantContextMenu = {
+			combatantId,
+			x: event.clientX,
+			y: event.clientY,
+			canTakeTurn,
+		};
+	}
+
+	function closeCombatantContextMenu(): void {
+		combatantContextMenu = null;
+	}
+
+	function resolveContextMenuCombatant(): Combatant.Implementation | null {
+		const menu = combatantContextMenu;
+		if (!menu) return null;
+		const combat = resolveActionCombat();
+		return combat?.combatants.get(menu.combatantId) ?? null;
+	}
+
+	function handlePingFromContextMenu(): void {
+		const combatant = resolveContextMenuCombatant();
+		closeCombatantContextMenu();
+		if (combatant) void pingCombatantToken(combatant);
+	}
+
+	async function handleTakeTurnFromContextMenu(): Promise<void> {
+		const menu = combatantContextMenu;
+		closeCombatantContextMenu();
+		if (!menu) return;
+
+		const combat = resolveActionCombat();
+		if (!combat) return;
+
+		try {
+			const changed = await requestSetActiveCombatTurn({
+				combat,
+				targetCombatantId: menu.combatantId,
+			});
+			if (changed) updateCurrentCombat(true);
+		} catch (error) {
+			console.error('[Nimble][CT] Failed to set active turn from context menu', {
+				combatantId: menu.combatantId,
+				error,
+			});
+		}
 	}
 
 	function handleCombatantCardKeyDown(
@@ -1285,6 +1345,12 @@ export function createCtTopTrackerState() {
 	let scrollbarDragOffsetPx = $state(0);
 	let pendingDropPreview: CombatantDropPreview | null = null;
 	let expandedMonsterGroupBars = $state<ExpandedMonsterGroupBar[]>([]);
+	let combatantContextMenu = $state<{
+		combatantId: string;
+		x: number;
+		y: number;
+		canTakeTurn: boolean;
+	} | null>(null);
 	const currentCombat = $derived(trackerStore.currentCombat);
 	const playerHpBarTextMode = $derived(trackerStore.playerHpBarTextMode);
 	const nonPlayerHpBarEnabled = $derived(trackerStore.nonPlayerHpBarEnabled);
@@ -1614,6 +1680,12 @@ export function createCtTopTrackerState() {
 		handleActionDeltaClick,
 		canToggleHeroicReactionFromDrawer,
 		handleHeroicReactionToggle,
+		get combatantContextMenu() {
+			return combatantContextMenu;
+		},
+		closeCombatantContextMenu,
+		handlePingFromContextMenu,
+		handleTakeTurnFromContextMenu,
 		handleCombatantCardClick,
 		handleCombatantCardContextMenu,
 		handleCombatantCardKeyDown,

--- a/src/view/ui/CtTopTracker.state.svelte.ts
+++ b/src/view/ui/CtTopTracker.state.svelte.ts
@@ -9,6 +9,7 @@ import {
 	getCombatantMaxActions,
 	requestAdvanceCombatTurn,
 	requestSetActiveCombatTurn,
+	requestSwapCombatTurn,
 	resolveCombatantCurrentActionsAfterDelta,
 } from '#utils/combatTurnActions.js';
 import type { HeroicReactionKey } from '#utils/heroicActions.js';
@@ -501,17 +502,22 @@ export function createCtTopTrackerState() {
 		}
 
 		const combat = resolveActionCombat();
+		const activeCombatantId = combat?.combatant?.id ?? null;
 		const canTakeTurn = Boolean(
 			combat &&
-				(combat.combatant?.id ?? null) !== combatantId &&
+				activeCombatantId !== combatantId &&
 				canUserTakeCombatTurn(combat, combatant, game.user),
 		);
+		// A swap exchanges the target's slot with the active combatant's, so it additionally
+		// requires an active combatant to trade places with.
+		const canSwapTurn = Boolean(canTakeTurn && activeCombatantId);
 
 		combatantContextMenu = {
 			combatantId,
 			x: event.clientX,
 			y: event.clientY,
 			canTakeTurn,
+			canSwapTurn,
 		};
 	}
 
@@ -548,6 +554,28 @@ export function createCtTopTrackerState() {
 			if (changed) updateCurrentCombat(true);
 		} catch (error) {
 			console.error('[Nimble][CT] Failed to set active turn from context menu', {
+				combatantId: menu.combatantId,
+				error,
+			});
+		}
+	}
+
+	async function handleSwapTurnFromContextMenu(): Promise<void> {
+		const menu = combatantContextMenu;
+		closeCombatantContextMenu();
+		if (!menu) return;
+
+		const combat = resolveActionCombat();
+		if (!combat) return;
+
+		try {
+			const changed = await requestSwapCombatTurn({
+				combat,
+				targetCombatantId: menu.combatantId,
+			});
+			if (changed) updateCurrentCombat(true);
+		} catch (error) {
+			console.error('[Nimble][CT] Failed to swap turn from context menu', {
 				combatantId: menu.combatantId,
 				error,
 			});
@@ -1350,6 +1378,7 @@ export function createCtTopTrackerState() {
 		x: number;
 		y: number;
 		canTakeTurn: boolean;
+		canSwapTurn: boolean;
 	} | null>(null);
 	const currentCombat = $derived(trackerStore.currentCombat);
 	const playerHpBarTextMode = $derived(trackerStore.playerHpBarTextMode);
@@ -1686,6 +1715,7 @@ export function createCtTopTrackerState() {
 		closeCombatantContextMenu,
 		handlePingFromContextMenu,
 		handleTakeTurnFromContextMenu,
+		handleSwapTurnFromContextMenu,
 		handleCombatantCardClick,
 		handleCombatantCardContextMenu,
 		handleCombatantCardKeyDown,

--- a/src/view/ui/CtTopTracker.svelte
+++ b/src/view/ui/CtTopTracker.svelte
@@ -78,6 +78,7 @@
 	const closeCombatantContextMenu = trackerViewState.closeCombatantContextMenu;
 	const handlePingFromContextMenu = trackerViewState.handlePingFromContextMenu;
 	const handleTakeTurnFromContextMenu = trackerViewState.handleTakeTurnFromContextMenu;
+	const handleSwapTurnFromContextMenu = trackerViewState.handleSwapTurnFromContextMenu;
 	let combatantContextMenu = $derived(trackerViewState.combatantContextMenu);
 	const handleCombatantCardKeyDown = trackerViewState.handleCombatantCardKeyDown;
 	const handleCombatantCardMouseEnter = trackerViewState.handleCombatantCardMouseEnter;
@@ -845,6 +846,18 @@
 			style={`--nimble-ct-context-menu-x: ${combatantContextMenu.x}px; --nimble-ct-context-menu-y: ${combatantContextMenu.y}px;`}
 			transition:fade={{ duration: 80 }}
 		>
+			{#if combatantContextMenu.canSwapTurn}
+				<li>
+					<button
+						type="button"
+						class="nimble-ct__context-menu-item"
+						onclick={() => void handleSwapTurnFromContextMenu()}
+					>
+						<i class="fa-solid fa-arrow-right-arrow-left" aria-hidden="true"></i>
+						<span>{localize('NIMBLE.ui.combatTracker.swapTurns')}</span>
+					</button>
+				</li>
+			{/if}
 			{#if combatantContextMenu.canTakeTurn}
 				<li>
 					<button

--- a/src/view/ui/CtTopTracker.svelte
+++ b/src/view/ui/CtTopTracker.svelte
@@ -75,6 +75,10 @@
 	const handleHeroicReactionToggle = trackerViewState.handleHeroicReactionToggle;
 	const handleCombatantCardClick = trackerViewState.handleCombatantCardClick;
 	const handleCombatantCardContextMenu = trackerViewState.handleCombatantCardContextMenu;
+	const closeCombatantContextMenu = trackerViewState.closeCombatantContextMenu;
+	const handlePingFromContextMenu = trackerViewState.handlePingFromContextMenu;
+	const handleTakeTurnFromContextMenu = trackerViewState.handleTakeTurnFromContextMenu;
+	let combatantContextMenu = $derived(trackerViewState.combatantContextMenu);
 	const handleCombatantCardKeyDown = trackerViewState.handleCombatantCardKeyDown;
 	const handleCombatantCardMouseEnter = trackerViewState.handleCombatantCardMouseEnter;
 	const handleCombatantCardMouseLeave = trackerViewState.handleCombatantCardMouseLeave;
@@ -207,6 +211,12 @@
 		{@render renderNameDrawer(cardName)}
 	</div>
 {/snippet}
+
+<svelte:window
+	onkeydown={(event) => {
+		if (combatantContextMenu && event.key === 'Escape') closeCombatantContextMenu();
+	}}
+/>
 
 {#if ctEnabled && currentCombat}
 	<section
@@ -819,6 +829,46 @@
 			{/if}
 		</div>
 	</section>
+
+	{#if combatantContextMenu}
+		<!-- svelte-ignore a11y_no_static_element_interactions -->
+		<div
+			class="nimble-ct__context-menu-backdrop"
+			onpointerdown={closeCombatantContextMenu}
+			oncontextmenu={(event) => {
+				event.preventDefault();
+				closeCombatantContextMenu();
+			}}
+		></div>
+		<menu
+			class="nimble-ct__context-menu faded-ui"
+			style={`--nimble-ct-context-menu-x: ${combatantContextMenu.x}px; --nimble-ct-context-menu-y: ${combatantContextMenu.y}px;`}
+			transition:fade={{ duration: 80 }}
+		>
+			{#if combatantContextMenu.canTakeTurn}
+				<li>
+					<button
+						type="button"
+						class="nimble-ct__context-menu-item"
+						onclick={() => void handleTakeTurnFromContextMenu()}
+					>
+						<i class="fa-solid fa-flag-checkered" aria-hidden="true"></i>
+						<span>{localize('NIMBLE.ui.combatTracker.takeTurn')}</span>
+					</button>
+				</li>
+			{/if}
+			<li>
+				<button
+					type="button"
+					class="nimble-ct__context-menu-item"
+					onclick={handlePingFromContextMenu}
+				>
+					<i class="fa-solid fa-bullseye" aria-hidden="true"></i>
+					<span>{localize('NIMBLE.ui.combatTracker.pingToken')}</span>
+				</button>
+			</li>
+		</menu>
+	{/if}
 {/if}
 
 <style lang="scss">
@@ -827,6 +877,63 @@
 	}
 	:global(body.nimble-ct--track-hover canvas) {
 		cursor: grab !important;
+	}
+
+	.nimble-ct__context-menu-backdrop {
+		position: fixed;
+		inset: 0;
+		z-index: 100;
+	}
+
+	.nimble-ct__context-menu {
+		position: fixed;
+		top: var(--nimble-ct-context-menu-y, 0);
+		left: var(--nimble-ct-context-menu-x, 0);
+		z-index: 101;
+		margin: 0;
+		padding: 0.25rem;
+		min-width: 11rem;
+		max-width: min(16rem, 90vw);
+		list-style: none;
+		display: flex;
+		flex-direction: column;
+		gap: 0.125rem;
+		border: 1px solid var(--nimble-ct-action-box-border, rgba(255, 255, 255, 0.25));
+		border-radius: 0.375rem;
+		background: var(--nimble-ct-action-box-bg, hsl(225 27% 9%));
+		box-shadow: 0 0.5rem 1.25rem rgba(0, 0, 0, 0.45);
+
+		li {
+			margin: 0;
+			padding: 0;
+			list-style: none;
+		}
+	}
+
+	.nimble-ct__context-menu-item {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		width: 100%;
+		padding: 0.375rem 0.5rem;
+		border: none;
+		border-radius: 0.25rem;
+		background: transparent;
+		color: inherit;
+		font-size: var(--font-size-13, 0.8125rem);
+		text-align: left;
+		cursor: pointer;
+
+		i {
+			width: 1rem;
+			text-align: center;
+			opacity: 0.85;
+		}
+
+		&:hover,
+		&:focus-visible {
+			background: color-mix(in srgb, currentColor 16%, transparent);
+		}
 	}
 
 	.nimble-ct-shell {

--- a/src/view/ui/CtTopTracker.svelte
+++ b/src/view/ui/CtTopTracker.svelte
@@ -213,6 +213,15 @@
 	</div>
 {/snippet}
 
+{#snippet contextMenuItem(iconClass, labelKey, onSelect)}
+	<li>
+		<button type="button" class="nimble-ct__context-menu-item" onclick={onSelect}>
+			<i class={`fa-solid ${iconClass}`} aria-hidden="true"></i>
+			<span>{localize(labelKey)}</span>
+		</button>
+	</li>
+{/snippet}
+
 <svelte:window
 	onkeydown={(event) => {
 		if (combatantContextMenu && event.key === 'Escape') closeCombatantContextMenu();
@@ -847,39 +856,24 @@
 			transition:fade={{ duration: 80 }}
 		>
 			{#if combatantContextMenu.canSwapTurn}
-				<li>
-					<button
-						type="button"
-						class="nimble-ct__context-menu-item"
-						onclick={() => void handleSwapTurnFromContextMenu()}
-					>
-						<i class="fa-solid fa-arrow-right-arrow-left" aria-hidden="true"></i>
-						<span>{localize('NIMBLE.ui.combatTracker.swapTurns')}</span>
-					</button>
-				</li>
+				{@render contextMenuItem(
+					'fa-arrow-right-arrow-left',
+					'NIMBLE.ui.combatTracker.swapTurns',
+					() => void handleSwapTurnFromContextMenu(),
+				)}
 			{/if}
 			{#if combatantContextMenu.canTakeTurn}
-				<li>
-					<button
-						type="button"
-						class="nimble-ct__context-menu-item"
-						onclick={() => void handleTakeTurnFromContextMenu()}
-					>
-						<i class="fa-solid fa-flag-checkered" aria-hidden="true"></i>
-						<span>{localize('NIMBLE.ui.combatTracker.takeTurn')}</span>
-					</button>
-				</li>
+				{@render contextMenuItem(
+					'fa-flag-checkered',
+					'NIMBLE.ui.combatTracker.takeTurn',
+					() => void handleTakeTurnFromContextMenu(),
+				)}
 			{/if}
-			<li>
-				<button
-					type="button"
-					class="nimble-ct__context-menu-item"
-					onclick={handlePingFromContextMenu}
-				>
-					<i class="fa-solid fa-bullseye" aria-hidden="true"></i>
-					<span>{localize('NIMBLE.ui.combatTracker.pingToken')}</span>
-				</button>
-			</li>
+			{@render contextMenuItem(
+				'fa-bullseye',
+				'NIMBLE.ui.combatTracker.pingToken',
+				handlePingFromContextMenu,
+			)}
 		</menu>
 	{/if}
 {/if}


### PR DESCRIPTION
## Summary

Implements #718 — lets a GM (and eligible players) hand the active turn to a different combatant within the current round, **without** advancing the round or running round-end cleanup. There are now **two distinct, complementary handoff actions** plus drag-to-front:

- **Take the Turn** — repoints the active turn to the clicked combatant, leaving the turn order untouched.
- **Swap Turns** — exchanges the target's slot with the active combatant's slot, so the target becomes active at the front and the previously active combatant drops into the target's old position.

Both build on the core primitive `NimbleCombat#setActiveTurnToCombatant` (which repoints the active turn via the existing turn-identity / atomic-turn-state machinery). `swapTurnWithActiveCombatant` layers a sort-value exchange on top before repointing.

## Changes

- **Right-click context menu** (`CtTopTracker.svelte` + `.state.svelte.ts`) — right-clicking a combatant card opens a small menu with **Swap Turns** and **Take the Turn** (each shown when allowed) plus **Ping Token** (the prior right-click behavior, preserved). Closes on outside-click or Escape.
- **Drag into the active slot** (`combatSorting.ts`) — dropping a combatant *ahead of* the active combatant makes it the active turn; dropping anywhere else preserves the active combatant (unchanged #718 behavior).
- **End-of-turn on depleted handoff** (`combat.svelte.ts`) — when the active combatant has spent **all** of their actions and the turn is handed away (Take or Swap), their turn now ends as if it had completed normally: actions refilled, additional actions cleared, heroic reactions restored, and the `nimbleCombatTurnEnd` hook fires (charge-pool recovery). A combatant who still has actions left is merely interrupted and keeps them for when play returns.
- **Permissions** (`combatTurnActions.ts`, `canUserTakeCombatTurn`) — both actions reuse the same gate:
  - **GM** can hand/swap the turn to any living combatant.
  - **Owning players** can only target a character they own, and only while a fellow player character is active — never pulling the turn off a monster's turn. Reuses Foundry ownership (`testUserPermission`) and mirrors the existing drag-reorder rule.
  - Players can't write `combat.turn` (or reorder a combatant they don't own), so both the take and swap player paths relay to the primary GM over the existing `system.nimble` socket, each with a stale-active-combatant guard against races.

## Tests

New unit tests across `combat.svelte.test.ts` and `combatTurnActions.test.ts` covering `setActiveTurnToCombatant`, the new `swapTurnWithActiveCombatant` slot exchange, the depleted-vs-still-has-actions end-of-turn refill, the drag-to-front vs preserve-active branches, and the permission/relay matrix (including the GM swap path and the swap-onto-self refusal). Full suite: **1613 passing**. `type-check`, `biome lint`, `svelte` lint, and `circular-deps` all clean.

## Needs human review

**English** localization keys added to `public/lang/en.json` (no other locales touched), per `AGENTS.md`:
- `NIMBLE.ui.combatTracker.takeTurn` → "Take the Turn"
- `NIMBLE.ui.combatTracker.swapTurns` → "Swap Turns"
- `NIMBLE.ui.combatTracker.pingToken` → "Ping Token"

## Not yet done

Logic + unit-test verified, but not yet smoke-tested live in Foundry — worth clicking through both menu actions, the depleted-turn refill, and the player→GM socket relay for both take and swap before merge.

Closes #718