### PR TITLE
ci: preserve release state when attaching build artifacts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+
     steps:
     - uses: actions/checkout@v4
 
@@ -59,18 +62,19 @@ jobs:
       working-directory: ./dist
       run: zip -r ./nimble.zip ./*
 
-    # Create a release for this specific version
+    # Attach files to the release that triggered this run.
     - name: Update Release with Files
       id: create_version_release
       uses: ncipollo/release-action@v1
       with:
         allowUpdates: true # Set this to false if you want to prevent updating existing releases
-        name: ${{ github.event.release.name }}
-        draft: false
+        omitPrereleaseDuringUpdate: true
+        omitDraftDuringUpdate: true
+        omitNameDuringUpdate: true
+        omitBodyDuringUpdate: true
         token: ${{ secrets.GITHUB_TOKEN }}
         artifacts: './dist/system.json, ./dist/nimble.zip'
         tag: ${{ github.event.release.tag_name }}
-        body: ${{ github.event.release.body }}
 
   # Stable releases only. Pre-releases still get GitHub assets from `build`.
   publish:


### PR DESCRIPTION
## Summary
The release job ran ncipollo/release-action@v1 without a `prerelease` input. That input defaults to '', which the action coerces to boolean false and sends in the update PATCH, so every run cleared the pre-release flag and let GitHub promote the release to `latest`.

Set the omit*DuringUpdate flags so the action drops those fields from the PATCH and the release keeps the state it was published with. Name and body were only being read from the event payload and written back unchanged, so they are omitted too, which also stops CI from clobbering post-publish edits.

Also pin `contents: write` on the job rather than relying on the repo-wide default token permissions.