### PR TITLE
feat(items): zero-cost activations and activation cost labels

### DIFF
--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -1489,6 +1489,7 @@ export const myStore = writable<MyStoreState>(initialState);
 | `getSubclassChoices()` | `src/utils/getSubclassChoices.ts` | Get available subclass options |
 | `resolveItemActionCost()` | `src/utils/resolveItemActionCost.ts` | Get an item's activation action cost (0 for non-action cost types; missing quantity defaults to 1) |
 | `resolveMinionAttackActionCost()` | `src/utils/resolveMinionAttackActionCost.ts` | Action cost for group-attack activations; a missing or `none` cost defaults to 1 (legacy pack convention), an explicit zero stays free |
+| `formatActivationCostLabel()` | `src/utils/formatActivationCostLabel.ts` | Render an activation cost as "1 Action", "2 Actions", "10 Minutes" or "Free"; returns `null` for the types that carry no quantity so the caller can label them |
 | `spell/*` | `src/utils/spell/` | Spell-related utilities |
 | `treeManipulation/*` | `src/utils/treeManipulation/` | Tree data structure utilities |
 | `countAdjacentEnemies()`, `ADJACENCY_QUALIFIER` | `src/utils/tokenAdjacency.ts` | Count enemy tokens adjacent to a given token; respects the `adjacencyIncludesDiagonals` world setting; accepts position overrides for pre-commit token moves |

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -1487,7 +1487,8 @@ export const myStore = writable<MyStoreState>(initialState);
 | `getChoicesFromCompendium()` | `src/utils/getChoicesFromCompendium.ts` | Fetch selectable options from compendiums |
 | `isLevelUpOptionApplicable()` | `src/utils/isLevelUpOptionApplicable.ts` | Whether a feature's level-up option applies at a given level (empty `applyAtLevels` ⇒ every level) |
 | `getSubclassChoices()` | `src/utils/getSubclassChoices.ts` | Get available subclass options |
-| `resolveItemActionCost()` | `src/utils/resolveItemActionCost.ts` | Get an item's activation action cost (defaults to 1) |
+| `resolveItemActionCost()` | `src/utils/resolveItemActionCost.ts` | Get an item's activation action cost (0 for non-action cost types; missing quantity defaults to 1) |
+| `resolveMinionAttackActionCost()` | `src/utils/resolveMinionAttackActionCost.ts` | Action cost for group-attack activations; a missing or `none` cost defaults to 1 (legacy pack convention), an explicit zero stays free |
 | `spell/*` | `src/utils/spell/` | Spell-related utilities |
 | `treeManipulation/*` | `src/utils/treeManipulation/` | Tree data structure utilities |
 | `countAdjacentEnemies()`, `ADJACENCY_QUALIFIER` | `src/utils/tokenAdjacency.ts` | Count enemy tokens adjacent to a given token; respects the `adjacencyIncludesDiagonals` world setting; accepts position overrides for pre-commit token moves |

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -172,6 +172,7 @@
 		},
 		"activationCosts": {
 			"action": "Action",
+			"free": "Free",
 			"minute": "Minute",
 			"hour": "Hour",
 			"none": "None",

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -173,17 +173,18 @@
 		"activationCosts": {
 			"action": "Action",
 			"free": "Free",
+			"reaction": "Reaction",
+			"freeReaction": "Free Reaction",
+			"reactionWithCost": "Reaction ({cost})",
 			"minute": "Minute",
 			"hour": "Hour",
 			"none": "None",
-			"special": "Special",
-			"turn": "Turn"
+			"special": "Special"
 		},
 		"activationCostsPlural": {
 			"action": "Actions",
 			"minute": "Minutes",
-			"hour": "Hours",
-			"turn": "Turns"
+			"hour": "Hours"
 		},
 		"armorEffects": {
 			"none": "<p>None</p>",

--- a/src/config.ts
+++ b/src/config.ts
@@ -221,20 +221,23 @@ const sectionHeaders = {
 	stats: 'NIMBLE.sectionHeaders.stats',
 };
 
+/**
+ * The selectable activation cost types. `turn` is deliberately absent: "1/turn"
+ * is how often an ability may be used, not what it costs to use, so it belongs
+ * to a usage limit rather than to this list.
+ */
 const activationCostTypes = {
 	action: 'NIMBLE.activationCosts.action',
 	minute: 'NIMBLE.activationCosts.minute',
 	hour: 'NIMBLE.activationCosts.hour',
 	none: 'NIMBLE.activationCosts.none',
 	special: 'NIMBLE.activationCosts.special',
-	turn: 'NIMBLE.activationCosts.turn',
 };
 
 const activationCostTypesPlural = {
 	action: 'NIMBLE.activationCostsPlural.action',
 	minute: 'NIMBLE.activationCostsPlural.minute',
 	hour: 'NIMBLE.activationCostsPlural.hour',
-	turn: 'NIMBLE.activationCostsPlural.turn',
 };
 
 const actorTypeBanners = {

--- a/src/documents/actor/character.ts
+++ b/src/documents/actor/character.ts
@@ -16,7 +16,9 @@ import type { NimbleCharacterData } from '../../models/actor/CharacterDataModel.
 import calculateRollMode from '../../utils/calculateRollMode.js';
 import { consumeCombatantAction } from '../../utils/combatTurnActions.js';
 import getRollFormula from '../../utils/getRollFormula.js';
-import resolveItemActionCost from '../../utils/resolveItemActionCost.js';
+import resolveItemActionCost, {
+	type ItemWithActivationCost,
+} from '../../utils/resolveItemActionCost.js';
 import CharacterArmorProficienciesConfigDialog from '../../view/dialogs/CharacterArmorProficienciesConfigDialog.svelte';
 import CharacterLanguageProficienciesConfigDialog from '../../view/dialogs/CharacterLanguageProficienciesConfigDialog.svelte';
 import CharacterLevelDownDialog from '../../view/dialogs/CharacterLevelDownDialog.svelte';
@@ -1846,9 +1848,7 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 		const result = await super.activateItem(id, options);
 
 		if (result && item && !options.skipActionDeduction) {
-			const actionCost = resolveItemActionCost(
-				item as unknown as Parameters<typeof resolveItemActionCost>[0],
-			);
+			const actionCost = resolveItemActionCost(item as ItemWithActivationCost);
 			if (actionCost > 0) {
 				const combat = game.combat as Combat | null;
 				const combatant =

--- a/src/documents/actor/character.ts
+++ b/src/documents/actor/character.ts
@@ -16,6 +16,7 @@ import type { NimbleCharacterData } from '../../models/actor/CharacterDataModel.
 import calculateRollMode from '../../utils/calculateRollMode.js';
 import { consumeCombatantAction } from '../../utils/combatTurnActions.js';
 import getRollFormula from '../../utils/getRollFormula.js';
+import resolveItemActionCost from '../../utils/resolveItemActionCost.js';
 import CharacterArmorProficienciesConfigDialog from '../../view/dialogs/CharacterArmorProficienciesConfigDialog.svelte';
 import CharacterLanguageProficienciesConfigDialog from '../../view/dialogs/CharacterLanguageProficienciesConfigDialog.svelte';
 import CharacterLevelDownDialog from '../../view/dialogs/CharacterLevelDownDialog.svelte';
@@ -1845,10 +1846,10 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 		const result = await super.activateItem(id, options);
 
 		if (result && item && !options.skipActionDeduction) {
-			const activation = (
-				item.system as { activation?: { cost?: { type: string; quantity: number } } }
-			).activation;
-			if (activation?.cost?.type === 'action') {
+			const actionCost = resolveItemActionCost(
+				item as unknown as Parameters<typeof resolveItemActionCost>[0],
+			);
+			if (actionCost > 0) {
 				const combat = game.combat as Combat | null;
 				const combatant =
 					combat?.combatants?.find(
@@ -1858,7 +1859,7 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 					await consumeCombatantAction({
 						combat,
 						combatantId: combatant.id,
-						actionCost: activation.cost.quantity ?? 1,
+						actionCost,
 					});
 				}
 			}

--- a/src/documents/combat/combat.svelte.test.ts
+++ b/src/documents/combat/combat.svelte.test.ts
@@ -3815,7 +3815,10 @@ describe('NimbleCombat', () => {
 					name: 'Stab',
 					system: {
 						subtype: 'action',
-						activation: { effects: [{ type: 'damage', formula: '1d6' }] },
+						activation: {
+							cost: { type: 'action', quantity: 1 },
+							effects: [{ type: 'damage', formula: '1d6' }],
+						},
 					},
 				},
 			],
@@ -3831,7 +3834,10 @@ describe('NimbleCombat', () => {
 					name: 'Bite',
 					system: {
 						subtype: 'action',
-						activation: { effects: [{ type: 'damage', formula: '1d6' }] },
+						activation: {
+							cost: { type: 'action', quantity: 1 },
+							effects: [{ type: 'damage', formula: '1d6' }],
+						},
 					},
 				},
 			],

--- a/src/documents/combat/combatCommon.test.ts
+++ b/src/documents/combat/combatCommon.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import { resolveMinionAttackSkipReason } from './combatCommon.js';
+import type { ActorWithActivateItem, ItemLike } from './combatTypes.js';
+
+function createActor(): ActorWithActivateItem {
+	return { type: 'minion', name: 'Test Minion' };
+}
+
+function createAction(cost?: { type?: string; quantity?: number }): ItemLike {
+	return {
+		id: 'action-1',
+		name: 'Test Action',
+		system: { activation: cost ? { cost } : {} },
+	};
+}
+
+describe('resolveMinionAttackSkipReason', () => {
+	it('skips a member with no actions remaining when the cost type is none', () => {
+		expect(
+			resolveMinionAttackSkipReason({
+				selectedActionId: 'action-1',
+				currentActions: 0,
+				actor: createActor(),
+				selectedAction: createAction({ type: 'none', quantity: 1 }),
+			}),
+		).toBe('noActionsRemaining');
+	});
+
+	it('skips a member with no actions remaining when the cost is missing', () => {
+		expect(
+			resolveMinionAttackSkipReason({
+				selectedActionId: 'action-1',
+				currentActions: 0,
+				actor: createActor(),
+				selectedAction: createAction(),
+			}),
+		).toBe('noActionsRemaining');
+	});
+
+	it('does not skip a member at zero actions when the action cost is explicitly zero', () => {
+		expect(
+			resolveMinionAttackSkipReason({
+				selectedActionId: 'action-1',
+				currentActions: 0,
+				actor: createActor(),
+				selectedAction: createAction({ type: 'action', quantity: 0 }),
+			}),
+		).toBeNull();
+	});
+
+	it('skips a member with no actions remaining for a standard one-action cost', () => {
+		expect(
+			resolveMinionAttackSkipReason({
+				selectedActionId: 'action-1',
+				currentActions: 0,
+				actor: createActor(),
+				selectedAction: createAction({ type: 'action', quantity: 1 }),
+			}),
+		).toBe('noActionsRemaining');
+	});
+
+	it('does not skip a member with one action remaining for a one-action cost', () => {
+		expect(
+			resolveMinionAttackSkipReason({
+				selectedActionId: 'action-1',
+				currentActions: 1,
+				actor: createActor(),
+				selectedAction: createAction({ type: 'action', quantity: 1 }),
+			}),
+		).toBeNull();
+	});
+
+	it('skips a member whose remaining actions cannot cover a multi-action cost', () => {
+		expect(
+			resolveMinionAttackSkipReason({
+				selectedActionId: 'action-1',
+				currentActions: 1,
+				actor: createActor(),
+				selectedAction: createAction({ type: 'action', quantity: 2 }),
+			}),
+		).toBe('noActionsRemaining');
+	});
+
+	it('reports noActionSelected when the selected action id is empty', () => {
+		expect(
+			resolveMinionAttackSkipReason({
+				selectedActionId: '',
+				currentActions: 2,
+				actor: createActor(),
+				selectedAction: null,
+			}),
+		).toBe('noActionSelected');
+	});
+
+	it('reports actorCannotActivate when the actor is missing', () => {
+		expect(
+			resolveMinionAttackSkipReason({
+				selectedActionId: 'action-1',
+				currentActions: 2,
+				actor: null,
+				selectedAction: createAction({ type: 'action', quantity: 1 }),
+			}),
+		).toBe('actorCannotActivate');
+	});
+
+	it('reports actionNotFound when the selected action cannot be resolved', () => {
+		expect(
+			resolveMinionAttackSkipReason({
+				selectedActionId: 'action-1',
+				currentActions: 2,
+				actor: createActor(),
+				selectedAction: null,
+			}),
+		).toBe('actionNotFound');
+	});
+});

--- a/src/documents/combat/combatCommon.ts
+++ b/src/documents/combat/combatCommon.ts
@@ -1,5 +1,5 @@
 import { getCombatantImage } from '../../utils/combatantImage.js';
-import resolveItemActionCost from '../../utils/resolveItemActionCost.js';
+import resolveMinionAttackActionCost from '../../utils/resolveMinionAttackActionCost.js';
 import { getTargetTokenUuid } from '../../utils/tokenTargetLookup.js';
 import {
 	getCombatantBaseActionCurrent,
@@ -191,7 +191,7 @@ export function resolveMinionAttackSkipReason(params: {
 	actor: ActorWithActivateItem | null;
 	selectedAction: ItemLike | null;
 }): string | null {
-	const requiredActions = resolveItemActionCost(params.selectedAction);
+	const requiredActions = resolveMinionAttackActionCost(params.selectedAction);
 	const checks: Array<{ valid: boolean; reason: string }> = [
 		{ valid: params.selectedActionId.length > 0, reason: 'noActionSelected' },
 		{

--- a/src/documents/combat/combatMinionAttacks.ts
+++ b/src/documents/combat/combatMinionAttacks.ts
@@ -6,7 +6,7 @@ import {
 import { getCombatantImage } from '../../utils/combatantImage.js';
 import { isCombatantDead } from '../../utils/isCombatantDead.js';
 import { isMinionCombatant } from '../../utils/minionGrouping.js';
-import resolveItemActionCost from '../../utils/resolveItemActionCost.js';
+import resolveMinionAttackActionCost from '../../utils/resolveMinionAttackActionCost.js';
 import { getCurrentUserTargetTokenIds, getTargetTokenName } from '../../utils/tokenTargetLookup.js';
 import {
 	appendMinionAttackRollOutcome,
@@ -251,7 +251,7 @@ async function rollSingleMinionAttack(params: {
 		});
 		await damageRoll.evaluate();
 
-		const actionCost = resolveItemActionCost(resolvedActionContext.selectedAction);
+		const actionCost = resolveMinionAttackActionCost(resolvedActionContext.selectedAction);
 		return {
 			rollEntry: buildMinionAttackRollEntry({
 				member: params.member,

--- a/src/hooks/minionGroupTokenActions.ts
+++ b/src/hooks/minionGroupTokenActions.ts
@@ -2261,13 +2261,9 @@ async function executeNonMinionAttackActivation(
 
 	await validatedAttack.actor.activateItem(validatedAttack.selectedActionId, activationOptions);
 
-	const latestCombatant =
-		validatedAttack.combat.combatants.get(validatedAttack.memberCombatantId) ??
-		validatedAttack.combatant;
 	await consumeCombatantAction({
 		combat: validatedAttack.combat,
 		combatantId: validatedAttack.memberCombatantId,
-		fallbackCombatant: latestCombatant,
 		actionCost: validatedAttack.selectedAction.actionCost,
 	});
 

--- a/src/hooks/minionGroupTokenActions.ts
+++ b/src/hooks/minionGroupTokenActions.ts
@@ -26,7 +26,7 @@ import {
 	rememberMemberActionSelection,
 } from '../utils/minionGroupAttackSession.js';
 import { isMinionCombatant } from '../utils/minionGrouping.js';
-import resolveItemActionCost from '../utils/resolveItemActionCost.js';
+import resolveMinionAttackActionCost from '../utils/resolveMinionAttackActionCost.js';
 import { tokenHoverIn, tokenHoverOut } from '../utils/tokenHoverHighlight.js';
 
 const NCSW_PANEL_ID = 'nimble-minion-group-attack-panel';
@@ -476,7 +476,7 @@ function buildGroupAttackActionOptions(
 				rollFormula: getActionRollFormulaLabel(item),
 				description: getActionDescriptionLabel(item),
 				unsupportedReasons,
-				actionCost: resolveItemActionCost(item),
+				actionCost: resolveMinionAttackActionCost(item),
 			};
 		})
 		.filter((option) => option.actionId.length > 0)

--- a/src/macros/activateItemMacro.ts
+++ b/src/macros/activateItemMacro.ts
@@ -1,15 +1,7 @@
 import { getActiveCombatForCurrentScene } from '../utils/combatState.js';
-
-interface ActivationCost {
-	type: string;
-	quantity: number;
-}
-
-interface ItemActivationSystem {
-	activation?: {
-		cost?: ActivationCost;
-	};
-}
+import resolveItemActionCost, {
+	type ItemWithActivationCost,
+} from '../utils/resolveItemActionCost.js';
 
 /**
  * The function called by macros created by dragging an item to the macro hot bar.
@@ -40,10 +32,9 @@ export async function activateItemMacro(itemName: string) {
 
 	// If activation was successful and item has an action cost, deduct action pips
 	if (result) {
-		const itemSystem = item.system as unknown as ItemActivationSystem;
-		const activationCost = itemSystem?.activation?.cost;
-		if (activationCost?.type === 'action') {
-			await deductActionPips(actor!, activationCost.quantity ?? 1);
+		const actionCost = resolveItemActionCost(item as ItemWithActivationCost);
+		if (actionCost > 0) {
+			await deductActionPips(actor!, actionCost);
 		}
 	}
 

--- a/src/models/item/common.ts
+++ b/src/models/item/common.ts
@@ -21,7 +21,7 @@ export const activation = () => ({
 				required: true,
 				initial: 1,
 				nullable: false,
-				min: 1,
+				min: 0,
 				integer: true,
 			}),
 			type: new fields.StringField({

--- a/src/utils/combatTurnActions.test.ts
+++ b/src/utils/combatTurnActions.test.ts
@@ -400,17 +400,15 @@ describe('consumeCombatantAction', () => {
 			actionsMax: 3,
 		});
 		const combatants = createCombatantsCollectionFixture([combatant]);
-		const updateEmbeddedDocuments = vi.fn().mockResolvedValue([]);
 		const combat = {
 			id: 'combat-action',
 			combatants,
-			updateEmbeddedDocuments,
 		} as unknown as Combat;
-		return { combat, combatant, updateEmbeddedDocuments };
+		return { combat, combatant };
 	}
 
 	it('deducts 2 actions when actionCost is 2', async () => {
-		const { combat, updateEmbeddedDocuments } = createCombatWithCombatant('c1', 3);
+		const { combat, combatant } = createCombatWithCombatant('c1', 3);
 
 		const result = await consumeCombatantAction({
 			combat,
@@ -419,13 +417,13 @@ describe('consumeCombatantAction', () => {
 		});
 
 		expect(result).toBe(1);
-		expect(updateEmbeddedDocuments).toHaveBeenCalledWith('Combatant', [
-			{ _id: 'c1', 'system.actions.base.current': 1 },
-		]);
+		expect(combatant.update).toHaveBeenCalledWith({
+			'system.actions.base.current': 1,
+		});
 	});
 
 	it('defaults to 1 action when actionCost is undefined', async () => {
-		const { combat, updateEmbeddedDocuments } = createCombatWithCombatant('c1', 3);
+		const { combat, combatant } = createCombatWithCombatant('c1', 3);
 
 		const result = await consumeCombatantAction({
 			combat,
@@ -433,13 +431,13 @@ describe('consumeCombatantAction', () => {
 		});
 
 		expect(result).toBe(2);
-		expect(updateEmbeddedDocuments).toHaveBeenCalledWith('Combatant', [
-			{ _id: 'c1', 'system.actions.base.current': 2 },
-		]);
+		expect(combatant.update).toHaveBeenCalledWith({
+			'system.actions.base.current': 2,
+		});
 	});
 
-	it('normalizes actionCost of 0 to 1', async () => {
-		const { combat, updateEmbeddedDocuments } = createCombatWithCombatant('c1', 3);
+	it('deducts nothing when actionCost is 0', async () => {
+		const { combat, combatant } = createCombatWithCombatant('c1', 3);
 
 		const result = await consumeCombatantAction({
 			combat,
@@ -447,14 +445,12 @@ describe('consumeCombatantAction', () => {
 			actionCost: 0,
 		});
 
-		expect(result).toBe(2);
-		expect(updateEmbeddedDocuments).toHaveBeenCalledWith('Combatant', [
-			{ _id: 'c1', 'system.actions.base.current': 2 },
-		]);
+		expect(result).toBe(3);
+		expect(combatant.update).not.toHaveBeenCalled();
 	});
 
 	it('normalizes negative actionCost to 1', async () => {
-		const { combat, updateEmbeddedDocuments } = createCombatWithCombatant('c1', 3);
+		const { combat, combatant } = createCombatWithCombatant('c1', 3);
 
 		const result = await consumeCombatantAction({
 			combat,
@@ -463,9 +459,9 @@ describe('consumeCombatantAction', () => {
 		});
 
 		expect(result).toBe(2);
-		expect(updateEmbeddedDocuments).toHaveBeenCalledWith('Combatant', [
-			{ _id: 'c1', 'system.actions.base.current': 2 },
-		]);
+		expect(combatant.update).toHaveBeenCalledWith({
+			'system.actions.base.current': 2,
+		});
 	});
 
 	describe('action-tracking automation gate', () => {

--- a/src/utils/combatTurnActions.test.ts
+++ b/src/utils/combatTurnActions.test.ts
@@ -464,6 +464,28 @@ describe('consumeCombatantAction', () => {
 		});
 	});
 
+	it('returns the unchanged action count when the queued write is skipped', async () => {
+		const fallbackCombatant = createMockCombatant({
+			id: 'c1',
+			actionsCurrent: 3,
+			actionsMax: 3,
+		});
+		const combat = {
+			id: 'combat-action',
+			combatants: createCombatantsCollectionFixture([]),
+		} as unknown as Combat;
+
+		const result = await consumeCombatantAction({
+			combat,
+			combatantId: 'c1',
+			fallbackCombatant,
+			actionCost: 1,
+		});
+
+		expect(result).toBe(3);
+		expect(fallbackCombatant.update).not.toHaveBeenCalled();
+	});
+
 	describe('action-tracking automation gate', () => {
 		// The other tests in this suite exercise the enabled path via the
 		// fail-open default (no game.settings mock); this block installs an
@@ -489,7 +511,7 @@ describe('consumeCombatantAction', () => {
 		});
 
 		it('returns the untouched action pool without persisting when action tracking is off', async () => {
-			const { combat, updateEmbeddedDocuments } = createCombatWithCombatant('c1', 3);
+			const { combat, combatant } = createCombatWithCombatant('c1', 3);
 
 			const result = await consumeCombatantAction({
 				combat,
@@ -498,7 +520,7 @@ describe('consumeCombatantAction', () => {
 			});
 
 			expect(result).toBe(3);
-			expect(updateEmbeddedDocuments).not.toHaveBeenCalled();
+			expect(combatant.update).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/src/utils/combatTurnActions.test.ts
+++ b/src/utils/combatTurnActions.test.ts
@@ -465,25 +465,55 @@ describe('consumeCombatantAction', () => {
 	});
 
 	it('returns the unchanged action count when the queued write is skipped', async () => {
-		const fallbackCombatant = createMockCombatant({
+		const combatant = createMockCombatant({
 			id: 'c1',
 			actionsCurrent: 3,
 			actionsMax: 3,
 		});
+		const combatants = createCombatantsCollectionFixture([combatant]);
+		// The pre-queue read finds the combatant, but by the time the queued
+		// mutation re-fetches a fresh document the combatant has been removed
+		// from the combat, so the write is skipped.
+		const originalGet = combatants.get;
+		let hasServedPreQueueRead = false;
+		combatants.get = (id: string) => {
+			if (hasServedPreQueueRead) return null;
+			hasServedPreQueueRead = true;
+			return originalGet(id);
+		};
 		const combat = {
 			id: 'combat-action',
-			combatants: createCombatantsCollectionFixture([]),
+			combatants,
 		} as unknown as Combat;
 
 		const result = await consumeCombatantAction({
 			combat,
 			combatantId: 'c1',
-			fallbackCombatant,
 			actionCost: 1,
 		});
 
 		expect(result).toBe(3);
-		expect(fallbackCombatant.update).not.toHaveBeenCalled();
+		expect(combatant.update).not.toHaveBeenCalled();
+	});
+
+	it('recomputes overlapping deductions from the fresh combatant document', async () => {
+		const { combat, combatant } = createCombatWithCombatant('c1', 3);
+		combatant.update.mockImplementation(async (updates: Record<string, unknown>) => {
+			(
+				combatant.system as unknown as { actions: { base: { current: number } } }
+			).actions.base.current = updates['system.actions.base.current'] as number;
+			return { id: combatant.id };
+		});
+
+		const [firstResult, secondResult] = await Promise.all([
+			consumeCombatantAction({ combat, combatantId: 'c1', actionCost: 1 }),
+			consumeCombatantAction({ combat, combatantId: 'c1', actionCost: 1 }),
+		]);
+
+		expect(firstResult).toBe(2);
+		expect(secondResult).toBe(1);
+		expect(combatant.update).toHaveBeenNthCalledWith(1, { 'system.actions.base.current': 2 });
+		expect(combatant.update).toHaveBeenNthCalledWith(2, { 'system.actions.base.current': 1 });
 	});
 
 	describe('action-tracking automation gate', () => {

--- a/src/utils/combatTurnActions.ts
+++ b/src/utils/combatTurnActions.ts
@@ -375,11 +375,9 @@ export async function requestSwapCombatTurn(params: {
 export async function consumeCombatantAction(params: {
 	combat: Combat;
 	combatantId: string;
-	fallbackCombatant?: Combatant.Implementation | null;
 	actionCost?: number;
 }): Promise<number> {
-	const combatant =
-		params.combat.combatants.get(params.combatantId) ?? params.fallbackCombatant ?? null;
+	const combatant = params.combat.combatants.get(params.combatantId) ?? null;
 	if (!combatant) return 0;
 
 	// With action-tracking automation off, item use never deducts actions. The
@@ -387,18 +385,26 @@ export async function consumeCombatantAction(params: {
 	// callers must not branch on it.
 	if (!isActionTrackingAutomationEnabled()) return getCombatantCurrentActions(combatant);
 
-	const currentActions = getCombatantCurrentActions(combatant);
-	if (currentActions < 1) return 0;
+	// Cheap early-out on a possibly stale snapshot. The queued mutation below
+	// recomputes from the fresh document before writing, so at worst a stale
+	// zero here skips a deduction; it can never cause an incorrect write.
+	const snapshotActions = getCombatantCurrentActions(combatant);
+	if (snapshotActions < 1) return 0;
 
 	const cost = Number(params.actionCost ?? 1);
 	const normalizedCost = Number.isFinite(cost) && cost >= 0 ? cost : 1;
-	if (normalizedCost === 0) return currentActions;
+	if (normalizedCost === 0) return snapshotActions;
 
-	const nextActions = Math.max(0, currentActions - normalizedCost);
 	const appliedActions = await queueCombatantMutationWithFreshDocument({
 		combat: params.combat,
 		combatantId: params.combatantId,
 		mutation: async (currentCombatant) => {
+			// Recompute from the fresh document so overlapping deductions each
+			// apply on top of the latest persisted value instead of a shared
+			// pre-queue snapshot clobbering one another.
+			const currentActions = getCombatantCurrentActions(currentCombatant);
+			const nextActions = Math.max(0, currentActions - normalizedCost);
+			if (nextActions === currentActions) return currentActions;
 			await currentCombatant.update({
 				[COMBATANT_ACTIONS_CURRENT_PATH]: nextActions,
 			} as Record<string, unknown>);
@@ -408,7 +414,7 @@ export async function consumeCombatantAction(params: {
 	// A skipped write (the combatant vanished before the queued mutation ran)
 	// leaves the action count unchanged, so report the value that is actually
 	// persisted rather than the deduction we intended to make.
-	return appliedActions ?? currentActions;
+	return appliedActions ?? snapshotActions;
 }
 
 export async function maybeAdvanceTurnForCombatant(params: {

--- a/src/utils/combatTurnActions.ts
+++ b/src/utils/combatTurnActions.ts
@@ -2,6 +2,7 @@ import { isActionTrackingAutomationEnabled } from '../settings/automationSetting
 import { getActorDyingActionLimit, isActorDying } from './actorHealthState.js';
 import { combatantActionMutationQueue } from './combatantActionMutationQueue.js';
 import { isCombatantDead } from './isCombatantDead.js';
+import { queueCombatantMutationWithFreshDocument } from './queueCombatantMutationWithFreshDocument.js';
 
 export const COMBATANT_ACTIONS_CURRENT_PATH = 'system.actions.base.current';
 export const COMBATANT_ACTIONS_MAX_PATH = 'system.actions.base.max';
@@ -390,13 +391,19 @@ export async function consumeCombatantAction(params: {
 	if (currentActions < 1) return 0;
 
 	const cost = Number(params.actionCost ?? 1);
-	const normalizedCost = Number.isFinite(cost) && cost >= 1 ? cost : 1;
+	const normalizedCost = Number.isFinite(cost) && cost >= 0 ? cost : 1;
+	if (normalizedCost === 0) return currentActions;
+
 	const nextActions = Math.max(0, currentActions - normalizedCost);
-	const actionUpdate: Record<string, unknown> = {
-		_id: params.combatantId,
-		[COMBATANT_ACTIONS_CURRENT_PATH]: nextActions,
-	};
-	await params.combat.updateEmbeddedDocuments('Combatant', [actionUpdate]);
+	await queueCombatantMutationWithFreshDocument({
+		combat: params.combat,
+		combatantId: params.combatantId,
+		mutation: async (currentCombatant) => {
+			await currentCombatant.update({
+				[COMBATANT_ACTIONS_CURRENT_PATH]: nextActions,
+			} as Record<string, unknown>);
+		},
+	});
 	return nextActions;
 }
 

--- a/src/utils/combatTurnActions.ts
+++ b/src/utils/combatTurnActions.ts
@@ -395,16 +395,20 @@ export async function consumeCombatantAction(params: {
 	if (normalizedCost === 0) return currentActions;
 
 	const nextActions = Math.max(0, currentActions - normalizedCost);
-	await queueCombatantMutationWithFreshDocument({
+	const appliedActions = await queueCombatantMutationWithFreshDocument({
 		combat: params.combat,
 		combatantId: params.combatantId,
 		mutation: async (currentCombatant) => {
 			await currentCombatant.update({
 				[COMBATANT_ACTIONS_CURRENT_PATH]: nextActions,
 			} as Record<string, unknown>);
+			return nextActions;
 		},
 	});
-	return nextActions;
+	// A skipped write (the combatant vanished before the queued mutation ran)
+	// leaves the action count unchanged, so report the value that is actually
+	// persisted rather than the deduction we intended to make.
+	return appliedActions ?? currentActions;
 }
 
 export async function maybeAdvanceTurnForCombatant(params: {

--- a/src/utils/formatActivationCostLabel.test.ts
+++ b/src/utils/formatActivationCostLabel.test.ts
@@ -37,7 +37,46 @@ describe('formatActivationCostLabel', () => {
 	it('returns null for the cost types that carry no quantity', () => {
 		expect(formatActivationCostLabel({ type: 'none', quantity: 1 })).toBeNull();
 		expect(formatActivationCostLabel({ type: 'special', quantity: 1 })).toBeNull();
-		expect(formatActivationCostLabel({ type: 'reaction', quantity: 1 })).toBeNull();
+	});
+
+	describe('reactions', () => {
+		it('names the reaction rather than counting actions at the default cost', () => {
+			expect(formatActivationCostLabel({ type: 'action', quantity: 1, isReaction: true })).toBe(
+				'Reaction',
+			);
+		});
+
+		it('spells out an action cost above the default of one', () => {
+			// One reaction costing two actions, never "2 Reactions".
+			expect(formatActivationCostLabel({ type: 'action', quantity: 2, isReaction: true })).toBe(
+				'Reaction (2 Actions)',
+			);
+			expect(formatActivationCostLabel({ type: 'action', quantity: 3, isReaction: true })).toBe(
+				'Reaction (3 Actions)',
+			);
+		});
+
+		it('renders a zero-cost reaction as a free reaction', () => {
+			expect(formatActivationCostLabel({ type: 'action', quantity: 0, isReaction: true })).toBe(
+				'Free Reaction',
+			);
+		});
+
+		it('reads the legacy reaction cost type the same way', () => {
+			// Authored before `isReaction` split "what it costs" from "when you pay
+			// it"; these used to render the literal string "undefined".
+			expect(formatActivationCostLabel({ type: 'reaction', quantity: 1 })).toBe('Reaction');
+			expect(formatActivationCostLabel({ type: 'reaction', quantity: 2 })).toBe(
+				'Reaction (2 Actions)',
+			);
+			expect(formatActivationCostLabel({ type: 'reaction' })).toBe('Reaction');
+		});
+
+		it('ignores the flag on an elapsed-time cost, which is not a reaction', () => {
+			expect(formatActivationCostLabel({ type: 'minute', quantity: 10, isReaction: true })).toBe(
+				'10 Minutes',
+			);
+		});
 	});
 
 	it('returns null for a missing or empty cost', () => {

--- a/src/utils/formatActivationCostLabel.test.ts
+++ b/src/utils/formatActivationCostLabel.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import formatActivationCostLabel from './formatActivationCostLabel.js';
+
+describe('formatActivationCostLabel', () => {
+	it('renders a single action', () => {
+		expect(formatActivationCostLabel({ type: 'action', quantity: 1 })).toBe('1 Action');
+	});
+
+	it('pluralises multiple actions', () => {
+		expect(formatActivationCostLabel({ type: 'action', quantity: 2 })).toBe('2 Actions');
+		expect(formatActivationCostLabel({ type: 'action', quantity: 3 })).toBe('3 Actions');
+	});
+
+	it('renders an explicit zero action cost as Free', () => {
+		expect(formatActivationCostLabel({ type: 'action', quantity: 0 })).toBe('Free');
+	});
+
+	it('renders the elapsed-time units', () => {
+		expect(formatActivationCostLabel({ type: 'minute', quantity: 1 })).toBe('1 Minute');
+		expect(formatActivationCostLabel({ type: 'minute', quantity: 10 })).toBe('10 Minutes');
+		expect(formatActivationCostLabel({ type: 'hour', quantity: 1 })).toBe('1 Hour');
+		expect(formatActivationCostLabel({ type: 'hour', quantity: 24 })).toBe('24 Hours');
+	});
+
+	it('never renders an elapsed-time unit as Free', () => {
+		// `min: 0` is shared across every cost type, so a clamped zero can reach
+		// here; a single unit is the closest sensible reading of "0 minutes".
+		expect(formatActivationCostLabel({ type: 'minute', quantity: 0 })).toBe('1 Minute');
+		expect(formatActivationCostLabel({ type: 'hour', quantity: 0 })).toBe('1 Hour');
+	});
+
+	it('defaults a missing quantity to a single unit', () => {
+		expect(formatActivationCostLabel({ type: 'action' })).toBe('1 Action');
+		expect(formatActivationCostLabel({ type: 'minute' })).toBe('1 Minute');
+	});
+
+	it('returns null for the cost types that carry no quantity', () => {
+		expect(formatActivationCostLabel({ type: 'none', quantity: 1 })).toBeNull();
+		expect(formatActivationCostLabel({ type: 'special', quantity: 1 })).toBeNull();
+		expect(formatActivationCostLabel({ type: 'reaction', quantity: 1 })).toBeNull();
+	});
+
+	it('returns null for a missing or empty cost', () => {
+		expect(formatActivationCostLabel(null)).toBeNull();
+		expect(formatActivationCostLabel(undefined)).toBeNull();
+		expect(formatActivationCostLabel({})).toBeNull();
+	});
+});

--- a/src/utils/formatActivationCostLabel.ts
+++ b/src/utils/formatActivationCostLabel.ts
@@ -2,8 +2,8 @@ import localize from './localize.ts';
 
 /**
  * The activation cost types that are rendered as a quantity plus a unit. Every
- * other type (`none`, `special`, `reaction`) carries no number and is labelled
- * by its call site, which decides what extra detail to hang off it.
+ * other type (`none`, `special`) carries no number and is labelled by its call
+ * site, which decides what extra detail to hang off it.
  */
 const QUANTIFIED_COST_TYPES = ['action', 'minute', 'hour'] as const;
 
@@ -12,6 +12,7 @@ type QuantifiedCostType = (typeof QUANTIFIED_COST_TYPES)[number];
 export interface ActivationCost {
 	type?: string;
 	quantity?: number;
+	isReaction?: boolean;
 }
 
 function isQuantifiedCostType(type: string | undefined): type is QuantifiedCostType {
@@ -19,7 +20,24 @@ function isQuantifiedCostType(type: string | undefined): type is QuantifiedCostT
 }
 
 /**
+ * Whether a cost is paid as a reaction. `isReaction` is the current shape, set
+ * alongside an ordinary action cost; `type: 'reaction'` is the legacy shape from
+ * before the flag split "what it costs" from "when you pay it", and survives in
+ * worlds authored against that model.
+ */
+function isReactionCost(cost: ActivationCost | null | undefined): boolean {
+	if (cost?.type === 'reaction') return true;
+	return cost?.isReaction === true && cost.type === 'action';
+}
+
+/**
  * Renders an activation cost as "1 Action", "2 Actions", "10 Minutes" or "Free".
+ *
+ * Reactions read as "Reaction", "Reaction (2 Actions)" or "Free Reaction". A
+ * reaction is a single response that costs actions rather than a resource you
+ * spend several of, so the count never pluralises the reaction itself, and the
+ * action cost is only spelled out when it differs from the default of one
+ * (CoreRules-2:438, "Reactions cost 1 action").
  *
  * Returns `null` for costs that carry no quantity, leaving the caller to label
  * them; `PlayerCharacterSpellsTab` appends a tooltip to those, the other sheets
@@ -35,6 +53,18 @@ export default function formatActivationCostLabel(
 	cost: ActivationCost | null | undefined,
 ): string | null {
 	const { activationCostTypes, activationCostTypesPlural } = CONFIG.NIMBLE;
+
+	if (isReactionCost(cost)) {
+		const actionCost = normalizeQuantity(cost?.quantity);
+
+		if (cost?.quantity === 0) return localize('NIMBLE.activationCosts.freeReaction');
+		if (actionCost === 1) return localize('NIMBLE.activationCosts.reaction');
+
+		return localize('NIMBLE.activationCosts.reactionWithCost', {
+			cost: `${actionCost} ${activationCostTypesPlural.action}`,
+		});
+	}
+
 	const type = cost?.type;
 
 	if (!isQuantifiedCostType(type)) return null;
@@ -43,9 +73,13 @@ export default function formatActivationCostLabel(
 		return localize('NIMBLE.activationCosts.free');
 	}
 
-	const rawQuantity = Number(cost?.quantity);
-	const quantity = Number.isFinite(rawQuantity) && rawQuantity > 0 ? rawQuantity : 1;
+	const quantity = normalizeQuantity(cost?.quantity);
 	const unit = quantity > 1 ? activationCostTypesPlural[type] : activationCostTypes[type];
 
 	return `${quantity} ${unit}`;
+}
+
+function normalizeQuantity(quantity: number | undefined): number {
+	const parsed = Number(quantity);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : 1;
 }

--- a/src/utils/formatActivationCostLabel.ts
+++ b/src/utils/formatActivationCostLabel.ts
@@ -1,0 +1,51 @@
+import localize from './localize.ts';
+
+/**
+ * The activation cost types that are rendered as a quantity plus a unit. Every
+ * other type (`none`, `special`, `reaction`) carries no number and is labelled
+ * by its call site, which decides what extra detail to hang off it.
+ */
+const QUANTIFIED_COST_TYPES = ['action', 'minute', 'hour'] as const;
+
+type QuantifiedCostType = (typeof QUANTIFIED_COST_TYPES)[number];
+
+export interface ActivationCost {
+	type?: string;
+	quantity?: number;
+}
+
+function isQuantifiedCostType(type: string | undefined): type is QuantifiedCostType {
+	return QUANTIFIED_COST_TYPES.includes(type as QuantifiedCostType);
+}
+
+/**
+ * Renders an activation cost as "1 Action", "2 Actions", "10 Minutes" or "Free".
+ *
+ * Returns `null` for costs that carry no quantity, leaving the caller to label
+ * them; `PlayerCharacterSpellsTab` appends a tooltip to those, the other sheets
+ * print the bare type.
+ *
+ * A zero-quantity action is the system's free activation. The elapsed-time units
+ * have no equivalent — there is no zero minutes — but `min: 0` on the schema is
+ * shared by every cost type, so a clamped zero can still reach here through pack
+ * JSON or a migration. Those fall back to a single unit rather than rendering a
+ * nonsensical "0 Minutes".
+ */
+export default function formatActivationCostLabel(
+	cost: ActivationCost | null | undefined,
+): string | null {
+	const { activationCostTypes, activationCostTypesPlural } = CONFIG.NIMBLE;
+	const type = cost?.type;
+
+	if (!isQuantifiedCostType(type)) return null;
+
+	if (type === 'action' && cost?.quantity === 0) {
+		return localize('NIMBLE.activationCosts.free');
+	}
+
+	const rawQuantity = Number(cost?.quantity);
+	const quantity = Number.isFinite(rawQuantity) && rawQuantity > 0 ? rawQuantity : 1;
+	const unit = quantity > 1 ? activationCostTypesPlural[type] : activationCostTypes[type];
+
+	return `${quantity} ${unit}`;
+}

--- a/src/utils/resolveItemActionCost.test.ts
+++ b/src/utils/resolveItemActionCost.test.ts
@@ -2,25 +2,36 @@ import { describe, expect, it } from 'vitest';
 import resolveItemActionCost from './resolveItemActionCost.js';
 
 describe('resolveItemActionCost', () => {
-	it('returns 1 when item is null', () => {
-		expect(resolveItemActionCost(null)).toBe(1);
+	it('returns 0 when item is null', () => {
+		expect(resolveItemActionCost(null)).toBe(0);
 	});
 
-	it('returns 1 when system is missing', () => {
-		expect(resolveItemActionCost({} as Parameters<typeof resolveItemActionCost>[0])).toBe(1);
+	it('returns 0 when system is missing', () => {
+		expect(resolveItemActionCost({} as Parameters<typeof resolveItemActionCost>[0])).toBe(0);
 	});
 
-	it('returns 1 when activation is missing', () => {
-		expect(resolveItemActionCost({ system: {} })).toBe(1);
+	it('returns 0 when activation is missing', () => {
+		expect(resolveItemActionCost({ system: {} })).toBe(0);
 	});
 
-	it('returns 1 when cost is missing', () => {
-		expect(resolveItemActionCost({ system: { activation: {} } })).toBe(1);
+	it('returns 0 when cost is missing', () => {
+		expect(resolveItemActionCost({ system: { activation: {} } })).toBe(0);
 	});
 
-	it('returns 1 when cost type is not action', () => {
+	it('returns 0 when cost type is not action', () => {
 		expect(
 			resolveItemActionCost({ system: { activation: { cost: { type: 'bonus', quantity: 2 } } } }),
+		).toBe(0);
+		expect(
+			resolveItemActionCost({ system: { activation: { cost: { type: 'none', quantity: 1 } } } }),
+		).toBe(0);
+	});
+
+	it('returns 1 when quantity is missing on an action cost', () => {
+		expect(
+			resolveItemActionCost({
+				system: { activation: { cost: { type: 'action' } } },
+			}),
 		).toBe(1);
 	});
 
@@ -40,12 +51,12 @@ describe('resolveItemActionCost', () => {
 		).toBe(1);
 	});
 
-	it('returns 1 when quantity is zero', () => {
+	it('returns 0 when quantity is explicitly zero', () => {
 		expect(
 			resolveItemActionCost({
 				system: { activation: { cost: { type: 'action', quantity: 0 } } },
 			}),
-		).toBe(1);
+		).toBe(0);
 	});
 
 	it('returns the correct quantity for valid action costs', () => {

--- a/src/utils/resolveItemActionCost.ts
+++ b/src/utils/resolveItemActionCost.ts
@@ -10,7 +10,7 @@ interface ItemWithActivationCost {
 
 export default function resolveItemActionCost(item: ItemWithActivationCost | null): number {
 	const cost = item?.system?.activation?.cost;
-	if (!cost || cost.type !== 'action') return DEFAULT_ACTION_COST;
+	if (!cost || cost.type !== 'action') return 0;
 	const quantity = Number(cost.quantity ?? DEFAULT_ACTION_COST);
-	return Number.isFinite(quantity) && quantity >= 1 ? quantity : DEFAULT_ACTION_COST;
+	return Number.isFinite(quantity) && quantity >= 0 ? quantity : DEFAULT_ACTION_COST;
 }

--- a/src/utils/resolveItemActionCost.ts
+++ b/src/utils/resolveItemActionCost.ts
@@ -1,6 +1,6 @@
 const DEFAULT_ACTION_COST = 1;
 
-interface ItemWithActivationCost {
+export interface ItemWithActivationCost {
 	system?: {
 		activation?: {
 			cost?: { type?: string; quantity?: number };

--- a/src/utils/resolveMinionAttackActionCost.test.ts
+++ b/src/utils/resolveMinionAttackActionCost.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import resolveMinionAttackActionCost from './resolveMinionAttackActionCost.js';
+
+describe('resolveMinionAttackActionCost', () => {
+	it('defaults to 1 when the item is null', () => {
+		expect(resolveMinionAttackActionCost(null)).toBe(1);
+	});
+
+	it('defaults to 1 when the activation cost is missing', () => {
+		expect(resolveMinionAttackActionCost({ system: { activation: {} } })).toBe(1);
+	});
+
+	it('defaults to 1 when the cost type is missing', () => {
+		expect(
+			resolveMinionAttackActionCost({ system: { activation: { cost: { quantity: 2 } } } }),
+		).toBe(1);
+	});
+
+	it('defaults to 1 when the cost type is none', () => {
+		expect(
+			resolveMinionAttackActionCost({
+				system: { activation: { cost: { type: 'none', quantity: 1 } } },
+			}),
+		).toBe(1);
+	});
+
+	it('returns 0 for an explicit zero action cost', () => {
+		expect(
+			resolveMinionAttackActionCost({
+				system: { activation: { cost: { type: 'action', quantity: 0 } } },
+			}),
+		).toBe(0);
+	});
+
+	it('returns the authored quantity for action costs', () => {
+		expect(
+			resolveMinionAttackActionCost({
+				system: { activation: { cost: { type: 'action', quantity: 2 } } },
+			}),
+		).toBe(2);
+	});
+});

--- a/src/utils/resolveMinionAttackActionCost.test.ts
+++ b/src/utils/resolveMinionAttackActionCost.test.ts
@@ -24,6 +24,27 @@ describe('resolveMinionAttackActionCost', () => {
 		).toBe(1);
 	});
 
+	it('defaults to 1 for any non-action cost type', () => {
+		expect(
+			resolveMinionAttackActionCost({
+				system: { activation: { cost: { type: 'minute', quantity: 10 } } },
+			}),
+		).toBe(1);
+		expect(
+			resolveMinionAttackActionCost({
+				system: { activation: { cost: { type: 'special', quantity: 0 } } },
+			}),
+		).toBe(1);
+	});
+
+	it('defaults the quantity to 1 for an action cost with no quantity', () => {
+		expect(
+			resolveMinionAttackActionCost({
+				system: { activation: { cost: { type: 'action' } } },
+			}),
+		).toBe(1);
+	});
+
 	it('returns 0 for an explicit zero action cost', () => {
 		expect(
 			resolveMinionAttackActionCost({

--- a/src/utils/resolveMinionAttackActionCost.ts
+++ b/src/utils/resolveMinionAttackActionCost.ts
@@ -3,14 +3,15 @@ import resolveItemActionCost, { type ItemWithActivationCost } from './resolveIte
 /**
  * Resolves the action cost a group-attack activation charges a combatant.
  *
- * Legacy pack content routinely ships attack actions with no activation cost
- * or a cost of type `none` while still representing a standard attack that
- * spends one action, so those default to a cost of one. An explicitly
- * authored action cost is honoured as written, including an explicit zero,
- * which stays genuinely free.
+ * Only an explicit `action` cost is honoured as written, including an
+ * explicit zero, which stays genuinely free (a missing quantity defaults to
+ * one). Every other activation cost, whether missing, `none`, or any
+ * non-action type, charges the standard single action, because legacy pack
+ * content routinely ships attack actions with such costs while still
+ * representing a standard attack that spends one action.
  */
 export default function resolveMinionAttackActionCost(item: ItemWithActivationCost | null): number {
 	const cost = item?.system?.activation?.cost;
-	if (!cost?.type || cost.type === 'none') return 1;
+	if (cost?.type !== 'action') return 1;
 	return resolveItemActionCost(item);
 }

--- a/src/utils/resolveMinionAttackActionCost.ts
+++ b/src/utils/resolveMinionAttackActionCost.ts
@@ -1,0 +1,16 @@
+import resolveItemActionCost, { type ItemWithActivationCost } from './resolveItemActionCost.js';
+
+/**
+ * Resolves the action cost a group-attack activation charges a combatant.
+ *
+ * Legacy pack content routinely ships attack actions with no activation cost
+ * or a cost of type `none` while still representing a standard attack that
+ * spends one action, so those default to a cost of one. An explicitly
+ * authored action cost is honoured as written, including an explicit zero,
+ * which stays genuinely free.
+ */
+export default function resolveMinionAttackActionCost(item: ItemWithActivationCost | null): number {
+	const cost = item?.system?.activation?.cost;
+	if (!cost?.type || cost.type === 'none') return 1;
+	return resolveItemActionCost(item);
+}

--- a/src/view/dialogs/components/characterCreator/SpellReferenceCard.svelte.test.ts
+++ b/src/view/dialogs/components/characterCreator/SpellReferenceCard.svelte.test.ts
@@ -2,7 +2,39 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { createSpellCardState } from './SpellReferenceCard.svelte.js';
 
+function createSpellFixture(cost: { type?: string; quantity?: number }): Item {
+	return {
+		name: 'Shadow Blast',
+		system: {
+			tier: 1,
+			description: { baseEffect: '<p>Base Effect</p>' },
+			activation: {
+				cost,
+				targets: { count: 1 },
+				acquireTargetsFromTemplate: false,
+				effects: [],
+			},
+			properties: {
+				selected: ['range'],
+				range: { max: 8 },
+			},
+		},
+	} as unknown as Item;
+}
+
 describe('createSpellCardState', () => {
+	it('shows the localized Free label for an explicit zero action cost', () => {
+		const state = createSpellCardState(() => createSpellFixture({ type: 'action', quantity: 0 }));
+
+		expect(state.displayData.meta).toBe('Free');
+	});
+
+	it('defaults a missing action cost quantity to a single action', () => {
+		const state = createSpellCardState(() => createSpellFixture({ type: 'action' }));
+
+		expect(state.displayData.meta).toBe('1 Action');
+	});
+
 	it('lazily enriches a combined spell description once and opens the spell sheet on demand', async () => {
 		const enrichHtml = vi
 			.mocked(foundry.applications.ux.TextEditor.implementation.enrichHTML)

--- a/src/view/dialogs/components/characterCreator/SpellReferenceCard.svelte.ts
+++ b/src/view/dialogs/components/characterCreator/SpellReferenceCard.svelte.ts
@@ -75,6 +75,10 @@ function getSpellMetadata(system: SpellSystemData): string | null {
 	if (!activationType || activationType === 'none') return null;
 
 	if (['action', 'minute', 'hour'].includes(activationType)) {
+		if (activationType === 'action' && activationCost === 0) {
+			return localize('NIMBLE.activationCosts.free');
+		}
+
 		const label =
 			activationCost > 1
 				? activationCostTypesPlural[activationType]

--- a/src/view/dialogs/components/characterCreator/SpellReferenceCard.svelte.ts
+++ b/src/view/dialogs/components/characterCreator/SpellReferenceCard.svelte.ts
@@ -4,6 +4,7 @@ import type {
 	SpellSystemData,
 } from '#types/components/SpellReferenceCard.d.ts';
 import { flattenActivationEffects } from '#utils/activationEffects.js';
+import formatActivationCostLabel from '#utils/formatActivationCostLabel.js';
 import localize from '#utils/localize.js';
 import enrichSpellText from '#utils/spellDescription.js';
 
@@ -66,7 +67,7 @@ function getSpellEffect(system: SpellSystemData): SpellEffect | null {
  * Gets the activation cost metadata for a spell (e.g., "1 Action", "Reaction")
  */
 function getSpellMetadata(system: SpellSystemData): string | null {
-	const { activationCostTypes, activationCostTypesPlural } = CONFIG.NIMBLE;
+	const { activationCostTypes } = CONFIG.NIMBLE;
 	const activation = system.activation;
 	if (!activation?.cost) return null;
 
@@ -74,17 +75,11 @@ function getSpellMetadata(system: SpellSystemData): string | null {
 
 	if (!activationType || activationType === 'none') return null;
 
-	if (['action', 'minute', 'hour'].includes(activationType)) {
-		if (activationType === 'action' && activationCost === 0) {
-			return localize('NIMBLE.activationCosts.free');
-		}
-
-		const label =
-			activationCost > 1
-				? activationCostTypesPlural[activationType]
-				: activationCostTypes[activationType];
-		return `${activationCost || 1} ${label}`;
-	}
+	const quantifiedLabel = formatActivationCostLabel({
+		type: activationType,
+		quantity: activationCost,
+	});
+	if (quantifiedLabel) return quantifiedLabel;
 
 	if (activationType === 'reaction' || activationType === 'special') {
 		return activationCostTypes[activationType];

--- a/src/view/dialogs/components/characterCreator/SpellReferenceCard.svelte.ts
+++ b/src/view/dialogs/components/characterCreator/SpellReferenceCard.svelte.ts
@@ -71,18 +71,15 @@ function getSpellMetadata(system: SpellSystemData): string | null {
 	const activation = system.activation;
 	if (!activation?.cost) return null;
 
-	const { type: activationType, quantity: activationCost } = activation.cost;
+	const { type: activationType } = activation.cost;
 
 	if (!activationType || activationType === 'none') return null;
 
-	const quantifiedLabel = formatActivationCostLabel({
-		type: activationType,
-		quantity: activationCost,
-	});
-	if (quantifiedLabel) return quantifiedLabel;
+	const label = formatActivationCostLabel(activation.cost);
+	if (label) return label;
 
-	if (activationType === 'reaction' || activationType === 'special') {
-		return activationCostTypes[activationType];
+	if (activationType === 'special') {
+		return activationCostTypes.special;
 	}
 
 	return null;

--- a/src/view/dialogs/components/levelUpHelper/LevelUpSpellCard.svelte.ts
+++ b/src/view/dialogs/components/levelUpHelper/LevelUpSpellCard.svelte.ts
@@ -20,12 +20,12 @@ function extractDisplayData(system: SpellSystemDataWithMana): SpellDisplayData {
 	let meta: string | null = null;
 	const activation = system.activation;
 	if (activation?.cost) {
-		const { type: activationType, quantity: activationCost } = activation.cost;
+		const { type: activationType } = activation.cost;
 		if (activationType && activationType !== 'none') {
-			meta = formatActivationCostLabel({ type: activationType, quantity: activationCost });
+			meta = formatActivationCostLabel(activation.cost);
 
-			if (!meta && (activationType === 'reaction' || activationType === 'special')) {
-				meta = activationCostTypes[activationType];
+			if (!meta && activationType === 'special') {
+				meta = activationCostTypes.special;
 			}
 		}
 	}

--- a/src/view/dialogs/components/levelUpHelper/LevelUpSpellCard.svelte.ts
+++ b/src/view/dialogs/components/levelUpHelper/LevelUpSpellCard.svelte.ts
@@ -1,6 +1,7 @@
 import type { SpellDisplayData } from '#types/components/LevelUpSpellCard.d.ts';
 import type { SpellSystemData } from '#types/components/SpellReferenceCard.d.ts';
 import { flattenActivationEffects } from '#utils/activationEffects.js';
+import formatActivationCostLabel from '#utils/formatActivationCostLabel.js';
 import type { SpellIndexEntry } from '#utils/getSpells.js';
 import localize from '#utils/localize.js';
 
@@ -13,7 +14,7 @@ interface SpellSystemDataWithMana extends SpellSystemData {
  * Extracts display data from a spell's system data for rendering in the card.
  */
 function extractDisplayData(system: SpellSystemDataWithMana): SpellDisplayData {
-	const { activationCostTypes, activationCostTypesPlural } = CONFIG.NIMBLE;
+	const { activationCostTypes } = CONFIG.NIMBLE;
 
 	// Action cost
 	let meta: string | null = null;
@@ -21,15 +22,9 @@ function extractDisplayData(system: SpellSystemDataWithMana): SpellDisplayData {
 	if (activation?.cost) {
 		const { type: activationType, quantity: activationCost } = activation.cost;
 		if (activationType && activationType !== 'none') {
-			if (activationType === 'action' && activationCost === 0) {
-				meta = localize('NIMBLE.activationCosts.free');
-			} else if (['action', 'minute', 'hour'].includes(activationType)) {
-				const label =
-					activationCost > 1
-						? activationCostTypesPlural[activationType]
-						: activationCostTypes[activationType];
-				meta = `${activationCost || 1} ${label}`;
-			} else if (activationType === 'reaction' || activationType === 'special') {
+			meta = formatActivationCostLabel({ type: activationType, quantity: activationCost });
+
+			if (!meta && (activationType === 'reaction' || activationType === 'special')) {
 				meta = activationCostTypes[activationType];
 			}
 		}

--- a/src/view/dialogs/components/levelUpHelper/LevelUpSpellCard.svelte.ts
+++ b/src/view/dialogs/components/levelUpHelper/LevelUpSpellCard.svelte.ts
@@ -21,7 +21,9 @@ function extractDisplayData(system: SpellSystemDataWithMana): SpellDisplayData {
 	if (activation?.cost) {
 		const { type: activationType, quantity: activationCost } = activation.cost;
 		if (activationType && activationType !== 'none') {
-			if (['action', 'minute', 'hour'].includes(activationType)) {
+			if (activationType === 'action' && activationCost === 0) {
+				meta = localize('NIMBLE.activationCosts.free');
+			} else if (['action', 'minute', 'hour'].includes(activationType)) {
 				const label =
 					activationCost > 1
 						? activationCostTypesPlural[activationType]

--- a/src/view/sheets/character/pdfExport/generatePdfContent.ts
+++ b/src/view/sheets/character/pdfExport/generatePdfContent.ts
@@ -313,7 +313,7 @@ function extractSpellDetails(spell: NimbleSpellItem): string {
 	if (cost?.type && cost.type !== 'none' && cost.type !== 'mana') {
 		let castingTimeStr: string;
 		if (cost.type === 'action' && cost.quantity === 0) {
-			castingTimeStr = 'Free';
+			castingTimeStr = game.i18n.localize('NIMBLE.activationCosts.free');
 		} else {
 			castingTimeStr = cost.quantity > 1 ? `${cost.quantity} ${cost.type}s` : `1 ${cost.type}`;
 		}

--- a/src/view/sheets/character/pdfExport/generatePdfContent.ts
+++ b/src/view/sheets/character/pdfExport/generatePdfContent.ts
@@ -311,7 +311,12 @@ function extractSpellDetails(spell: NimbleSpellItem): string {
 	const hasReach = properties?.selected?.includes('reach') && properties.reach?.min;
 
 	if (cost?.type && cost.type !== 'none' && cost.type !== 'mana') {
-		let castingTimeStr = cost.quantity > 1 ? `${cost.quantity} ${cost.type}s` : `1 ${cost.type}`;
+		let castingTimeStr: string;
+		if (cost.type === 'action' && cost.quantity === 0) {
+			castingTimeStr = 'Free';
+		} else {
+			castingTimeStr = cost.quantity > 1 ? `${cost.quantity} ${cost.type}s` : `1 ${cost.type}`;
+		}
 
 		// Add target type suffix
 		if (hasTemplate) {

--- a/src/view/sheets/character/pdfExport/generatePdfContent.ts
+++ b/src/view/sheets/character/pdfExport/generatePdfContent.ts
@@ -4,6 +4,7 @@ import type { NimbleFeatureItem } from '#documents/item/feature.js';
 import type { NimbleObjectItem } from '#documents/item/object.js';
 import type { NimbleSpellItem } from '#documents/item/spell.js';
 import type { NimbleSubclassItem } from '#documents/item/subclass.js';
+import formatActivationCostLabel from '#utils/formatActivationCostLabel.js';
 
 /** Estimated characters per column based on PDF config */
 const CHARS_PER_COLUMN = 1150;
@@ -311,21 +312,21 @@ function extractSpellDetails(spell: NimbleSpellItem): string {
 	const hasReach = properties?.selected?.includes('reach') && properties.reach?.min;
 
 	if (cost?.type && cost.type !== 'none' && cost.type !== 'mana') {
-		let castingTimeStr: string;
-		if (cost.type === 'action' && cost.quantity === 0) {
-			castingTimeStr = game.i18n.localize('NIMBLE.activationCosts.free');
-		} else {
-			castingTimeStr = cost.quantity > 1 ? `${cost.quantity} ${cost.type}s` : `1 ${cost.type}`;
-		}
+		// `special` carries no quantity, so the formatter returns null and it prints
+		// as the bare type rather than the pluralised "1 special" this used to emit.
+		let castingTimeStr =
+			formatActivationCostLabel(cost) ?? CONFIG.NIMBLE.activationCostTypes[cost.type] ?? null;
 
-		// Add target type suffix
-		if (hasTemplate) {
-			castingTimeStr += ' AOE';
-		} else if (!hasRange && !hasReach) {
-			castingTimeStr += ' self';
-		}
+		if (castingTimeStr) {
+			// Add target type suffix
+			if (hasTemplate) {
+				castingTimeStr += ' AOE';
+			} else if (!hasRange && !hasReach) {
+				castingTimeStr += ' self';
+			}
 
-		parts.push(castingTimeStr);
+			parts.push(castingTimeStr);
+		}
 	}
 
 	// Mana cost

--- a/src/view/sheets/components/CastSpellActionPanel.svelte.test.ts
+++ b/src/view/sheets/components/CastSpellActionPanel.svelte.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import type { NimbleCharacter } from '../../../documents/actor/character.js';
+import { createSpellPanelState } from './CastSpellActionPanel.svelte.js';
+
+function createSpellFixture(cost: { type: string; quantity?: number }): Item {
+	return {
+		system: {
+			activation: { cost },
+		},
+	} as unknown as Item;
+}
+
+function createPanelState() {
+	return createSpellPanelState(
+		() => ({ reactive: { items: [] } }) as unknown as NimbleCharacter,
+		() => async () => {},
+	);
+}
+
+describe('createSpellPanelState', () => {
+	describe('getSpellMetadata', () => {
+		it('shows the localized Free label for an explicit zero action cost', () => {
+			const state = createPanelState();
+
+			expect(state.getSpellMetadata(createSpellFixture({ type: 'action', quantity: 0 }))).toBe(
+				'Free',
+			);
+		});
+
+		it('defaults a missing action cost quantity to a single action', () => {
+			const state = createPanelState();
+
+			expect(state.getSpellMetadata(createSpellFixture({ type: 'action' }))).toBe('1 Action');
+		});
+
+		it('pluralizes multi-action costs', () => {
+			const state = createPanelState();
+
+			expect(state.getSpellMetadata(createSpellFixture({ type: 'action', quantity: 2 }))).toBe(
+				'2 Actions',
+			);
+		});
+	});
+});

--- a/src/view/sheets/components/CastSpellActionPanel.svelte.test.ts
+++ b/src/view/sheets/components/CastSpellActionPanel.svelte.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import type { NimbleCharacter } from '../../../documents/actor/character.js';
 import { createSpellPanelState } from './CastSpellActionPanel.svelte.js';
 
-function createSpellFixture(cost: { type: string; quantity?: number }): Item {
+function createSpellFixture(cost: { type: string; quantity?: number; isReaction?: boolean }): Item {
 	return {
 		system: {
 			activation: { cost },
@@ -39,6 +39,29 @@ describe('createSpellPanelState', () => {
 
 			expect(state.getSpellMetadata(createSpellFixture({ type: 'action', quantity: 2 }))).toBe(
 				'2 Actions',
+			);
+		});
+
+		it('names a reaction instead of counting its actions', () => {
+			const state = createPanelState();
+
+			expect(
+				state.getSpellMetadata(
+					createSpellFixture({ type: 'action', quantity: 1, isReaction: true }),
+				),
+			).toBe('Reaction');
+			expect(
+				state.getSpellMetadata(
+					createSpellFixture({ type: 'action', quantity: 2, isReaction: true }),
+				),
+			).toBe('Reaction (2 Actions)');
+		});
+
+		it('labels the legacy reaction cost type instead of rendering undefined', () => {
+			const state = createPanelState();
+
+			expect(state.getSpellMetadata(createSpellFixture({ type: 'reaction', quantity: 1 }))).toBe(
+				'Reaction',
 			);
 		});
 	});

--- a/src/view/sheets/components/CastSpellActionPanel.svelte.ts
+++ b/src/view/sheets/components/CastSpellActionPanel.svelte.ts
@@ -99,18 +99,15 @@ export function createSpellPanelState(
 		const activation = getSystemData(spell).activation;
 		if (!activation?.cost) return null;
 
-		const { type: activationType, quantity: activationCost } = activation.cost;
+		const { type: activationType } = activation.cost;
 
 		if (!activationType || activationType === 'none') return null;
 
-		const quantifiedLabel = formatActivationCostLabel({
-			type: activationType,
-			quantity: activationCost,
-		});
-		if (quantifiedLabel) return quantifiedLabel;
+		const label = formatActivationCostLabel(activation.cost);
+		if (label) return label;
 
-		if (activationType === 'reaction' || activationType === 'special') {
-			return activationCostTypes[activationType];
+		if (activationType === 'special') {
+			return activationCostTypes.special;
 		}
 
 		return null;

--- a/src/view/sheets/components/CastSpellActionPanel.svelte.ts
+++ b/src/view/sheets/components/CastSpellActionPanel.svelte.ts
@@ -1,6 +1,7 @@
 import type { NimbleCharacter } from '../../../documents/actor/character.js';
 import { flattenActivationEffects } from '../../../utils/activationEffects.js';
 import { evaluateFormula as evalFormula } from '../../../utils/evaluateFormula.js';
+import formatActivationCostLabel from '../../../utils/formatActivationCostLabel.js';
 import localize from '../../../utils/localize.js';
 import sortItems from '../../../utils/sortItems.js';
 import filterItems from '../../dataPreparationHelpers/filterItems.js';
@@ -40,7 +41,7 @@ export function createSpellPanelState(
 	getActor: () => NimbleCharacter,
 	_getOnActivateItem: () => (cost: number) => Promise<void>,
 ) {
-	const { activationCostTypes, activationCostTypesPlural } = CONFIG.NIMBLE;
+	const { activationCostTypes } = CONFIG.NIMBLE;
 	let searchTerm = $state('');
 	let expandedDescriptions = $state(new Set<string>());
 
@@ -102,17 +103,11 @@ export function createSpellPanelState(
 
 		if (!activationType || activationType === 'none') return null;
 
-		if (['action', 'minute', 'hour'].includes(activationType)) {
-			if (activationType === 'action' && activationCost === 0) {
-				return localize('NIMBLE.activationCosts.free');
-			}
-
-			const label =
-				activationCost > 1
-					? activationCostTypesPlural[activationType]
-					: activationCostTypes[activationType];
-			return `${activationCost || 1} ${label}`;
-		}
+		const quantifiedLabel = formatActivationCostLabel({
+			type: activationType,
+			quantity: activationCost,
+		});
+		if (quantifiedLabel) return quantifiedLabel;
 
 		if (activationType === 'reaction' || activationType === 'special') {
 			return activationCostTypes[activationType];

--- a/src/view/sheets/components/CastSpellActionPanel.svelte.ts
+++ b/src/view/sheets/components/CastSpellActionPanel.svelte.ts
@@ -103,6 +103,10 @@ export function createSpellPanelState(
 		if (!activationType || activationType === 'none') return null;
 
 		if (['action', 'minute', 'hour'].includes(activationType)) {
+			if (activationType === 'action' && activationCost === 0) {
+				return localize('NIMBLE.activationCosts.free');
+			}
+
 			const label =
 				activationCost > 1
 					? activationCostTypesPlural[activationType]

--- a/src/view/sheets/components/CustomReactionsPanel.svelte.ts
+++ b/src/view/sheets/components/CustomReactionsPanel.svelte.ts
@@ -49,7 +49,10 @@ export function createCustomReactionsPanelState(getActor: () => NimbleCharacter)
 		const quantity = cost.quantity ?? 1;
 		if (quantity !== 0 && quantity <= 1) return null;
 
-		return formatActivationCostLabel(cost);
+		// Everything in this panel is a reaction, so the reaction wording the
+		// formatter adds for `isReaction` would only repeat the heading. Ask it
+		// for the bare cost instead.
+		return formatActivationCostLabel({ type: cost.type, quantity });
 	}
 
 	/** The free-text reaction trigger configured under Activation > Core. */

--- a/src/view/sheets/components/CustomReactionsPanel.svelte.ts
+++ b/src/view/sheets/components/CustomReactionsPanel.svelte.ts
@@ -1,5 +1,6 @@
 import type { NimbleCharacter } from '../../../documents/actor/character.js';
 import type { NimbleBaseItem } from '../../../documents/item/base.svelte.js';
+import localize from '../../../utils/localize.js';
 
 /** A prepared embedded item always has a non-null `_id`. */
 export type ReactionItem = NimbleBaseItem & { _id: string };
@@ -38,13 +39,14 @@ export function createCustomReactionsPanelState(getActor: () => NimbleCharacter)
 
 	/**
 	 * The action cost label, shown only when the reaction costs more than a single
-	 * action (per the issue: "Action cost, if more than one").
+	 * action (per the issue: "Action cost, if more than one") or is explicitly free.
 	 */
 	function getActionCost(item: Item): string | null {
 		const cost = getActivation(item);
 		if (!cost || cost.type !== 'action') return null;
 
 		const quantity = cost.quantity ?? 1;
+		if (quantity === 0) return localize('NIMBLE.activationCosts.free');
 		if (quantity <= 1) return null;
 
 		return `${quantity} ${activationCostTypesPlural.action ?? activationCostTypes.action}`;

--- a/src/view/sheets/components/CustomReactionsPanel.svelte.ts
+++ b/src/view/sheets/components/CustomReactionsPanel.svelte.ts
@@ -1,6 +1,6 @@
 import type { NimbleCharacter } from '../../../documents/actor/character.js';
 import type { NimbleBaseItem } from '../../../documents/item/base.svelte.js';
-import localize from '../../../utils/localize.js';
+import formatActivationCostLabel from '../../../utils/formatActivationCostLabel.js';
 
 /** A prepared embedded item always has a non-null `_id`. */
 export type ReactionItem = NimbleBaseItem & { _id: string };
@@ -28,7 +28,6 @@ export function isCustomReaction(item: Item): boolean {
 }
 
 export function createCustomReactionsPanelState(getActor: () => NimbleCharacter) {
-	const { activationCostTypes, activationCostTypesPlural } = CONFIG.NIMBLE;
 	let expandedDescriptions = $state(new Set<string>());
 
 	const reactions = $derived(
@@ -45,11 +44,12 @@ export function createCustomReactionsPanelState(getActor: () => NimbleCharacter)
 		const cost = getActivation(item);
 		if (!cost || cost.type !== 'action') return null;
 
+		// A single action is the default and goes unlabelled; zero is not, so it
+		// falls through to the shared formatter and renders as "Free".
 		const quantity = cost.quantity ?? 1;
-		if (quantity === 0) return localize('NIMBLE.activationCosts.free');
-		if (quantity <= 1) return null;
+		if (quantity !== 0 && quantity <= 1) return null;
 
-		return `${quantity} ${activationCostTypesPlural.action ?? activationCostTypes.action}`;
+		return formatActivationCostLabel(cost);
 	}
 
 	/** The free-text reaction trigger configured under Activation > Core. */

--- a/src/view/sheets/components/CustomReactionsPanel.test.ts
+++ b/src/view/sheets/components/CustomReactionsPanel.test.ts
@@ -92,6 +92,17 @@ describe('CustomReactionsPanel', () => {
 		expect(screen.queryByText('1 Action')).not.toBeInTheDocument();
 	});
 
+	it('shows the localized Free label for an explicit zero action cost', () => {
+		const actor = createActor([
+			createItem({ id: 'free-reaction', name: 'Sidestep', isReaction: true, quantity: 0 }),
+		]);
+		const application = { _onDragStart: vi.fn() };
+
+		render(CustomReactionsPanelTestHarness, { actor, application });
+
+		expect(screen.getByText('Free')).toBeInTheDocument();
+	});
+
 	it('shows the configured reaction trigger', () => {
 		const actor = createActor([
 			createItem({

--- a/src/view/sheets/pages/ItemActivationCoreConfigTab.svelte
+++ b/src/view/sheets/pages/ItemActivationCoreConfigTab.svelte
@@ -47,6 +47,7 @@
 				{#if ['action', 'minute', 'hour'].includes(activationCostType)}
 					<input
 						type="number"
+						min="0"
 						value={activationCost}
 						onchange={({ target }) =>
 							document.update({

--- a/src/view/sheets/pages/ItemActivationCoreConfigTab.svelte
+++ b/src/view/sheets/pages/ItemActivationCoreConfigTab.svelte
@@ -47,7 +47,7 @@
 				{#if ['action', 'minute', 'hour'].includes(activationCostType)}
 					<input
 						type="number"
-						min="0"
+						min={activationCostType === 'action' ? 0 : 1}
 						value={activationCost}
 						onchange={({ target }) =>
 							document.update({

--- a/src/view/sheets/pages/PlayerCharacterSpellsTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterSpellsTab.svelte
@@ -2,6 +2,7 @@
 	import type { NimbleCharacter } from '#documents/actor/character.js';
 	import type PlayerCharacterSheet from '#documents/sheets/PlayerCharacterSheet.svelte.js';
 	import { getPools, getPoolsForItem } from '#utils/chargePool/chargePoolSync.js';
+	import localize from '#utils/localize.js';
 	import shouldFlashDroppedItem from '#utils/shouldFlashDroppedItem.js';
 	import sortItems from '#utils/sortItems.js';
 	import ChargeIndicator from '#view/components/ChargeIndicator.svelte';
@@ -48,6 +49,10 @@
 		if (!activationType || activationType === 'none') return null;
 
 		if (['action', 'minute', 'hour'].includes(activationType)) {
+			if (activationType === 'action' && activationCost === 0) {
+				return localize('NIMBLE.activationCosts.free');
+			}
+
 			const activationTypeLabel =
 				activationCost > 1
 					? activationCostTypesPlural[activationType]

--- a/src/view/sheets/pages/PlayerCharacterSpellsTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterSpellsTab.svelte
@@ -42,47 +42,34 @@
 	}
 
 	function getSpellMetadata(spell) {
-		const activationType = spell.reactive.system.activation.cost.type;
-		const activationCost = spell.reactive.system.activation.cost.quantity;
-		const activationCostDetails = spell.reactive.system.activation.cost.details;
+		const cost = spell.reactive.system.activation.cost;
+		const { type: activationType, details: activationCostDetails, isReaction } = cost;
 
 		if (!activationType || activationType === 'none') return null;
 
-		const quantifiedLabel = formatActivationCostLabel({
-			type: activationType,
-			quantity: activationCost,
-		});
-		if (quantifiedLabel) return quantifiedLabel;
+		// `special` is the one type carrying no quantity of its own to render.
+		const label =
+			formatActivationCostLabel(cost) ??
+			(activationType === 'special' ? activationCostTypes.special : null);
 
-		if (activationType === 'reaction') {
-			let label = activationCostTypes[activationType];
+		if (!label) return null;
 
-			if (activationCostDetails) {
-				label += ` <i
-                    class="nimble-document-card__meta-icon fa-solid fa-circle-info"
-                    data-tooltip="Reaction Trigger: ${activationCostDetails}"
-                    data-tooltip-direction="UP"
-                ></i>`;
-			}
-
+		// Reactions and Special costs are the two the config tab lets you annotate
+		// with a free-text trigger; surface it on hover.
+		const carriesTrigger = isReaction || activationType === 'reaction';
+		if (!activationCostDetails || !(carriesTrigger || activationType === 'special')) {
 			return label;
 		}
 
-		if (activationType === 'special') {
-			let label = activationCostTypes[activationType];
+		const tooltip = carriesTrigger
+			? `Reaction Trigger: ${activationCostDetails}`
+			: activationCostDetails;
 
-			if (activationCostDetails) {
-				label += ` <i
+		return `${label} <i
                     class="nimble-document-card__meta-icon fa-solid fa-circle-info"
-                    data-tooltip="${activationCostDetails}"
+                    data-tooltip="${tooltip}"
                     data-tooltip-direction="UP"
                 ></i>`;
-			}
-
-			return label;
-		}
-
-		return null;
 	}
 
 	function getSpellSchoolTabs(spells) {

--- a/src/view/sheets/pages/PlayerCharacterSpellsTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterSpellsTab.svelte
@@ -2,7 +2,7 @@
 	import type { NimbleCharacter } from '#documents/actor/character.js';
 	import type PlayerCharacterSheet from '#documents/sheets/PlayerCharacterSheet.svelte.js';
 	import { getPools, getPoolsForItem } from '#utils/chargePool/chargePoolSync.js';
-	import localize from '#utils/localize.js';
+	import formatActivationCostLabel from '#utils/formatActivationCostLabel.js';
 	import shouldFlashDroppedItem from '#utils/shouldFlashDroppedItem.js';
 	import sortItems from '#utils/sortItems.js';
 	import ChargeIndicator from '#view/components/ChargeIndicator.svelte';
@@ -48,18 +48,11 @@
 
 		if (!activationType || activationType === 'none') return null;
 
-		if (['action', 'minute', 'hour'].includes(activationType)) {
-			if (activationType === 'action' && activationCost === 0) {
-				return localize('NIMBLE.activationCosts.free');
-			}
-
-			const activationTypeLabel =
-				activationCost > 1
-					? activationCostTypesPlural[activationType]
-					: activationCostTypes[activationType];
-
-			return `${activationCost || 1} ${activationTypeLabel}`;
-		}
+		const quantifiedLabel = formatActivationCostLabel({
+			type: activationType,
+			quantity: activationCost,
+		});
+		if (quantifiedLabel) return quantifiedLabel;
 
 		if (activationType === 'reaction') {
 			let label = activationCostTypes[activationType];
@@ -156,13 +149,7 @@
 		}, {});
 	}
 
-	const {
-		activationCostTypes,
-		activationCostTypesPlural,
-		spellSchools,
-		spellSchoolIcons,
-		spellTierHeadings,
-	} = CONFIG.NIMBLE;
+	const { activationCostTypes, spellSchools, spellSchoolIcons, spellTierHeadings } = CONFIG.NIMBLE;
 
 	let actor = getContext<NimbleCharacter>('actor');
 	let sheet = getContext<PlayerCharacterSheet>('application');


### PR DESCRIPTION
## Summary

Makes a zero action cost representable so features worded "for free" stop debiting an action. Previously `activation.cost.quantity` was floored at 1 in the schema, in `resolveItemActionCost`, and again in `consumeCombatantAction`, so every free-use feature charged 1 action that the player had to refund by hand.

Review follow-up then pulled in the activation cost label itself: six sites rendered it by hand, which is why the "Free" case had to be added to each one separately, and two cost shapes rendered wrong or not at all.

## Changes

### Zero-cost activations

- `activation.cost.quantity` schema `min: 1` -> `min: 0` (duration untouched; no migration needed since relaxing a `min` is strictly widening). The config tab keeps the per-unit floor: `min` is 0 for `action`, 1 for the elapsed-time units.
- `resolveItemActionCost` new contract: returns `0` for non-action cost types and an explicit `quantity: 0`; `1` remains only the default for a *missing* quantity on an action-type cost. This also fixes a latent bug where `type: 'none'` items reported cost 1.
- `resolveMinionAttackActionCost` is a separate helper for group attacks, so the two contracts stay distinct: a missing or `none` cost defaults to 1 (the legacy pack convention), while an explicit `{type: 'action', quantity: 0}` stays free. The minion gate in `combatCommon.ts` and both consumption sites use it, so the skip check still fires for all 184 shipped `monsterFeature`s carrying `cost.type: 'none'`.
- `consumeCombatantAction` drops its `cost >= 1` floor, early-returns with no write at cost 0, and routes its write through `queueCombatantMutationWithFreshDocument`. The current-actions read and the `Math.max(0, current - cost)` now happen *inside* the mutation callback against the fresh combatant, so two overlapping deductions from 3 serialize 3 -> 2 -> 1 instead of both landing on 2.
- `NimbleCharacter.activateItem` and `activateItemMacro` both skip the deduction when the resolved cost is 0, the macro by calling `resolveItemActionCost` rather than rebuilding the contract inline.

### Activation cost labels

- New `formatActivationCostLabel()` in `src/utils/`, now the single source for "1 Action", "2 Actions", "10 Minutes" and "Free". Replaces six hand-rolled copies (`PlayerCharacterSpellsTab`, `CastSpellActionPanel`, `SpellReferenceCard`, `LevelUpSpellCard`, `generatePdfContent`, `CustomReactionsPanel`), three of which had no test.
- The `${quantity || 1}` falsy-zero fallback is gone from every call site. It survives once inside the formatter, guarding the elapsed-time units only: `min: 0` is shared across every cost type and Foundry's `NumberField.min` clamps rather than rejects, so a zero can still arrive through pack JSON or a migration, and "1 Minute" beats "0 Minutes".
- **Reactions now label correctly.** Four sheets read `activationCostTypes['reaction']`, but that map has no `reaction` key, so anything authored against the legacy `type: 'reaction'` shape rendered the literal string `undefined`. Reactions read as "Reaction", "Reaction (2 Actions)" or "Free Reaction" for both shapes (`isReaction` on an action cost, and the legacy cost type). One reaction costs N actions rather than being a resource you spend several of, so the count never pluralises the reaction itself and the cost is only spelled out when it differs from the default of 1 (CoreRules-2:438, "Reactions cost 1 action"). `CustomReactionsPanel` deliberately opts out and keeps showing the bare cost, since every row there is already a reaction.
- The spells tab surfaced its reaction-trigger tooltip only for the legacy cost type, so a reaction authored the current way had no trigger on hover despite the config tab offering the field. It now keys off either shape.
- **`turn` leaves the cost dropdown.** "1/turn" is how often an ability may be used, not what it costs to use it, so it belongs to a usage limit rather than to `activationCostTypes` (CoreRules-2:500 "1/Turn Abilities", :818, GMguide-2:1662 `ACTION: (1/turn)`). It was selectable but rendered no label at all, and nothing in `packs/` authored it (0 of 1032 authored activation costs, counting items embedded in monster actors). Frequency stays unmodelled.
- The PDF export printed "1 special" for the one shipped spell with a `special` cost (Redeem), since its guard excluded only `none` and `mana`. Only `extractSpellDetails` renders an activation cost, so the five features that also carry a `special` cost never hit this path. Those types carry no quantity, so the formatter returns `null` and the caller prints the bare type label. Side effect worth a look: casting times in the PDF are now capitalized ("1 Action AOE" rather than "1 action AOE"), which matches the "Free"/"Range 1-5"/"1 Mana" already around them.
- English strings only, flagged for review: added `activationCosts.free`, `.reaction`, `.freeReaction`, `.reactionWithCost`; removed the now-unused `activationCosts.turn` and `activationCostsPlural.turn`.

No new cost type was added for "free": `{type: 'action', quantity: 0}` is the representation, keeping the item classified as an action-economy item (it still shows in the relevant panels) while costing nothing.

## Test Plan

- `pnpm check` green on this branch, and on the top of the stack (#880) after restacking: 187 files, 3029 tests.
- New unit coverage: `formatActivationCostLabel.test.ts` (13 cases, including the reaction shapes and the legacy cost type that used to render `undefined`), `resolveMinionAttackActionCost.test.ts`, and `combatCommon.test.ts` (9 cases, including `cost.type: 'none'` at `currentActions: 0`, which had no test before and is why CI stayed green through the earlier behavior flip).
- Live-verified in Foundry v13 (world session, real UI clicks): a feature with `{type:'action', quantity: 0}` activated in combat leaves the action pips untouched and still posts its chat card; the same feature at quantity 1 debits exactly 1.
- **Not yet live-verified:** the label changes in the last two commits are unit-tested only. Worth a reviewer eyeballing the spell list, the level-up spell cards, the character-creator spell cards and a PDF export.

Reviewer repro:

1. Author a feature, set its activation cost quantity to 0 in the config tab, activate it during the character's combat turn, and watch the action tracker.
2. Check "Is Reaction" on a spell with a 1-action cost and look at the chip in the spell list: it should read "Reaction", not "1 Action". Set the quantity to 2 for "Reaction (2 Actions)", 0 for "Free Reaction". Add trigger text under Activation > Core and hover the info icon.
3. Open the activation cost dropdown and confirm "Turn" is no longer offered.

## Checklist

- [x] Added or updated unit tests
- [x] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [x] Tested in Foundry with no console errors (zero-cost activation path; see the Test Plan note on the label changes)
- [x] **Have you used AI to assist with this PR?** yes
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues

Relates to #582 (first of five PRs for the action-economy foundation).
