### PR TITLE
fix(combat): restore per-turn actions for characters and solo monsters

### DIFF
--- a/src/documents/combat/combat.svelte.test.ts
+++ b/src/documents/combat/combat.svelte.test.ts
@@ -512,6 +512,9 @@ describe('NimbleCombat', () => {
 		(combat as NimbleCombat & { update: ReturnType<typeof vi.fn> }).update = vi
 			.fn()
 			.mockResolvedValue(combat);
+		(
+			combat as NimbleCombat & { updateEmbeddedDocuments: ReturnType<typeof vi.fn> }
+		).updateEmbeddedDocuments = vi.fn().mockResolvedValue([]);
 
 		await combat.nextTurn();
 
@@ -963,6 +966,83 @@ describe('NimbleCombat', () => {
 		expect(combat.updateEmbeddedDocuments).toHaveBeenCalledWith('Combatant', [
 			{
 				_id: 'monster-rewind',
+				'system.actions.base.current': 3,
+			},
+		]);
+		expect(foundry.utils.getProperty(monster, 'system.actions.base.current')).toBe(3);
+	});
+
+	it('restores a solo monster’s actions to max when advancing forward into its turn', async () => {
+		const combatId = 'combat-advance-restore-monster-actions';
+		const monster = createMockCombatant({
+			id: 'monster-advance',
+			type: 'soloMonster',
+			sort: 1,
+			isOwner: false,
+			initiative: 12,
+			actionsCurrent: 0,
+			actionsMax: 3,
+			actor: createCombatActorFixture({ hp: 40 }),
+			combatId,
+		});
+		const player = createMockCombatant({
+			id: 'player-acting',
+			type: 'character',
+			sort: 2,
+			isOwner: true,
+			initiative: 10,
+			actor: createCombatActorFixture({ hp: 8, woundsValue: 0, woundsMax: 6 }),
+			combatId,
+		});
+
+		const superNextTurn = globals().Combat.prototype.nextTurn as ReturnType<typeof vi.fn>;
+		superNextTurn.mockImplementation(async function (
+			this: Combat & {
+				turn?: number;
+				combatant?: Combatant.Implementation | null;
+			},
+		) {
+			// Advance from the player to the interleaved solo-monster turn.
+			this.turn = 1;
+			this.combatant = monster;
+			return this;
+		});
+
+		const combat = new NimbleCombat({
+			id: combatId,
+			combatants: createCombatantsCollectionFixture([player, monster]),
+			turns: [player, monster],
+			turn: 0,
+			combatant: player,
+		} as unknown as Combat.CreateData) as NimbleCombat & {
+			update: ReturnType<typeof vi.fn>;
+			updateEmbeddedDocuments: ReturnType<typeof vi.fn>;
+		};
+
+		combat.update = vi.fn().mockResolvedValue(combat);
+		combat.updateEmbeddedDocuments = vi
+			.fn()
+			.mockImplementation(
+				async (_documentName: string, updates: Array<Record<string, unknown>>) => {
+					for (const update of updates) {
+						const id = update._id as string | undefined;
+						if (!id) continue;
+						const target = combat.combatants.get(id);
+						if (!target) continue;
+						const nextActions = update['system.actions.base.current'];
+						if (typeof nextActions === 'number') {
+							foundry.utils.setProperty(target, 'system.actions.base.current', nextActions);
+						}
+					}
+					return updates as unknown as Combatant.Implementation[];
+				},
+			);
+
+		await combat.nextTurn();
+
+		expect(combat.updateEmbeddedDocuments).toHaveBeenCalledWith('Combatant', [
+			{
+				_id: 'monster-advance',
 				'system.actions.base.current': 3,
 			},
 		]);
@@ -3710,9 +3790,11 @@ describe('NimbleCombat', () => {
 			combatant: character,
 		} as unknown as Combat.CreateData) as NimbleCombat & {
 			update: ReturnType<typeof vi.fn>;
+			updateEmbeddedDocuments: ReturnType<typeof vi.fn>;
 		};
 
 		combat.update = vi.fn().mockResolvedValue(combat);
+		combat.updateEmbeddedDocuments = vi.fn().mockResolvedValue([]);
 
 		await combat.nextTurn();
 

--- a/src/documents/combat/combat.svelte.test.ts
+++ b/src/documents/combat/combat.svelte.test.ts
@@ -1049,6 +1049,69 @@ describe('NimbleCombat', () => {
 		expect(foundry.utils.getProperty(monster, 'system.actions.base.current')).toBe(3);
 	});
 
+	it('refills the outgoing hero on turn-end even when Foundry reports the wrong combatant', async () => {
+		const combatId = 'combat-end-turn-wrong-combatant';
+		const outgoingHero = createMockCombatant({
+			id: 'outgoing-hero',
+			type: 'character',
+			sort: 1,
+			isOwner: true,
+			initiative: 8,
+			actionsCurrent: 0,
+			actionsMax: 3,
+			actor: createCombatActorFixture({ hp: 8, woundsValue: 0, woundsMax: 6 }),
+			combatId,
+		});
+		const monster = createMockCombatant({
+			id: 'solo-monster',
+			type: 'soloMonster',
+			sort: 2,
+			isOwner: false,
+			initiative: 12,
+			actionsCurrent: 0,
+			actionsMax: 1,
+			actor: createCombatActorFixture({ hp: 40 }),
+			combatId,
+		});
+
+		const superNextTurn = globals().Combat.prototype.nextTurn as ReturnType<typeof vi.fn>;
+		superNextTurn.mockImplementation(async function (
+			this: Combat & { turn?: number; combatant?: Combatant.Implementation | null },
+		) {
+			// Foundry fires the turn-end event during the advance, but resolves the ending
+			// combatant from its stale `previous` snapshot — here, the wrong one (the monster).
+			await (this as unknown as NimbleCombat)._onEndTurn(monster, {} as Combat.TurnEventContext);
+			this.turn = 1;
+			this.combatant = monster;
+			return this;
+		});
+
+		const combat = new NimbleCombat({
+			id: combatId,
+			combatants: createCombatantsCollectionFixture([outgoingHero, monster]),
+			turns: [outgoingHero, monster],
+			turn: 0,
+			combatant: outgoingHero,
+		} as unknown as Combat.CreateData) as NimbleCombat & {
+			update: ReturnType<typeof vi.fn>;
+			updateEmbeddedDocuments: ReturnType<typeof vi.fn>;
+		};
+		combat.update = vi.fn().mockResolvedValue(combat);
+		combat.updateEmbeddedDocuments = vi.fn().mockResolvedValue([]);
+
+		await combat.nextTurn();
+
+		// The hero whose turn actually ended is refilled to max, despite Foundry naming the monster.
+		expect(outgoingHero.update).toHaveBeenCalledWith(
+			expect.objectContaining({
+				'system.actions.base.current': 3,
+				'system.actions.base.additional': 0,
+			}),
+		);
+		// The monster never receives the character-style turn-end refill.
+		expect(monster.update).not.toHaveBeenCalled();
+	});
+
 	it('restores all alive minion-group member actions when rewinding to the group turn', async () => {
 		const combatId = 'combat-rewind-restore-minion-group-actions';
 		const leaderActor = {

--- a/src/documents/combat/combat.svelte.test.ts
+++ b/src/documents/combat/combat.svelte.test.ts
@@ -1112,6 +1112,137 @@ describe('NimbleCombat', () => {
 		expect(monster.update).not.toHaveBeenCalled();
 	});
 
+	it('refills the outgoing hero on turn-end even when Foundry never fires _onEndTurn', async () => {
+		// Regression: under the expanded solo-monster turn order, Foundry's cached turn history
+		// can desync from our directly-resynced turn index, so its turn-event dispatcher computes
+		// an empty interval and skips the outgoing hero's `_onEndTurn` entirely. The last hero
+		// before the solo-monster's trailing turn was left at 0 actions. `nextTurn` must backstop
+		// the refill even though `_onEndTurn` was never called.
+		const combatId = 'combat-end-turn-no-event';
+		const outgoingHero = createMockCombatant({
+			id: 'outgoing-hero',
+			type: 'character',
+			sort: 1,
+			isOwner: true,
+			initiative: 8,
+			actionsCurrent: 0,
+			actionsMax: 3,
+			actor: createCombatActorFixture({ hp: 8, woundsValue: 0, woundsMax: 6 }),
+			combatId,
+		});
+		const monster = createMockCombatant({
+			id: 'solo-monster',
+			type: 'soloMonster',
+			sort: 2,
+			isOwner: false,
+			initiative: 12,
+			actionsCurrent: 0,
+			actionsMax: 1,
+			actor: createCombatActorFixture({ hp: 40 }),
+			combatId,
+		});
+
+		const superNextTurn = globals().Combat.prototype.nextTurn as ReturnType<typeof vi.fn>;
+		superNextTurn.mockImplementation(async function (
+			this: Combat & { turn?: number; combatant?: Combatant.Implementation | null },
+		) {
+			// Advance the turn WITHOUT firing `_onEndTurn` — reproducing Foundry skipping the
+			// outgoing hero's end-of-turn event.
+			this.turn = 1;
+			this.combatant = monster;
+			return this;
+		});
+
+		const combat = new NimbleCombat({
+			id: combatId,
+			combatants: createCombatantsCollectionFixture([outgoingHero, monster]),
+			turns: [outgoingHero, monster],
+			turn: 0,
+			combatant: outgoingHero,
+		} as unknown as Combat.CreateData) as NimbleCombat & {
+			update: ReturnType<typeof vi.fn>;
+			updateEmbeddedDocuments: ReturnType<typeof vi.fn>;
+		};
+		combat.update = vi.fn().mockResolvedValue(combat);
+		combat.updateEmbeddedDocuments = vi.fn().mockResolvedValue([]);
+
+		await combat.nextTurn();
+
+		// The hero whose turn ended is refilled to max via the backstop.
+		expect(outgoingHero.update).toHaveBeenCalledWith(
+			expect.objectContaining({
+				'system.actions.base.current': 3,
+				'system.actions.base.additional': 0,
+			}),
+		);
+		// The backstop fires exactly once — one hook call, one refill update.
+		expect(outgoingHero.update).toHaveBeenCalledTimes(1);
+		expect(monster.update).not.toHaveBeenCalled();
+	});
+
+	it('does not double-refill the outgoing hero when both _onEndTurn and the backstop run', async () => {
+		// When Foundry DOES fire `_onEndTurn` for the correct outgoing hero, the post-advance
+		// backstop must recognize the refill already happened and not run it (or the turn-end
+		// hook) a second time.
+		const combatId = 'combat-end-turn-no-double';
+		const outgoingHero = createMockCombatant({
+			id: 'outgoing-hero',
+			type: 'character',
+			sort: 1,
+			isOwner: true,
+			initiative: 8,
+			actionsCurrent: 0,
+			actionsMax: 3,
+			actor: createCombatActorFixture({ hp: 8, woundsValue: 0, woundsMax: 6 }),
+			combatId,
+		});
+		const monster = createMockCombatant({
+			id: 'solo-monster',
+			type: 'soloMonster',
+			sort: 2,
+			isOwner: false,
+			initiative: 12,
+			actionsCurrent: 0,
+			actionsMax: 1,
+			actor: createCombatActorFixture({ hp: 40 }),
+			combatId,
+		});
+
+		const superNextTurn = globals().Combat.prototype.nextTurn as ReturnType<typeof vi.fn>;
+		superNextTurn.mockImplementation(async function (
+			this: Combat & { turn?: number; combatant?: Combatant.Implementation | null },
+		) {
+			await (this as unknown as NimbleCombat)._onEndTurn(
+				outgoingHero,
+				{} as Combat.TurnEventContext,
+			);
+			this.turn = 1;
+			this.combatant = monster;
+			return this;
+		});
+
+		const combat = new NimbleCombat({
+			id: combatId,
+			combatants: createCombatantsCollectionFixture([outgoingHero, monster]),
+			turns: [outgoingHero, monster],
+			turn: 0,
+			combatant: outgoingHero,
+		} as unknown as Combat.CreateData) as NimbleCombat & {
+			update: ReturnType<typeof vi.fn>;
+			updateEmbeddedDocuments: ReturnType<typeof vi.fn>;
+		};
+		combat.update = vi.fn().mockResolvedValue(combat);
+		combat.updateEmbeddedDocuments = vi.fn().mockResolvedValue([]);
+
+		await combat.nextTurn();
+
+		// Refilled exactly once — the backstop is a no-op because `_onEndTurn` already refilled.
+		expect(outgoingHero.update).toHaveBeenCalledTimes(1);
+		expect(outgoingHero.update).toHaveBeenCalledWith(
+			expect.objectContaining({ 'system.actions.base.current': 3 }),
+		);
+	});
+
 	it('restores all alive minion-group member actions when rewinding to the group turn', async () => {
 		const combatId = 'combat-rewind-restore-minion-group-actions';
 		const leaderActor = {

--- a/src/documents/combat/combat.svelte.ts
+++ b/src/documents/combat/combat.svelte.ts
@@ -118,11 +118,13 @@ class NimbleCombat extends Combat {
 	// `_onEndTurn` can refill the correct combatant even when Foundry's own `previous`
 	// turn snapshot is stale under the expanded solo-monster turn order.
 	#endingTurnCombatantId: string | null = null;
-	// The character combatant id already refilled by `_onEndTurn` during the current
-	// forward advance. Reset at the start of each `nextTurn`/`nextRound` so the post-advance
-	// fallback (`#ensureOutgoingCharacterRefilled`) can tell whether Foundry actually fired
-	// the turn-end event for the outgoing hero — Foundry skips it when its cached turn history
-	// desyncs from our expanded (duplicate solo-monster) turn order.
+	// The character combatant id whose turn-end refill has been claimed during the current
+	// forward advance. Foundry dispatches turn events fire-and-forget, so `_onEndTurn` and the
+	// post-advance backstop (`#ensureOutgoingCharacterRefilled`) can interleave; whichever runs
+	// first claims the id synchronously — before any await — and the other becomes a no-op.
+	// Reset at the start of every turn-changing entry point (`nextTurn`, `nextRound`,
+	// `previousTurn`, `previousRound`, `setActiveTurnToCombatant`) so a stale claim never
+	// suppresses a later legitimate refill.
 	#endingTurnRefilledCharacterId: string | null = null;
 	#initiativeRollRequests = new Map<string, Promise<LockedInitiativeRollOutcome | null>>();
 
@@ -711,10 +713,23 @@ class NimbleCombat extends Combat {
 			: null;
 		const endingCombatant = capturedCombatant ?? combatant;
 
+		// Claim the refill synchronously — before any await — because Foundry dispatches turn
+		// events fire-and-forget, so `nextTurn`'s backstop can run interleaved with this method.
+		// Whoever claims the id first performs the refill; the other becomes a no-op.
+		const endingCombatantId = endingCombatant.id ?? null;
+		let shouldRefillCharacter = false;
+		if (endingCombatant.type === 'character') {
+			shouldRefillCharacter =
+				endingCombatantId === null || this.#endingTurnRefilledCharacterId !== endingCombatantId;
+			if (shouldRefillCharacter && endingCombatantId) {
+				this.#endingTurnRefilledCharacterId = endingCombatantId;
+			}
+		}
+
 		await super._onEndTurn(combatant, context);
 
 		if (endingCombatant.type === 'character') {
-			await this.#applyCharacterTurnEndRefill(endingCombatant);
+			if (shouldRefillCharacter) await this.#applyCharacterTurnEndRefill(endingCombatant);
 		} else {
 			// @ts-expect-error Custom hook
 			Hooks.call('nimbleCombatTurnEnd', endingCombatant);
@@ -724,12 +739,12 @@ class NimbleCombat extends Combat {
 	/**
 	 * Refill an outgoing character's turn-end state: fire the Nimble end-of-turn hook (charge-pool
 	 * recovery, etc.), reset base actions to max (capped by Dying), clear additional actions, and
-	 * restore heroic reactions. Records the id so a single forward advance never refills — or
-	 * fires the hook for — the same hero twice.
+	 * restore heroic reactions. Callers claim `#endingTurnRefilledCharacterId` synchronously
+	 * before invoking this so a single forward advance never refills — or fires the hook for —
+	 * the same hero twice.
 	 */
 	async #applyCharacterTurnEndRefill(combatant: Combatant.Implementation): Promise<void> {
 		if (combatant.type !== 'character') return;
-		const combatantId = combatant.id ?? null;
 
 		// @ts-expect-error Custom hook
 		Hooks.call('nimbleCombatTurnEnd', combatant);
@@ -739,8 +754,6 @@ class NimbleCombat extends Combat {
 			'system.actions.base.additional': 0,
 			...this.#buildHeroicReactionAvailabilityUpdate(true),
 		} as Record<string, unknown>);
-
-		if (combatantId) this.#endingTurnRefilledCharacterId = combatantId;
 	}
 
 	/**
@@ -756,6 +769,8 @@ class NimbleCombat extends Combat {
 		const combatant = this.combatants.get(outgoingCombatantId);
 		if (!combatant || combatant.type !== 'character') return;
 
+		// Claim before any await so a late-dispatched `_onEndTurn` skips its own refill.
+		this.#endingTurnRefilledCharacterId = outgoingCombatantId;
 		await this.#applyCharacterTurnEndRefill(combatant);
 	}
 
@@ -1164,6 +1179,9 @@ class NimbleCombat extends Combat {
 		const targetIdentity = this.#resolveTurnIdentityAtIndex(this.turns, targetIndex);
 		if (!targetIdentity) return false;
 		const previousTurnIndex = Number.isInteger(this.turn) ? Number(this.turn) : -1;
+		// Clear any claim from a prior forward advance so a turn-end Foundry fires for the
+		// outgoing combatant on this direct turn hand-off is never mistaken for a duplicate.
+		this.#endingTurnRefilledCharacterId = null;
 		await this.#syncTurnToCombatant(targetIdentity);
 		const changed = this.turn !== previousTurnIndex;
 		if (changed) {
@@ -1304,6 +1322,9 @@ class NimbleCombat extends Combat {
 
 	override async previousTurn(): Promise<this> {
 		this.#syncTurnIndexWithAliveTurns();
+		// Clear any claim from a prior forward advance so a turn-end fired for this hero
+		// later (e.g. after navigating back to them) is never mistaken for a duplicate.
+		this.#endingTurnRefilledCharacterId = null;
 		const preferredPreviousTurnIdentity = this.#resolvePreviousTurnIdentity();
 		const { intercepted, result } = await this.#runAtomicTurnStateOperation(
 			preferredPreviousTurnIdentity,
@@ -1321,6 +1342,8 @@ class NimbleCombat extends Combat {
 
 	override async previousRound(): Promise<this> {
 		this.#syncTurnIndexWithAliveTurns();
+		// Clear any claim from a prior forward advance (see `previousTurn`).
+		this.#endingTurnRefilledCharacterId = null;
 		const preferredLastTurnIdentity = this.#resolveTurnIdentityAtIndex(
 			this.turns,
 			Math.max(this.turns.length - 1, 0),

--- a/src/documents/combat/combat.svelte.ts
+++ b/src/documents/combat/combat.svelte.ts
@@ -114,6 +114,10 @@ class NimbleCombat extends Combat {
 	#expandedTurnIdentity: TurnIdentity | null = null;
 	#pendingAtomicTurnIdentity: TurnIdentity | null = null;
 	#didInterceptAtomicTurnStateUpdate = false;
+	// The combatant that was active immediately before a forward advance, captured so
+	// `_onEndTurn` can refill the correct combatant even when Foundry's own `previous`
+	// turn snapshot is stale under the expanded solo-monster turn order.
+	#endingTurnCombatantId: string | null = null;
 	#initiativeRollRequests = new Map<string, Promise<LockedInitiativeRollOutcome | null>>();
 
 	#findActorCombatantInScene(actorId: string, sceneId: string): Combatant.Implementation | null {
@@ -690,14 +694,24 @@ class NimbleCombat extends Combat {
 	}
 
 	override async _onEndTurn(combatant: Combatant.Implementation, context: Combat.TurnEventContext) {
+		// Under the expanded solo-monster turn order, Foundry derives `combatant` from its
+		// own `previous` turn snapshot, which our direct turn-index resync can leave pointing
+		// at the wrong combatant — so a hero ending their turn might not get refilled, or a
+		// hero who hasn't acted yet might be refilled early. Prefer the combatant we captured
+		// as active immediately before advancing; fall back to Foundry's value when we have no
+		// capture (e.g. drag-drop or a direct `_onEndTurn` call).
+		const endingCombatant =
+			(this.#endingTurnCombatantId ? this.combatants.get(this.#endingTurnCombatantId) : null) ??
+			combatant;
+
 		// @ts-expect-error Custom hook
-		Hooks.call('nimbleCombatTurnEnd', combatant);
+		Hooks.call('nimbleCombatTurnEnd', endingCombatant);
 
 		await super._onEndTurn(combatant, context);
 
-		if (combatant.type === 'character') {
-			await combatant.update({
-				'system.actions.base.current': getCombatantResetActions(combatant),
+		if (endingCombatant.type === 'character') {
+			await endingCombatant.update({
+				'system.actions.base.current': getCombatantResetActions(endingCombatant),
 				'system.actions.base.additional': 0,
 				...this.#buildHeroicReactionAvailabilityUpdate(true),
 			} as Record<string, unknown>);
@@ -1188,10 +1202,19 @@ class NimbleCombat extends Combat {
 	override async nextTurn(): Promise<this> {
 		this.#syncTurnIndexWithAliveTurns();
 		const preferredNextTurnIdentity = this.#resolveNextTurnIdentity();
-		const { intercepted, result } = await this.#runAtomicTurnStateOperation(
-			preferredNextTurnIdentity,
-			async () => (await super.nextTurn()) as this,
-		);
+		// Capture the outgoing combatant before advancing so `_onEndTurn` (fired inside
+		// `super.nextTurn`) refills the right one. Cleared in `finally` so it never leaks.
+		this.#endingTurnCombatantId = this.combatant?.id ?? null;
+		let intercepted: boolean;
+		let result: this;
+		try {
+			({ intercepted, result } = await this.#runAtomicTurnStateOperation(
+				preferredNextTurnIdentity,
+				async () => (await super.nextTurn()) as this,
+			));
+		} finally {
+			this.#endingTurnCombatantId = null;
+		}
 		this.#syncTurnIndexWithAliveTurns({ preferredTurnIdentity: preferredNextTurnIdentity });
 		if (!intercepted) {
 			await this.#persistAtomicTurnState({ turn: this.turn });
@@ -1206,10 +1229,19 @@ class NimbleCombat extends Combat {
 	override async nextRound(): Promise<this> {
 		this.#syncTurnIndexWithAliveTurns();
 		const preferredFirstTurnIdentity = this.#resolveTurnIdentityAtIndex(this.turns, 0);
-		const { intercepted, result } = await this.#runAtomicTurnStateOperation(
-			preferredFirstTurnIdentity,
-			async () => (await super.nextRound()) as this,
-		);
+		// Capture the outgoing combatant before advancing so the turn-end refill in
+		// `_onEndTurn` targets the right one. Cleared in `finally` so it never leaks.
+		this.#endingTurnCombatantId = this.combatant?.id ?? null;
+		let intercepted: boolean;
+		let result: this;
+		try {
+			({ intercepted, result } = await this.#runAtomicTurnStateOperation(
+				preferredFirstTurnIdentity,
+				async () => (await super.nextRound()) as this,
+			));
+		} finally {
+			this.#endingTurnCombatantId = null;
+		}
 		this.#syncTurnIndexWithAliveTurns({ preferredTurnIdentity: preferredFirstTurnIdentity });
 		if (!intercepted) {
 			await this.#persistAtomicTurnState({ turn: this.turn });

--- a/src/documents/combat/combat.svelte.ts
+++ b/src/documents/combat/combat.svelte.ts
@@ -118,6 +118,12 @@ class NimbleCombat extends Combat {
 	// `_onEndTurn` can refill the correct combatant even when Foundry's own `previous`
 	// turn snapshot is stale under the expanded solo-monster turn order.
 	#endingTurnCombatantId: string | null = null;
+	// The character combatant id already refilled by `_onEndTurn` during the current
+	// forward advance. Reset at the start of each `nextTurn`/`nextRound` so the post-advance
+	// fallback (`#ensureOutgoingCharacterRefilled`) can tell whether Foundry actually fired
+	// the turn-end event for the outgoing hero — Foundry skips it when its cached turn history
+	// desyncs from our expanded (duplicate solo-monster) turn order.
+	#endingTurnRefilledCharacterId: string | null = null;
 	#initiativeRollRequests = new Map<string, Promise<LockedInitiativeRollOutcome | null>>();
 
 	#findActorCombatantInScene(actorId: string, sceneId: string): Combatant.Implementation | null {
@@ -700,22 +706,57 @@ class NimbleCombat extends Combat {
 		// hero who hasn't acted yet might be refilled early. Prefer the combatant we captured
 		// as active immediately before advancing; fall back to Foundry's value when we have no
 		// capture (e.g. drag-drop or a direct `_onEndTurn` call).
-		const endingCombatant =
-			(this.#endingTurnCombatantId ? this.combatants.get(this.#endingTurnCombatantId) : null) ??
-			combatant;
-
-		// @ts-expect-error Custom hook
-		Hooks.call('nimbleCombatTurnEnd', endingCombatant);
+		const capturedCombatant = this.#endingTurnCombatantId
+			? this.combatants.get(this.#endingTurnCombatantId)
+			: null;
+		const endingCombatant = capturedCombatant ?? combatant;
 
 		await super._onEndTurn(combatant, context);
 
 		if (endingCombatant.type === 'character') {
-			await endingCombatant.update({
-				'system.actions.base.current': getCombatantResetActions(endingCombatant),
-				'system.actions.base.additional': 0,
-				...this.#buildHeroicReactionAvailabilityUpdate(true),
-			} as Record<string, unknown>);
+			await this.#applyCharacterTurnEndRefill(endingCombatant);
+		} else {
+			// @ts-expect-error Custom hook
+			Hooks.call('nimbleCombatTurnEnd', endingCombatant);
 		}
+	}
+
+	/**
+	 * Refill an outgoing character's turn-end state: fire the Nimble end-of-turn hook (charge-pool
+	 * recovery, etc.), reset base actions to max (capped by Dying), clear additional actions, and
+	 * restore heroic reactions. Records the id so a single forward advance never refills — or
+	 * fires the hook for — the same hero twice.
+	 */
+	async #applyCharacterTurnEndRefill(combatant: Combatant.Implementation): Promise<void> {
+		if (combatant.type !== 'character') return;
+		const combatantId = combatant.id ?? null;
+
+		// @ts-expect-error Custom hook
+		Hooks.call('nimbleCombatTurnEnd', combatant);
+
+		await combatant.update({
+			'system.actions.base.current': getCombatantResetActions(combatant),
+			'system.actions.base.additional': 0,
+			...this.#buildHeroicReactionAvailabilityUpdate(true),
+		} as Record<string, unknown>);
+
+		if (combatantId) this.#endingTurnRefilledCharacterId = combatantId;
+	}
+
+	/**
+	 * Guarantee the hero whose turn just ended is refilled even when Foundry never fired
+	 * `_onEndTurn` for them. Under the expanded solo-monster turn order, Foundry's cached turn
+	 * history can desync from our directly-resynced turn index, so its turn-event dispatcher
+	 * computes an empty interval and skips the outgoing hero's end-of-turn entirely — leaving that
+	 * hero at 0 actions. This backstops that case; it is a no-op when `_onEndTurn` already ran.
+	 */
+	async #ensureOutgoingCharacterRefilled(outgoingCombatantId: string | null): Promise<void> {
+		if (!outgoingCombatantId) return;
+		if (this.#endingTurnRefilledCharacterId === outgoingCombatantId) return;
+		const combatant = this.combatants.get(outgoingCombatantId);
+		if (!combatant || combatant.type !== 'character') return;
+
+		await this.#applyCharacterTurnEndRefill(combatant);
 	}
 
 	override async _onEndRound() {
@@ -1205,6 +1246,8 @@ class NimbleCombat extends Combat {
 		// Capture the outgoing combatant before advancing so `_onEndTurn` (fired inside
 		// `super.nextTurn`) refills the right one. Cleared in `finally` so it never leaks.
 		this.#endingTurnCombatantId = this.combatant?.id ?? null;
+		const outgoingCombatantId = this.#endingTurnCombatantId;
+		this.#endingTurnRefilledCharacterId = null;
 		let intercepted: boolean;
 		let result: this;
 		try {
@@ -1223,6 +1266,10 @@ class NimbleCombat extends Combat {
 		// at end of round. Restore the incoming non-character's actions so they start each
 		// of their interleaved turns with a full action pool (mirrors `previousTurn`).
 		await this.#restoreNonCharacterTurnState(this.combatant ?? null);
+		// Backstop: Foundry can skip `_onEndTurn` for the outgoing hero when its cached turn
+		// history desyncs from our expanded turn order (e.g. the last hero before a solo-monster
+		// wrap), leaving them at 0 actions. Refill them here if that happened.
+		await this.#ensureOutgoingCharacterRefilled(outgoingCombatantId);
 		return result;
 	}
 
@@ -1232,6 +1279,8 @@ class NimbleCombat extends Combat {
 		// Capture the outgoing combatant before advancing so the turn-end refill in
 		// `_onEndTurn` targets the right one. Cleared in `finally` so it never leaks.
 		this.#endingTurnCombatantId = this.combatant?.id ?? null;
+		const outgoingCombatantId = this.#endingTurnCombatantId;
+		this.#endingTurnRefilledCharacterId = null;
 		let intercepted: boolean;
 		let result: this;
 		try {
@@ -1247,6 +1296,9 @@ class NimbleCombat extends Combat {
 			await this.#persistAtomicTurnState({ turn: this.turn });
 		}
 		await this.#restoreNonCharacterTurnState(this.combatant ?? null);
+		// Backstop the outgoing hero's refill in case Foundry skipped `_onEndTurn` for them
+		// (see `nextTurn`); no-op when `_onEndTurn` already handled it.
+		await this.#ensureOutgoingCharacterRefilled(outgoingCombatantId);
 		return result;
 	}
 

--- a/src/documents/combat/combat.svelte.ts
+++ b/src/documents/combat/combat.svelte.ts
@@ -1196,6 +1196,10 @@ class NimbleCombat extends Combat {
 		if (!intercepted) {
 			await this.#persistAtomicTurnState({ turn: this.turn });
 		}
+		// Solo monsters take a turn after each character, but their actions are only reset
+		// at end of round. Restore the incoming non-character's actions so they start each
+		// of their interleaved turns with a full action pool (mirrors `previousTurn`).
+		await this.#restoreNonCharacterTurnState(this.combatant ?? null);
 		return result;
 	}
 
@@ -1210,6 +1214,7 @@ class NimbleCombat extends Combat {
 		if (!intercepted) {
 			await this.#persistAtomicTurnState({ turn: this.turn });
 		}
+		await this.#restoreNonCharacterTurnState(this.combatant ?? null);
 		return result;
 	}
 

--- a/src/documents/combat/combatInitiative.test.ts
+++ b/src/documents/combat/combatInitiative.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { applyCharacterInitiativeActionUpdate } from './combatInitiative.js';
+
+function createCharacter() {
+	return { type: 'character' } as unknown as Combatant.Implementation;
+}
+
+describe('applyCharacterInitiativeActionUpdate', () => {
+	it('sets both current and max to 3 for an initiative roll of 20 or more', () => {
+		const updates: Record<string, unknown> = {};
+		applyCharacterInitiativeActionUpdate(createCharacter(), updates, 22);
+
+		expect(updates['system.actions.base.current']).toBe(3);
+		expect(updates['system.actions.base.max']).toBe(3);
+	});
+
+	it('sets both current and max to 2 for an initiative roll between 10 and 19', () => {
+		const updates: Record<string, unknown> = {};
+		applyCharacterInitiativeActionUpdate(createCharacter(), updates, 14);
+
+		expect(updates['system.actions.base.current']).toBe(2);
+		expect(updates['system.actions.base.max']).toBe(2);
+	});
+
+	it('sets both current and max to 1 for an initiative roll below 10', () => {
+		const updates: Record<string, unknown> = {};
+		applyCharacterInitiativeActionUpdate(createCharacter(), updates, 7);
+
+		expect(updates['system.actions.base.current']).toBe(1);
+		expect(updates['system.actions.base.max']).toBe(1);
+	});
+
+	it('leaves the boundary roll of exactly 20 at 3 actions', () => {
+		const updates: Record<string, unknown> = {};
+		applyCharacterInitiativeActionUpdate(createCharacter(), updates, 20);
+
+		expect(updates['system.actions.base.current']).toBe(3);
+		expect(updates['system.actions.base.max']).toBe(3);
+	});
+
+	it('does not modify actions for non-character combatants', () => {
+		const updates: Record<string, unknown> = {};
+		applyCharacterInitiativeActionUpdate(
+			{ type: 'soloMonster' } as unknown as Combatant.Implementation,
+			updates,
+			22,
+		);
+
+		expect(updates['system.actions.base.current']).toBeUndefined();
+		expect(updates['system.actions.base.max']).toBeUndefined();
+	});
+});

--- a/src/documents/combat/combatInitiative.test.ts
+++ b/src/documents/combat/combatInitiative.test.ts
@@ -6,36 +6,38 @@ function createCharacter() {
 }
 
 describe('applyCharacterInitiativeActionUpdate', () => {
-	it('sets both current and max to 3 for an initiative roll of 20 or more', () => {
+	// The initiative roll only seeds a character's starting actions for the first
+	// round. `max` is always 3 (reduced only by Dying at restore time), so the
+	// update must set `current` and never touch `max`.
+	it('seeds current to 3 for an initiative roll of 20 or more without setting max', () => {
 		const updates: Record<string, unknown> = {};
 		applyCharacterInitiativeActionUpdate(createCharacter(), updates, 22);
 
 		expect(updates['system.actions.base.current']).toBe(3);
-		expect(updates['system.actions.base.max']).toBe(3);
+		expect(updates['system.actions.base.max']).toBeUndefined();
 	});
 
-	it('sets both current and max to 2 for an initiative roll between 10 and 19', () => {
+	it('seeds current to 2 for an initiative roll between 10 and 19 without setting max', () => {
 		const updates: Record<string, unknown> = {};
 		applyCharacterInitiativeActionUpdate(createCharacter(), updates, 14);
 
 		expect(updates['system.actions.base.current']).toBe(2);
-		expect(updates['system.actions.base.max']).toBe(2);
+		expect(updates['system.actions.base.max']).toBeUndefined();
 	});
 
-	it('sets both current and max to 1 for an initiative roll below 10', () => {
+	it('seeds current to 1 for an initiative roll below 10 without setting max', () => {
 		const updates: Record<string, unknown> = {};
 		applyCharacterInitiativeActionUpdate(createCharacter(), updates, 7);
 
 		expect(updates['system.actions.base.current']).toBe(1);
-		expect(updates['system.actions.base.max']).toBe(1);
+		expect(updates['system.actions.base.max']).toBeUndefined();
 	});
 
-	it('leaves the boundary roll of exactly 20 at 3 actions', () => {
+	it('treats the boundary roll of exactly 20 as 3 starting actions', () => {
 		const updates: Record<string, unknown> = {};
 		applyCharacterInitiativeActionUpdate(createCharacter(), updates, 20);
 
 		expect(updates['system.actions.base.current']).toBe(3);
-		expect(updates['system.actions.base.max']).toBe(3);
 	});
 
 	it('does not modify actions for non-character combatants', () => {

--- a/src/documents/combat/combatInitiative.ts
+++ b/src/documents/combat/combatInitiative.ts
@@ -8,13 +8,20 @@ export function applyCharacterInitiativeActionUpdate(
 ): void {
 	if (combatant.type !== 'character') return;
 
-	// The initiative roll determines how many actions the character gets each
-	// round. Set both `current` and `max` so that per-turn restoration (which
-	// resets `current` back up to `max`) honors the initiative-assigned amount
-	// rather than snapping every character to the default max of 3.
-	const actions = rollTotal >= 20 ? 3 : rollTotal >= 10 ? 2 : 1;
-	combatantUpdates['system.actions.base.current'] = actions;
-	combatantUpdates['system.actions.base.max'] = actions;
+	// The initiative roll only sets the character's starting actions for the
+	// first round. Their max stays at 3 — per-turn restoration always refills
+	// to max (reduced only by the Dying condition), so we must not touch max
+	// here or low-initiative heroes would be permanently capped below 3.
+	const actionPath = 'system.actions.base.current';
+	if (rollTotal >= 20) {
+		combatantUpdates[actionPath] = 3;
+		return;
+	}
+	if (rollTotal >= 10) {
+		combatantUpdates[actionPath] = 2;
+		return;
+	}
+	combatantUpdates[actionPath] = 1;
 }
 
 export async function buildInitiativeChatData(params: {

--- a/src/documents/combat/combatInitiative.ts
+++ b/src/documents/combat/combatInitiative.ts
@@ -8,16 +8,13 @@ export function applyCharacterInitiativeActionUpdate(
 ): void {
 	if (combatant.type !== 'character') return;
 
-	const actionPath = 'system.actions.base.current';
-	if (rollTotal >= 20) {
-		combatantUpdates[actionPath] = 3;
-		return;
-	}
-	if (rollTotal >= 10) {
-		combatantUpdates[actionPath] = 2;
-		return;
-	}
-	combatantUpdates[actionPath] = 1;
+	// The initiative roll determines how many actions the character gets each
+	// round. Set both `current` and `max` so that per-turn restoration (which
+	// resets `current` back up to `max`) honors the initiative-assigned amount
+	// rather than snapping every character to the default max of 3.
+	const actions = rollTotal >= 20 ? 3 : rollTotal >= 10 ? 2 : 1;
+	combatantUpdates['system.actions.base.current'] = actions;
+	combatantUpdates['system.actions.base.max'] = actions;
 }
 
 export async function buildInitiativeChatData(params: {


### PR DESCRIPTION
## Summary

Fixes combat action-economy bugs seen in solo-monster encounters, where action points were not restored correctly at the start/end of turns.

### Action model (for reference)
- A hero's **max actions is always 3**.
- The **initiative roll only seeds starting actions for round 1** (≥20 → 3, ≥10 → 2, <10 → 1).
- **End of turn** → a hero's actions restore to 3.
- **Dying** → restore to 1 only.
- **Dazed** (which applies Hampered) → one fewer action: reduces *current* by 1, max stays 3.

## Fixes

### 1. Refill the correct hero on turn-end (expanded solo-monster turns)
Foundry derives the combatant passed to `_onEndTurn` from its own `previous` turn snapshot. Our direct turn-index resync (`#syncTurnIndexWithAliveTurns`) can leave that snapshot stale when the turn list contains **duplicate solo-monster entries**, so the turn-end refill could target the wrong combatant — a hero might not regain actions on their own turn-end, or a hero who hadn't acted yet could be refilled early (matching the report).

**Fix:** capture the active combatant immediately before advancing (`nextTurn`/`nextRound`) and have `_onEndTurn` refill *that* captured combatant. Falls back to Foundry's value when there's no capture (drag-drop, direct calls), so it's a no-op except in the buggy case. The captured id is cleared in a `finally` so it never leaks into a later turn-end.

### 2. Solo monsters refill on each interleaved turn
Solo monsters take a turn after each character (`expandLegendaryTurns`), but their actions were only reset at `_onEndRound`. `nextTurn`/`nextRound` never restored the incoming non-character, while `previousTurn`/`previousRound` already did — an asymmetry that left a solo monster stuck at 0 actions for the rest of the round.

**Fix:** `nextTurn`/`nextRound` now restore the incoming non-character via the existing `#restoreNonCharacterTurnState()`. No-op for ordinary single-turn NPCs.

### 3. Keep hero max at 3 (initiative seeds round 1 only)
An early pass on this branch tied a hero's `system.actions.base.max` to their initiative roll — wrong, since max must always stay 3 (restoration refills to max, lowered only by Dying). Reverted; `applyCharacterInitiativeActionUpdate` now seeds only `current` and never touches `max`.

### 4. Backstop when Foundry skips the outgoing hero's turn-end entirely
The `#endingTurnCombatantId` capture (fix #1) corrects *which* combatant `_onEndTurn` refills — but only when `_onEndTurn` actually fires. Live logs from a 3-hero + solo-monster encounter showed that the **last hero before the solo monster's trailing turn never received an `_onEndTurn` call at all**, so they were left at 0 actions after clicking End Turn.

**Root cause:** Foundry's turn-event dispatcher (`#triggerTurnEvents`) decides which `_onEndTurn`s to fire by comparing its **cached** `current`/`previous` turn *indices*. Because our resync mutates `this.turn` directly (outside any `update()`), that cached history desyncs from the real position under the expanded (duplicate solo-monster) turn order, and Foundry computes an empty interval for the last hero — skipping their end-of-turn.

**Fix:** don't depend solely on Foundry firing `_onEndTurn`. The refill is extracted into `#applyCharacterTurnEndRefill`, and `nextTurn`/`nextRound` call `#ensureOutgoingCharacterRefilled` after advancing as a backstop. It refills the captured outgoing hero when `_onEndTurn` never ran, deduped by id so a single advance never refills — or fires the `nimbleCombatTurnEnd` hook for — the same hero twice. No-op in the cases where `_onEndTurn` already handled it.

## Tests
- `combatInitiative.test.ts` — initiative seeds `current` (all roll bands + the 20 boundary), never sets `max`, no-op for non-characters.
- `combat.svelte.test.ts`:
  - turn-end refills the captured outgoing hero even when Foundry reports the wrong combatant;
  - **turn-end refills the outgoing hero even when Foundry never fires `_onEndTurn`** (fix #4);
  - **does not double-refill when both `_onEndTurn` and the backstop run** (fix #4);
  - advancing forward into a solo monster's turn restores its actions to max;
  - two existing `nextTurn` tests updated to mock `updateEmbeddedDocuments`, now exercised by the forward restore path.

Full suite: 1660 tests pass; typecheck and Biome clean.
