### PR TITLE
fix(combat): let players roll initiative from their character sheet

### DIFF
--- a/src/documents/combat/combat.svelte.test.ts
+++ b/src/documents/combat/combat.svelte.test.ts
@@ -1883,6 +1883,155 @@ describe('NimbleCombat', () => {
 		]);
 	});
 
+	it('lets a non-GM roll initiative without writing to the Combat document', async () => {
+		// Regression: a non-GM may set their own initiative but cannot update the (GM-owned) Combat
+		// document. Because initiative doesn't affect turn order in Nimble, rolling it must not touch
+		// `Combat#turn` — otherwise a player rolling from their sheet hits a "lacks permission to
+		// update Combat" error.
+		globals().game.user = { isGM: false, role: 1 };
+
+		const combatId = 'combat-initiative-non-gm-turn-guard';
+		const actor = createCombatActorFixture({
+			id: 'actor-initiative-non-gm',
+			type: 'character',
+			isOwner: true,
+			hp: 8,
+			woundsValue: 0,
+			woundsMax: 6,
+		});
+
+		const combatant = createMockCombatant({
+			id: 'character-initiative-non-gm',
+			type: 'character',
+			sort: 1,
+			isOwner: true,
+			initiative: null,
+			actor,
+			combatId,
+			flags: {},
+		}) as unknown as Combatant.Implementation & {
+			getInitiativeRoll: ReturnType<typeof vi.fn>;
+		};
+
+		const initiativeRoll = {
+			total: 15,
+			evaluate: vi.fn().mockResolvedValue(null),
+			toMessage: vi.fn().mockResolvedValue({ id: 'initiative-chat-data' }),
+		};
+		combatant.getInitiativeRoll = vi.fn().mockReturnValue(initiativeRoll);
+
+		const combat = new NimbleCombat({
+			id: combatId,
+			scene: { id: 'scene-1' },
+			combatants: createCombatantsCollectionFixture([combatant]),
+			// An active combatant makes `currentId` truthy so the turn-update branch is reachable.
+			combatant,
+			turns: [combatant],
+			turn: 0,
+		} as unknown as Combat.CreateData) as NimbleCombat & {
+			updateEmbeddedDocuments: ReturnType<typeof vi.fn>;
+			update: ReturnType<typeof vi.fn>;
+		};
+
+		combat.updateEmbeddedDocuments = vi
+			.fn()
+			.mockImplementation(async (_embeddedName: string, updates: Record<string, unknown>[]) => {
+				for (const update of updates) {
+					const combatantId = update._id as string;
+					const targetCombatant = combat.combatants.get(combatantId) as unknown as Record<
+						string,
+						unknown
+					> | null;
+					if (!targetCombatant) continue;
+
+					for (const [path, value] of Object.entries(update)) {
+						if (path === '_id') continue;
+						foundry.utils.setProperty(targetCombatant, path, value);
+					}
+				}
+
+				return [];
+			});
+		combat.update = vi.fn().mockResolvedValue(combat);
+
+		await combat.rollInitiative([combatant.id ?? '']);
+
+		expect(combatant.initiative).toBe(15);
+		expect(combat.update).not.toHaveBeenCalled();
+	});
+
+	it('does not change turn order when rolling initiative (initiative is decoupled from turn order)', async () => {
+		globals().game.user = { isGM: true, role: 4 };
+
+		const combatId = 'combat-initiative-gm-turn-guard';
+		const actor = createCombatActorFixture({
+			id: 'actor-initiative-gm',
+			type: 'character',
+			isOwner: true,
+			hp: 8,
+			woundsValue: 0,
+			woundsMax: 6,
+		});
+
+		const combatant = createMockCombatant({
+			id: 'character-initiative-gm',
+			type: 'character',
+			sort: 1,
+			isOwner: true,
+			initiative: null,
+			actor,
+			combatId,
+			flags: {},
+		}) as unknown as Combatant.Implementation & {
+			getInitiativeRoll: ReturnType<typeof vi.fn>;
+		};
+
+		const initiativeRoll = {
+			total: 19,
+			evaluate: vi.fn().mockResolvedValue(null),
+			toMessage: vi.fn().mockResolvedValue({ id: 'initiative-chat-data' }),
+		};
+		combatant.getInitiativeRoll = vi.fn().mockReturnValue(initiativeRoll);
+
+		const combat = new NimbleCombat({
+			id: combatId,
+			scene: { id: 'scene-1' },
+			combatants: createCombatantsCollectionFixture([combatant]),
+			combatant,
+			turns: [combatant],
+			turn: 0,
+		} as unknown as Combat.CreateData) as NimbleCombat & {
+			updateEmbeddedDocuments: ReturnType<typeof vi.fn>;
+			update: ReturnType<typeof vi.fn>;
+		};
+
+		combat.updateEmbeddedDocuments = vi
+			.fn()
+			.mockImplementation(async (_embeddedName: string, updates: Record<string, unknown>[]) => {
+				for (const update of updates) {
+					const combatantId = update._id as string;
+					const targetCombatant = combat.combatants.get(combatantId) as unknown as Record<
+						string,
+						unknown
+					> | null;
+					if (!targetCombatant) continue;
+
+					for (const [path, value] of Object.entries(update)) {
+						if (path === '_id') continue;
+						foundry.utils.setProperty(targetCombatant, path, value);
+					}
+				}
+
+				return [];
+			});
+		combat.update = vi.fn().mockResolvedValue(combat);
+
+		await combat.rollInitiative([combatant.id ?? '']);
+
+		expect(combatant.initiative).toBe(19);
+		expect(combat.update).not.toHaveBeenCalled();
+	});
+
 	it('uses prompted initiative roll data for single-combatant initiative rolls', async () => {
 		const combatId = 'combat-initiative-prompted-roll';
 		const actor = Object.assign(

--- a/src/documents/combat/combat.svelte.ts
+++ b/src/documents/combat/combat.svelte.ts
@@ -1073,16 +1073,10 @@ class NimbleCombat extends Combat {
 			rollOptions?: Record<string, unknown>;
 		},
 	): Promise<this> {
-		const {
-			formula = null,
-			messageOptions = {},
-			promptRollDialog = false,
-			updateTurn = true,
-		} = options ?? {};
+		const { formula = null, messageOptions = {}, promptRollDialog = false } = options ?? {};
 
 		// Structure Input data
 		const combatantIds = [...new Set((typeof ids === 'string' ? [ids] : ids).filter(Boolean))];
-		const currentId = this.combatant?.id;
 		const chatRollMode = game.settings.get('core', 'rollMode');
 		const shouldPromptRollDialog = promptRollDialog && combatantIds.length === 1;
 
@@ -1133,10 +1127,12 @@ class NimbleCombat extends Combat {
 			await Promise.all(combatManaUpdates);
 		}
 
-		// Ensure the turn order remains with the same combatant
-		if (updateTurn && currentId && updates.length > 0) {
-			await this.update({ turn: this.turns.findIndex((t) => t.id === currentId) });
-		}
+		// In Nimble, initiative sets a combatant's starting number of actions — it does not
+		// determine turn order (turn order follows the manual combatant sort). Rolling initiative
+		// never reorders the turn list, so there is no active-turn index to reconcile afterwards.
+		// Foundry core updates `Combat#turn` here because it assumes initiative-based ordering;
+		// that assumption doesn't hold, and performing the update would also fail for players, who
+		// may set their own initiative but cannot write to the (GM-owned) Combat document.
 
 		// Create multiple chat messages
 		if (messages.length > 0) {


### PR DESCRIPTION
## Problem

Players got a *"lacks permission to update Combat"* error when rolling initiative **from their character sheet** (both the initiative-value button and the ActionTracker button). The d20 icons on/around the combat tracker worked fine.

Reported on Discord by a GM whose players couldn't roll into initiative from their sheets.

## Root cause

In Nimble, initiative sets a combatant's **starting number of actions** — it does **not** determine turn order (turn order follows the manual combatant sort in `sortCombatants`: dead state → `system.sort` → type priority → name).

`Combat#rollInitiative`, however, still carried Foundry core's initiative-based turn reconciliation. After rolling, it ran a turn update on the **Combat document**:

```ts
if (updateTurn && currentId && updates.length > 0) {
    await this.update({ turn: this.turns.findIndex((t) => t.id === currentId) });
}
```

`NimbleCombat#update` augments any `turn`/`round` update with a `flags.nimble.expandedTurnIdentity` write. Foundry lets a non-GM update a Combat's **turn-only** fields, but the added flag write makes it a disallowed update. A player may set their own initiative, but cannot write to the GM-owned Combat document — so they hit the permission error.

Because turn order in Nimble is decoupled from initiative, this reconciliation was a no-op that only ever caused harm: rolling initiative never reorders the turn list, so there is no active-turn index to correct.

## Fix

Remove the turn reconciliation from `rollInitiative` entirely (rather than gating it on GM), since it only made sense under D&D-style initiative-as-turn-order. This fixes the player permission error and drops logic that doesn't apply to Nimble. GMs and players alike simply set initiative; turn order is untouched.

The existing "already rolled" guard is unchanged — if a combatant's initiative is already set, it still can't be re-rolled.

## Tests

- New regression tests in `combat.svelte.test.ts`: a non-GM can roll initiative with **no** write to the Combat document, and rolling initiative never updates `Combat#turn`.
- Full suite green: **2361 tests pass**; typecheck, Biome lint/format, ESLint (Svelte), and Prettier all clean.
