### PR TITLE
ci: skip FoundryVTT publish for pre-releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,13 @@ jobs:
         tag: ${{ github.event.release.tag_name }}
         body: ${{ github.event.release.body }}
 
-    # Publish the module to the FoundryVTT Website
+  # Stable releases only. Pre-releases still get GitHub assets from `build`.
+  publish:
+    needs: build
+    if: ${{ !github.event.release.prerelease }}
+    runs-on: ubuntu-latest
+
+    steps:
     - name: Publish to FoundryVTT Website
       id: publish_to_fvtt
       uses: cs96and/FoundryVTT-release-package@v1


### PR DESCRIPTION
## Summary

Pre-release GitHub releases no longer publish to the FoundryVTT package registry. Only stable releases are pushed to Foundry.

## Changes

- Moved the `Publish to FoundryVTT Website` step out of the `build` job in `main.yml` and into its own `publish` job.
- Guarded that job with `if: ${{ !github.event.release.prerelease }}` and `needs: build`.
- Pre-releases still build and attach `system.json` and `nimble.zip` to the GitHub release; only the registry push is skipped.

## Test Plan

Release CI only, nothing to exercise from Foundry.

## Checklist

- [ ] Added or updated unit tests
- [x] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [ ] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** yes
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

Notes on the unchecked boxes: there is no unit test surface for a GitHub Actions workflow, and the change is not reachable from Foundry.

## Related Issues

None.
