### PR TITLE
test(damage): cover the unsourced banked reduction label

### DIFF
--- a/src/documents/chatMessage.test.ts
+++ b/src/documents/chatMessage.test.ts
@@ -2147,7 +2147,7 @@ describe('NimbleChatMessage.applyDamage — resistance, immunity, and vulnerabil
 			});
 		});
 
-		it('describes immunity, resistance, labeled reductions, and banked reduction', () => {
+		it('describes immunity, resistance, and labeled reductions', () => {
 			const actor = createResistanceActor({
 				damageImmunities: ['fire'],
 				damageResistances: ['fire'],
@@ -2157,6 +2157,8 @@ describe('NimbleChatMessage.applyDamage — resistance, immunity, and vulnerabil
 					{ value: 2, damageTypes: [] },
 				],
 			});
+			// The bank is not credited here: immunity zeroes the component, so
+			// nothing consumes the bank and it survives for a later hit.
 			withBankedReduction(actor, 6);
 			globals().fromUuidSync.mockReturnValue({ actor });
 
@@ -2167,6 +2169,14 @@ describe('NimbleChatMessage.applyDamage — resistance, immunity, and vulnerabil
 				'Frost Ward (-3)',
 				'damage reduction (-2)',
 			]);
+		});
+
+		it('describes an unsourced banked reduction on the component that consumes it', () => {
+			const actor = createResistanceActor({});
+			withBankedReduction(actor, 6);
+			globals().fromUuidSync.mockReturnValue({ actor });
+
+			expect(getModifiers(createModifierMessage())).toEqual(['damage reduction (-6)']);
 		});
 
 		it('names the banking feature when the banked effect carries a source', () => {


### PR DESCRIPTION
## Summary

Follow-up to #871. A breakdown test claimed to assert the banked damage reduction label, but its target actor is immune to the damage type, so the bank is never consumed and the label is never produced. The title is corrected and the uncovered branch gets a real test.

## Changes

- Renamed `describes immunity, resistance, labeled reductions, and banked reduction` to drop the banked-reduction claim, and added a comment explaining that immunity zeroing the component is why no bank label appears (the `withBankedReduction` setup stays as the documented negative case).
- Added `describes an unsourced banked reduction on the component that consumes it`, which pins the sourceless `NIMBLE.damageModifiers.banked` string (`damage reduction (-6)`) on a non-immune target. The only other test through that code path sets a source, so it exercised just the `bankedSource` arm.

## Test Plan

Test-only change, no runtime behaviour touched.

- `pnpm check` passes (2863 tests across 173 files).
- To confirm the new test genuinely covers the branch rather than passing incidentally: in `describeBankedReduction` (`src/documents/chatMessage.ts`), replace the non-source arm's `localize('NIMBLE.damageModifiers.banked', ...)` with a literal string and run `pnpm vitest run src/documents/chatMessage.test.ts` — exactly one test fails, the new one. Reverting restores a green run.

## Checklist

- [x] Added or updated unit tests
- [x] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [ ] Tested in Foundry with no console errors — n/a, test-only change with no runtime effect
- [x] **Have you used AI to assist with this PR?** yes
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues

Follow-up to #871 / #785.
