### PR TITLE
fix(charges): don't auto-consume charges when no chargeConsumer rule exists

### DIFF
--- a/src/utils/chargePool/helpers.ts
+++ b/src/utils/chargePool/helpers.ts
@@ -361,10 +361,8 @@ function getChargeConsumers(
 	if (sourceItemId.length < 1) return [];
 
 	const consumers: ChargeConsumerState[] = [];
-	let hasExplicitConsumer = false;
 	for (const rule of rules.values()) {
 		if (rule.type !== 'chargeConsumer' || rule.disabled) continue;
-		hasExplicitConsumer = true;
 		const consumerRule = rule as ChargeConsumerRuleLike;
 		const poolIdentifier = normalizeIdentifier(
 			consumerRule.poolIdentifier || consumerRule.identifier || consumerRule.id,
@@ -378,31 +376,6 @@ function getChargeConsumers(
 			poolId,
 			poolIdentifier,
 			cost,
-		});
-	}
-
-	if (hasExplicitConsumer) return consumers;
-
-	if (item.flags == null || typeof item.flags !== 'object') return [];
-	const nimbleFlags = (item.flags as Record<string, unknown>)[SYSTEM_ID] as
-		| Record<string, unknown>
-		| undefined;
-	if (nimbleFlags == null || typeof nimbleFlags !== 'object') return [];
-	const chargePoolsOnItem = nimbleFlags.chargePools;
-	if (
-		!chargePoolsOnItem ||
-		typeof chargePoolsOnItem !== 'object' ||
-		Array.isArray(chargePoolsOnItem)
-	)
-		return [];
-
-	for (const poolIdentifier of Object.keys(chargePoolsOnItem)) {
-		const normalizedPoolId = normalizeIdentifier(poolIdentifier);
-		if (normalizedPoolId.length < 1) continue;
-		consumers.push({
-			poolId: normalizedPoolId,
-			poolIdentifier: normalizedPoolId,
-			cost: 1,
 		});
 	}
 

--- a/src/utils/chargePoolService.test.ts
+++ b/src/utils/chargePoolService.test.ts
@@ -240,6 +240,54 @@ describe('ChargePoolService', () => {
 		expect(validation.failure?.required).toBe(3);
 	});
 
+	it('does not consume charges when the item has a chargePool rule but no chargeConsumer rule', async () => {
+		const actor = createMockActor({
+			items: [
+				{
+					id: 'item-1',
+					name: 'Wand',
+					rules: [
+						{
+							type: 'chargePool',
+							id: 'pool-rule',
+							identifier: 'wand',
+							scope: 'item',
+							max: '3',
+							initial: 'max',
+						},
+					],
+					itemFlags: {
+						nimble: {
+							chargePools: {
+								wand: {
+									current: 3,
+									max: 3,
+									recoveries: [],
+								},
+							},
+						},
+					},
+				},
+			],
+		});
+
+		const item = actor.items.contents[0];
+		const validation = validateItemChargeConsumption(item as unknown as Item.Implementation);
+		expect(validation.ok).toBe(true);
+
+		const result = await consumeOnResolvedItemUse(item as unknown as Item.Implementation, {
+			isMiss: false,
+			isCritical: false,
+		});
+
+		expect(result.ok).toBe(true);
+		expect(result.consumption).toEqual([]);
+		expect(
+			((item.flags.nimble.chargePools as Record<string, unknown>).wand as Record<string, unknown>)
+				.current,
+		).toBe(3);
+	});
+
 	it('spends charges on resolved use and applies onHit/onCriticalHit recoveries', async () => {
 		const actor = createMockActor({
 			items: [


### PR DESCRIPTION
## Summary

Items with a Charge Pool rule but no Charge Consumer rule were silently consuming one charge from each of their pools on every activation, forcing users to add a cost-0 Charge Consumer as a workaround. Automatic consumption is now driven solely by explicit Charge Consumer rules.

## Changes

- Removed the implicit-consumer fallback in `getChargeConsumers`: it synthesized a cost-1 consumer from the item's `chargePools` flag whenever no explicit `chargeConsumer` rule existed. Since the Charge Pool rule itself persists pool state to that flag, every pool-only item was affected.
- Added a regression test covering the reported scenario (pool rule only, no consumer: validation passes, zero consumption, charges untouched).

Unaffected paths (verified, no code changes): the activation dialog's die-size stepper and the sheet's roll-on-spend pips both deduct via `adjustPool`/`rollChargeDie` directly and never used the fallback.

The only pack item with a pool and no consumer is Commander's "Fit for Any Battlefield" (Combat Dice), where the implicit consumption was itself a bug: expending a Combat Die is optional per the Commander rules ("You *may* expend a Combat Die"), so activating the feature should not drain a die.

## Test Plan

1. Create a weapon with a single Charge Pool rule (any max, no die size, no Charge Consumer rule) and attack with it: charges should stay untouched.
2. Add a die size to the pool and attack again: the dialog stepper at 0 spends nothing; setting it to N spends exactly N (previously N+1 due to the implicit consumer).
3. Add a Charge Consumer rule with cost 1: each attack now consumes 1 charge, and activation is blocked with an error when the pool is empty (unchanged behavior).
4. On a Commander with Fit for Any Battlefield, roll initiative and confirm Combat Dice refresh, then spend one via the sheet's die button: exactly one die is consumed.
5. `pnpm vitest run src/utils/chargePoolService.test.ts` for the automated coverage.

## Checklist

- [x] Added or updated unit tests
- [x] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [x] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** yes
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues

Reported via community question (Discord); no GitHub issue filed.
