### PR TITLE
fix: all inventory item quantities can be modified

### DIFF
--- a/src/view/sheets/pages/PlayerCharacterInventoryTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterInventoryTab.svelte
@@ -323,7 +323,6 @@
 										actor.updateItem(item._id, {
 											'system.quantity': currentTarget.value,
 										})}
-									disabled={item.system.objectSizeType === 'slots'}
 								/>
 							{/if}
 

--- a/src/view/sheets/pages/PlayerCharacterInventoryTab.svelte.test.ts
+++ b/src/view/sheets/pages/PlayerCharacterInventoryTab.svelte.test.ts
@@ -1,7 +1,6 @@
 import { fireEvent, render } from '@testing-library/svelte';
 import { describe, expect, it, vi } from 'vitest';
 
-// @ts-expect-error - Svelte component default export is provided by the Svelte compiler
 import PlayerCharacterInventoryTabHarness from '../../../../tests/harnesses/PlayerCharacterInventoryTabHarness.svelte';
 
 function renderInventory(

--- a/src/view/sheets/pages/PlayerCharacterInventoryTab.svelte.test.ts
+++ b/src/view/sheets/pages/PlayerCharacterInventoryTab.svelte.test.ts
@@ -1,0 +1,56 @@
+import { fireEvent, render } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+
+// @ts-expect-error - Svelte component default export is provided by the Svelte compiler
+import PlayerCharacterInventoryTabHarness from '../../../../tests/harnesses/PlayerCharacterInventoryTabHarness.svelte';
+
+function renderInventory(
+	items: { _id: string; name: string; system: Record<string, unknown> }[],
+	updateItem = vi.fn(),
+) {
+	const result = render(PlayerCharacterInventoryTabHarness, {
+		props: { items, updateItem },
+	});
+
+	const quantityInputs = Array.from(
+		result.container.querySelectorAll<HTMLInputElement>('.nimble-document-card__quantity'),
+	);
+
+	return { ...result, updateItem, quantityInputs };
+}
+
+describe('PlayerCharacterInventoryTab quantity input', () => {
+	it('does not disable the quantity input for slot-sized objects', () => {
+		const { quantityInputs } = renderInventory([
+			{ _id: 'slots-item', name: 'Bedroll', system: { objectSizeType: 'slots', quantity: 3 } },
+		]);
+
+		expect(quantityInputs).toHaveLength(1);
+		expect(quantityInputs[0].disabled).toBe(false);
+	});
+
+	it('does not disable the quantity input for negligible objects', () => {
+		const { quantityInputs } = renderInventory([
+			{
+				_id: 'negligible-item',
+				name: 'Coin',
+				system: { objectSizeType: 'negligible', quantity: 5 },
+			},
+		]);
+
+		expect(quantityInputs).toHaveLength(1);
+		expect(quantityInputs[0].disabled).toBe(false);
+	});
+
+	it('persists a new quantity for a slot-sized object via updateItem', async () => {
+		const { quantityInputs, updateItem } = renderInventory([
+			{ _id: 'slots-item', name: 'Bedroll', system: { objectSizeType: 'slots', quantity: 3 } },
+		]);
+
+		const input = quantityInputs[0];
+		input.value = '7';
+		await fireEvent.change(input);
+
+		expect(updateItem).toHaveBeenCalledWith('slots-item', { 'system.quantity': '7' });
+	});
+});

--- a/tests/harnesses/PlayerCharacterInventoryTabHarness.svelte
+++ b/tests/harnesses/PlayerCharacterInventoryTabHarness.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+	import { setContext, untrack } from 'svelte';
+
+	import PlayerCharacterInventoryTab from '../../src/view/sheets/pages/PlayerCharacterInventoryTab.svelte';
+
+	type HarnessItem = {
+		_id: string;
+		name: string;
+		system: Record<string, unknown>;
+	};
+
+	let {
+		items = [],
+		updateItem = () => {},
+	}: {
+		items?: HarnessItem[];
+		updateItem?: (id: string, changes: Record<string, unknown>) => unknown;
+	} = $props();
+
+	// Build item objects that mirror the shape the inventory tab reads:
+	// each item exposes both a direct `system` (used for the disabled binding)
+	// and a `reactive` view (used for value bindings and rendering).
+	const preparedItems = untrack(() => items).map((item) => {
+		const prepared: Record<string, unknown> = {
+			_id: item._id,
+			id: item._id,
+			type: 'object',
+			sort: 0,
+			name: item.name,
+			img: 'icons/svg/item-bag.svg',
+			uuid: `Item.${item._id}`,
+			system: { objectType: 'gear', quantity: 1, rules: [], equipped: false, ...item.system },
+		};
+		// The template reads `item.reactive.*`; point it back at the item itself.
+		prepared.reactive = prepared;
+		return prepared;
+	});
+
+	const actor = {
+		updateItem: untrack(() => updateItem),
+		update: () => {},
+		activateItem: () => {},
+		createItem: () => {},
+		configureItem: () => {},
+		deleteItem: () => {},
+		items: preparedItems,
+		reactive: {
+			items: preparedItems,
+			system: {
+				currency: {},
+				inventory: { totalSlots: 0, usedSlots: 0 },
+			},
+			flags: {},
+		},
+	};
+
+	setContext('actor', actor);
+	setContext('application', {
+		_onDragStart: () => {},
+		_onDropItem: () => {},
+		_onSortItem: () => {},
+		clearDroppedItemFlash: () => {},
+	});
+	setContext('sheetState', {});
+</script>
+
+<PlayerCharacterInventoryTab />


### PR DESCRIPTION
## Summary

Weapons and misc items can now have a quantity applied.

## Changes

- Removed the `disabled={item.system.objectSizeType === 'slots'}` binding on the inventory quantity `<input>` in `PlayerCharacterInventoryTab.svelte`, so quantities can be edited for objects of any `objectSizeType` (previously slot-sized items were locked).
- Added a component test (`PlayerCharacterInventoryTab.svelte.test.ts`) plus a rendering harness (`tests/harnesses/PlayerCharacterInventoryTabHarness.svelte`) covering:
  - slot-sized objects render an enabled quantity input,
  - negligible objects render an enabled quantity input,
  - editing the quantity persists via `actor.updateItem(id, { 'system.quantity': value })`.

## Test Plan

Manual:
- Open the app
- Go to character inventory
- Verify that the quantity of weapons and magic items can be changed.

Automated:
- `pnpm test` — the new tests pass, and were confirmed to fail against the pre-fix code (regression guard).

## Checklist

- [x] Added or updated unit tests
- [ ] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [ ] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** yes / no
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues

Closes #836
