### PR TITLE
fix(ci): change rolling dev release tag due to `latest-dev` got set as immutable

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -84,6 +84,11 @@ jobs:
         MANIFEST_URL: https://github.com/${{ github.repository }}/releases/download/${{ env.dev_tag }}/system.json
       run: node ./build/generate-dev-changelog.mjs
 
+    - name: Move dev tag to current commit
+      run: |
+        git tag -f "${{ env.dev_tag }}" "${{ github.sha }}"
+        git push -f origin "refs/tags/${{ env.dev_tag }}"
+
     - name: Update Rolling Dev Release
       uses: ncipollo/release-action@v1
       with:

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -11,7 +11,7 @@ concurrency:
 
 env:
   node_version: 22
-  dev_tag: latest-dev
+  dev_tag: latest-dev-1
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
Change rolling dev release tag due to `latest-dev` got set as immutable and is no longer able to be used.