### PR TITLE
feat(rules): actionCost rule

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -653,6 +653,7 @@
 		},
 		"ruleTypes": {
 			"abilityBonus": "Stat Bonus",
+			"actionCost": "Action Cost",
 			"applyCondition": "Apply Condition",
 			"armorClass": "Armor Class",
 			"chargeConsumer": "Charge Consumer",
@@ -704,6 +705,25 @@
 				"abilities": {
 					"label": "Apply to",
 					"hint": "Pick one or more abilities. Use \"all\" to apply to every ability."
+				}
+			},
+			"actionCost": {
+				"description": "Change how many actions it costs to activate matching items. Adjust adds to the printed cost (use a negative value to reduce it); Set replaces it. The final cost never drops below 0.",
+				"mode": {
+					"label": "How to apply",
+					"hint": "Adjust: add the value to the item's action cost (negative values reduce it). Set: replace the action cost with the value."
+				},
+				"value": {
+					"label": "Value",
+					"hint": "A flat number or formula (e.g. @level). Combined per the mode above."
+				},
+				"itemTypes": {
+					"label": "Item types",
+					"hint": "Only activations of these item types are affected. Leave empty to affect every item type."
+				},
+				"itemIdentifier": {
+					"label": "Item identifier",
+					"hint": "Only affect the item whose identifier matches this. Leave blank to affect all matching items."
 				}
 			},
 			"applyCondition": {

--- a/src/config/registerRulesConfig.ts
+++ b/src/config/registerRulesConfig.ts
@@ -1,4 +1,5 @@
 import { AbilityBonusRule } from '../models/rules/abilityBonus.js';
+import { ActionCostRule } from '../models/rules/actionCost.js';
 import { ApplyConditionRule } from '../models/rules/applyCondition.js';
 import { ArmorClassRule } from '../models/rules/armorClass.js';
 import { ChargeConsumerRule } from '../models/rules/chargeConsumer.js';
@@ -43,6 +44,7 @@ import { UnarmedDamageRule } from '../models/rules/unarmedDamage.js';
 export default function registerRulesConfig() {
 	const ruleTypes = {
 		abilityBonus: 'NIMBLE.ruleTypes.abilityBonus',
+		actionCost: 'NIMBLE.ruleTypes.actionCost',
 		applyCondition: 'NIMBLE.ruleTypes.applyCondition',
 		armorClass: 'NIMBLE.ruleTypes.armorClass',
 		chargeConsumer: 'NIMBLE.ruleTypes.chargeConsumer',
@@ -87,6 +89,7 @@ export default function registerRulesConfig() {
 
 	const ruleDataModels = {
 		abilityBonus: AbilityBonusRule,
+		actionCost: ActionCostRule,
 		applyCondition: ApplyConditionRule,
 		armorClass: ArmorClassRule,
 		chargeConsumer: ChargeConsumerRule,

--- a/src/documents/actor/character.ts
+++ b/src/documents/actor/character.ts
@@ -16,9 +16,6 @@ import type { NimbleCharacterData } from '../../models/actor/CharacterDataModel.
 import calculateRollMode from '../../utils/calculateRollMode.js';
 import { consumeCombatantAction } from '../../utils/combatTurnActions.js';
 import getRollFormula from '../../utils/getRollFormula.js';
-import resolveItemActionCost, {
-	type ItemWithActivationCost,
-} from '../../utils/resolveItemActionCost.js';
 import CharacterArmorProficienciesConfigDialog from '../../view/dialogs/CharacterArmorProficienciesConfigDialog.svelte';
 import CharacterLanguageProficienciesConfigDialog from '../../view/dialogs/CharacterLanguageProficienciesConfigDialog.svelte';
 import CharacterLevelDownDialog from '../../view/dialogs/CharacterLevelDownDialog.svelte';
@@ -38,6 +35,9 @@ import SafeRestDialog from '../../view/dialogs/SafeRestDialog.svelte';
 import GenericDialog from '../dialogs/GenericDialog.svelte.js';
 import type { ActorRollOptions } from './actorInterfaces.ts';
 import { NimbleBaseActor } from './base.svelte.js';
+import resolveCharacterItemActionCost, {
+	type ActivatableItem,
+} from './resolveCharacterItemActionCost.js';
 
 // Note: NimbleClassItem, NimbleSubclassItem, NimbleAncestryItem, NimbleBackgroundItem
 // are ambient types declared in src/documents/item/item.d.ts
@@ -1848,7 +1848,7 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 		const result = await super.activateItem(id, options);
 
 		if (result && item && !options.skipActionDeduction) {
-			const actionCost = resolveItemActionCost(item as ItemWithActivationCost);
+			const actionCost = resolveCharacterItemActionCost(this, item as ActivatableItem);
 			if (actionCost > 0) {
 				const combat = game.combat as Combat | null;
 				const combatant =

--- a/src/documents/actor/resolveCharacterItemActionCost.test.ts
+++ b/src/documents/actor/resolveCharacterItemActionCost.test.ts
@@ -1,0 +1,352 @@
+import type { Mock } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ActionCostRule } from '../../models/rules/actionCost.js';
+import resolveCharacterItemActionCost from './resolveCharacterItemActionCost.js';
+
+interface MockRollData {
+	level?: number;
+	[key: string]: unknown;
+}
+
+interface MockActor {
+	rules: unknown[];
+	getRollData: Mock<() => MockRollData>;
+	getDomain: Mock<() => Set<string>>;
+}
+
+interface MockOwnerItem {
+	isEmbedded: boolean;
+	actor: MockActor;
+	name: string;
+	uuid: string;
+	getDomain: Mock<() => Set<string>>;
+}
+
+interface ActivationItem {
+	type?: string;
+	system?: {
+		identifier?: string;
+		activation?: {
+			cost?: { type?: string; quantity?: number };
+		};
+	};
+}
+
+// Type for test instances where we need to set internal properties directly.
+// `itemTypes` is omitted and re-added as `string[]` because the schema infers a
+// closed choice-union type that plain string literals don't satisfy.
+type ActionCostRuleTestInstance = Omit<ActionCostRule, 'itemTypes'> & {
+	mode: 'delta' | 'set';
+	value: string;
+	itemTypes: string[];
+	itemIdentifier: string;
+	disabled: boolean;
+	priority: number;
+	type: string;
+};
+
+function createMockActor(rollData: MockRollData = {}): MockActor {
+	return {
+		rules: [],
+		getRollData: vi.fn(() => rollData),
+		getDomain: vi.fn(() => new Set<string>()),
+	};
+}
+
+function createActivationItem(
+	overrides: { type?: string; identifier?: string; costType?: string; quantity?: number } = {},
+): ActivationItem {
+	return {
+		type: overrides.type ?? 'spell',
+		system: {
+			identifier: overrides.identifier ?? '',
+			activation: {
+				cost: {
+					type: overrides.costType ?? 'action',
+					quantity: overrides.quantity ?? 1,
+				},
+			},
+		},
+	};
+}
+
+/**
+ * Creates an ActionCostRule instance owned by a mock item on the given actor,
+ * and registers it in the actor's rules array.
+ */
+function addActionCostRule(
+	actor: MockActor,
+	config: {
+		mode?: 'delta' | 'set';
+		value?: string;
+		itemTypes?: string[];
+		itemIdentifier?: string;
+		disabled?: boolean;
+		priority?: number;
+		predicatePasses?: boolean;
+	} = {},
+): ActionCostRuleTestInstance {
+	const ownerItem: MockOwnerItem = {
+		isEmbedded: true,
+		actor,
+		name: 'Test Feature',
+		uuid: 'test-owner-item-uuid',
+		getDomain: vi.fn(() => new Set<string>()),
+	};
+
+	const sourceData = {
+		mode: config.mode ?? 'delta',
+		value: config.value ?? '1',
+		itemTypes: config.itemTypes ?? [],
+		itemIdentifier: config.itemIdentifier ?? '',
+		disabled: config.disabled ?? false,
+		label: 'Test Rule',
+		id: 'test-rule-id',
+		identifier: '',
+		priority: config.priority ?? 1,
+		predicate: {},
+		type: 'actionCost',
+	};
+
+	const rule = new ActionCostRule(
+		sourceData as foundry.data.fields.SchemaField.CreateData<ActionCostRule['schema']['fields']>,
+		{ parent: ownerItem as unknown as foundry.abstract.DataModel.Any, strict: false },
+	) as ActionCostRuleTestInstance;
+
+	// Manually set properties since the mock DataModel doesn't do this automatically
+	rule.mode = config.mode ?? 'delta';
+	rule.value = config.value ?? '1';
+	rule.itemTypes = config.itemTypes ?? [];
+	rule.itemIdentifier = config.itemIdentifier ?? '';
+	rule.disabled = config.disabled ?? false;
+	rule.priority = config.priority ?? 1;
+	rule.type = 'actionCost';
+
+	Object.defineProperty(rule, 'item', {
+		get: () => ownerItem,
+		configurable: true,
+	});
+
+	const predicatePasses = config.predicatePasses ?? true;
+	Object.defineProperty(rule, '_predicate', {
+		get: () => ({ size: predicatePasses ? 0 : 1, test: () => predicatePasses }),
+		configurable: true,
+	});
+
+	actor.rules.push(rule);
+
+	return rule;
+}
+
+describe('resolveCharacterItemActionCost', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe('base cost passthrough', () => {
+		it('returns the base cost when the actor has no rules', () => {
+			const actor = createMockActor();
+			const item = createActivationItem({ quantity: 2 });
+
+			expect(resolveCharacterItemActionCost(actor, item)).toBe(2);
+		});
+
+		it('returns the base cost when the actor is null', () => {
+			const item = createActivationItem({ quantity: 1 });
+
+			expect(resolveCharacterItemActionCost(null, item)).toBe(1);
+		});
+
+		it('returns 0 for a null item', () => {
+			const actor = createMockActor();
+
+			expect(resolveCharacterItemActionCost(actor, null)).toBe(0);
+		});
+
+		it('ignores rules of other types', () => {
+			const actor = createMockActor();
+			actor.rules.push({ type: 'damageBonus' });
+			const item = createActivationItem({ quantity: 1 });
+
+			expect(resolveCharacterItemActionCost(actor, item)).toBe(1);
+		});
+	});
+
+	describe('delta mode', () => {
+		it('reduces a 2-action cost to 1 with a -1 delta', () => {
+			const actor = createMockActor();
+			addActionCostRule(actor, { mode: 'delta', value: '-1' });
+			const item = createActivationItem({ quantity: 2 });
+
+			expect(resolveCharacterItemActionCost(actor, item)).toBe(1);
+		});
+
+		it('increases the cost with a +1 delta', () => {
+			const actor = createMockActor();
+			addActionCostRule(actor, { mode: 'delta', value: '1' });
+			const item = createActivationItem({ quantity: 1 });
+
+			expect(resolveCharacterItemActionCost(actor, item)).toBe(2);
+		});
+
+		it('clamps the final cost at 0', () => {
+			const actor = createMockActor();
+			addActionCostRule(actor, { mode: 'delta', value: '-3' });
+			const item = createActivationItem({ quantity: 1 });
+
+			expect(resolveCharacterItemActionCost(actor, item)).toBe(0);
+		});
+
+		it('stacks multiple delta rules', () => {
+			const actor = createMockActor();
+			addActionCostRule(actor, { mode: 'delta', value: '1' });
+			addActionCostRule(actor, { mode: 'delta', value: '1' });
+			const item = createActivationItem({ quantity: 1 });
+
+			expect(resolveCharacterItemActionCost(actor, item)).toBe(3);
+		});
+
+		it('resolves formula values against actor roll data', () => {
+			const actor = createMockActor({ level: 2 });
+			addActionCostRule(actor, { mode: 'delta', value: '@level' });
+			const item = createActivationItem({ quantity: 1 });
+
+			expect(resolveCharacterItemActionCost(actor, item)).toBe(3);
+		});
+	});
+
+	describe('set mode', () => {
+		it('sets the cost to 0 regardless of base cost', () => {
+			const actor = createMockActor();
+			addActionCostRule(actor, { mode: 'set', value: '0' });
+			const item = createActivationItem({ quantity: 2 });
+
+			expect(resolveCharacterItemActionCost(actor, item)).toBe(0);
+		});
+
+		it('overwrites the running cost with the set value', () => {
+			const actor = createMockActor();
+			addActionCostRule(actor, { mode: 'set', value: '3' });
+			const item = createActivationItem({ quantity: 1 });
+
+			expect(resolveCharacterItemActionCost(actor, item)).toBe(3);
+		});
+	});
+
+	describe('priority ordering', () => {
+		it('applies a lower-priority set before a higher-priority delta', () => {
+			const actor = createMockActor();
+			// Registered out of order to prove the resolver sorts by priority
+			addActionCostRule(actor, { mode: 'delta', value: '1', priority: 2 });
+			addActionCostRule(actor, { mode: 'set', value: '0', priority: 1 });
+			const item = createActivationItem({ quantity: 2 });
+
+			// set → 0 first, then delta +1 → 1
+			expect(resolveCharacterItemActionCost(actor, item)).toBe(1);
+		});
+
+		it('lets a later set overwrite an earlier delta', () => {
+			const actor = createMockActor();
+			addActionCostRule(actor, { mode: 'delta', value: '1', priority: 1 });
+			addActionCostRule(actor, { mode: 'set', value: '0', priority: 2 });
+			const item = createActivationItem({ quantity: 2 });
+
+			expect(resolveCharacterItemActionCost(actor, item)).toBe(0);
+		});
+	});
+
+	describe('scoping', () => {
+		it('does not apply a spell-scoped rule to a feature activation', () => {
+			const actor = createMockActor();
+			addActionCostRule(actor, { mode: 'delta', value: '1', itemTypes: ['spell'] });
+			const item = createActivationItem({ type: 'feature', quantity: 1 });
+
+			expect(resolveCharacterItemActionCost(actor, item)).toBe(1);
+		});
+
+		it('applies a spell-scoped rule to a spell activation', () => {
+			const actor = createMockActor();
+			addActionCostRule(actor, { mode: 'delta', value: '1', itemTypes: ['spell'] });
+			const item = createActivationItem({ type: 'spell', quantity: 1 });
+
+			expect(resolveCharacterItemActionCost(actor, item)).toBe(2);
+		});
+
+		it('applies a rule with empty scoping to every activation', () => {
+			const actor = createMockActor();
+			addActionCostRule(actor, { mode: 'delta', value: '1' });
+
+			expect(resolveCharacterItemActionCost(actor, createActivationItem({ type: 'feature' }))).toBe(
+				2,
+			);
+			expect(resolveCharacterItemActionCost(actor, createActivationItem({ type: 'object' }))).toBe(
+				2,
+			);
+		});
+
+		it('scopes by item identifier', () => {
+			const actor = createMockActor();
+			addActionCostRule(actor, { mode: 'set', value: '0', itemIdentifier: 'defend' });
+
+			const matching = createActivationItem({ identifier: 'defend', quantity: 1 });
+			const other = createActivationItem({ identifier: 'attack', quantity: 1 });
+
+			expect(resolveCharacterItemActionCost(actor, matching)).toBe(0);
+			expect(resolveCharacterItemActionCost(actor, other)).toBe(1);
+		});
+
+		it('requires both itemTypes and itemIdentifier to match when both are set', () => {
+			const actor = createMockActor();
+			addActionCostRule(actor, {
+				mode: 'set',
+				value: '0',
+				itemTypes: ['spell'],
+				itemIdentifier: 'fireball',
+			});
+
+			const wrongType = createActivationItem({
+				type: 'feature',
+				identifier: 'fireball',
+				quantity: 1,
+			});
+			const match = createActivationItem({ type: 'spell', identifier: 'fireball', quantity: 1 });
+
+			expect(resolveCharacterItemActionCost(actor, wrongType)).toBe(1);
+			expect(resolveCharacterItemActionCost(actor, match)).toBe(0);
+		});
+	});
+
+	describe('rule gating', () => {
+		it('ignores disabled rules', () => {
+			const actor = createMockActor();
+			addActionCostRule(actor, { mode: 'delta', value: '1', disabled: true });
+			const item = createActivationItem({ quantity: 1 });
+
+			expect(resolveCharacterItemActionCost(actor, item)).toBe(1);
+		});
+
+		it('ignores rules whose predicate fails', () => {
+			const actor = createMockActor();
+			addActionCostRule(actor, { mode: 'delta', value: '1', predicatePasses: false });
+			const item = createActivationItem({ quantity: 1 });
+
+			expect(resolveCharacterItemActionCost(actor, item)).toBe(1);
+		});
+
+		it('does not price activations without an action cost type', () => {
+			const actor = createMockActor();
+			addActionCostRule(actor, { mode: 'set', value: '2' });
+			const item = createActivationItem({ costType: 'minutes', quantity: 10 });
+
+			expect(resolveCharacterItemActionCost(actor, item)).toBe(0);
+		});
+
+		it('modifies an explicit zero-cost action activation', () => {
+			const actor = createMockActor();
+			addActionCostRule(actor, { mode: 'delta', value: '1' });
+			const item = createActivationItem({ quantity: 0 });
+
+			expect(resolveCharacterItemActionCost(actor, item)).toBe(1);
+		});
+	});
+});

--- a/src/documents/actor/resolveCharacterItemActionCost.ts
+++ b/src/documents/actor/resolveCharacterItemActionCost.ts
@@ -1,0 +1,47 @@
+import type { ActionCostRule } from '../../models/rules/actionCost.js';
+import resolveItemActionCost from '../../utils/resolveItemActionCost.js';
+
+interface ActorWithRules {
+	rules?: unknown[];
+}
+
+export interface ActivatableItem {
+	type?: string;
+	system?: {
+		identifier?: string;
+		activation?: {
+			cost?: { type?: string; quantity?: number };
+		};
+	};
+}
+
+/**
+ * Resolves the action cost of activating `item` on `actor`, folding the actor's
+ * `actionCost` rules over the item's base cost. Matching rules apply in `priority`
+ * order: `delta` adds its value, `set` overwrites the running cost. The result is
+ * clamped at 0.
+ *
+ * Only activations whose cost type is `action` are priced — rules never charge
+ * actions for activations measured in other units (minutes, none, etc.).
+ */
+export default function resolveCharacterItemActionCost(
+	actor: ActorWithRules | null | undefined,
+	item: ActivatableItem | null,
+): number {
+	const baseCost = resolveItemActionCost(item);
+	if (item?.system?.activation?.cost?.type !== 'action') return baseCost;
+
+	const rules = (actor?.rules ?? []) as ActionCostRule[];
+	const matching = rules
+		.filter((rule) => rule.type === 'actionCost' && rule.appliesTo() && rule.matchesItem(item))
+		.sort((a, b) => a.priority - b.priority);
+
+	let cost = baseCost;
+	for (const rule of matching) {
+		const value = rule.resolveValue();
+		if (value === null) continue;
+		cost = rule.mode === 'set' ? value : cost + value;
+	}
+
+	return Math.max(0, cost);
+}

--- a/src/models/rules/actionCost.test.ts
+++ b/src/models/rules/actionCost.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { ActionCostRule } from './actionCost.js';
+
+describe('ActionCostRule', () => {
+	describe('schema', () => {
+		it('defines the expected fields', () => {
+			const schema = ActionCostRule.defineSchema();
+			expect(schema).toHaveProperty('type');
+			expect(schema).toHaveProperty('mode');
+			expect(schema).toHaveProperty('value');
+			expect(schema).toHaveProperty('itemTypes');
+			expect(schema).toHaveProperty('itemIdentifier');
+		});
+
+		it('declares closed mode and item-type choice sets', () => {
+			const schema = ActionCostRule.defineSchema();
+			const mode = schema.mode as unknown as { choices: string[] };
+			expect(mode.choices).toEqual(['delta', 'set']);
+
+			const itemTypes = schema.itemTypes as unknown as {
+				element: { choices: string[] };
+			};
+			expect(itemTypes.element.choices).toEqual(['feature', 'monsterFeature', 'object', 'spell']);
+		});
+	});
+
+	describe('class metadata', () => {
+		it('exposes the picker group and i18n description key', () => {
+			expect(ActionCostRule.group).toBe('resource');
+			expect(ActionCostRule.description).toBe('NIMBLE.rules.actionCost.description');
+		});
+
+		it('declares no lifecycle hooks', () => {
+			// A pure cost descriptor must never run during data preparation.
+			expect(ActionCostRule.appliesInPrePrepareData).toBe(false);
+			expect(Object.getOwnPropertyNames(ActionCostRule.prototype)).not.toContain(
+				'afterPrepareData',
+			);
+		});
+	});
+
+	describe('matchesItem', () => {
+		function createRule(config: { itemTypes?: string[]; itemIdentifier?: string } = {}) {
+			// `itemTypes` is omitted and re-added as `string[]` because the schema
+			// infers a closed choice-union type that plain string literals don't satisfy.
+			const rule = new ActionCostRule(
+				{ type: 'actionCost' } as foundry.data.fields.SchemaField.CreateData<
+					ActionCostRule['schema']['fields']
+				>,
+				{ strict: false },
+			) as unknown as Omit<ActionCostRule, 'itemTypes'> & {
+				itemTypes: string[];
+				itemIdentifier: string;
+			};
+
+			rule.itemTypes = config.itemTypes ?? [];
+			rule.itemIdentifier = config.itemIdentifier ?? '';
+			return rule;
+		}
+
+		it('matches everything when both scoping fields are empty', () => {
+			const rule = createRule();
+			expect(rule.matchesItem({ type: 'spell' })).toBe(true);
+			expect(rule.matchesItem({ type: 'feature', system: { identifier: 'defend' } })).toBe(true);
+		});
+
+		it('rejects null items', () => {
+			expect(createRule().matchesItem(null)).toBe(false);
+		});
+
+		it('scopes by item type', () => {
+			const rule = createRule({ itemTypes: ['spell'] });
+			expect(rule.matchesItem({ type: 'spell' })).toBe(true);
+			expect(rule.matchesItem({ type: 'feature' })).toBe(false);
+		});
+
+		it('scopes by item identifier', () => {
+			const rule = createRule({ itemIdentifier: 'defend' });
+			expect(rule.matchesItem({ type: 'feature', system: { identifier: 'defend' } })).toBe(true);
+			expect(rule.matchesItem({ type: 'feature', system: { identifier: 'load' } })).toBe(false);
+			expect(rule.matchesItem({ type: 'feature' })).toBe(false);
+		});
+	});
+});

--- a/src/models/rules/actionCost.ts
+++ b/src/models/rules/actionCost.ts
@@ -1,0 +1,127 @@
+import { withWidget } from './_widgetOption.js';
+import { NimbleBaseRule } from './base.js';
+
+type ActionCostMode = 'delta' | 'set';
+
+/** The item types whose activation carries an action cost. */
+const ACTION_COST_ITEM_TYPES = ['feature', 'monsterFeature', 'object', 'spell'] as const;
+
+function schema() {
+	const { fields } = foundry.data;
+
+	return {
+		mode: new fields.StringField({
+			required: true,
+			nullable: false,
+			initial: 'delta',
+			label: 'NIMBLE.rules.actionCost.mode.label',
+			hint: 'NIMBLE.rules.actionCost.mode.hint',
+			choices: ['delta', 'set'],
+		}),
+		value: new fields.StringField(
+			withWidget({
+				required: true,
+				nullable: false,
+				initial: '1',
+				label: 'NIMBLE.rules.actionCost.value.label',
+				hint: 'NIMBLE.rules.actionCost.value.hint',
+				widget: 'formula',
+			}),
+		),
+		itemTypes: new fields.ArrayField(
+			new fields.StringField({
+				required: true,
+				nullable: false,
+				blank: false,
+				choices: [...ACTION_COST_ITEM_TYPES],
+			}),
+			{
+				required: true,
+				nullable: false,
+				initial: [],
+				label: 'NIMBLE.rules.actionCost.itemTypes.label',
+				hint: 'NIMBLE.rules.actionCost.itemTypes.hint',
+			},
+		),
+		itemIdentifier: new fields.StringField({
+			required: true,
+			nullable: false,
+			blank: true,
+			initial: '',
+			label: 'NIMBLE.rules.actionCost.itemIdentifier.label',
+			hint: 'NIMBLE.rules.actionCost.itemIdentifier.hint',
+		}),
+		type: new fields.StringField({ required: true, nullable: false, initial: 'actionCost' }),
+	};
+}
+
+declare namespace ActionCostRule {
+	type Schema = NimbleBaseRule.Schema & ReturnType<typeof schema>;
+}
+
+interface ActionCostTargetItem {
+	type?: string;
+	system?: {
+		identifier?: string;
+	};
+}
+
+/**
+ * A pure cost descriptor: modifies the action cost of activating matching items.
+ * Carries no lifecycle hooks — the character's activation flow reads matching
+ * rules through `resolveCharacterItemActionCost` when an item is activated.
+ *
+ * Because the rule lives on the actor but prices individual activations, the
+ * `itemTypes` / `itemIdentifier` scoping fields decide which activations it
+ * affects. Both empty means every activation with an action cost.
+ */
+class ActionCostRule extends NimbleBaseRule<ActionCostRule.Schema> {
+	static override group = 'resource';
+	static override description = 'NIMBLE.rules.actionCost.description';
+
+	declare mode: ActionCostMode;
+
+	declare value: string;
+
+	// `itemTypes` is inferred from the schema's `choices` (the closed set of
+	// activatable item types); re-declaring it as the wider `string[]` clashes
+	// with that type.
+
+	declare itemIdentifier: string;
+
+	static override defineSchema(): ActionCostRule.Schema {
+		return {
+			...NimbleBaseRule.defineSchema(),
+			...schema(),
+		};
+	}
+
+	override tooltipInfo(): string {
+		return super.tooltipInfo(
+			new Map([
+				['mode', '"delta" | "set"'],
+				['value', 'string'],
+				['itemTypes', 'string[]'],
+				['itemIdentifier', 'string'],
+			]),
+		);
+	}
+
+	/** True when this rule's scoping matches the activating item. Empty scoping fields match all. */
+	matchesItem(item: ActionCostTargetItem | null | undefined): boolean {
+		if (!item) return false;
+		const itemTypes = this.itemTypes as unknown as string[];
+		if (itemTypes.length > 0 && !itemTypes.includes(item.type ?? '')) return false;
+		if (this.itemIdentifier !== '' && this.itemIdentifier !== (item.system?.identifier ?? '')) {
+			return false;
+		}
+		return true;
+	}
+
+	/** Resolves the configured value against the actor's roll data. */
+	resolveValue(): number | null {
+		return this.resolveFormula(this.value);
+	}
+}
+
+export { ActionCostRule };

--- a/src/view/rulesBuilder/components/RuleTypePicker.svelte.ts
+++ b/src/view/rulesBuilder/components/RuleTypePicker.svelte.ts
@@ -11,6 +11,7 @@ interface PickerEntry {
 
 const RULE_ICONS: Record<string, string> = {
 	abilityBonus: 'fa-solid fa-dumbbell',
+	actionCost: 'fa-solid fa-stopwatch',
 	applyCondition: 'fa-solid fa-bolt-lightning',
 	armorClass: 'fa-solid fa-shield-halved',
 	chargeConsumer: 'fa-solid fa-arrow-down-from-line',


### PR DESCRIPTION
## Summary

New `actionCost` rule: a pure declarative descriptor (zero lifecycle hooks, modelled on `chargeConsumer`) that modifies the action cost of item activations. Covers the largest unserved rulebook bucket — 31 features worded "costs 0 / costs 1 less / costs 1 more" — including the four cost *increases* (e.g. non-proficient armor Defend, weapon Load) as `mode: 'delta', value: '1'`.

## Changes

- `src/models/rules/actionCost.ts` — fields: `mode` (`delta`/`set`), `value` (formula), `itemTypes` (restricted to the four item types that carry `activation()`: feature, monsterFeature, object, spell), optional `itemIdentifier`. Helpers `matchesItem()` / `resolveValue()`; `group: 'resource'`.
- `src/documents/actor/resolveCharacterItemActionCost.ts` — actor-level resolver, sole caller `character.ts` (Code Promotion Rules). Fold order: base cost from `resolveItemActionCost`, then matching rules sorted by envelope `priority` (`delta` adds, `set` overwrites), clamped ≥ 0.
- `NimbleCharacter.activateItem` deducts via the resolver instead of the raw item quantity.
- Registration in all four places (`registerRulesConfig.ts` both maps, `RULE_ICONS`, en.json keys — English only).

Design notes:

- Rules only apply to `cost.type: 'action'` activations — without that gate, a `+1` rule would charge a combat action for rituals measured in minutes.
- The deduction deliberately stays in `activateItem`, not a `preUseItem` hook: `Hooks.call` doesn't receive `options` (which would break `skipActionDeduction` used by the opportunity-attack path), and `activate()` exists in two copies so a hook would double-fire.
- The scoping fields are the load-bearing part of the design: the rule lives on the actor but must scope to an item, or "+1 action to spells" would tax every activation on the sheet. Review focus welcome there.

**Known gap (deferred to polish):** the chat card renders `activation.cost` from the snapshot in `ItemActivationManager.getData()`, so a rule-zeroed cost still prints "1 Action" on the card. The deduction itself is correct.

## Test Plan

- `pnpm check` green; 22 new resolver tests (delta/set, clamp, itemTypes/itemIdentifier scoping, priority ordering, formula resolution, disabled/predicate gating) plus co-located rule schema tests; `RuleCard.allRules.test.ts` picks the type up automatically.
- Live-verified in Foundry v13 (real UI): `delta −1` on a 2-action spell debits 1; `delta +1` debits 3; a rule scoped `itemTypes: ['spell']` does not tax a 1-cost feature activation.
- Reviewer repro: add an `actionCost` rule to any owned feature via the Rules Builder, then activate a spell in combat and watch the tracker.

## Checklist

- [x] Added or updated unit tests
- [x] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [x] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** yes
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues

Relates to #582. Stacked on #876; retarget to `dev` when it merges.
