### PR TITLE
fix(combat): apply banked dice-pool bonuses through monster armor

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -1820,7 +1820,8 @@
 			"noTargetsSelected": "No targets selected",
 			"addSelectedTokensAsTargets": "Add Selected Tokens as Targets",
 			"addTargetedTokensAsTargets": "Add Targeted Tokens as Targets",
-			"removeTarget": "Remove Target"
+			"removeTarget": "Remove Target",
+			"damagePreview": "Damage this target will take (after armor)"
 		},
 		"chatEffects": {
 			"noEffect": "No Effect"

--- a/src/documents/chatMessage.test.ts
+++ b/src/documents/chatMessage.test.ts
@@ -1225,14 +1225,52 @@ describe('NimbleChatMessage.getDamagePreviewForTarget', () => {
 		expect(message.getDamagePreviewForTarget('Scene.scene.Token.token')).toBe(42);
 	});
 
-	it('returns 0 for a miss (no damage is applied)', () => {
+	it('returns null for a miss so the target list shows no preview', () => {
 		globals().fromUuidSync.mockReturnValue({
 			actor: { system: { attributes: { armor: 'none' } } },
 		});
 
 		const message = createDamageMessage({ roll: battleaxeRoll(), isMiss: true });
 
-		expect(message.getDamagePreviewForTarget('Scene.scene.Token.token')).toBe(0);
+		expect(message.getDamagePreviewForTarget('Scene.scene.Token.token')).toBeNull();
+	});
+
+	it('counts a disposition-targeted damage node once when its outcome child is also surfaced', () => {
+		globals().fromUuidSync.mockReturnValue({
+			actor: { system: { attributes: { armor: 'none' } } },
+		});
+
+		const message = new NimbleChatMessage({
+			type: 'spell',
+			system: {
+				targets: ['Scene.scene.Token.token'],
+				isCritical: false,
+				isMiss: false,
+				activation: {
+					effects: [
+						{
+							id: 'dmg',
+							type: 'damage',
+							formula: '1d10',
+							damageType: 'slashing',
+							targetDisposition: 'hostile',
+							canCrit: true,
+							canMiss: true,
+							roll: battleaxeRoll(),
+							parentNode: null,
+							parentContext: null,
+							on: {
+								hit: [
+									{ id: 'dmg-hit', type: 'damageOutcome', parentNode: 'dmg', parentContext: 'hit' },
+								],
+							},
+						},
+					],
+				},
+			},
+		} as unknown as ChatMessage.CreateData);
+
+		expect(message.getDamagePreviewForTarget('Scene.scene.Token.token')).toBe(42);
 	});
 
 	it('returns null when the card has no applicable damage rolls', () => {

--- a/src/documents/chatMessage.test.ts
+++ b/src/documents/chatMessage.test.ts
@@ -593,6 +593,141 @@ describe('NimbleChatMessage.applyDamage', () => {
 		expect(actor.applyDamage).toHaveBeenCalledWith(3);
 	});
 
+	it('counts banked dice-pool bonuses (Fury Dice) as dice, not modifiers, for medium armor', async () => {
+		const actor = {
+			applyDamage: vi.fn().mockResolvedValue(undefined),
+			system: {
+				attributes: {
+					armor: 'medium',
+					hp: {
+						value: 50,
+						temp: 0,
+						max: 50,
+					},
+				},
+			},
+			update: vi.fn().mockResolvedValue(undefined),
+		};
+
+		globals().fromUuidSync.mockReturnValue({ actor });
+
+		// Battleaxe hit: 1d10 (rolled 5) + 5 + 10[Fury Dice] + 4[Fury Dice] + 18 = 42.
+		// Medium armor keeps the dice (d10 5 + Fury 10 + Fury 4 = 19) and drops the
+		// flat +5 / +18 modifiers.
+		const roll = {
+			class: 'DamageRoll',
+			formula: '1d10 + 5 + 10 + 4 + 18',
+			total: 42,
+			isCritical: false,
+			excludedPrimaryDieValue: 0,
+			terms: [
+				{ number: 1, faces: 10, results: [{ result: 5, active: true, discarded: false }] },
+				{ operator: '+' },
+				{ number: 5 },
+				{ operator: '+' },
+				{ number: 10, options: { flavor: 'Fury Dice' } },
+				{ operator: '+' },
+				{ number: 4, options: { flavor: 'Fury Dice' } },
+				{ operator: '+' },
+				{ number: 18 },
+			],
+		};
+
+		const message = createActivationMessage();
+		await message.applyDamage(42, { outcome: 'fullDamage', roll });
+
+		expect(actor.applyDamage).toHaveBeenCalledWith(19);
+	});
+
+	it('halves banked dice-pool bonuses (Fury Dice) with the dice for heavy armor', async () => {
+		const actor = {
+			applyDamage: vi.fn().mockResolvedValue(undefined),
+			system: {
+				attributes: {
+					armor: 'heavy',
+					hp: {
+						value: 50,
+						temp: 0,
+						max: 50,
+					},
+				},
+			},
+			update: vi.fn().mockResolvedValue(undefined),
+		};
+
+		globals().fromUuidSync.mockReturnValue({ actor });
+
+		// Same Battleaxe hit against a heavy-armor target: dice total 19 is halved
+		// (Math.ceil(19 * 0.5) = 10); the flat +5 / +18 modifiers are ignored.
+		const roll = {
+			class: 'DamageRoll',
+			formula: '1d10 + 5 + 10 + 4 + 18',
+			total: 42,
+			isCritical: false,
+			excludedPrimaryDieValue: 0,
+			terms: [
+				{ number: 1, faces: 10, results: [{ result: 5, active: true, discarded: false }] },
+				{ operator: '+' },
+				{ number: 5 },
+				{ operator: '+' },
+				{ number: 10, options: { flavor: 'Fury Dice' } },
+				{ operator: '+' },
+				{ number: 4, options: { flavor: 'Fury Dice' } },
+				{ operator: '+' },
+				{ number: 18 },
+			],
+		};
+
+		const message = createActivationMessage();
+		await message.applyDamage(42, { outcome: 'fullDamage', roll });
+
+		expect(actor.applyDamage).toHaveBeenCalledWith(10);
+	});
+
+	it('counts other banked dice pools (e.g. Oathsworn Judgment Dice) as dice for armor', async () => {
+		const actor = {
+			applyDamage: vi.fn().mockResolvedValue(undefined),
+			system: {
+				attributes: {
+					armor: 'medium',
+					hp: {
+						value: 50,
+						temp: 0,
+						max: 50,
+					},
+				},
+			},
+			update: vi.fn().mockResolvedValue(undefined),
+		};
+
+		globals().fromUuidSync.mockReturnValue({ actor });
+
+		// Manually-spent Judgment Dice arrive on the roll the same way Fury Dice do
+		// (flavored numeric terms). 1d8 (6) + 3[Judgment Dice] + 5[Judgment Dice] + 4
+		// against medium armor keeps the dice (6 + 3 + 5 = 14), drops the flat +4.
+		const roll = {
+			class: 'DamageRoll',
+			formula: '1d8 + 3 + 5 + 4',
+			total: 18,
+			isCritical: false,
+			excludedPrimaryDieValue: 0,
+			terms: [
+				{ number: 1, faces: 8, results: [{ result: 6, active: true, discarded: false }] },
+				{ operator: '+' },
+				{ number: 3, options: { flavor: 'Judgment Dice' } },
+				{ operator: '+' },
+				{ number: 5, options: { flavor: 'Judgment Dice' } },
+				{ operator: '+' },
+				{ number: 4 },
+			],
+		};
+
+		const message = createActivationMessage();
+		await message.applyDamage(18, { outcome: 'fullDamage', roll });
+
+		expect(actor.applyDamage).toHaveBeenCalledWith(14);
+	});
+
 	it('applies heavy armor by halving dice-only damage and rounding up on non-critical hits', async () => {
 		const actor = {
 			applyDamage: vi.fn().mockResolvedValue(undefined),
@@ -990,5 +1125,131 @@ describe('NimbleChatMessage.applyDamage', () => {
 		});
 
 		expect(actor.applyDamage).toHaveBeenCalledWith(11);
+	});
+});
+
+describe('NimbleChatMessage.getDamagePreviewForTarget', () => {
+	beforeEach(() => {
+		globals().fromUuidSync = vi.fn();
+	});
+
+	// Battleaxe hit: 1d10 (rolled 5) + 5 + 10[Fury Dice] + 4[Fury Dice] + 18 = 42.
+	function battleaxeRoll() {
+		return {
+			class: 'DamageRoll',
+			formula: '1d10 + 5 + 10 + 4 + 18',
+			total: 42,
+			isCritical: false,
+			excludedPrimaryDieValue: 0,
+			terms: [
+				{ number: 1, faces: 10, results: [{ result: 5, active: true, discarded: false }] },
+				{ operator: '+' },
+				{ number: 5 },
+				{ operator: '+' },
+				{ number: 10, options: { flavor: 'Fury Dice' } },
+				{ operator: '+' },
+				{ number: 4, options: { flavor: 'Fury Dice' } },
+				{ operator: '+' },
+				{ number: 18 },
+			],
+		};
+	}
+
+	// Mirrors the effects tree shape produced by the attack flow: a base damage
+	// node whose on-hit outcome node inherits its roll (see processNodes).
+	function createDamageMessage(params: {
+		roll: object;
+		isMiss?: boolean;
+		ignoreArmor?: boolean;
+		targets?: string[];
+	}) {
+		return new NimbleChatMessage({
+			type: 'spell',
+			system: {
+				targets: params.targets ?? ['Scene.scene.Token.token'],
+				isCritical: false,
+				isMiss: params.isMiss ?? false,
+				activation: {
+					effects: [
+						{
+							id: 'dmg',
+							type: 'damage',
+							formula: '1d10',
+							damageType: 'slashing',
+							ignoreArmor: params.ignoreArmor ?? false,
+							canCrit: true,
+							canMiss: true,
+							roll: params.roll,
+							parentNode: null,
+							parentContext: null,
+							on: {
+								hit: [
+									{ id: 'dmg-hit', type: 'damageOutcome', parentNode: 'dmg', parentContext: 'hit' },
+								],
+							},
+						},
+					],
+				},
+			},
+		} as unknown as ChatMessage.CreateData);
+	}
+
+	it('returns the full displayed total for an unarmored target', () => {
+		globals().fromUuidSync.mockReturnValue({
+			actor: { system: { attributes: { armor: 'none' } } },
+		});
+
+		const message = createDamageMessage({ roll: battleaxeRoll() });
+
+		expect(message.getDamagePreviewForTarget('Scene.scene.Token.token')).toBe(42);
+	});
+
+	it('returns the armor-reduced total for a heavy-armor target (Fury Dice count as dice)', () => {
+		globals().fromUuidSync.mockReturnValue({
+			actor: { system: { attributes: { armor: 'heavy' } } },
+		});
+
+		const message = createDamageMessage({ roll: battleaxeRoll() });
+
+		// Dice = d10 5 + Fury 10 + 4 = 19; heavy halves to ceil(9.5) = 10; +5/+18 dropped.
+		expect(message.getDamagePreviewForTarget('Scene.scene.Token.token')).toBe(10);
+	});
+
+	it('ignores armor for the preview when the damage ignores armor', () => {
+		globals().fromUuidSync.mockReturnValue({
+			actor: { system: { attributes: { armor: 'heavy' } } },
+		});
+
+		const message = createDamageMessage({ roll: battleaxeRoll(), ignoreArmor: true });
+
+		expect(message.getDamagePreviewForTarget('Scene.scene.Token.token')).toBe(42);
+	});
+
+	it('returns 0 for a miss (no damage is applied)', () => {
+		globals().fromUuidSync.mockReturnValue({
+			actor: { system: { attributes: { armor: 'none' } } },
+		});
+
+		const message = createDamageMessage({ roll: battleaxeRoll(), isMiss: true });
+
+		expect(message.getDamagePreviewForTarget('Scene.scene.Token.token')).toBe(0);
+	});
+
+	it('returns null when the card has no applicable damage rolls', () => {
+		globals().fromUuidSync.mockReturnValue({
+			actor: { system: { attributes: { armor: 'none' } } },
+		});
+
+		const message = createActivationMessage();
+
+		expect(message.getDamagePreviewForTarget('Scene.scene.Token.token')).toBeNull();
+	});
+
+	it('returns null when the target token does not resolve to an actor', () => {
+		globals().fromUuidSync.mockReturnValue(null);
+
+		const message = createDamageMessage({ roll: battleaxeRoll() });
+
+		expect(message.getDamagePreviewForTarget('Scene.scene.Token.token')).toBeNull();
 	});
 });

--- a/src/documents/chatMessage.ts
+++ b/src/documents/chatMessage.ts
@@ -84,6 +84,22 @@ function getSerializedDamageRolls(
 	return serializedRolls;
 }
 
+/**
+ * Read a roll term's flavor from either the live term (`term.flavor` getter) or
+ * its serialized shape (`term.options.flavor`). Flavored numeric terms in a
+ * damage roll are banked dice-pool contributions (e.g. Berserker Fury Dice, or
+ * manually-spent pool faces). Pack-authored formulas never flavor a flat
+ * constant; static/situational modifiers are always added unflavored.
+ */
+function getTermFlavor(term: unknown): string {
+	const serializedTerm = term as { flavor?: unknown; options?: { flavor?: unknown } };
+	if (typeof serializedTerm.flavor === 'string' && serializedTerm.flavor.trim().length > 0) {
+		return serializedTerm.flavor;
+	}
+	const optionsFlavor = serializedTerm.options?.flavor;
+	return typeof optionsFlavor === 'string' ? optionsFlavor : '';
+}
+
 function getDiceDamageTotal(serializedRoll: DamageRoll.SerializedData): number | null {
 	let diceDamage = 0;
 	let hasDiceTerm = false;
@@ -91,9 +107,21 @@ function getDiceDamageTotal(serializedRoll: DamageRoll.SerializedData): number |
 	if (!Array.isArray(serializedRoll.terms)) return null;
 
 	for (const term of serializedRoll.terms) {
-		const serializedTerm = term as { faces?: unknown; results?: unknown };
+		const serializedTerm = term as { faces?: unknown; results?: unknown; number?: unknown };
 		const faces = Number(serializedTerm.faces);
-		if (!Number.isFinite(faces) || faces <= 0) continue;
+
+		if (!Number.isFinite(faces) || faces <= 0) {
+			// Banked dice-pool faces (Fury Dice etc.) ship as flavored numeric
+			// terms. Per Nimble rules "your Fury Dice are dice when calculating
+			// damage for monster armor", so they belong in the dice total, not
+			// among the armor-ignored modifiers.
+			if (getTermFlavor(term).length < 1) continue;
+			const numericValue = Number(serializedTerm.number);
+			if (!Number.isFinite(numericValue)) continue;
+			hasDiceTerm = true;
+			diceDamage += numericValue;
+			continue;
+		}
 
 		hasDiceTerm = true;
 
@@ -138,6 +166,14 @@ function getNegativeModifierTotal(serializedRoll: DamageRoll.SerializedData): nu
 
 		const faces = Number(serializedTerm.faces);
 		if (Number.isFinite(faces) && faces > 0) {
+			pendingOperator = '+';
+			continue;
+		}
+
+		// Flavored numeric terms are dice-pool contributions counted as dice by
+		// getDiceDamageTotal, not modifiers, so skip them here to avoid
+		// double-counting.
+		if (getTermFlavor(term).length > 0) {
 			pendingOperator = '+';
 			continue;
 		}
@@ -534,6 +570,78 @@ class NimbleChatMessage extends ChatMessage {
 		const damageApplicationPlan = buildDamageApplicationPlan({ targets, damage, options });
 		if (!damageApplicationPlan.hasTargets) return true;
 		return damageApplicationPlan.applicableTargets.length > 0;
+	}
+
+	/**
+	 * Collect the damage rolls currently surfaced on this card that carry an
+	 * Apply Damage action: the top-level `damage` / `damageOutcome` nodes for the
+	 * resolved hit/miss/crit context. Save-gated damage is intentionally excluded
+	 * its per-target outcome is unknown until each target rolls its save.
+	 *
+	 * Each entry mirrors what `RollSummary` forwards to `applyDamage`: the
+	 * outcome-scaled value plus the options needed for armor adjustment.
+	 */
+	#collectApplicableDamageRolls(): Array<{ value: number; options: DamageApplyOptions }> {
+		const entries: Array<{ value: number; options: DamageApplyOptions }> = [];
+		const isMiss = (this.system as unknown as ActivationCardSystemData).isMiss === true;
+
+		for (const group of this.effectNodes) {
+			for (const node of group) {
+				if (node.type !== 'damage' && node.type !== 'damageOutcome') continue;
+
+				const roll = (node as { roll?: Record<string, unknown> }).roll;
+				if (!roll || typeof roll.class !== 'string') continue;
+
+				const outcome: DamageApplyOutcome =
+					node.type === 'damageOutcome'
+						? (node as DamageOutcomeNode).outcome
+						: isMiss
+							? 'noDamage'
+							: 'fullDamage';
+
+				const multiplier = outcome === 'halfDamage' ? 0.5 : 1;
+				const rollTotal = Number(roll.total ?? 0);
+				const value = Math.ceil((Number.isFinite(rollTotal) ? rollTotal : 0) * multiplier);
+
+				entries.push({
+					value,
+					options: {
+						ignoreArmor: (node as { ignoreArmor?: boolean }).ignoreArmor,
+						outcome,
+						roll: roll as unknown as DamageRoll.SerializedData,
+						isCritical: typeof roll.isCritical === 'boolean' ? roll.isCritical : undefined,
+					},
+				});
+			}
+		}
+
+		return entries;
+	}
+
+	/**
+	 * Total damage a single target would take from every Apply Damage action on
+	 * this card, accounting for that target's armor. Returns null when the card
+	 * has no applicable damage rolls (healing / condition / save-gated cards), so
+	 * the target list can omit the preview.
+	 */
+	getDamagePreviewForTarget(targetUuid: string): number | null {
+		if (!this.isActivationCard()) return null;
+
+		const damageRolls = this.#collectApplicableDamageRolls();
+		if (damageRolls.length < 1) return null;
+
+		const tokenDocument = fromUuidSync(targetUuid) as TokenDocument | null;
+		const actor = tokenDocument?.actor as Actor.Implementation | null;
+		if (!actor) return null;
+
+		let total = 0;
+		for (const { value, options } of damageRolls) {
+			if (options.outcome === 'noDamage') continue;
+			const adjusted = calculateArmorAdjustedDamage({ actor, damage: value, options });
+			if (Number.isFinite(adjusted) && adjusted > 0) total += Math.floor(adjusted);
+		}
+
+		return total;
 	}
 
 	async applyHealing(value: number, healingType?: string, effectId?: string): Promise<void> {

--- a/src/documents/chatMessage.ts
+++ b/src/documents/chatMessage.ts
@@ -576,7 +576,7 @@ class NimbleChatMessage extends ChatMessage {
 	 * Collect the damage rolls currently surfaced on this card that carry an
 	 * Apply Damage action: the top-level `damage` / `damageOutcome` nodes for the
 	 * resolved hit/miss/crit context. Save-gated damage is intentionally excluded
-	 * its per-target outcome is unknown until each target rolls its save.
+	 * because its per-target outcome is unknown until each target rolls its save.
 	 *
 	 * Each entry mirrors what `RollSummary` forwards to `applyDamage`: the
 	 * outcome-scaled value plus the options needed for armor adjustment.
@@ -585,9 +585,21 @@ class NimbleChatMessage extends ChatMessage {
 		const entries: Array<{ value: number; options: DamageApplyOptions }> = [];
 		const isMiss = (this.system as unknown as ActivationCardSystemData).isMiss === true;
 
+		// Disposition-targeted damage nodes are surfaced alongside their own
+		// outcome children, which carry the same roll; count only the children.
+		const surfacedOutcomeParentIds = new Set<string>();
+		for (const group of this.effectNodes) {
+			for (const node of group) {
+				if (node.type === 'damageOutcome') {
+					surfacedOutcomeParentIds.add((node as DamageOutcomeNode).parentNode);
+				}
+			}
+		}
+
 		for (const group of this.effectNodes) {
 			for (const node of group) {
 				if (node.type !== 'damage' && node.type !== 'damageOutcome') continue;
+				if (node.type === 'damage' && surfacedOutcomeParentIds.has(node.id)) continue;
 
 				const roll = (node as { roll?: Record<string, unknown> }).roll;
 				if (!roll || typeof roll.class !== 'string') continue;
@@ -627,7 +639,9 @@ class NimbleChatMessage extends ChatMessage {
 	getDamagePreviewForTarget(targetUuid: string): number | null {
 		if (!this.isActivationCard()) return null;
 
-		const damageRolls = this.#collectApplicableDamageRolls();
+		const damageRolls = this.#collectApplicableDamageRolls().filter(
+			({ options }) => options.outcome !== 'noDamage',
+		);
 		if (damageRolls.length < 1) return null;
 
 		const tokenDocument = fromUuidSync(targetUuid) as TokenDocument | null;
@@ -636,7 +650,6 @@ class NimbleChatMessage extends ChatMessage {
 
 		let total = 0;
 		for (const { value, options } of damageRolls) {
-			if (options.outcome === 'noDamage') continue;
 			const adjusted = calculateArmorAdjustedDamage({ actor, damage: value, options });
 			if (Number.isFinite(adjusted) && adjusted > 0) total += Math.floor(adjusted);
 		}

--- a/src/view/chat/components/Targets.svelte
+++ b/src/view/chat/components/Targets.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import type { NimbleChatMessage } from '#documents/chatMessage.ts';
+
 	import { getContext } from 'svelte';
 	import localize from '../../../utils/localize.js';
 	import { tokenHoverIn, tokenHoverOut } from '../../../utils/tokenHoverHighlight.js';
@@ -55,7 +57,7 @@
 
 	const { npcArmorEffects, npcArmorIcons, npcArmorTypes } = CONFIG.NIMBLE;
 
-	let messageDocument = getContext('messageDocument');
+	let messageDocument = getContext<NimbleChatMessage>('messageDocument');
 	let targets = $derived(messageDocument?.reactive?.system?.targets ?? []);
 </script>
 
@@ -91,6 +93,10 @@
 	<ul class="nimble-target-list">
 		{#await prepareTargets(targets) then tokens}
 			{#each tokens as token}
+				{@const damagePreview =
+					token && game.user?.isGM
+						? messageDocument?.reactive?.getDamagePreviewForTarget(token.uuid)
+						: null}
 				<li
 					class="nimble-card"
 					onmouseenter={() => tokenHoverIn(token.object)}
@@ -104,6 +110,14 @@
 
 					<span class="nimble-card__title">
 						{token?.actor?.name || token.name}
+						{#if damagePreview !== null && damagePreview !== undefined}
+							<span
+								class="nimble-target-damage"
+								data-tooltip={localize('NIMBLE.chatTargets.damagePreview')}
+							>
+								({damagePreview})
+							</span>
+						{/if}
 					</span>
 
 					{#if token?.actor?.type !== 'character'}
@@ -152,6 +166,12 @@
 		&:not(:last-of-type) {
 			border-bottom: 1px solid var(--nimble-card-border-color);
 		}
+	}
+
+	.nimble-target-damage {
+		margin-left: 0.25rem;
+		font-weight: 700;
+		color: var(--color-level-error, #7a1e1e);
 	}
 
 	.nimble-target-list {


### PR DESCRIPTION
## Summary

Fixes Apply Damage dropping banked dice-pool bonuses (Berserker Fury Dice, Oathsworn Judgment Dice) against armored monsters, and adds a per-target damage preview so the GM can see exactly how much each target will take before applying.

<img width="355" height="256" alt="image" src="https://github.com/user-attachments/assets/8d4792cc-d4cc-420e-a67b-7098e401edda" />


## Changes

- Count banked dice-pool contributions as dice for monster armor. These bonuses ship on the damage roll as flavored numeric terms, so `calculateArmorAdjustedDamage` was treating them as ignorable modifiers and stripping them for medium/heavy armor targets. Per the rules ("your Fury Dice are dice when calculating damage for monster armor") they now count toward dice damage: full against medium armor, halved against heavy. Flat static modifiers stay stripped by armor as before.
- The fix is general across every banked-dice mechanic, not just Fury Dice: Fury Dice (auto and manual), Judgment Dice, and charge-die pools (Combat/Mana Dice) all resolve correctly. Charge dice were already counted; flat damage bonuses remain armor-stripped.
- Add a per-target damage preview next to each name in the chat card target list (GM only), computed through the same armor-aware path as Apply Damage so the number always matches what gets applied. Shows nothing on cards with no applicable damage (healing, conditions, save-gated damage).

## Test Plan

1. As a Berserker with banked Fury Dice, attack a monster that has Heavy Armor (e.g. Basilisk) with a melee weapon and hit.
2. Confirm the target row shows a damage preview in parentheses next to the name, and that it equals half the combined weapon dice plus Fury Dice rounded up, with flat modifiers excluded.
3. Press Apply Damage and confirm the target's HP drops by that same previewed amount (previously it dropped only by the base weapon die).
4. Repeat against a Medium Armor target and confirm the full dice total (weapon dice plus Fury Dice) is applied, with flat modifiers excluded.
5. Repeat against an unarmored target and confirm the full card total is applied and previewed.
6. Confirm a Berserker manual Fury Dice spend and an Oathsworn Judgment Dice spend behave the same way.

## Checklist

- [x] Added or updated unit tests
- [x] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [ ] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** yes
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->
