### PR TITLE
feat(rules): add skillRollMode rule type for skill check advantage

### DIFF
--- a/docs/documentation/reference/_partials/skillRollMode.md
+++ b/docs/documentation/reference/_partials/skillRollMode.md
@@ -6,3 +6,5 @@
 - **How to apply** → `adjust`
 
 Advantage stacks: two separate advantage rules (or a value of `2`) roll two extra dice. Negative values apply disadvantage instead, and advantage and disadvantage from different sources cancel each other one for one. Use `set` to override other sources entirely.
+
+When mixing `set` and `adjust` rules on the same skill, order matters. Rules run in priority order, so a `set` rule that runs after an `adjust` rule discards that adjustment, while a `set` that runs before it composes normally. Use the rule priority to control which one wins.

--- a/docs/documentation/reference/_partials/skillRollMode.md
+++ b/docs/documentation/reference/_partials/skillRollMode.md
@@ -1,0 +1,8 @@
+**Example: Professional Skulker.** A feature that grants advantage on Stealth checks.
+
+- **Label** → `Professional Skulker`
+- **Roll mode value** → `1`
+- **Apply to** → `Stealth`
+- **How to apply** → `adjust`
+
+Advantage stacks: two separate advantage rules (or a value of `2`) roll two extra dice. Negative values apply disadvantage instead, and advantage and disadvantage from different sources cancel each other one for one. Use `set` to override other sources entirely.

--- a/packs/classFeatures/core/the-cheat/the-cheat-subclasses/tools-of-the-silent-blade/leave-no-trace.json
+++ b/packs/classFeatures/core/the-cheat/the-cheat-subclasses/tools-of-the-silent-blade/leave-no-trace.json
@@ -6,7 +6,19 @@
 	"system": {
 		"macro": "",
 		"identifier": "",
-		"rules": [],
+		"rules": [
+			{
+				"type": "skillRollMode",
+				"label": "Leave No Trace",
+				"skills": ["stealth"],
+				"value": 1,
+				"mode": "adjust",
+				"predicate": {
+					"self": "fullHp"
+				},
+				"id": "lyHWwQGcbooGei1a"
+			}
+		],
 		"activation": {
 			"acquireTargetsFromTemplate": false,
 			"cost": {

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -662,6 +662,7 @@
 			"savingThrowBonus": "Save Bonus",
 			"savingThrowRollMode": "Save Roll Mode",
 			"skillBonus": "Skill Bonus",
+			"skillRollMode": "Skill Roll Mode",
 			"speedBonus": "Speed Bonus",
 			"toggleEffect": "Toggle Effect",
 			"unarmedDamage": "Unarmed Damage"
@@ -987,6 +988,21 @@
 				"skills": {
 					"label": "Apply to",
 					"hint": "Pick one or more skills. Use \"all\" to apply to every skill."
+				}
+			},
+			"skillRollMode": {
+				"description": "Set or adjust the roll mode (advantage/disadvantage) for one or more skill checks. Use ‘all’ to apply to every skill.",
+				"value": {
+					"label": "Roll mode value",
+					"hint": "Positive values grant levels of advantage; negative values grant levels of disadvantage."
+				},
+				"skills": {
+					"label": "Apply to",
+					"hint": "Pick one or more skills. Use \"all\" to apply to every skill."
+				},
+				"mode": {
+					"label": "How to apply",
+					"hint": "Adjust stacks with other sources; set overrides them."
 				}
 			},
 			"speedBonus": {

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -1002,7 +1002,7 @@
 				},
 				"mode": {
 					"label": "How to apply",
-					"hint": "Adjust stacks with other sources; set overrides them."
+					"hint": "Adjust stacks with other sources; set overrides them. When mixing modes on one skill, order matters: a set that runs after an adjust discards it, so use priority to control which wins."
 				}
 			},
 			"speedBonus": {

--- a/src/config/registerRulesConfig.ts
+++ b/src/config/registerRulesConfig.ts
@@ -30,6 +30,7 @@ import { NoteRule } from '../models/rules/note.js';
 import { SavingThrowBonusRule } from '../models/rules/savingThrowBonus.js';
 import { SavingThrowRollModeRule } from '../models/rules/savingThrowRollMode.js';
 import { SkillBonusRule } from '../models/rules/skillBonus.js';
+import { SkillRollModeRule } from '../models/rules/skillRollMode.js';
 import { SpeedBonusRule } from '../models/rules/speedBonus.js';
 import { ToggleEffectRule } from '../models/rules/toggleEffect.js';
 import { UnarmedDamageRule } from '../models/rules/unarmedDamage.js';
@@ -68,6 +69,7 @@ export default function registerRulesConfig() {
 		savingThrowBonus: 'NIMBLE.ruleTypes.savingThrowBonus',
 		savingThrowRollMode: 'NIMBLE.ruleTypes.savingThrowRollMode',
 		skillBonus: 'NIMBLE.ruleTypes.skillBonus',
+		skillRollMode: 'NIMBLE.ruleTypes.skillRollMode',
 		speedBonus: 'NIMBLE.ruleTypes.speedBonus',
 		toggleEffect: 'NIMBLE.ruleTypes.toggleEffect',
 		unarmedDamage: 'NIMBLE.ruleTypes.unarmedDamage',
@@ -106,6 +108,7 @@ export default function registerRulesConfig() {
 		savingThrowBonus: SavingThrowBonusRule,
 		savingThrowRollMode: SavingThrowRollModeRule,
 		skillBonus: SkillBonusRule,
+		skillRollMode: SkillRollModeRule,
 		speedBonus: SpeedBonusRule,
 		toggleEffect: ToggleEffectRule,
 		unarmedDamage: UnarmedDamageRule,

--- a/src/documents/actor/character.ts
+++ b/src/documents/actor/character.ts
@@ -247,6 +247,10 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 
 			// Cap skill modifiers at 12
 			skill.mod = Math.min(abilityMod + skillPoints + skillBonus, 12);
+
+			// Reset defaultRollMode to 0 before rules apply their modifiers
+			// This prevents accumulation when rules use 'adjust' mode
+			skill.defaultRollMode = 0;
 		});
 
 		// Prepare Initiative Data

--- a/src/models/rules/abilityBonus.test.ts
+++ b/src/models/rules/abilityBonus.test.ts
@@ -25,4 +25,67 @@ describe('AbilityBonusRule', () => {
 			expect(AbilityBonusRule.description).toBe('NIMBLE.rules.abilityBonus.description');
 		});
 	});
+
+	describe('prePrepareData predicate gating', () => {
+		function createRule(
+			actor: object,
+			predicate?: { size: number; test: (domain: Set<string>) => boolean },
+		) {
+			const item = {
+				isEmbedded: true,
+				actor,
+				name: 'Test Item',
+				uuid: 'test-item-uuid',
+				getDomain: () => [],
+			};
+			const rule = new AbilityBonusRule(
+				{
+					value: '2',
+					abilities: ['strength'],
+					disabled: false,
+					label: 'Test Rule',
+					id: 'test-rule-id',
+					identifier: '',
+					priority: 1,
+					predicate: {},
+					type: 'abilityBonus',
+				} as foundry.data.fields.SchemaField.CreateData<AbilityBonusRule['schema']['fields']>,
+				{ parent: item as unknown as foundry.abstract.DataModel.Any, strict: false },
+			) as AbilityBonusRule & { value: string; abilities: string[]; disabled: boolean };
+
+			rule.value = '2';
+			rule.abilities = ['strength'];
+			rule.disabled = false;
+
+			Object.defineProperty(rule, 'item', { get: () => item, configurable: true });
+			Object.defineProperty(rule, 'actor', { get: () => item.actor, configurable: true });
+			Object.defineProperty(rule, '_predicate', {
+				get: () => predicate ?? { size: 0 },
+				configurable: true,
+			});
+			return rule;
+		}
+
+		function createMockActor() {
+			return {
+				system: { abilities: { strength: { bonus: 0 } } },
+				getRollData: () => ({}),
+				getDomain: () => [],
+			};
+		}
+
+		it('applies the bonus when the predicate passes', () => {
+			const actor = createMockActor();
+			createRule(actor).prePrepareData();
+
+			expect(actor.system.abilities.strength.bonus).toBe(2);
+		});
+
+		it('does nothing when the predicate fails', () => {
+			const actor = createMockActor();
+			createRule(actor, { size: 1, test: () => false }).prePrepareData();
+
+			expect(actor.system.abilities.strength.bonus).toBe(0);
+		});
+	});
 });

--- a/src/models/rules/abilityBonus.ts
+++ b/src/models/rules/abilityBonus.ts
@@ -61,6 +61,7 @@ class AbilityBonusRule extends NimbleBaseRule<AbilityBonusRule.Schema> {
 	prePrepareData(): void {
 		const { item } = this;
 		if (!item.isEmbedded) return;
+		if (!this.test()) return;
 
 		const actor = item.actor as NimbleCharacter;
 		const value = this.resolveFormula(this.value);

--- a/src/models/rules/healingPotionBonus.test.ts
+++ b/src/models/rules/healingPotionBonus.test.ts
@@ -18,4 +18,65 @@ describe('HealingPotionBonusRule', () => {
 			);
 		});
 	});
+
+	describe('prePrepareData predicate gating', () => {
+		function createRule(
+			actor: object,
+			predicate?: { size: number; test: (domain: Set<string>) => boolean },
+		) {
+			const item = {
+				isEmbedded: true,
+				actor,
+				name: 'Test Item',
+				uuid: 'test-item-uuid',
+				getDomain: () => [],
+			};
+			const rule = new HealingPotionBonusRule(
+				{
+					value: '2',
+					disabled: false,
+					label: 'Test Rule',
+					id: 'test-rule-id',
+					identifier: '',
+					priority: 1,
+					predicate: {},
+					type: 'healingPotionBonus',
+				} as foundry.data.fields.SchemaField.CreateData<HealingPotionBonusRule['schema']['fields']>,
+				{ parent: item as unknown as foundry.abstract.DataModel.Any, strict: false },
+			) as HealingPotionBonusRule & { value: string; disabled: boolean };
+
+			rule.value = '2';
+			rule.disabled = false;
+
+			Object.defineProperty(rule, 'item', { get: () => item, configurable: true });
+			Object.defineProperty(rule, 'actor', { get: () => item.actor, configurable: true });
+			Object.defineProperty(rule, '_predicate', {
+				get: () => predicate ?? { size: 0 },
+				configurable: true,
+			});
+			return rule;
+		}
+
+		function createMockActor() {
+			return {
+				system: {} as { healingPotionBonus?: number },
+				getRollData: () => ({}),
+				getDomain: () => [],
+			};
+		}
+
+		it('applies the bonus when the predicate passes', () => {
+			const actor = createMockActor();
+			createRule(actor).prePrepareData();
+
+			expect(actor.system.healingPotionBonus).toBe(2);
+		});
+
+		it('does nothing when the predicate fails', () => {
+			const actor = createMockActor();
+			createRule(actor, { size: 1, test: () => false }).prePrepareData();
+
+			expect(actor.system.healingPotionBonus).toBeUndefined();
+		});
+	});
 });

--- a/src/models/rules/healingPotionBonus.ts
+++ b/src/models/rules/healingPotionBonus.ts
@@ -45,6 +45,7 @@ class HealingPotionBonusRule extends NimbleBaseRule<HealingPotionBonusRule.Schem
 	prePrepareData(): void {
 		const { item } = this;
 		if (!item.isEmbedded) return;
+		if (!this.test()) return;
 
 		const actor = item.actor as NimbleCharacter;
 		const value = this.resolveFormula(this.value) ?? 0;

--- a/src/models/rules/initiativeRollMode.test.ts
+++ b/src/models/rules/initiativeRollMode.test.ts
@@ -1,7 +1,80 @@
 import { describe, expect, it } from 'vitest';
 import { InitiativeRollModeRule } from './initiativeRollMode.js';
 
+interface MockActor {
+	system: { attributes: { initiative: { defaultRollMode?: number } } };
+	getDomain: () => string[];
+}
+
+function createRule(
+	config: {
+		value: number;
+		mode?: 'set' | 'adjust';
+		predicate?: { size: number; test: (domain: Set<string>) => boolean };
+	},
+	actor: MockActor,
+	isEmbedded = true,
+) {
+	const item = {
+		isEmbedded,
+		actor,
+		name: 'Test Item',
+		uuid: 'test-item-uuid',
+		getDomain: () => [],
+	};
+
+	const rule = new InitiativeRollModeRule(
+		{
+			value: config.value,
+			mode: config.mode ?? 'adjust',
+			disabled: false,
+			label: 'Test Rule',
+			id: 'test-rule-id',
+			identifier: '',
+			priority: 1,
+			predicate: {},
+			type: 'initiativeRollMode',
+		} as foundry.data.fields.SchemaField.CreateData<InitiativeRollModeRule['schema']['fields']>,
+		{ parent: item as unknown as foundry.abstract.DataModel.Any, strict: false },
+	) as InitiativeRollModeRule & { value: number; mode: string; disabled: boolean };
+
+	rule.value = config.value;
+	rule.mode = config.mode ?? 'adjust';
+	rule.disabled = false;
+
+	Object.defineProperty(rule, 'item', { get: () => item, configurable: true });
+	Object.defineProperty(rule, 'actor', { get: () => item.actor, configurable: true });
+	Object.defineProperty(rule, '_predicate', {
+		get: () => config.predicate ?? { size: 0 },
+		configurable: true,
+	});
+
+	return rule;
+}
+
 describe('InitiativeRollModeRule', () => {
+	describe('afterPrepareData', () => {
+		it('applies the roll mode when the predicate passes', () => {
+			const actor: MockActor = {
+				system: { attributes: { initiative: { defaultRollMode: 0 } } },
+				getDomain: () => [],
+			};
+			createRule({ value: 1 }, actor).afterPrepareData();
+
+			expect(actor.system.attributes.initiative.defaultRollMode).toBe(1);
+		});
+
+		it('does nothing when the predicate fails', () => {
+			const actor: MockActor = {
+				system: { attributes: { initiative: { defaultRollMode: 0 } } },
+				getDomain: () => [],
+			};
+			createRule({ value: 1, predicate: { size: 1, test: () => false } }, actor).afterPrepareData();
+
+			expect(actor.system.attributes.initiative.defaultRollMode).toBe(0);
+		});
+	});
+
 	describe('schema', () => {
 		it('defines the expected fields', () => {
 			const schema = InitiativeRollModeRule.defineSchema();

--- a/src/models/rules/initiativeRollMode.ts
+++ b/src/models/rules/initiativeRollMode.ts
@@ -56,6 +56,7 @@ class InitiativeRollModeRule extends NimbleBaseRule<InitiativeRollModeRule.Schem
 	override afterPrepareData(): void {
 		const { item } = this;
 		if (!item.isEmbedded) return;
+		if (!this.test()) return;
 
 		const { actor } = item;
 

--- a/src/models/rules/maxHitDice.test.ts
+++ b/src/models/rules/maxHitDice.test.ts
@@ -17,4 +17,68 @@ describe('MaxHitDiceRule', () => {
 			expect(MaxHitDiceRule.description).toBe('NIMBLE.rules.maxHitDice.description');
 		});
 	});
+
+	describe('prePrepareData predicate gating', () => {
+		function createRule(
+			actor: object,
+			predicate?: { size: number; test: (domain: Set<string>) => boolean },
+		) {
+			const item = {
+				isEmbedded: true,
+				actor,
+				name: 'Test Item',
+				uuid: 'test-item-uuid',
+				getDomain: () => [],
+			};
+			const rule = new MaxHitDiceRule(
+				{
+					value: '1',
+					dieSize: 8,
+					disabled: false,
+					label: 'Test Rule',
+					id: 'test-rule-id',
+					identifier: '',
+					priority: 1,
+					predicate: {},
+					type: 'maxHitDice',
+				} as foundry.data.fields.SchemaField.CreateData<MaxHitDiceRule['schema']['fields']>,
+				{ parent: item as unknown as foundry.abstract.DataModel.Any, strict: false },
+			) as MaxHitDiceRule & { disabled: boolean };
+
+			rule.value = '1';
+			rule.dieSize = 8;
+			rule.disabled = false;
+
+			Object.defineProperty(rule, 'item', { get: () => item, configurable: true });
+			Object.defineProperty(rule, 'actor', { get: () => item.actor, configurable: true });
+			Object.defineProperty(rule, '_predicate', {
+				get: () => predicate ?? { size: 0 },
+				configurable: true,
+			});
+			return rule;
+		}
+
+		function createMockActor() {
+			return {
+				type: 'character',
+				system: { attributes: { hitDice: {} as Record<string, { bonus?: number }> } },
+				getRollData: () => ({}),
+				getDomain: () => [],
+			};
+		}
+
+		it('applies the bonus when the predicate passes', () => {
+			const actor = createMockActor();
+			createRule(actor).prePrepareData();
+
+			expect(actor.system.attributes.hitDice['8']?.bonus).toBe(1);
+		});
+
+		it('does nothing when the predicate fails', () => {
+			const actor = createMockActor();
+			createRule(actor, { size: 1, test: () => false }).prePrepareData();
+
+			expect(actor.system.attributes.hitDice['8']).toBeUndefined();
+		});
+	});
 });

--- a/src/models/rules/maxHitDice.ts
+++ b/src/models/rules/maxHitDice.ts
@@ -56,6 +56,7 @@ class MaxHitDiceRule extends NimbleBaseRule<MaxHitDiceRule.Schema> {
 	prePrepareData(): void {
 		const { item } = this;
 		if (!item.isEmbedded) return;
+		if (!this.test()) return;
 
 		const { actor } = item;
 		if (actor.type !== 'character') return;

--- a/src/models/rules/maxWounds.test.ts
+++ b/src/models/rules/maxWounds.test.ts
@@ -16,4 +16,65 @@ describe('MaxWoundsRule', () => {
 			expect(MaxWoundsRule.description).toBe('NIMBLE.rules.maxWounds.description');
 		});
 	});
+
+	describe('prePrepareData predicate gating', () => {
+		function createRule(
+			actor: object,
+			predicate?: { size: number; test: (domain: Set<string>) => boolean },
+		) {
+			const item = {
+				isEmbedded: true,
+				actor,
+				name: 'Test Item',
+				uuid: 'test-item-uuid',
+				getDomain: () => [],
+			};
+			const rule = new MaxWoundsRule(
+				{
+					value: '2',
+					disabled: false,
+					label: 'Test Rule',
+					id: 'test-rule-id',
+					identifier: '',
+					priority: 1,
+					predicate: {},
+					type: 'maxWounds',
+				} as foundry.data.fields.SchemaField.CreateData<MaxWoundsRule['schema']['fields']>,
+				{ parent: item as unknown as foundry.abstract.DataModel.Any, strict: false },
+			) as MaxWoundsRule & { value: string; disabled: boolean };
+
+			rule.value = '2';
+			rule.disabled = false;
+
+			Object.defineProperty(rule, 'item', { get: () => item, configurable: true });
+			Object.defineProperty(rule, 'actor', { get: () => item.actor, configurable: true });
+			Object.defineProperty(rule, '_predicate', {
+				get: () => predicate ?? { size: 0 },
+				configurable: true,
+			});
+			return rule;
+		}
+
+		function createMockActor() {
+			return {
+				system: { attributes: { wounds: { bonus: 0 } } },
+				getRollData: () => ({}),
+				getDomain: () => [],
+			};
+		}
+
+		it('applies the bonus when the predicate passes', () => {
+			const actor = createMockActor();
+			createRule(actor).prePrepareData();
+
+			expect(actor.system.attributes.wounds.bonus).toBe(2);
+		});
+
+		it('does nothing when the predicate fails', () => {
+			const actor = createMockActor();
+			createRule(actor, { size: 1, test: () => false }).prePrepareData();
+
+			expect(actor.system.attributes.wounds.bonus).toBe(0);
+		});
+	});
 });

--- a/src/models/rules/maxWounds.ts
+++ b/src/models/rules/maxWounds.ts
@@ -40,6 +40,7 @@ class MaxWoundsRule extends NimbleBaseRule<MaxWoundsRule.Schema> {
 	prePrepareData(): void {
 		const { item } = this;
 		if (!item.isEmbedded) return;
+		if (!this.test()) return;
 
 		const { actor } = item;
 		const value = this.resolveFormula(this.value) ?? 0;

--- a/src/models/rules/savingThrowBonus.test.ts
+++ b/src/models/rules/savingThrowBonus.test.ts
@@ -25,4 +25,67 @@ describe('SavingThrowBonusRule', () => {
 			expect(SavingThrowBonusRule.description).toBe('NIMBLE.rules.savingThrowBonus.description');
 		});
 	});
+
+	describe('prePrepareData predicate gating', () => {
+		function createRule(
+			actor: object,
+			predicate?: { size: number; test: (domain: Set<string>) => boolean },
+		) {
+			const item = {
+				isEmbedded: true,
+				actor,
+				name: 'Test Item',
+				uuid: 'test-item-uuid',
+				getDomain: () => [],
+			};
+			const rule = new SavingThrowBonusRule(
+				{
+					value: '2',
+					savingThrows: ['strength'],
+					disabled: false,
+					label: 'Test Rule',
+					id: 'test-rule-id',
+					identifier: '',
+					priority: 1,
+					predicate: {},
+					type: 'savingThrowBonus',
+				} as foundry.data.fields.SchemaField.CreateData<SavingThrowBonusRule['schema']['fields']>,
+				{ parent: item as unknown as foundry.abstract.DataModel.Any, strict: false },
+			) as SavingThrowBonusRule & { value: string; savingThrows: string[]; disabled: boolean };
+
+			rule.value = '2';
+			rule.savingThrows = ['strength'];
+			rule.disabled = false;
+
+			Object.defineProperty(rule, 'item', { get: () => item, configurable: true });
+			Object.defineProperty(rule, 'actor', { get: () => item.actor, configurable: true });
+			Object.defineProperty(rule, '_predicate', {
+				get: () => predicate ?? { size: 0 },
+				configurable: true,
+			});
+			return rule;
+		}
+
+		function createMockActor() {
+			return {
+				system: { savingThrows: { strength: { bonus: 0 } } },
+				getRollData: () => ({}),
+				getDomain: () => [],
+			};
+		}
+
+		it('applies the bonus when the predicate passes', () => {
+			const actor = createMockActor();
+			createRule(actor).prePrepareData();
+
+			expect(actor.system.savingThrows.strength.bonus).toBe(2);
+		});
+
+		it('does nothing when the predicate fails', () => {
+			const actor = createMockActor();
+			createRule(actor, { size: 1, test: () => false }).prePrepareData();
+
+			expect(actor.system.savingThrows.strength.bonus).toBe(0);
+		});
+	});
 });

--- a/src/models/rules/savingThrowBonus.ts
+++ b/src/models/rules/savingThrowBonus.ts
@@ -63,6 +63,7 @@ class SavingThrowBonusRule extends NimbleBaseRule<SavingThrowBonusRule.Schema> {
 	prePrepareData(): void {
 		const { item } = this;
 		if (!item.isEmbedded) return;
+		if (!this.test()) return;
 
 		const actor = item.actor as NimbleCharacter;
 		const value = this.resolveFormula(this.value);

--- a/src/models/rules/skillBonus.test.ts
+++ b/src/models/rules/skillBonus.test.ts
@@ -1,7 +1,86 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { SkillBonusRule } from './skillBonus.js';
 
+interface MockActor {
+	system: { skills: Record<string, { bonus: number }> };
+	getRollData: () => Record<string, unknown>;
+	getDomain: () => string[];
+}
+
+function createRule(
+	config: {
+		value: string;
+		skills: string[];
+		predicate?: { size: number; test: (domain: Set<string>) => boolean };
+	},
+	actor: MockActor,
+	isEmbedded = true,
+) {
+	const item = {
+		isEmbedded,
+		actor,
+		name: 'Test Item',
+		uuid: 'test-item-uuid',
+		getDomain: () => [],
+	};
+
+	const rule = new SkillBonusRule(
+		{
+			value: config.value,
+			skills: config.skills,
+			disabled: false,
+			label: 'Test Rule',
+			id: 'test-rule-id',
+			identifier: '',
+			priority: 1,
+			predicate: {},
+			type: 'skillBonus',
+		} as foundry.data.fields.SchemaField.CreateData<SkillBonusRule['schema']['fields']>,
+		{ parent: item as unknown as foundry.abstract.DataModel.Any, strict: false },
+	) as SkillBonusRule & { value: string; skills: string[]; disabled: boolean };
+
+	rule.value = config.value;
+	rule.skills = config.skills;
+	rule.disabled = false;
+
+	Object.defineProperty(rule, 'item', { get: () => item, configurable: true });
+	Object.defineProperty(rule, 'actor', { get: () => item.actor, configurable: true });
+	Object.defineProperty(rule, '_predicate', {
+		get: () => config.predicate ?? { size: 0 },
+		configurable: true,
+	});
+
+	return rule;
+}
+
+function createMockActor(): MockActor {
+	return {
+		system: { skills: { stealth: { bonus: 0 } } },
+		getRollData: vi.fn(() => ({})),
+		getDomain: () => [],
+	};
+}
+
 describe('SkillBonusRule', () => {
+	describe('prePrepareData', () => {
+		it('applies the bonus when the predicate passes', () => {
+			const actor = createMockActor();
+			createRule({ value: '2', skills: ['stealth'] }, actor).prePrepareData();
+
+			expect(actor.system.skills.stealth.bonus).toBe(2);
+		});
+
+		it('does nothing when the predicate fails', () => {
+			const actor = createMockActor();
+			createRule(
+				{ value: '2', skills: ['stealth'], predicate: { size: 1, test: () => false } },
+				actor,
+			).prePrepareData();
+
+			expect(actor.system.skills.stealth.bonus).toBe(0);
+		});
+	});
+
 	describe('schema', () => {
 		it('defines the expected fields', () => {
 			const schema = SkillBonusRule.defineSchema();

--- a/src/models/rules/skillBonus.ts
+++ b/src/models/rules/skillBonus.ts
@@ -63,6 +63,7 @@ class SkillBonusRule extends NimbleBaseRule<SkillBonusRule.Schema> {
 	prePrepareData(): void {
 		const { item } = this;
 		if (!item.isEmbedded) return;
+		if (!this.test()) return;
 
 		const actor = item.actor as NimbleCharacter;
 		const value = this.resolveFormula(this.value);

--- a/src/models/rules/skillRollMode.test.ts
+++ b/src/models/rules/skillRollMode.test.ts
@@ -1,0 +1,281 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SkillRollModeRule } from './skillRollMode.js';
+
+interface MockSkill {
+	defaultRollMode?: number;
+	[key: string]: unknown;
+}
+
+interface MockActor {
+	system: {
+		skills?: Record<string, MockSkill>;
+	};
+	getDomain: () => string[];
+}
+
+interface MockItem {
+	isEmbedded: boolean;
+	actor: MockActor;
+	name: string;
+	uuid: string;
+	getDomain: () => string[];
+}
+
+interface SkillRollModeRuleTestInstance extends SkillRollModeRule {
+	value: number;
+	skills: string[];
+	mode: 'set' | 'adjust';
+	disabled: boolean;
+	label: string;
+}
+
+function createMockActor(skills: Record<string, MockSkill> | undefined): MockActor {
+	return {
+		system: { skills },
+		getDomain: () => [],
+	};
+}
+
+function createMockItem(actor: MockActor, isEmbedded = true): MockItem {
+	return {
+		isEmbedded,
+		actor,
+		name: 'Test Item',
+		uuid: 'test-item-uuid',
+		getDomain: () => [],
+	};
+}
+
+function createSkillRollModeRule(
+	config: {
+		value: number;
+		skills: string[];
+		mode?: 'set' | 'adjust';
+		disabled?: boolean;
+		predicate?: { size: number; test: (domain: Set<string>) => boolean };
+	},
+	actor: MockActor,
+	itemOptions?: { isEmbedded?: boolean },
+): SkillRollModeRuleTestInstance {
+	const item = createMockItem(actor, itemOptions?.isEmbedded ?? true);
+
+	const sourceData = {
+		value: config.value,
+		skills: config.skills,
+		mode: config.mode ?? 'adjust',
+		disabled: config.disabled ?? false,
+		label: 'Test Rule',
+		id: 'test-rule-id',
+		identifier: '',
+		priority: 1,
+		predicate: {},
+		type: 'skillRollMode',
+	};
+
+	const rule = new SkillRollModeRule(
+		sourceData as foundry.data.fields.SchemaField.CreateData<SkillRollModeRule['schema']['fields']>,
+		{ parent: item as unknown as foundry.abstract.DataModel.Any, strict: false },
+	) as SkillRollModeRuleTestInstance;
+
+	// Manually set properties since the mock DataModel doesn't do this automatically
+	rule.value = config.value;
+	rule.skills = config.skills;
+	rule.mode = config.mode ?? 'adjust';
+	rule.disabled = config.disabled ?? false;
+
+	Object.defineProperty(rule, 'item', {
+		get: () => item,
+		configurable: true,
+	});
+
+	Object.defineProperty(rule, 'actor', {
+		get: () => item.actor,
+		configurable: true,
+	});
+
+	Object.defineProperty(rule, '_predicate', {
+		get: () => config.predicate ?? { size: 0 },
+		configurable: true,
+	});
+
+	return rule;
+}
+
+describe('SkillRollModeRule', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe('afterPrepareData', () => {
+		it('should apply advantage to the targeted skill', () => {
+			const actor = createMockActor({ stealth: { defaultRollMode: 0 } });
+			const rule = createSkillRollModeRule({ value: 1, skills: ['stealth'] }, actor);
+
+			rule.afterPrepareData();
+
+			expect(actor.system.skills?.stealth.defaultRollMode).toBe(1);
+		});
+
+		it('should stack multiple adjust rules', () => {
+			const actor = createMockActor({ stealth: { defaultRollMode: 0 } });
+
+			createSkillRollModeRule({ value: 1, skills: ['stealth'] }, actor).afterPrepareData();
+			createSkillRollModeRule({ value: 1, skills: ['stealth'] }, actor).afterPrepareData();
+
+			expect(actor.system.skills?.stealth.defaultRollMode).toBe(2);
+		});
+
+		it('should apply disadvantage for negative values', () => {
+			const actor = createMockActor({ stealth: { defaultRollMode: 0 } });
+			const rule = createSkillRollModeRule({ value: -2, skills: ['stealth'] }, actor);
+
+			rule.afterPrepareData();
+
+			expect(actor.system.skills?.stealth.defaultRollMode).toBe(-2);
+		});
+
+		it('should cancel advantage and disadvantage per instance when adjusting', () => {
+			const actor = createMockActor({ stealth: { defaultRollMode: 2 } });
+			const rule = createSkillRollModeRule({ value: -1, skills: ['stealth'] }, actor);
+
+			rule.afterPrepareData();
+
+			expect(actor.system.skills?.stealth.defaultRollMode).toBe(1);
+		});
+
+		it('should override the current roll mode in set mode', () => {
+			const actor = createMockActor({ stealth: { defaultRollMode: 3 } });
+			const rule = createSkillRollModeRule({ value: 1, skills: ['stealth'], mode: 'set' }, actor);
+
+			rule.afterPrepareData();
+
+			expect(actor.system.skills?.stealth.defaultRollMode).toBe(1);
+		});
+
+		it('should let adjust rules stack on top of an earlier set rule', () => {
+			const actor = createMockActor({ stealth: { defaultRollMode: 0 } });
+
+			createSkillRollModeRule({ value: 2, skills: ['stealth'], mode: 'set' }, actor) //
+				.afterPrepareData();
+			createSkillRollModeRule({ value: 1, skills: ['stealth'] }, actor).afterPrepareData();
+
+			expect(actor.system.skills?.stealth.defaultRollMode).toBe(3);
+		});
+
+		it('should apply to every skill when skills includes "all"', () => {
+			const skills = Object.fromEntries(
+				Object.keys(CONFIG.NIMBLE.skills).map((key) => [key, { defaultRollMode: 0 }]),
+			);
+			const actor = createMockActor(skills);
+			const rule = createSkillRollModeRule({ value: 1, skills: ['all'] }, actor);
+
+			rule.afterPrepareData();
+
+			for (const skill of Object.values(actor.system.skills ?? {})) {
+				expect(skill.defaultRollMode).toBe(1);
+			}
+		});
+
+		it('should only modify the targeted skills', () => {
+			const actor = createMockActor({
+				stealth: { defaultRollMode: 0 },
+				perception: { defaultRollMode: 0 },
+			});
+			const rule = createSkillRollModeRule({ value: 1, skills: ['stealth'] }, actor);
+
+			rule.afterPrepareData();
+
+			expect(actor.system.skills?.perception.defaultRollMode).toBe(0);
+		});
+
+		it('should do nothing when skills is empty', () => {
+			const actor = createMockActor({ stealth: { defaultRollMode: 0 } });
+			const rule = createSkillRollModeRule({ value: 1, skills: [] }, actor);
+
+			rule.afterPrepareData();
+
+			expect(actor.system.skills?.stealth.defaultRollMode).toBe(0);
+		});
+
+		it('should do nothing for non-embedded items', () => {
+			const actor = createMockActor({ stealth: { defaultRollMode: 0 } });
+			const rule = createSkillRollModeRule({ value: 1, skills: ['stealth'] }, actor, {
+				isEmbedded: false,
+			});
+
+			rule.afterPrepareData();
+
+			expect(actor.system.skills?.stealth.defaultRollMode).toBe(0);
+		});
+
+		it('should not throw for actors without skills', () => {
+			const actor = createMockActor(undefined);
+			const rule = createSkillRollModeRule({ value: 1, skills: ['stealth'] }, actor);
+
+			expect(() => rule.afterPrepareData()).not.toThrow();
+		});
+
+		it('should do nothing when the rule is disabled', () => {
+			const actor = createMockActor({ stealth: { defaultRollMode: 0 } });
+			const rule = createSkillRollModeRule(
+				{ value: 1, skills: ['stealth'], disabled: true },
+				actor,
+			);
+
+			rule.afterPrepareData();
+
+			expect(actor.system.skills?.stealth.defaultRollMode).toBe(0);
+		});
+
+		it('should do nothing when the predicate fails', () => {
+			const actor = createMockActor({ stealth: { defaultRollMode: 0 } });
+			const rule = createSkillRollModeRule(
+				{ value: 1, skills: ['stealth'], predicate: { size: 1, test: () => false } },
+				actor,
+			);
+
+			rule.afterPrepareData();
+
+			expect(actor.system.skills?.stealth.defaultRollMode).toBe(0);
+		});
+	});
+
+	describe('schema', () => {
+		it('should define the correct schema fields', () => {
+			const schema = SkillRollModeRule.defineSchema();
+
+			expect(schema).toHaveProperty('value');
+			expect(schema).toHaveProperty('skills');
+			expect(schema).toHaveProperty('mode');
+			expect(schema).toHaveProperty('type');
+			expect(schema).toHaveProperty('disabled');
+			expect(schema).toHaveProperty('label');
+		});
+
+		it('declares closed mode choice set defaulting to adjust', () => {
+			const schema = SkillRollModeRule.defineSchema();
+			const mode = schema.mode as unknown as { choices: string[]; options: { initial: string } };
+
+			expect(mode.choices).toEqual(['set', 'adjust']);
+			expect(mode.options.initial).toBe('adjust');
+		});
+
+		it('offers every configured skill plus the "all" sentinel', () => {
+			const schema = SkillRollModeRule.defineSchema();
+			const skills = schema.skills as unknown as {
+				element: { options: { choices: () => string[] } };
+			};
+			const choices = skills.element.options.choices();
+
+			expect(choices).toContain('all');
+			expect(choices).toContain('arcana');
+		});
+	});
+
+	describe('class metadata', () => {
+		it('exposes the picker group and i18n description key', () => {
+			expect(SkillRollModeRule.group).toBe('bonuses');
+			expect(SkillRollModeRule.description).toBe('NIMBLE.rules.skillRollMode.description');
+		});
+	});
+});

--- a/src/models/rules/skillRollMode.ts
+++ b/src/models/rules/skillRollMode.ts
@@ -1,0 +1,99 @@
+import { NimbleBaseRule } from './base.js';
+
+function schema() {
+	const { fields } = foundry.data;
+
+	return {
+		value: new fields.NumberField({
+			required: true,
+			nullable: false,
+			integer: true,
+			initial: 1,
+			label: 'NIMBLE.rules.skillRollMode.value.label',
+			hint: 'NIMBLE.rules.skillRollMode.value.hint',
+		}),
+		skills: new fields.ArrayField(
+			new fields.StringField({
+				required: true,
+				nullable: false,
+				initial: '',
+				// `'all'` is a runtime sentinel resolved in afterPrepareData to mean
+				// "every skill". Must remain a valid choice.
+				choices: () => [...Object.keys(CONFIG.NIMBLE.skills), 'all'],
+			}),
+			{
+				required: true,
+				nullable: false,
+				label: 'NIMBLE.rules.skillRollMode.skills.label',
+				hint: 'NIMBLE.rules.skillRollMode.skills.hint',
+			},
+		),
+		mode: new fields.StringField({
+			required: true,
+			nullable: false,
+			initial: 'adjust',
+			label: 'NIMBLE.rules.skillRollMode.mode.label',
+			hint: 'NIMBLE.rules.skillRollMode.mode.hint',
+			choices: ['set', 'adjust'],
+		}),
+		type: new fields.StringField({ required: true, nullable: false, initial: 'skillRollMode' }),
+	};
+}
+
+declare namespace SkillRollModeRule {
+	type Schema = NimbleBaseRule.Schema & ReturnType<typeof schema>;
+}
+
+class SkillRollModeRule extends NimbleBaseRule<SkillRollModeRule.Schema> {
+	static override group = 'bonuses';
+	static override description = 'NIMBLE.rules.skillRollMode.description';
+
+	declare value: number;
+	declare skills: string[];
+	// `mode` is inferred from the schema's `choices` (`'set' | 'adjust'`).
+	// No explicit declare — the wider `string` would clash.
+
+	static override defineSchema(): SkillRollModeRule.Schema {
+		return {
+			...NimbleBaseRule.defineSchema(),
+			...schema(),
+		};
+	}
+
+	override tooltipInfo(): string {
+		return super.tooltipInfo(
+			new Map([
+				['value', 'number'],
+				['skills', 'string[]'],
+				['mode', '"set" | "adjust"'],
+			]),
+		);
+	}
+
+	override afterPrepareData(): void {
+		const { item } = this;
+		if (!item.isEmbedded) return;
+		if (!this.test()) return;
+
+		const { actor } = item;
+
+		interface ActorSkills {
+			skills?: Record<string, { defaultRollMode?: number }>;
+		}
+		const actorSystem = actor.system as object as ActorSkills;
+
+		let { skills } = this;
+		if (!skills.length) return;
+		if (skills.includes('all')) skills = Object.keys(CONFIG.NIMBLE.skills);
+
+		for (const skill of skills) {
+			const currentRollMode = actorSystem.skills?.[skill]?.defaultRollMode;
+			if (currentRollMode === undefined) continue;
+
+			const newRollMode = this.mode === 'set' ? this.value : currentRollMode + this.value;
+			foundry.utils.setProperty(actor.system, `skills.${skill}.defaultRollMode`, newRollMode);
+		}
+	}
+}
+
+export { SkillRollModeRule };

--- a/src/view/rulesBuilder/components/RuleTypePicker.svelte.ts
+++ b/src/view/rulesBuilder/components/RuleTypePicker.svelte.ts
@@ -36,6 +36,7 @@ const RULE_ICONS: Record<string, string> = {
 	savingThrowBonus: 'fa-solid fa-shield',
 	savingThrowRollMode: 'fa-solid fa-dice-five',
 	skillBonus: 'fa-solid fa-screwdriver-wrench',
+	skillRollMode: 'fa-solid fa-dice-d20',
 	speedBonus: 'fa-solid fa-person-running',
 	unarmedDamage: 'fa-solid fa-hand-fist',
 };


### PR DESCRIPTION
## Summary

Adds the `skillRollMode` rule type (#844): features can now grant stacking advantage/disadvantage levels on skill checks via the Rules Builder, with no dice syntax. Along the way, fixes a latent bug where seven existing rule types silently ignored their `predicate` field.

<img width="1600" height="1000" alt="skillRollMode-roll-dialog" src="https://github.com/user-attachments/assets/45339227-697c-4ffe-9935-16b767764c8b" />
<img width="720" height="405" alt="skillRollMode-rules-builder" src="https://github.com/user-attachments/assets/e0d35a13-3fff-4d3a-8462-57ce5791d56e" />


## Changes
- New `skillRollMode` rule: `skills` multi-select (with `"all"` sentinel), signed integer `value` (+N advantage / −N disadvantage), and `mode` (`adjust` stacks with other sources, `set` overrides). Applies live during data prep, mirroring `initiativeRollMode`'s reset-then-apply pattern on `skills.<skill>.defaultRollMode`.
- Ships **Leave No Trace** (The Cheat / Tools of the Silent Blade) as the first consumer: Stealth advantage gated on the `self:fullHp` tag.
- Fixes predicate gating in seven rules that mutated actor data without calling `this.test()`: `initiativeRollMode`, `skillBonus`, `abilityBonus`, `healingPotionBonus`, `maxHitDice`, `maxWounds`, `savingThrowBonus`. No shipped pack content carries predicates on these types, so existing compendium behavior is unchanged.
- Known limitation (documented in the sweep commit): these seven apply in `prePrepareData`, before late tags like `self:fullHp` are populated, so predicates on late tags won't match for them. Follow-up branch `feature/predicate-late-tags` addresses this.

## Test Plan

1. Create a character and give it any feature item. Open the item's Rules tab, then Rules Builder, and add a **Skill Roll Mode** rule: Apply to `stealth`, Roll mode value `1`, How to apply `adjust`.
2. Roll a Stealth check from the character sheet. The roll dialog slider should seed at **Advantage × 1** and the formula should read `2d20khn`.
3. Add a second identical rule (or set value to `2`). The dialog should seed at **Advantage × 2** (`3d20khn`).
4. Set a negative value. The slider should seed on the disadvantage side. Disable or delete the item, and Stealth should return to a straight roll.
5. Drag **Leave No Trace** from the class features compendium onto a character with full HP. Stealth seeds at Advantage × 1. Damage the character and the advantage disappears. Heal to full and it returns.
6. Predicate regression: add a rule of any fixed type (e.g. Skill Bonus) with an impossible predicate (key `self`, value `nonexistent`). The bonus must **not** apply. Clear the predicate and it applies.

## Checklist

- [x] Added or updated unit tests
- [x] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [x] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** yes
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues

Closes #844
