### PR TITLE
fix(spells): let Ignite miss and crit; migrate existing copies (#835)

### DIFF
--- a/packs/spells/core/fire/ignite.json
+++ b/packs/spells/core/fire/ignite.json
@@ -7,7 +7,7 @@
 		"identifier": "",
 		"rules": [],
 		"activation": {
-			"acquireTargetsFromTemplate": true,
+			"acquireTargetsFromTemplate": false,
 			"cost": {
 				"details": "",
 				"quantity": 2,
@@ -49,8 +49,8 @@
 			},
 			"template": {
 				"length": 1,
-				"radius": 3,
-				"shape": "circle",
+				"radius": 1,
+				"shape": "",
 				"width": 1
 			}
 		},

--- a/src/migration/MigrationRunnerBase.ts
+++ b/src/migration/MigrationRunnerBase.ts
@@ -9,7 +9,7 @@ interface CollectionDiff<T = any> {
 class MigrationRunnerBase {
 	migrations: MigrationBase[];
 
-	static LATEST_SCHEMA_VERSION = 25;
+	static LATEST_SCHEMA_VERSION = 26;
 
 	static RECOMMENDED_SAFE_VERSION = 0;
 

--- a/src/migration/migrations/Migration026IgniteSingleTarget.ts
+++ b/src/migration/migrations/Migration026IgniteSingleTarget.ts
@@ -1,0 +1,53 @@
+import { MigrationBase } from '../MigrationBase.js';
+
+// Ignite is a single-target spell ("Damage: 4d10 to a Smoldering target") that
+// shipped with an AoE circle template. `ItemActivationManager` treats any
+// template shape as AoE and forces canMiss/canCrit off (AoE uses one shared
+// roll), so Ignite's explicit canMiss/canCrit were overridden and a 1 on the
+// primary die never registered as a miss (issue #835). The compendium source
+// was corrected to clear the template; this migration repairs copies already
+// living on actors, in world items, or in duplicated world compendiums.
+const IGNITE_SOURCE_IDS = new Set([
+	'Compendium.nimble.spells.Item.FL6JcWWzAjdMchhJ',
+	'Compendium.nimble.nimble-spells.Item.FL6JcWWzAjdMchhJ',
+]);
+const IGNITE_NAME = 'Ignite';
+
+/**
+ * Migration to clear Ignite's stray AoE circle template so it can miss and crit.
+ *
+ * Matching strategy:
+ * 1. Source ID — canonical match for anything dragged from the official pack.
+ * 2. Spell name — fallback for duplicated world compendiums where the item has
+ *    no `compendiumSource`.
+ *
+ * In both cases the fix is only applied when the spell still carries the broken
+ * `circle` template, so intentional GM edits (e.g. reshaping it into a real
+ * AoE) are left untouched.
+ */
+class Migration026IgniteSingleTarget extends MigrationBase {
+	static override readonly version = 26;
+
+	override readonly version = Migration026IgniteSingleTarget.version;
+
+	override async updateItem(source: any): Promise<void> {
+		if (source.type !== 'spell') return;
+
+		const sourceId = this.getSourceId(source);
+		const isIgnite = (sourceId && IGNITE_SOURCE_IDS.has(sourceId)) || source.name === IGNITE_NAME;
+		if (!isIgnite) return;
+
+		const activation = source.system?.activation;
+		const template = activation?.template;
+		// Only repair the specific broken state; leave intentional GM edits alone.
+		if (!template || template.shape !== 'circle') return;
+
+		template.shape = '';
+		template.radius = 1;
+		activation.acquireTargetsFromTemplate = false;
+
+		console.log(`Nimble Migration | ${source.name}: cleared AoE template so it can miss and crit`);
+	}
+}
+
+export { Migration026IgniteSingleTarget };

--- a/src/migration/migrations/index.ts
+++ b/src/migration/migrations/index.ts
@@ -23,3 +23,4 @@ export { Migration022CelestialSavingThrow } from './Migration022CelestialSavingT
 export { Migration023SpellClasses } from './Migration023SpellClasses.js';
 export { Migration024OathswornRefillMode } from './Migration024OathswornRefillMode.js';
 export { Migration025DiceConsumerSplit } from './Migration025DiceConsumerSplit.js';
+export { Migration026IgniteSingleTarget } from './Migration026IgniteSingleTarget.js';


### PR DESCRIPTION
## Summary

Fixes #835 — the Ignite spell can't miss on a `1` (and shows no primary-die separation).

**Root cause:** `ItemActivationManager` treats any item with an `activation.template.shape` as AoE and forces `canMiss: false` / `canCrit: false` (AoE uses one shared roll, so it can't miss or crit). Ignite is a **single-target** spell ("Damage: 4d10 to a Smoldering target") but shipped with a stray `circle` template, so its explicit `canMiss: true` / `canCrit: true` were silently overridden. That also suppresses primary-die extraction, explaining the missing primary-die display the reporter noticed.

Every genuine AoE damage spell (Arctic Blast, Glacier Strike, Thousand Cuts, Stormlash, Seething Storm) explicitly sets `canMiss: false`; the real fire AoE (Pyroclasm) is a save-for-half effect with no attack roll. Ignite was the lone templated spell with `canMiss: true` — clearly intended to hit/miss like a normal single-target attack.

## Changes

- **`packs/spells/core/fire/ignite.json`** — model Ignite like other single-target damage spells (e.g. Flame Dart): clear `template.shape` and set `acquireTargetsFromTemplate: false`. `isAoE` is no longer triggered, so its `canMiss`/`canCrit` apply.
- **`src/migration/migrations/Migration026IgniteSingleTarget.ts`** (+ registered in `index.ts`) — repair existing Ignite copies already living on actors, in world items, and in duplicated world compendiums. Matches by compendium source id (old `spells` and current `nimble-spells` pack-name forms) with a name fallback, and only touches items still carrying the broken `circle` template so intentional GM edits are left alone.
- **`src/migration/MigrationRunnerBase.ts`** — bump `LATEST_SCHEMA_VERSION` 25 → 26 so the schema-version gate in `ready.ts` actually fires the new migration (each migration must bump this alongside registering itself).

## Testing

- `tsc --noEmit` clean
- `systemId.test.ts` passes (the `Compendium.nimble.*` literals in the migration are the audited `src/migration/**` exception)
- Biome format/lint clean
- Verified against a live world: after loading, an existing on-actor Ignite has its `circle` template cleared and rolls miss on a `1` / crit on max.
