### PR TITLE
chore: add worktree:reset script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"build:compendia": "node ./build/buildCompendia.mjs",
 		"worktree:setup": "node ./build/worktreeSetup.mjs",
 		"worktree:cleanup": "node ./build/worktreeCleanup.mjs",
+		"worktree:reset": "pnpm worktree:cleanup && pnpm worktree:setup",
 		"dev": "vite",
 		"format": "biome format --write ./src/ ./types/ ./lib/ && prettier --write \"src/**/*.svelte\"",
 		"format:biome": "biome format --write ./src/ ./types/ ./lib/",


### PR DESCRIPTION
## Summary

Adds a `worktree:reset` npm script that chains `worktree:cleanup` and `worktree:setup`:

```json
"worktree:reset": "pnpm worktree:cleanup && pnpm worktree:setup"
```

This provides a one-shot way to tear down and recreate the dev symlink.

## Notes

- `worktree:cleanup` is interactive and prompts for which artifacts to remove. `reset` will pause for that prompt, then run `worktree:setup`.
- If you pick **Cancel** in cleanup (exit 0), setup still runs (idempotent).