### PR TITLE
fix(system): resolve Babele dependency from the package listing

### DIFF
--- a/public/system.json
+++ b/public/system.json
@@ -216,8 +216,7 @@
 			{
 				"id": "babele",
 				"type": "module",
-				"reason": "Optional. Enables runtime translation of Nimble compendium packs into the active Foundry language using the translation skeletons shipped under systems/nimble/lang/babele/.",
-				"manifest": "https://gitlab.com/riccisi/foundryvtt-babele/-/raw/master/module.json"
+				"reason": "Optional. Enables runtime translation of Nimble compendium packs into the active Foundry language using the translation skeletons shipped under systems/nimble/lang/babele/."
 			}
 		]
 	},


### PR DESCRIPTION
## Summary

The Babele manifest URL hardcoded in `system.json` is dead, which makes Foundry throw an error and show a misleading "dependency needs to be manually installed" dialog every time someone installs Nimble. Removing the `manifest` field lets Foundry resolve Babele from the official package listing instead, so the optional dependency becomes auto-installable again.

## Changes

- Removed the dead `manifest` URL from the `babele` entry in `relationships.recommends` in `public/system.json`.

## Test Plan

**Reproducing the bug (on `dev`):** install the system in a fresh Foundry v13 instance and go to create a world. You get a red error banner reading `No module manifest found at https://gitlab.com/riccisi/foundryvtt-babele/-/raw/master/module.json`, plus an "Install Package Dependencies" dialog reporting `0 dependencies can be automatically installed` / `A dependency needs to be manually installed`.

**Why it happens:** `https://gitlab.com/riccisi/foundryvtt-babele/-/raw/master/module.json` returns 404. Babele publishes its manifest as a GitLab CI job artifact now, not as a raw file on `master`. You can confirm with:

```sh
curl -o /dev/null -w '%{http_code}\n' \
  'https://gitlab.com/riccisi/foundryvtt-babele/-/raw/master/module.json'   # 404
```

**Why removing the field is the fix:** Foundry's `#checkDependency` branches on whether a relationship declares a manifest (identical logic in v13 and v14):

- With a `manifest`, it calls `fromRemoteManifest()` on that URL. On failure the dependency lands in `cantInstallOptional`, which is what renders the dialog above.
- Without a `manifest`, it falls through to *"Discover from package listing"* and looks the id up in the module directory, which returns Babele's current working manifest. The dependency then reports `canInstall = true`.

**Verifying the fix:** install this branch's build into a fresh Foundry v13 instance and create a world. Expected: no error banner, and the dependency dialog (if it appears at all) offers Babele under `1 dependency can be automatically installed` with a working checkbox. Installing Babele from that dialog should succeed.

Note that this path only triggers when Babele is *not* already installed — if it is, `#checkDependency` returns early with `installNeeded = false` and no dialog appears at all. Test with Babele uninstalled.

**No compatibility range is declared** on this branch on purpose. Every current Babele release (2.8.0 through 2.9.1) still declares `compatibility.minimum: 13`, so they all work on v13. Adding a `maximum` here would be actively harmful: Foundry only checks whether the *latest* listed version falls inside the declared range rather than searching for an older matching release, so a cap below latest would fail the range check and drop straight back into the manual-install dialog. The `feature/v14` branch does declare `minimum: "2.8.0"`, since 2.7.x only verifies through Foundry 13.351.

## Checklist

- [ ] Added or updated unit tests
- [x] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [ ] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** yes / no
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

Two boxes are deliberately left unchecked:

- **Unit tests** — this is a manifest-only change with no runnable surface; the behaviour lives entirely in Foundry's setup-screen dependency resolver.
- **Tested in Foundry** — the URL failure and the core resolver logic were verified directly, but the end-to-end install flow was *not* exercised in a live Foundry instance, since that means uninstalling and reinstalling the system. A reviewer should confirm using the steps above.

## Related Issues
