### PR TITLE
fix(dicepool): let players add dice to their own pool (#803)

### DIFF
--- a/src/view/sheets/components/DicePoolTracker.svelte
+++ b/src/view/sheets/components/DicePoolTracker.svelte
@@ -105,7 +105,7 @@
 							</button>
 						{/each}
 
-						{#if pool.kind === 'rolled' && pool.faces.length < pool.max && tracker.isGM}
+						{#if pool.kind === 'rolled' && pool.faces.length < pool.max && tracker.isOwner}
 							<button
 								class="dice-pool-tracker__die-chip dice-pool-tracker__add-die"
 								type="button"
@@ -173,7 +173,7 @@
 							<i class="fa-solid {getDieFaceIcon(pool.dieSize)}"></i>
 						</div>
 
-						{#if pool.kind === 'rolled' && pool.faces.length < pool.max && tracker.isGM}
+						{#if pool.kind === 'rolled' && pool.faces.length < pool.max && tracker.isOwner}
 							<button
 								class="dice-pool-tracker__die-chip dice-pool-tracker__add-die"
 								type="button"

--- a/src/view/sheets/components/DicePoolTracker.svelte.ts
+++ b/src/view/sheets/components/DicePoolTracker.svelte.ts
@@ -165,7 +165,7 @@ export function createDicePoolTrackerState(getActor: () => NimbleCharacter) {
 		await setPoolFaces(getActor(), poolId, next);
 	}
 
-	/** Roll one die into a rolled pool (GM tool). Delegates to dicePoolRefill. */
+	/** Roll one die into a rolled pool (owner action). Delegates to dicePoolRefill. */
 	async function rollOneIntoPool(poolId: string): Promise<void> {
 		const pool = pools.find((p) => p.id === poolId);
 		if (!pool || pool.kind !== 'rolled') return;
@@ -203,9 +203,6 @@ export function createDicePoolTrackerState(getActor: () => NimbleCharacter) {
 		},
 		get isOwner() {
 			return getActor().isOwner === true;
-		},
-		get isGM() {
-			return (game?.user?.isGM ?? false) === true;
 		},
 		discardRolledDie,
 		discardAllRolled,


### PR DESCRIPTION
## Summary

Lets a player add dice to their own dicepool via the "+" button in the sheet's dicepool tracker. Previously the button was GM-only, so a GM had to open each player's sheet to make missing dice-pool features "work".

## Changes

- Changed the "+" add-die button guard in the dicepool tracker from `tracker.isGM` to `tracker.isOwner`, in both the with-faces and empty-pool branches ([DicePoolTracker.svelte](../../worktrees/dev/src/view/sheets/components/DicePoolTracker.svelte)). This matches how every other pool control (discard, edit, spend, panel toggle) is already gated.
- Removed the now-unused `isGM` getter from the tracker state factory and updated the `rollOneIntoPool` doc comment (owner action, not a GM tool).

No socket relay is needed: `rollDieIntoPool` persists through `actor.update()` / `item.update()`, which any document owner (a player on their own character) can already perform, the same write path the existing discard/edit controls use.

## Test Plan

1. As the GM, assign a class/feature that grants a rolled dice pool (e.g. Oathsworn Judgment Dice or Berserker Fury Dice) to a player-owned character.
2. Log in as the **player** (not GM) who owns that character and open their sheet.
3. Confirm the dicepool tracker shows the dashed "+" button whenever the pool has room (`faces.length < max`), on both a pool that already has dice and an empty pool.
4. Click "+": a die is rolled, a chat message is posted, and the new die appears in the pool.
5. Confirm the button hides once the pool is at max, and that a non-owner (a different player) does not see the button.

## Checklist

- [ ] Added or updated unit tests
- [x] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [ ] No hardcoded user-facing strings (used `localize()`)
- [x] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** yes / no
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues

Closes #803
