### PR TITLE
fix(rules-builder): resolve modifyPool pool picker from poolType (#806)

### DIFF
--- a/docs/system/rules.md
+++ b/docs/system/rules.md
@@ -333,9 +333,27 @@ value: new fields.StringField(
 ),
 ```
 
-The closed widget catalog is **`formula | diceFormula | documentUuid | predicate | templateString | richText | hidden`**. `withWidget()` validates the hint in dev and warns on typos.
+The closed widget catalog is **`formula | diceFormula | documentUuid | predicate | templateString | richText | dicePoolPicker | chargePoolPicker | hidden`**. `withWidget()` validates the hint in dev and warns on typos.
 
 For `widget: 'documentUuid'`, set `documentTypes: ['Item.spell']` (or `['Item']`, `['Actor']`) to gate accepted drops.
+
+### Conditional widgets
+
+When the right input depends on a sibling field, pass a function instead of a hint. It receives the same data object as `showWhen`:
+
+```typescript
+poolIdentifier: new fields.StringField(
+  withWidget({
+    required: true,
+    label: 'Pool',
+    widget: (data) => (data.poolType === 'charge' ? 'chargePoolPicker' : 'dicePoolPicker'),
+  }),
+),
+```
+
+The resolved value must still be in the catalog — `withWidget()` cannot check a resolver's return value, so `<SchemaFieldRenderer>` warns at render time if it isn't. `'hidden'` works here too, giving conditional visibility that depends on which widget applies.
+
+Write the fallback branch to match the sibling field's `initial` value: the generated reference docs resolve the function against schema initials, so that branch is what gets documented (the field's description then notes that the input varies).
 
 ### Conditional fields with `showWhen`
 

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -608,6 +608,7 @@
 				"empty": "No charge pools defined on this actor",
 				"notFound": "⚠ {identifier} (not found)"
 			},
+			"poolIdentifierPlaceholder": "Type a pool identifier",
 			"templateValueHintBefore": "Use",
 			"templateValueHintAfter": "to insert the formula result.",
 			"pickerMissingMetaTooltip": "Description missing — flag for review.",

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -609,6 +609,7 @@
 				"notFound": "⚠ {identifier} (not found)"
 			},
 			"poolIdentifierPlaceholder": "Type a pool identifier",
+			"poolPickerNoActor": "This item is not on an actor, so its pools cannot be listed",
 			"templateValueHintBefore": "Use",
 			"templateValueHintAfter": "to insert the formula result.",
 			"pickerMissingMetaTooltip": "Description missing — flag for review.",

--- a/scripts/docs/generateReference.gen.ts
+++ b/scripts/docs/generateReference.gen.ts
@@ -213,13 +213,54 @@ function resolveInitial(rawInitial: unknown): string {
 	return String(initial);
 }
 
-function describeRuleField(name: string, field: any): FieldRow | null {
-	const opts = field?.options ?? {};
-	if (opts.widget === 'hidden') return null;
+/** Raw `initial` value, for feeding widget resolvers. Unlike `resolveInitial`,
+ *  this keeps the value as-is rather than formatting it for display. */
+function rawInitialValue(rawInitial: unknown): unknown {
+	if (typeof rawInitial !== 'function') return rawInitial;
+	try {
+		return (rawInitial as () => unknown)();
+	} catch {
+		return undefined;
+	}
+}
 
-	const kind = widgetKindLabel(opts.widget, field?.constructor?.name ?? '');
+/** Collect each field's raw `initial`, so a widget resolver can be evaluated
+ *  against the state a freshly added rule starts in. */
+function collectSiblingInitials(schema: Record<string, any>): Record<string, unknown> {
+	const initials: Record<string, unknown> = {};
+	for (const [name, field] of Object.entries(schema)) {
+		initials[name] = rawInitialValue(field?.options?.initial);
+	}
+	return initials;
+}
+
+/** `widget` may be a function of sibling values (see `WidgetResolver`). Docs are
+ *  static, so describe the default state and flag that the input varies. */
+function resolveWidget(
+	rawWidget: unknown,
+	siblingInitials: Record<string, unknown>,
+): string | undefined {
+	if (typeof rawWidget !== 'function') return rawWidget as string | undefined;
+	try {
+		return (rawWidget as (data: Record<string, unknown>) => string)(siblingInitials);
+	} catch {
+		return undefined;
+	}
+}
+
+function describeRuleField(
+	name: string,
+	field: any,
+	siblingInitials: Record<string, unknown> = {},
+): FieldRow | null {
+	const opts = field?.options ?? {};
+	const widget = resolveWidget(opts.widget, siblingInitials);
+	if (widget === 'hidden') return null;
+
+	const kind = widgetKindLabel(widget, field?.constructor?.name ?? '');
 	const hint = opts.hint ? escapeVueText(localize(opts.hint)) : '';
 	const shownConditionally = typeof opts.showWhen === 'function';
+	const widgetVaries = typeof opts.widget === 'function';
 
 	const choiceText = resolveChoices(opts.choices);
 	let options = choiceText ?? kind;
@@ -228,6 +269,7 @@ function describeRuleField(name: string, field: any): FieldRow | null {
 	let description = hint || kind;
 	if (hint && !choiceText) description = hint;
 	if (shownConditionally) description += ' (Only shown when relevant.)';
+	if (widgetVaries) description += ' (The input changes with the other field values.)';
 
 	return {
 		name,
@@ -241,6 +283,7 @@ function describeRuleField(name: string, field: any): FieldRow | null {
 /** Flatten a rule schema into display rows, descending one level into groups/lists. */
 function collectFieldRows(schema: Record<string, any>, prefix = '', skipBase = true): FieldRow[] {
 	const rows: FieldRow[] = [];
+	const siblingInitials = collectSiblingInitials(schema);
 
 	for (const [name, field] of Object.entries(schema)) {
 		if (skipBase && !prefix && BASE_RULE_FIELDS.has(name)) continue;
@@ -248,7 +291,7 @@ function collectFieldRows(schema: Record<string, any>, prefix = '', skipBase = t
 		const constructorName = field?.constructor?.name ?? '';
 
 		if (constructorName === 'SchemaField' && field.fields) {
-			const parent = describeRuleField(name, field);
+			const parent = describeRuleField(name, field, siblingInitials);
 			if (!parent) continue;
 			rows.push(...collectFieldRows(field.fields, `${parent.label} → `, false));
 			continue;
@@ -259,13 +302,13 @@ function collectFieldRows(schema: Record<string, any>, prefix = '', skipBase = t
 			field.element?.constructor?.name === 'SchemaField' &&
 			field.element.fields
 		) {
-			const parent = describeRuleField(name, field);
+			const parent = describeRuleField(name, field, siblingInitials);
 			if (!parent) continue;
 			rows.push(...collectFieldRows(field.element.fields, `${parent.label} → `, false));
 			continue;
 		}
 
-		const row = describeRuleField(name, field);
+		const row = describeRuleField(name, field, siblingInitials);
 		if (!row) continue;
 		row.label = `${prefix}${row.label}`;
 		rows.push(row);

--- a/src/models/rules/_widgetOption.test.ts
+++ b/src/models/rules/_widgetOption.test.ts
@@ -51,6 +51,19 @@ describe('withWidget validation', () => {
 		expect(warnSpy.mock.calls[0]?.[0]).toContain('item.spell');
 	});
 
+	it('does not warn for a function-valued widget hint', () => {
+		withWidget({ widget: () => 'formula' }, 'value');
+		expect(warnSpy).not.toHaveBeenCalled();
+	});
+
+	it('does not invoke a function-valued widget hint during validation', () => {
+		// defineSchema() runs at system init, where the rule's data doesn't
+		// exist yet — the resolver must only run at render time.
+		const resolver = vi.fn(() => 'formula' as const);
+		withWidget({ widget: resolver }, 'value');
+		expect(resolver).not.toHaveBeenCalled();
+	});
+
 	it('accepts well-formed documentTypes entries', () => {
 		withWidget({ documentTypes: ['Item', 'Item.spell', 'Actor'] }, 'uuid');
 		expect(warnSpy).not.toHaveBeenCalled();

--- a/src/models/rules/_widgetOption.ts
+++ b/src/models/rules/_widgetOption.ts
@@ -2,7 +2,8 @@
  * Per-field UI metadata for the rules-builder `<SchemaFieldRenderer>`:
  *
  * - `widget` — picks a specific input widget when the field's type alone
- *   isn't enough to dispatch.
+ *   isn't enough to dispatch. May be a function of the rule's source data
+ *   when the right widget depends on a sibling field's value.
  * - `showWhen` — visibility predicate evaluated against the current rule's
  *   source data; returning `false` hides the field.
  *
@@ -32,8 +33,22 @@ export type WidgetHint = (typeof WIDGET_HINTS)[number];
 
 export const VALID_WIDGETS: ReadonlySet<string> = new Set(WIDGET_HINTS);
 
+/**
+ * Picks a widget from the rule's current source data — the same object
+ * `showWhen` receives. Write the fallback branch to match the sibling field's
+ * `initial` value: the generated reference docs resolve the function against
+ * schema initials, so that branch is what gets documented.
+ */
+export type WidgetResolver = (data: Record<string, unknown>) => WidgetHint;
+
 export interface WidgetExtras {
-	widget?: WidgetHint;
+	/**
+	 * A hint from the catalog, or a resolver picking one from sibling values.
+	 * A resolver's return value can't be checked here (it depends on data
+	 * that doesn't exist at schema-construction time) — `<SchemaFieldRenderer>`
+	 * validates the resolved hint on every render instead.
+	 */
+	widget?: WidgetHint | WidgetResolver;
 	showWhen?: (data: Record<string, unknown>) => boolean;
 	/**
 	 * Restrict accepted drops on `widget: 'documentUuid'` fields. Each entry
@@ -54,7 +69,13 @@ function isDev(): boolean {
 }
 
 function validateWidgetExtras(opts: WidgetExtras, label: string): void {
-	if (opts.widget !== undefined && !VALID_WIDGETS.has(opts.widget)) {
+	// A resolver is deliberately not invoked here: `defineSchema()` runs at
+	// system init, and a resolver is free to assume populated data.
+	if (
+		opts.widget !== undefined &&
+		typeof opts.widget !== 'function' &&
+		!VALID_WIDGETS.has(opts.widget)
+	) {
 		console.warn(
 			`Nimble | ${label}: unknown widget hint "${opts.widget}". ` +
 				`Valid: ${WIDGET_HINTS.join(', ')}.`,

--- a/src/models/rules/modifyPool.test.ts
+++ b/src/models/rules/modifyPool.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest';
+import type { WidgetResolver } from './_widgetOption.js';
 import { ModifyPoolRule } from './modifyPool.js';
-
-type WidgetResolver = (data: Record<string, unknown>) => string;
 
 function poolIdentifierWidget(): WidgetResolver {
 	const schema = ModifyPoolRule.defineSchema();

--- a/src/models/rules/modifyPool.test.ts
+++ b/src/models/rules/modifyPool.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { ModifyPoolRule } from './modifyPool.js';
+
+type WidgetResolver = (data: Record<string, unknown>) => string;
+
+function poolIdentifierWidget(): WidgetResolver {
+	const schema = ModifyPoolRule.defineSchema();
+	const widget = (schema.poolIdentifier as unknown as { options: { widget: unknown } }).options
+		.widget;
+
+	expect(typeof widget).toBe('function');
+	return widget as WidgetResolver;
+}
+
+describe('ModifyPoolRule schema', () => {
+	it('picks the charge pool picker when poolType is charge', () => {
+		expect(poolIdentifierWidget()({ poolType: 'charge' })).toBe('chargePoolPicker');
+	});
+
+	it('picks the dice pool picker when poolType is dice', () => {
+		expect(poolIdentifierWidget()({ poolType: 'dice' })).toBe('dicePoolPicker');
+	});
+
+	it('falls back to the dice pool picker when poolType is absent', () => {
+		// The reference-docs generator resolves widgets against schema initials,
+		// and a partially-typed rule can reach the renderer without poolType.
+		expect(poolIdentifierWidget()({})).toBe('dicePoolPicker');
+	});
+
+	it('defaults poolType to dice, matching the widget fallback', () => {
+		const schema = ModifyPoolRule.defineSchema();
+		const poolType = schema.poolType as unknown as { initial: string };
+
+		expect(poolType.initial).toBe('dice');
+	});
+});

--- a/src/models/rules/modifyPool.ts
+++ b/src/models/rules/modifyPool.ts
@@ -32,13 +32,12 @@ function schema() {
 				initial: '',
 				label: 'NIMBLE.rules.modifyPool.poolIdentifier.label',
 				hint: 'NIMBLE.rules.modifyPool.poolIdentifier.hint',
-				// modifyPool can target either a dice or charge pool (`poolType`
-				// switches between them). The widget catalog has no conditional-
-				// widget primitive yet, so default to the dice picker — the more
-				// common case — and let authors fall back to typing for charge
-				// pools (the stored value is a plain string regardless).
-				widget: 'dicePoolPicker',
+				// The picker follows `poolType`: dice pools and charge pools are
+				// separate subsystems with separate identifier namespaces, so the
+				// wrong picker lists nothing and flags the stored value as missing.
+				widget: (data) => (data.poolType === 'charge' ? 'chargePoolPicker' : 'dicePoolPicker'),
 			}),
+			'modifyPool.poolIdentifier',
 		),
 		dieSize: new fields.StringField({
 			required: false,

--- a/src/models/rules/modifyPool.ts
+++ b/src/models/rules/modifyPool.ts
@@ -35,9 +35,9 @@ function schema() {
 				// The picker follows `poolType`: dice pools and charge pools are
 				// separate subsystems with separate identifier namespaces, so the
 				// wrong picker lists nothing and flags the stored value as missing.
-				widget: (data) => (data.poolType === 'charge' ? 'chargePoolPicker' : 'dicePoolPicker'),
+				widget: (data: Record<string, unknown>) =>
+					data.poolType === 'charge' ? 'chargePoolPicker' : 'dicePoolPicker',
 			}),
-			'modifyPool.poolIdentifier',
 		),
 		dieSize: new fields.StringField({
 			required: false,

--- a/src/view/rulesBuilder/components/ChargePoolPicker.svelte
+++ b/src/view/rulesBuilder/components/ChargePoolPicker.svelte
@@ -27,21 +27,25 @@
 	);
 
 	function handleChange(event: Event) {
-		const target = event.target as HTMLSelectElement;
+		const target = event.target as HTMLSelectElement | HTMLInputElement;
 		onChange(target.value);
 	}
 </script>
 
 {#if !hasPools}
-	<select class="nimble-field-input nimble-pool-picker nimble-pool-picker--charge" {value} disabled>
-		{#if isStaleValue}
-			<option {value}
-				>{localize('NIMBLE.rulesBuilder.chargePoolPicker.notFound', { identifier: value })}</option
-			>
-		{:else}
-			<option value="">{localize('NIMBLE.rulesBuilder.chargePoolPicker.empty')}</option>
-		{/if}
-	</select>
+	<!-- No actor to enumerate pools from (a compendium or world item). Fall back
+	     to free text so pack authors can still write an identifier by hand. -->
+	<input
+		class="nimble-field-input nimble-pool-picker nimble-pool-picker--charge"
+		type="text"
+		{value}
+		{disabled}
+		placeholder={localize('NIMBLE.rulesBuilder.poolIdentifierPlaceholder')}
+		onchange={handleChange}
+	/>
+	<small class="nimble-field-hint">
+		{localize('NIMBLE.rulesBuilder.chargePoolPicker.empty')}
+	</small>
 {:else}
 	<select
 		class="nimble-field-input nimble-pool-picker nimble-pool-picker--charge"
@@ -72,5 +76,12 @@
 		color: inherit;
 		border: var(--nimble-input-border, 1px solid var(--nimble-accent-color));
 		border-radius: 4px;
+	}
+
+	.nimble-field-hint {
+		display: block;
+		margin-top: 0.125rem;
+		color: var(--color-text-dark-secondary);
+		font-size: var(--nimble-xs-text);
 	}
 </style>

--- a/src/view/rulesBuilder/components/ChargePoolPicker.svelte
+++ b/src/view/rulesBuilder/components/ChargePoolPicker.svelte
@@ -22,6 +22,7 @@
 
 	const options = $derived(state.options);
 	const hasPools = $derived(options.length > 0);
+	const hasActor = $derived(state.hasActor);
 	const isStaleValue = $derived(
 		value.length > 0 && !options.some((option) => option.identifier === value),
 	);
@@ -33,8 +34,9 @@
 </script>
 
 {#if !hasPools}
-	<!-- No actor to enumerate pools from (a compendium or world item). Fall back
-	     to free text so pack authors can still write an identifier by hand. -->
+	<!-- Nothing to list: either the item is unowned (compendium or world
+	     directory) or its actor has no pools yet. Fall back to free text so
+	     pack authors can still write an identifier by hand. -->
 	<input
 		class="nimble-field-input nimble-pool-picker nimble-pool-picker--charge"
 		type="text"
@@ -44,7 +46,9 @@
 		onchange={handleChange}
 	/>
 	<small class="nimble-field-hint">
-		{localize('NIMBLE.rulesBuilder.chargePoolPicker.empty')}
+		{hasActor
+			? localize('NIMBLE.rulesBuilder.chargePoolPicker.empty')
+			: localize('NIMBLE.rulesBuilder.poolPickerNoActor')}
 	</small>
 {:else}
 	<select

--- a/src/view/rulesBuilder/components/ChargePoolPicker.svelte
+++ b/src/view/rulesBuilder/components/ChargePoolPicker.svelte
@@ -33,7 +33,7 @@
 </script>
 
 {#if !hasPools}
-	<select class="nimble-field-input" {value} disabled>
+	<select class="nimble-field-input nimble-pool-picker nimble-pool-picker--charge" {value} disabled>
 		{#if isStaleValue}
 			<option {value}
 				>{localize('NIMBLE.rulesBuilder.chargePoolPicker.notFound', { identifier: value })}</option
@@ -43,7 +43,12 @@
 		{/if}
 	</select>
 {:else}
-	<select class="nimble-field-input" {value} {disabled} onchange={handleChange}>
+	<select
+		class="nimble-field-input nimble-pool-picker nimble-pool-picker--charge"
+		{value}
+		{disabled}
+		onchange={handleChange}
+	>
 		{#if isStaleValue}
 			<option {value}
 				>{localize('NIMBLE.rulesBuilder.chargePoolPicker.notFound', { identifier: value })}</option

--- a/src/view/rulesBuilder/components/ChargePoolPicker.svelte.ts
+++ b/src/view/rulesBuilder/components/ChargePoolPicker.svelte.ts
@@ -64,6 +64,11 @@ function dedupeAndSort(pools: ChargePoolState[]): ChargePoolOption[] {
 export function createChargePoolPickerState(getDocument: () => unknown) {
 	const subscribePoolState = createSubscriber(registerPoolHooks);
 
+	// An unowned item (compendium or world directory) has no actor to enumerate
+	// pools from. That is a different situation from an actor that simply has no
+	// pools yet, and the two need different messaging.
+	const hasActor = $derived(resolveActor(getDocument()) !== null);
+
 	const options = $derived.by((): ChargePoolOption[] => {
 		subscribePoolState();
 		const actor = resolveActor(getDocument());
@@ -72,6 +77,9 @@ export function createChargePoolPickerState(getDocument: () => unknown) {
 	});
 
 	return {
+		get hasActor() {
+			return hasActor;
+		},
 		get options() {
 			return options;
 		},

--- a/src/view/rulesBuilder/components/DicePoolPicker.svelte
+++ b/src/view/rulesBuilder/components/DicePoolPicker.svelte
@@ -33,7 +33,7 @@
 </script>
 
 {#if !hasPools}
-	<select class="nimble-field-input" {value} disabled>
+	<select class="nimble-field-input nimble-pool-picker nimble-pool-picker--dice" {value} disabled>
 		{#if isStaleValue}
 			<option {value}
 				>{localize('NIMBLE.rulesBuilder.dicePoolPicker.notFound', { identifier: value })}</option
@@ -43,7 +43,12 @@
 		{/if}
 	</select>
 {:else}
-	<select class="nimble-field-input" {value} {disabled} onchange={handleChange}>
+	<select
+		class="nimble-field-input nimble-pool-picker nimble-pool-picker--dice"
+		{value}
+		{disabled}
+		onchange={handleChange}
+	>
 		{#if isStaleValue}
 			<option {value}
 				>{localize('NIMBLE.rulesBuilder.dicePoolPicker.notFound', { identifier: value })}</option

--- a/src/view/rulesBuilder/components/DicePoolPicker.svelte
+++ b/src/view/rulesBuilder/components/DicePoolPicker.svelte
@@ -27,21 +27,25 @@
 	);
 
 	function handleChange(event: Event) {
-		const target = event.target as HTMLSelectElement;
+		const target = event.target as HTMLSelectElement | HTMLInputElement;
 		onChange(target.value);
 	}
 </script>
 
 {#if !hasPools}
-	<select class="nimble-field-input nimble-pool-picker nimble-pool-picker--dice" {value} disabled>
-		{#if isStaleValue}
-			<option {value}
-				>{localize('NIMBLE.rulesBuilder.dicePoolPicker.notFound', { identifier: value })}</option
-			>
-		{:else}
-			<option value="">{localize('NIMBLE.rulesBuilder.dicePoolPicker.empty')}</option>
-		{/if}
-	</select>
+	<!-- No actor to enumerate pools from (a compendium or world item). Fall back
+	     to free text so pack authors can still write an identifier by hand. -->
+	<input
+		class="nimble-field-input nimble-pool-picker nimble-pool-picker--dice"
+		type="text"
+		{value}
+		{disabled}
+		placeholder={localize('NIMBLE.rulesBuilder.poolIdentifierPlaceholder')}
+		onchange={handleChange}
+	/>
+	<small class="nimble-field-hint">
+		{localize('NIMBLE.rulesBuilder.dicePoolPicker.empty')}
+	</small>
 {:else}
 	<select
 		class="nimble-field-input nimble-pool-picker nimble-pool-picker--dice"
@@ -72,5 +76,12 @@
 		color: inherit;
 		border: var(--nimble-input-border, 1px solid var(--nimble-accent-color));
 		border-radius: 4px;
+	}
+
+	.nimble-field-hint {
+		display: block;
+		margin-top: 0.125rem;
+		color: var(--color-text-dark-secondary);
+		font-size: var(--nimble-xs-text);
 	}
 </style>

--- a/src/view/rulesBuilder/components/DicePoolPicker.svelte
+++ b/src/view/rulesBuilder/components/DicePoolPicker.svelte
@@ -22,6 +22,7 @@
 
 	const options = $derived(state.options);
 	const hasPools = $derived(options.length > 0);
+	const hasActor = $derived(state.hasActor);
 	const isStaleValue = $derived(
 		value.length > 0 && !options.some((option) => option.identifier === value),
 	);
@@ -33,8 +34,9 @@
 </script>
 
 {#if !hasPools}
-	<!-- No actor to enumerate pools from (a compendium or world item). Fall back
-	     to free text so pack authors can still write an identifier by hand. -->
+	<!-- Nothing to list: either the item is unowned (compendium or world
+	     directory) or its actor has no pools yet. Fall back to free text so
+	     pack authors can still write an identifier by hand. -->
 	<input
 		class="nimble-field-input nimble-pool-picker nimble-pool-picker--dice"
 		type="text"
@@ -44,7 +46,9 @@
 		onchange={handleChange}
 	/>
 	<small class="nimble-field-hint">
-		{localize('NIMBLE.rulesBuilder.dicePoolPicker.empty')}
+		{hasActor
+			? localize('NIMBLE.rulesBuilder.dicePoolPicker.empty')
+			: localize('NIMBLE.rulesBuilder.poolPickerNoActor')}
 	</small>
 {:else}
 	<select

--- a/src/view/rulesBuilder/components/DicePoolPicker.svelte.ts
+++ b/src/view/rulesBuilder/components/DicePoolPicker.svelte.ts
@@ -65,6 +65,11 @@ function dedupeAndSort(pools: DicePoolState[]): DicePoolOption[] {
 export function createDicePoolPickerState(getDocument: () => unknown) {
 	const subscribePoolState = createSubscriber(registerPoolHooks);
 
+	// An unowned item (compendium or world directory) has no actor to enumerate
+	// pools from. That is a different situation from an actor that simply has no
+	// pools yet, and the two need different messaging.
+	const hasActor = $derived(resolveActor(getDocument()) !== null);
+
 	const options = $derived.by((): DicePoolOption[] => {
 		subscribePoolState();
 		const actor = resolveActor(getDocument());
@@ -73,6 +78,9 @@ export function createDicePoolPickerState(getDocument: () => unknown) {
 	});
 
 	return {
+		get hasActor() {
+			return hasActor;
+		},
 		get options() {
 			return options;
 		},

--- a/src/view/rulesBuilder/components/SchemaFieldRenderer.svelte.test.ts
+++ b/src/view/rulesBuilder/components/SchemaFieldRenderer.svelte.test.ts
@@ -124,6 +124,32 @@ describe('SchemaFieldRenderer dispatch table', () => {
 		expect(container.querySelector('.nimble-pool-picker--charge')).toBeFalsy();
 	});
 
+	it.each([
+		['dicePoolPicker', 'nimble-pool-picker--dice'],
+		['chargePoolPicker', 'nimble-pool-picker--charge'],
+	])('widget=%s with no parent actor → editable free-text input', (widget, marker) => {
+		const field = new fields.StringField({
+			required: true,
+			nullable: false,
+			initial: '',
+			widget,
+		} as never);
+		// No `document` prop, so the picker can't resolve an actor — the
+		// compendium/world-item authoring path.
+		const { container } = render(SchemaFieldRenderer, {
+			field,
+			value: 'combat-dice',
+			parentData: {},
+			name: 'poolIdentifier',
+			onChange: noop,
+		});
+
+		const input = container.querySelector<HTMLInputElement>(`input[type="text"].${marker}`);
+		expect(input).toBeTruthy();
+		expect(input?.disabled).toBe(false);
+		expect(input?.value).toBe('combat-dice');
+	});
+
 	it('widget resolver returning hidden → renders nothing', () => {
 		const field = new fields.StringField({
 			required: true,

--- a/src/view/rulesBuilder/components/SchemaFieldRenderer.svelte.test.ts
+++ b/src/view/rulesBuilder/components/SchemaFieldRenderer.svelte.test.ts
@@ -86,6 +86,62 @@ describe('SchemaFieldRenderer dispatch table', () => {
 		expect(container.querySelector('.nimble-template-string-input')).toBeTruthy();
 	});
 
+	it('widget as a resolver → picks the charge pool picker from parentData', () => {
+		const field = new fields.StringField({
+			required: true,
+			nullable: false,
+			initial: '',
+			widget: (data: Record<string, unknown>) =>
+				data.poolType === 'charge' ? 'chargePoolPicker' : 'dicePoolPicker',
+		} as never);
+		const { container } = render(SchemaFieldRenderer, {
+			field,
+			value: 'combat-dice',
+			parentData: { poolType: 'charge' },
+			name: 'poolIdentifier',
+			onChange: noop,
+		});
+		expect(container.querySelector('.nimble-pool-picker--charge')).toBeTruthy();
+		expect(container.querySelector('.nimble-pool-picker--dice')).toBeFalsy();
+	});
+
+	it('widget as a resolver → picks the dice pool picker from parentData', () => {
+		const field = new fields.StringField({
+			required: true,
+			nullable: false,
+			initial: '',
+			widget: (data: Record<string, unknown>) =>
+				data.poolType === 'charge' ? 'chargePoolPicker' : 'dicePoolPicker',
+		} as never);
+		const { container } = render(SchemaFieldRenderer, {
+			field,
+			value: 'fury',
+			parentData: { poolType: 'dice' },
+			name: 'poolIdentifier',
+			onChange: noop,
+		});
+		expect(container.querySelector('.nimble-pool-picker--dice')).toBeTruthy();
+		expect(container.querySelector('.nimble-pool-picker--charge')).toBeFalsy();
+	});
+
+	it('widget resolver returning hidden → renders nothing', () => {
+		const field = new fields.StringField({
+			required: true,
+			nullable: false,
+			initial: '',
+			widget: (data: Record<string, unknown>) => (data.mode === 'auto' ? 'hidden' : 'formula'),
+		} as never);
+		const { container } = render(SchemaFieldRenderer, {
+			field,
+			value: '1',
+			parentData: { mode: 'auto' },
+			name: 'count',
+			onChange: noop,
+		});
+		expect(container.querySelector('.nimble-formula-input')).toBeFalsy();
+		expect(container.textContent?.trim()).toBe('');
+	});
+
 	it('PredicateField → mounts <PredicateBuilder>', () => {
 		const field = new PredicateField();
 		const { container } = render(SchemaFieldRenderer, {

--- a/src/view/rulesBuilder/components/SchemaFieldRenderer.svelte.test.ts
+++ b/src/view/rulesBuilder/components/SchemaFieldRenderer.svelte.test.ts
@@ -148,6 +148,11 @@ describe('SchemaFieldRenderer dispatch table', () => {
 		expect(input).toBeTruthy();
 		expect(input?.disabled).toBe(false);
 		expect(input?.value).toBe('combat-dice');
+
+		// The hint must not claim the actor has no pools — there is no actor.
+		const hint = container.querySelector('.nimble-field-hint')?.textContent ?? '';
+		expect(hint).toContain('not on an actor');
+		expect(hint).not.toContain('defined on this actor');
 	});
 
 	it('widget resolver returning hidden → renders nothing', () => {

--- a/src/view/rulesBuilder/components/SchemaFieldRendererState.svelte.ts
+++ b/src/view/rulesBuilder/components/SchemaFieldRendererState.svelte.ts
@@ -5,7 +5,7 @@ import { VALID_WIDGETS } from '../../../models/rules/_widgetOption.js';
 // stores the same options on `.options` (see tests/mocks/foundry.ts) so
 // `.options` is the canonical read site in both worlds.
 interface FieldExtras {
-	widget?: string;
+	widget?: string | ((data: Record<string, unknown>) => string);
 	showWhen?: (data: Record<string, unknown>) => boolean;
 	documentTypes?: string[];
 }
@@ -17,7 +17,14 @@ export function createSchemaFieldRendererState(
 	getOnChange: () => (next: unknown) => void,
 	getName: () => string,
 ) {
-	const widget = $derived((getField() as unknown as FieldWithOptions).options?.widget);
+	// A field may pick its widget from sibling values (see `WidgetResolver`),
+	// so resolve against the same data `showWhen` reads. Everything downstream
+	// — the dispatch table, `isHidden`, the unknown-hint warning — sees a
+	// plain string either way.
+	const widget = $derived.by(() => {
+		const raw = (getField() as unknown as FieldWithOptions).options?.widget;
+		return typeof raw === 'function' ? raw(getParentData()) : raw;
+	});
 	const documentTypes = $derived(
 		(getField() as unknown as FieldWithOptions).options?.documentTypes,
 	);


### PR DESCRIPTION
## Summary

The `modifyPool` rule can target a dice pool or a charge pool, but its `poolIdentifier` field always rendered the **dice** pool picker. With `poolType: 'charge'` the actor's charge pools never appeared in the dropdown and any stored identifier showed as `⚠ combat-dice (not found)`, because dice and charge pools are separate subsystems with separate identifier namespaces. This adds a conditional-widget primitive to the rules-builder schema layer so `modifyPool` picks its picker from `poolType`, and fixes the related case where an item with no parent actor left the picker permanently disabled.

## Changes

- **`_widgetOption.ts`**: `WidgetExtras.widget` now accepts `WidgetHint | WidgetResolver`, where a resolver is `(data) => WidgetHint` evaluated against the rule's source data. This mirrors the existing `showWhen` predicate. `withWidget()` deliberately does not invoke a resolver: `defineSchema()` runs at system init, before rule data exists.
- **`SchemaFieldRendererState.svelte.ts`**: `widget` becomes a `$derived.by` that resolves the function against `getParentData()`. Everything downstream (the dispatch table, `isHidden`, the unknown-hint warning) still sees a plain string, so the resolved hint is validated at render time and `SchemaFieldRenderer.svelte` needed no change at all.
- **`modifyPool.ts`**: `poolIdentifier` resolves to `chargePoolPicker` when `poolType` is `charge`, `dicePoolPicker` otherwise. Replaces the hardcoded hint and the stale "no conditional-widget primitive yet" comment.
- **`Dice/ChargePoolPicker.svelte`**: when the item has no parent actor (compendium or world item), the pool list is empty and the control was rendered as a permanently disabled `<select>`. It is now a free-text input with the empty-state message as a hint beneath it. The actor-owned path is unchanged. Both pickers also gained a `nimble-pool-picker--dice` / `--charge` marker class so tests can tell them apart (they otherwise share `.nimble-field-input`).
- **`generateReference.gen.ts`**: resolves function-valued widgets against the schema's field initials and appends "(The input changes with the other field values.)" to the description, alongside the existing `showWhen` note. `modifyPool.poolIdentifier` therefore documents as the dice picker, matching `poolType`'s `dice` default.
- **`docs/system/rules.md`**: documents the resolver form and the contract that the fallback branch must match the sibling field's `initial`. Also corrects the widget catalog list, which was already missing both pool pickers.
- **`en.json`**: one new key, `NIMBLE.rulesBuilder.poolIdentifierPlaceholder` ("Type a pool identifier"). **Flagging for human review per AGENTS.md.**

## Test Plan

**Automated** — `pnpm check` passes. New coverage:

- `src/models/rules/modifyPool.test.ts` (new file): the resolver returns `chargePoolPicker` for `poolType: 'charge'`, `dicePoolPicker` for `'dice'`, and `dicePoolPicker` for `{}`. The last one locks in the docs-generator contract, and a companion assertion pins `poolType`'s initial to `dice` so the two can't drift apart.
- `SchemaFieldRenderer.svelte.test.ts`: resolver dispatch for both branches, a resolver returning `'hidden'` (proves `isHidden` composes with resolution), and the free-text fallback for each picker when no actor is resolvable.
- `_widgetOption.test.ts`: a function-valued hint does not warn, and is **not invoked** during validation.

**Manual (v13)** — to reproduce the original bug, check out `dev` and open any item carrying a `modifyPool` rule with `poolType: charge`; the compendium already has one at `packs/classFeatures/core/commander/commander-progression/fit-for-any-battlefield.json` (`poolIdentifier: "combat-dice"`). The Pool identifier field shows `⚠ combat-dice (not found)`.

On this branch:

1. Create a character. Give it one item with a `chargePool` rule (`identifier: combat-dice`, `scope: actor`) and another with a `dicePool` rule (`identifier: fury`, `scope: actor`). Add a third item with a `modifyPool` rule set to `poolType: charge`, `poolIdentifier: combat-dice`.
2. Open that third item → **Rules** tab → **Open Rules Builder**. The Pool identifier field is now a charge picker showing **Combat Dice**, not a "not found" warning.
3. Change **Pool type** to `dice`. The field swaps to the dice picker listing **Fury** (and correctly flags the now-stale `combat-dice` value).
4. Open a **world or compendium** item with the same rule (no parent actor). The identifier is an editable text input pre-filled with the stored value, with "No charge pools defined on this actor" as a hint. Typing a new identifier persists it. On `dev` this control is disabled and unusable.

Steps 2 to 4 were run end-to-end in Foundry v13 through the real UI (sidebar → sheet → Rules tab → Rules Builder button → real `<select>` interaction), 8/8 assertions passing, no console errors beyond the world's pre-existing missing-asset warning.

## Checklist

- [x] Added or updated unit tests
- [x] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [x] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** yes
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

### Notes for the reviewer

- **KISS check.** AGENTS.md forbids "runtime string-to-function dispatch". This is the inverse: a resolver produces a hint *string*, and the existing explicit `{#if}` chain then dispatches on it. No component lookup table, no dynamic import. Worth a second opinion, since it is the one judgement call here.
- **Deliberately not done.** `DicePoolPicker` and `ChargePoolPicker` are roughly 95% identical (`resolveActor` and `dedupeAndSort` are byte-identical; `registerPoolHooks` differs only in the hook-name array). Deduplicating them meets neither the Rule of Three nor a behavioural need here, and parameterizing `createSubscriber(registerPoolHooks)` incorrectly would leak hook registrations or subscribe to the wrong invalidation events. It would also conflict with the in-flight `feat/berserker-automation` branch. Suggest a follow-up issue once that lands.
- `feat/berserker-automation` does not fix this; it adds `minFace`/`addRefills` to `modifyPool` but leaves the widget block untouched. Its `modifyConsumer` and `poolGainMessage` rules are dice-only by design and need no equivalent change.

## Related Issues

Closes #806
