### PR TITLE
feat(combat): heroic reaction cost + insufficient-action confirmation

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -708,10 +708,14 @@
 				}
 			},
 			"actionCost": {
-				"description": "Change how many actions it costs to activate matching items. Adjust adds to the printed cost (use a negative value to reduce it); Set replaces it. The final cost never drops below 0.",
+				"description": "Change how many actions it costs to activate matching items or use heroic reactions. Adjust adds to the base cost (use a negative value to reduce it); Set replaces it. The final cost never drops below 0. Cost only — a free reaction is still limited to once per round.",
+				"applies": {
+					"label": "Applies to",
+					"hint": "item: price matching item activations. heroicReaction: price the selected heroic reactions instead."
+				},
 				"mode": {
 					"label": "How to apply",
-					"hint": "Adjust: add the value to the item's action cost (negative values reduce it). Set: replace the action cost with the value."
+					"hint": "Adjust: add the value to the base action cost (negative values reduce it). Set: replace the action cost with the value."
 				},
 				"value": {
 					"label": "Value",
@@ -724,6 +728,10 @@
 				"itemIdentifier": {
 					"label": "Item identifier",
 					"hint": "Only affect the item whose identifier matches this. Leave blank to affect all matching items."
+				},
+				"reactions": {
+					"label": "Heroic reactions",
+					"hint": "Only these heroic reactions are affected. Leave empty to affect every heroic reaction."
 				}
 			},
 			"applyCondition": {
@@ -1511,6 +1519,13 @@
 			"cancel": "Cancel",
 			"loading": "Loading...",
 			"viewDetails": "View Details",
+			"confirmInsufficientActions": {
+				"title": "Not Enough Actions",
+				"message": "This costs {cost} action(s), but you only have {current} remaining.",
+				"confirmQuestion": "Do you still want to use {name}?",
+				"confirm": "Use Anyway",
+				"cancel": "Cancel"
+			},
 			"combatTracker": {
 				"scrollbar": "Combat turn order scrollbar",
 				"hitPoints": "Hit Points",

--- a/src/documents/actor/character.ts
+++ b/src/documents/actor/character.ts
@@ -14,8 +14,12 @@ import { HitDiceManager, incrementDieSize } from '../../managers/HitDiceManager.
 import { RestManager } from '../../managers/RestManager.js';
 import type { NimbleCharacterData } from '../../models/actor/CharacterDataModel.js';
 import calculateRollMode from '../../utils/calculateRollMode.js';
-import { consumeCombatantAction } from '../../utils/combatTurnActions.js';
+import {
+	consumeCombatantAction,
+	getCombatantCurrentActions,
+} from '../../utils/combatTurnActions.js';
 import getRollFormula from '../../utils/getRollFormula.js';
+import showInsufficientActionsConfirmation from '../../utils/showInsufficientActionsConfirmation.js';
 import CharacterArmorProficienciesConfigDialog from '../../view/dialogs/CharacterArmorProficienciesConfigDialog.svelte';
 import CharacterLanguageProficienciesConfigDialog from '../../view/dialogs/CharacterLanguageProficienciesConfigDialog.svelte';
 import CharacterLevelDownDialog from '../../view/dialogs/CharacterLevelDownDialog.svelte';
@@ -1845,6 +1849,32 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 		options: Record<string, unknown> = {},
 	): Promise<ChatMessage | null> {
 		const item = this.items.get(id);
+
+		// Soft-block gate: when the activation costs more actions than the
+		// combatant has remaining, confirm before any activation side effects
+		// (dialogs, rolls, card creation) so a cancelled overspend leaves no
+		// trace. `force` bypasses the prompt; paths that manage the cost
+		// themselves pass `skipActionDeduction` and are never prompted.
+		if (item && !options.skipActionDeduction) {
+			const actionCost = resolveCharacterItemActionCost(this, item as ActivatableItem);
+			if (actionCost > 0) {
+				const combat = game.combat as Combat | null;
+				const combatant =
+					combat?.combatants?.find(
+						(entry: Combatant.Implementation) => entry.actorId === this.id,
+					) ?? null;
+				if (combat?.started && combatant) {
+					const confirmed = await showInsufficientActionsConfirmation({
+						activityName: item.name ?? '',
+						requiredActions: actionCost,
+						currentActions: getCombatantCurrentActions(combatant),
+						force: options.force === true,
+					});
+					if (!confirmed) return null;
+				}
+			}
+		}
+
 		const result = await super.activateItem(id, options);
 
 		if (result && item && !options.skipActionDeduction) {

--- a/src/documents/actor/resolveCharacterItemActionCost.test.ts
+++ b/src/documents/actor/resolveCharacterItemActionCost.test.ts
@@ -35,11 +35,13 @@ interface ActivationItem {
 // Type for test instances where we need to set internal properties directly.
 // `itemTypes` is omitted and re-added as `string[]` because the schema infers a
 // closed choice-union type that plain string literals don't satisfy.
-type ActionCostRuleTestInstance = Omit<ActionCostRule, 'itemTypes'> & {
+type ActionCostRuleTestInstance = Omit<ActionCostRule, 'itemTypes' | 'reactions'> & {
+	applies: 'item' | 'heroicReaction';
 	mode: 'delta' | 'set';
 	value: string;
 	itemTypes: string[];
 	itemIdentifier: string;
+	reactions: string[];
 	disabled: boolean;
 	priority: number;
 	type: string;
@@ -77,10 +79,12 @@ function createActivationItem(
 function addActionCostRule(
 	actor: MockActor,
 	config: {
+		applies?: 'item' | 'heroicReaction';
 		mode?: 'delta' | 'set';
 		value?: string;
 		itemTypes?: string[];
 		itemIdentifier?: string;
+		reactions?: string[];
 		disabled?: boolean;
 		priority?: number;
 		predicatePasses?: boolean;
@@ -95,10 +99,12 @@ function addActionCostRule(
 	};
 
 	const sourceData = {
+		applies: config.applies ?? 'item',
 		mode: config.mode ?? 'delta',
 		value: config.value ?? '1',
 		itemTypes: config.itemTypes ?? [],
 		itemIdentifier: config.itemIdentifier ?? '',
+		reactions: config.reactions ?? [],
 		disabled: config.disabled ?? false,
 		label: 'Test Rule',
 		id: 'test-rule-id',
@@ -114,10 +120,12 @@ function addActionCostRule(
 	) as ActionCostRuleTestInstance;
 
 	// Manually set properties since the mock DataModel doesn't do this automatically
+	rule.applies = config.applies ?? 'item';
 	rule.mode = config.mode ?? 'delta';
 	rule.value = config.value ?? '1';
 	rule.itemTypes = config.itemTypes ?? [];
 	rule.itemIdentifier = config.itemIdentifier ?? '';
+	rule.reactions = config.reactions ?? [];
 	rule.disabled = config.disabled ?? false;
 	rule.priority = config.priority ?? 1;
 	rule.type = 'actionCost';
@@ -347,6 +355,14 @@ describe('resolveCharacterItemActionCost', () => {
 			const item = createActivationItem({ quantity: 0 });
 
 			expect(resolveCharacterItemActionCost(actor, item)).toBe(1);
+		});
+
+		it('ignores rules that apply to heroic reactions', () => {
+			const actor = createMockActor();
+			addActionCostRule(actor, { applies: 'heroicReaction', mode: 'set', value: '0' });
+			const item = createActivationItem({ quantity: 2 });
+
+			expect(resolveCharacterItemActionCost(actor, item)).toBe(2);
 		});
 	});
 });

--- a/src/documents/combat/combat.svelte.ts
+++ b/src/documents/combat/combat.svelte.ts
@@ -18,6 +18,7 @@ import { initiativeRollLock } from '#utils/initiativeRollLock.js';
 import { isCombatantDead } from '#utils/isCombatantDead.js';
 import { getMinionGroupId, getMinionGroupSummaries } from '#utils/minionGrouping.js';
 import { queueCombatantMutationWithFreshDocument } from '#utils/queueCombatantMutationWithFreshDocument.js';
+import resolveHeroicReactionActionCost from '#utils/resolveHeroicReactionActionCost.js';
 import { isCombatConvenienceAutomationEnabled } from '../../settings/automationSettings.js';
 import { getCombatantManualSortValue, getCombatantResetActions } from './combatantSystem.js';
 import { getCombatantCurrentActions, logMinionGroupingCombat } from './combatCommon.js';
@@ -945,10 +946,14 @@ class NimbleCombat extends Combat {
 
 					if (!canSpendAvailableReaction) return false;
 					const currentActions = getCombatantCurrentActions(combatant);
+					const reactionCost = resolveHeroicReactionActionCost(
+						combatant.actor as unknown as Parameters<typeof resolveHeroicReactionActionCost>[0],
+						[reactionKey],
+					);
 					if (!game.user?.isGM) {
 						if ((this.round ?? 0) < 1) return false;
 						if ((this.combatant?.id ?? null) === combatantId) return false;
-						if (currentActions < 1) return false;
+						if (currentActions < reactionCost) return false;
 					}
 
 					const reactionAvailabilityUpdate = {
@@ -958,7 +963,7 @@ class NimbleCombat extends Combat {
 					if (!game.user?.isGM) {
 						reactionAvailabilityUpdate['system.actions.base.current'] = Math.max(
 							0,
-							currentActions - 1,
+							currentActions - reactionCost,
 						);
 					}
 

--- a/src/models/rules/actionCost.test.ts
+++ b/src/models/rules/actionCost.test.ts
@@ -6,14 +6,19 @@ describe('ActionCostRule', () => {
 		it('defines the expected fields', () => {
 			const schema = ActionCostRule.defineSchema();
 			expect(schema).toHaveProperty('type');
+			expect(schema).toHaveProperty('applies');
 			expect(schema).toHaveProperty('mode');
 			expect(schema).toHaveProperty('value');
 			expect(schema).toHaveProperty('itemTypes');
 			expect(schema).toHaveProperty('itemIdentifier');
+			expect(schema).toHaveProperty('reactions');
 		});
 
-		it('declares closed mode and item-type choice sets', () => {
+		it('declares closed applies, mode, item-type, and reaction choice sets', () => {
 			const schema = ActionCostRule.defineSchema();
+			const applies = schema.applies as unknown as { choices: string[] };
+			expect(applies.choices).toEqual(['item', 'heroicReaction']);
+
 			const mode = schema.mode as unknown as { choices: string[] };
 			expect(mode.choices).toEqual(['delta', 'set']);
 
@@ -21,6 +26,22 @@ describe('ActionCostRule', () => {
 				element: { choices: string[] };
 			};
 			expect(itemTypes.element.choices).toEqual(['feature', 'monsterFeature', 'object', 'spell']);
+
+			const reactions = schema.reactions as unknown as {
+				element: { choices: string[] };
+			};
+			expect(reactions.element.choices).toEqual([
+				'defend',
+				'interpose',
+				'opportunityAttack',
+				'help',
+			]);
+		});
+
+		it('defaults applies to item, preserving pre-existing rule semantics', () => {
+			const schema = ActionCostRule.defineSchema();
+			const applies = schema.applies as unknown as { options: { initial: string } };
+			expect(applies.options.initial).toBe('item');
 		});
 	});
 
@@ -39,25 +60,37 @@ describe('ActionCostRule', () => {
 		});
 	});
 
+	function createRule(
+		config: {
+			applies?: 'item' | 'heroicReaction';
+			itemTypes?: string[];
+			itemIdentifier?: string;
+			reactions?: string[];
+		} = {},
+	) {
+		// `itemTypes` / `reactions` are omitted and re-added as `string[]` because
+		// the schema infers closed choice-union types that plain string literals
+		// don't satisfy.
+		const rule = new ActionCostRule(
+			{ type: 'actionCost' } as foundry.data.fields.SchemaField.CreateData<
+				ActionCostRule['schema']['fields']
+			>,
+			{ strict: false },
+		) as unknown as Omit<ActionCostRule, 'itemTypes' | 'reactions'> & {
+			applies: 'item' | 'heroicReaction';
+			itemTypes: string[];
+			itemIdentifier: string;
+			reactions: string[];
+		};
+
+		rule.applies = config.applies ?? 'item';
+		rule.itemTypes = config.itemTypes ?? [];
+		rule.itemIdentifier = config.itemIdentifier ?? '';
+		rule.reactions = config.reactions ?? [];
+		return rule;
+	}
+
 	describe('matchesItem', () => {
-		function createRule(config: { itemTypes?: string[]; itemIdentifier?: string } = {}) {
-			// `itemTypes` is omitted and re-added as `string[]` because the schema
-			// infers a closed choice-union type that plain string literals don't satisfy.
-			const rule = new ActionCostRule(
-				{ type: 'actionCost' } as foundry.data.fields.SchemaField.CreateData<
-					ActionCostRule['schema']['fields']
-				>,
-				{ strict: false },
-			) as unknown as Omit<ActionCostRule, 'itemTypes'> & {
-				itemTypes: string[];
-				itemIdentifier: string;
-			};
-
-			rule.itemTypes = config.itemTypes ?? [];
-			rule.itemIdentifier = config.itemIdentifier ?? '';
-			return rule;
-		}
-
 		it('matches everything when both scoping fields are empty', () => {
 			const rule = createRule();
 			expect(rule.matchesItem({ type: 'spell' })).toBe(true);
@@ -79,6 +112,32 @@ describe('ActionCostRule', () => {
 			expect(rule.matchesItem({ type: 'feature', system: { identifier: 'defend' } })).toBe(true);
 			expect(rule.matchesItem({ type: 'feature', system: { identifier: 'load' } })).toBe(false);
 			expect(rule.matchesItem({ type: 'feature' })).toBe(false);
+		});
+
+		it('never matches items when the rule applies to heroic reactions', () => {
+			const rule = createRule({ applies: 'heroicReaction' });
+			expect(rule.matchesItem({ type: 'spell' })).toBe(false);
+		});
+	});
+
+	describe('matchesReaction', () => {
+		it('matches every reaction when the reactions list is empty', () => {
+			const rule = createRule({ applies: 'heroicReaction' });
+			expect(rule.matchesReaction('defend')).toBe(true);
+			expect(rule.matchesReaction('interpose')).toBe(true);
+			expect(rule.matchesReaction('opportunityAttack')).toBe(true);
+			expect(rule.matchesReaction('help')).toBe(true);
+		});
+
+		it('scopes by reaction key', () => {
+			const rule = createRule({ applies: 'heroicReaction', reactions: ['defend'] });
+			expect(rule.matchesReaction('defend')).toBe(true);
+			expect(rule.matchesReaction('interpose')).toBe(false);
+		});
+
+		it('never matches reactions when the rule applies to items', () => {
+			const rule = createRule({ applies: 'item' });
+			expect(rule.matchesReaction('defend')).toBe(false);
 		});
 	});
 });

--- a/src/models/rules/actionCost.ts
+++ b/src/models/rules/actionCost.ts
@@ -1,7 +1,10 @@
+import { HEROIC_REACTIONS, type HeroicReactionKey } from '#utils/heroicActions.js';
 import { withWidget } from './_widgetOption.js';
 import { NimbleBaseRule } from './base.js';
 
 type ActionCostMode = 'delta' | 'set';
+
+type ActionCostApplies = 'item' | 'heroicReaction';
 
 /** The item types whose activation carries an action cost. */
 const ACTION_COST_ITEM_TYPES = ['feature', 'monsterFeature', 'object', 'spell'] as const;
@@ -10,6 +13,14 @@ function schema() {
 	const { fields } = foundry.data;
 
 	return {
+		applies: new fields.StringField({
+			required: true,
+			nullable: false,
+			initial: 'item',
+			label: 'NIMBLE.rules.actionCost.applies.label',
+			hint: 'NIMBLE.rules.actionCost.applies.hint',
+			choices: ['item', 'heroicReaction'],
+		}),
 		mode: new fields.StringField({
 			required: true,
 			nullable: false,
@@ -41,16 +52,36 @@ function schema() {
 				initial: [],
 				label: 'NIMBLE.rules.actionCost.itemTypes.label',
 				hint: 'NIMBLE.rules.actionCost.itemTypes.hint',
-			},
+				showWhen: (data: Record<string, unknown>) => data.applies !== 'heroicReaction',
+			} as unknown as never,
 		),
-		itemIdentifier: new fields.StringField({
-			required: true,
-			nullable: false,
-			blank: true,
-			initial: '',
-			label: 'NIMBLE.rules.actionCost.itemIdentifier.label',
-			hint: 'NIMBLE.rules.actionCost.itemIdentifier.hint',
-		}),
+		itemIdentifier: new fields.StringField(
+			withWidget({
+				required: true,
+				nullable: false,
+				blank: true,
+				initial: '',
+				label: 'NIMBLE.rules.actionCost.itemIdentifier.label',
+				hint: 'NIMBLE.rules.actionCost.itemIdentifier.hint',
+				showWhen: (data: Record<string, unknown>) => data.applies !== 'heroicReaction',
+			}),
+		),
+		reactions: new fields.ArrayField(
+			new fields.StringField({
+				required: true,
+				nullable: false,
+				blank: false,
+				choices: [...HEROIC_REACTIONS],
+			}),
+			{
+				required: true,
+				nullable: false,
+				initial: [],
+				label: 'NIMBLE.rules.actionCost.reactions.label',
+				hint: 'NIMBLE.rules.actionCost.reactions.hint',
+				showWhen: (data: Record<string, unknown>) => data.applies === 'heroicReaction',
+			} as unknown as never,
+		),
 		type: new fields.StringField({ required: true, nullable: false, initial: 'actionCost' }),
 	};
 }
@@ -67,25 +98,31 @@ interface ActionCostTargetItem {
 }
 
 /**
- * A pure cost descriptor: modifies the action cost of activating matching items.
- * Carries no lifecycle hooks — the character's activation flow reads matching
- * rules through `resolveCharacterItemActionCost` when an item is activated.
+ * A pure cost descriptor: modifies the action cost of activating matching items
+ * or of using heroic reactions, per the `applies` field. Carries no lifecycle
+ * hooks — the character's activation flow reads matching rules through
+ * `resolveCharacterItemActionCost`, and heroic reaction flows through
+ * `resolveHeroicReactionActionCost`.
  *
- * Because the rule lives on the actor but prices individual activations, the
- * `itemTypes` / `itemIdentifier` scoping fields decide which activations it
- * affects. Both empty means every activation with an action cost.
+ * Because the rule lives on the actor but prices individual uses, scoping
+ * fields decide which uses it affects: `itemTypes` / `itemIdentifier` for item
+ * activations, `reactions` for heroic reactions. Empty scoping fields match
+ * every use of the selected kind. Cost is orthogonal to per-round use limits —
+ * a reaction made free is still limited to once per round.
  */
 class ActionCostRule extends NimbleBaseRule<ActionCostRule.Schema> {
 	static override group = 'resource';
 	static override description = 'NIMBLE.rules.actionCost.description';
 
+	declare applies: ActionCostApplies;
+
 	declare mode: ActionCostMode;
 
 	declare value: string;
 
-	// `itemTypes` is inferred from the schema's `choices` (the closed set of
-	// activatable item types); re-declaring it as the wider `string[]` clashes
-	// with that type.
+	// `itemTypes` and `reactions` are inferred from the schema's `choices`
+	// (closed sets); re-declaring them as wider `string[]` clashes with those
+	// types.
 
 	declare itemIdentifier: string;
 
@@ -99,16 +136,22 @@ class ActionCostRule extends NimbleBaseRule<ActionCostRule.Schema> {
 	override tooltipInfo(): string {
 		return super.tooltipInfo(
 			new Map([
+				['applies', '"item" | "heroicReaction"'],
 				['mode', '"delta" | "set"'],
 				['value', 'string'],
 				['itemTypes', 'string[]'],
 				['itemIdentifier', 'string'],
+				['reactions', 'string[]'],
 			]),
 		);
 	}
 
-	/** True when this rule's scoping matches the activating item. Empty scoping fields match all. */
+	/**
+	 * True when this rule prices item activations and its scoping matches the
+	 * activating item. Empty scoping fields match all items.
+	 */
 	matchesItem(item: ActionCostTargetItem | null | undefined): boolean {
+		if (this.applies !== 'item') return false;
 		if (!item) return false;
 		const itemTypes = this.itemTypes as unknown as string[];
 		if (itemTypes.length > 0 && !itemTypes.includes(item.type ?? '')) return false;
@@ -116,6 +159,16 @@ class ActionCostRule extends NimbleBaseRule<ActionCostRule.Schema> {
 			return false;
 		}
 		return true;
+	}
+
+	/**
+	 * True when this rule prices heroic reactions and its scoping matches the
+	 * given reaction. An empty `reactions` list matches every heroic reaction.
+	 */
+	matchesReaction(reactionKey: HeroicReactionKey): boolean {
+		if (this.applies !== 'heroicReaction') return false;
+		const reactions = this.reactions as unknown as HeroicReactionKey[];
+		return reactions.length === 0 || reactions.includes(reactionKey);
 	}
 
 	/** Resolves the configured value against the actor's roll data. */

--- a/src/utils/getHeroicReactionUsageState.test.ts
+++ b/src/utils/getHeroicReactionUsageState.test.ts
@@ -18,6 +18,29 @@ function globals() {
 	return getTestGlobals<HeroicReactionUsageStateTestGlobals>();
 }
 
+/**
+ * Attaches a minimal reaction-scoped `actionCost` rule to the actor, exposing
+ * only the surface `resolveHeroicReactionActionCost` reads.
+ */
+function addReactionActionCostRule(
+	actor: object,
+	config: { mode: 'delta' | 'set'; value: number; reactions?: string[] },
+): void {
+	const rule = {
+		type: 'actionCost',
+		priority: 1,
+		mode: config.mode,
+		appliesTo: () => true,
+		matchesReaction: (reactionKey: string) =>
+			(config.reactions ?? []).length === 0 || (config.reactions ?? []).includes(reactionKey),
+		resolveValue: () => config.value,
+	};
+	(actor as { rules?: unknown[] }).rules = [
+		...((actor as { rules?: unknown[] }).rules ?? []),
+		rule,
+	];
+}
+
 describe('getHeroicReactionUsageState', () => {
 	beforeEach(() => {
 		globals().game.user = { isGM: false };
@@ -127,5 +150,93 @@ describe('getHeroicReactionUsageState', () => {
 		expect(usageState.canUse).toBe(false);
 		expect(usageState.blockedReason).toBe('spent');
 		expect(usageState.requiredActions).toBe(2);
+	});
+
+	it('reflects actor actionCost rules in the required actions', () => {
+		const actor = createCombatActorFixture({
+			hp: 8,
+			woundsValue: 0,
+			woundsMax: 6,
+			isOwner: true,
+		});
+		addReactionActionCostRule(actor, { mode: 'set', value: 0, reactions: ['defend'] });
+		const combatant = createMockCombatant({
+			id: 'reacting-character',
+			type: 'character',
+			actionsCurrent: 0,
+			actionsMax: 3,
+			actor,
+			combatId: 'combat-heroic-cost',
+		});
+		const activeCombatant = createMockCombatant({
+			id: 'active-character',
+			type: 'character',
+			actionsCurrent: 3,
+			actionsMax: 3,
+			actor: createCombatActorFixture({ hp: 8, woundsValue: 0, woundsMax: 6 }),
+			combatId: 'combat-heroic-cost',
+		});
+		const combat = {
+			round: 1,
+			combatant: activeCombatant,
+			combatants: createCombatantsCollectionFixture([activeCombatant, combatant]),
+		} as unknown as Combat;
+
+		// A free Defend is usable with 0 actions remaining...
+		const defendState = getHeroicReactionUsageState({
+			combat,
+			combatant,
+			reactionKeys: ['defend'],
+		});
+		expect(defendState.requiredActions).toBe(0);
+		expect(defendState.canUse).toBe(true);
+
+		// ...but the discount is scoped: other reactions still cost 1.
+		const helpState = getHeroicReactionUsageState({
+			combat,
+			combatant,
+			reactionKeys: ['help'],
+		});
+		expect(helpState.requiredActions).toBe(1);
+		expect(helpState.blockedReason).toBe('noActions');
+	});
+
+	it('still blocks a free reaction that was already used this round', () => {
+		const actor = createCombatActorFixture({
+			hp: 8,
+			woundsValue: 0,
+			woundsMax: 6,
+			isOwner: true,
+		});
+		addReactionActionCostRule(actor, { mode: 'set', value: 0 });
+		const combatant = createMockCombatant({
+			id: 'reacting-character',
+			type: 'character',
+			actionsCurrent: 3,
+			actionsMax: 3,
+			actor,
+			combatId: 'combat-heroic-cost-limit',
+		});
+		foundry.utils.setProperty(combatant, 'system.actions.heroic.defendAvailable', false);
+		const combat = {
+			round: 1,
+			combatant: createMockCombatant({
+				id: 'active-character',
+				type: 'character',
+				actor: createCombatActorFixture({ hp: 8, woundsValue: 0, woundsMax: 6 }),
+			}),
+			combatants: createCombatantsCollectionFixture([combatant]),
+		} as unknown as Combat;
+
+		const usageState = getHeroicReactionUsageState({
+			combat,
+			combatant,
+			reactionKeys: ['defend'],
+		});
+
+		// Cost and use-limit are orthogonal: a free reaction is still 1/round.
+		expect(usageState.requiredActions).toBe(0);
+		expect(usageState.canUse).toBe(false);
+		expect(usageState.blockedReason).toBe('spent');
 	});
 });

--- a/src/utils/getHeroicReactionUsageState.ts
+++ b/src/utils/getHeroicReactionUsageState.ts
@@ -5,6 +5,7 @@ import {
 } from './heroicActions.js';
 import { isCombatantDead } from './isCombatantDead.js';
 import { isCombatStarted } from './isCombatStarted.js';
+import resolveHeroicReactionActionCost from './resolveHeroicReactionActionCost.js';
 
 export type HeroicReactionUsageBlockedReason =
 	| 'outsideCombat'
@@ -54,7 +55,13 @@ export function getHeroicReactionUsageState({
 	reactionKeys,
 }: GetHeroicReactionUsageStateParams) {
 	const normalizedReactionKeys = normalizeReactionKeys(reactionKeys);
-	const requiredActions = normalizedReactionKeys.length;
+	// Actor-dependent: the combatant's actor may carry `actionCost` rules that
+	// discount or reprice reactions. Cost only — the availability flags below
+	// stay authoritative for the once-per-round limit.
+	const requiredActions = resolveHeroicReactionActionCost(
+		combatant?.actor as unknown as Parameters<typeof resolveHeroicReactionActionCost>[0],
+		normalizedReactionKeys,
+	);
 	const currentActions = getCombatantCurrentActions(combatant);
 	const activeCombatantId = combat?.combatant?.id ?? combat?.combatant?._id ?? null;
 	const combatantId = getCombatantId(combatant);

--- a/src/utils/resolveHeroicReactionActionCost.test.ts
+++ b/src/utils/resolveHeroicReactionActionCost.test.ts
@@ -1,0 +1,242 @@
+import type { Mock } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ActionCostRule } from '../models/rules/actionCost.js';
+import resolveHeroicReactionActionCost from './resolveHeroicReactionActionCost.js';
+
+interface MockRollData {
+	level?: number;
+	[key: string]: unknown;
+}
+
+interface MockActor {
+	rules: unknown[];
+	getRollData: Mock<() => MockRollData>;
+	getDomain: Mock<() => Set<string>>;
+}
+
+interface MockOwnerItem {
+	isEmbedded: boolean;
+	actor: MockActor;
+	name: string;
+	uuid: string;
+	getDomain: Mock<() => Set<string>>;
+}
+
+// Type for test instances where we need to set internal properties directly.
+// `itemTypes` / `reactions` are omitted and re-added as `string[]` because the
+// schema infers closed choice-union types that plain string literals don't
+// satisfy.
+type ActionCostRuleTestInstance = Omit<ActionCostRule, 'itemTypes' | 'reactions'> & {
+	applies: 'item' | 'heroicReaction';
+	mode: 'delta' | 'set';
+	value: string;
+	itemTypes: string[];
+	itemIdentifier: string;
+	reactions: string[];
+	disabled: boolean;
+	priority: number;
+	type: string;
+};
+
+function createMockActor(rollData: MockRollData = {}): MockActor {
+	return {
+		rules: [],
+		getRollData: vi.fn(() => rollData),
+		getDomain: vi.fn(() => new Set<string>()),
+	};
+}
+
+/**
+ * Creates an ActionCostRule instance owned by a mock item on the given actor,
+ * and registers it in the actor's rules array.
+ */
+function addActionCostRule(
+	actor: MockActor,
+	config: {
+		applies?: 'item' | 'heroicReaction';
+		mode?: 'delta' | 'set';
+		value?: string;
+		itemTypes?: string[];
+		itemIdentifier?: string;
+		reactions?: string[];
+		disabled?: boolean;
+		priority?: number;
+		predicatePasses?: boolean;
+	} = {},
+): ActionCostRuleTestInstance {
+	const ownerItem: MockOwnerItem = {
+		isEmbedded: true,
+		actor,
+		name: 'Test Feature',
+		uuid: 'test-owner-item-uuid',
+		getDomain: vi.fn(() => new Set<string>()),
+	};
+
+	const sourceData = {
+		applies: config.applies ?? 'heroicReaction',
+		mode: config.mode ?? 'delta',
+		value: config.value ?? '1',
+		itemTypes: config.itemTypes ?? [],
+		itemIdentifier: config.itemIdentifier ?? '',
+		reactions: config.reactions ?? [],
+		disabled: config.disabled ?? false,
+		label: 'Test Rule',
+		id: 'test-rule-id',
+		identifier: '',
+		priority: config.priority ?? 1,
+		predicate: {},
+		type: 'actionCost',
+	};
+
+	const rule = new ActionCostRule(
+		sourceData as foundry.data.fields.SchemaField.CreateData<ActionCostRule['schema']['fields']>,
+		{ parent: ownerItem as unknown as foundry.abstract.DataModel.Any, strict: false },
+	) as ActionCostRuleTestInstance;
+
+	// Manually set properties since the mock DataModel doesn't do this automatically
+	rule.applies = config.applies ?? 'heroicReaction';
+	rule.mode = config.mode ?? 'delta';
+	rule.value = config.value ?? '1';
+	rule.itemTypes = config.itemTypes ?? [];
+	rule.itemIdentifier = config.itemIdentifier ?? '';
+	rule.reactions = config.reactions ?? [];
+	rule.disabled = config.disabled ?? false;
+	rule.priority = config.priority ?? 1;
+	rule.type = 'actionCost';
+
+	Object.defineProperty(rule, 'item', {
+		get: () => ownerItem,
+		configurable: true,
+	});
+
+	const predicatePasses = config.predicatePasses ?? true;
+	Object.defineProperty(rule, '_predicate', {
+		get: () => ({ size: predicatePasses ? 0 : 1, test: () => predicatePasses }),
+		configurable: true,
+	});
+
+	actor.rules.push(rule);
+
+	return rule;
+}
+
+describe('resolveHeroicReactionActionCost', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe('base cost', () => {
+		it('costs 1 action per reaction key when the actor has no rules', () => {
+			const actor = createMockActor();
+
+			expect(resolveHeroicReactionActionCost(actor, ['defend'])).toBe(1);
+			expect(resolveHeroicReactionActionCost(actor, ['interpose', 'defend'])).toBe(2);
+		});
+
+		it('returns the key count when the actor is null', () => {
+			expect(resolveHeroicReactionActionCost(null, ['defend'])).toBe(1);
+		});
+
+		it('deduplicates repeated reaction keys', () => {
+			const actor = createMockActor();
+
+			expect(resolveHeroicReactionActionCost(actor, ['defend', 'defend'])).toBe(1);
+		});
+
+		it('returns 0 for an empty key list', () => {
+			expect(resolveHeroicReactionActionCost(createMockActor(), [])).toBe(0);
+		});
+	});
+
+	describe('reaction scoping', () => {
+		it('discounts only the scoped reaction', () => {
+			const actor = createMockActor();
+			addActionCostRule(actor, { mode: 'delta', value: '-1', reactions: ['defend'] });
+
+			expect(resolveHeroicReactionActionCost(actor, ['defend'])).toBe(0);
+			expect(resolveHeroicReactionActionCost(actor, ['opportunityAttack'])).toBe(1);
+		});
+
+		it('applies a rule with an empty reactions list to every reaction', () => {
+			const actor = createMockActor();
+			addActionCostRule(actor, { mode: 'set', value: '0' });
+
+			expect(resolveHeroicReactionActionCost(actor, ['defend'])).toBe(0);
+			expect(resolveHeroicReactionActionCost(actor, ['interpose'])).toBe(0);
+			expect(resolveHeroicReactionActionCost(actor, ['help'])).toBe(0);
+			expect(resolveHeroicReactionActionCost(actor, ['opportunityAttack'])).toBe(0);
+		});
+
+		it('prices each reaction of a combined use independently', () => {
+			const actor = createMockActor();
+			addActionCostRule(actor, { mode: 'delta', value: '-1', reactions: ['defend'] });
+
+			// Interpose keeps its full cost; the discount on Defend never
+			// subsidizes it.
+			expect(resolveHeroicReactionActionCost(actor, ['interpose', 'defend'])).toBe(1);
+		});
+	});
+
+	describe('fold semantics', () => {
+		it('clamps each reaction cost at 0', () => {
+			const actor = createMockActor();
+			addActionCostRule(actor, { mode: 'delta', value: '-3' });
+
+			expect(resolveHeroicReactionActionCost(actor, ['interpose', 'defend'])).toBe(0);
+		});
+
+		it('increases the cost with a positive delta', () => {
+			const actor = createMockActor();
+			addActionCostRule(actor, { mode: 'delta', value: '1' });
+
+			expect(resolveHeroicReactionActionCost(actor, ['defend'])).toBe(2);
+		});
+
+		it('resolves formula values against actor roll data', () => {
+			const actor = createMockActor({ level: 2 });
+			addActionCostRule(actor, { mode: 'delta', value: '@level' });
+
+			expect(resolveHeroicReactionActionCost(actor, ['defend'])).toBe(3);
+		});
+
+		it('applies rules in priority order', () => {
+			const actor = createMockActor();
+			// Registered out of order to prove the resolver sorts by priority
+			addActionCostRule(actor, { mode: 'delta', value: '1', priority: 2 });
+			addActionCostRule(actor, { mode: 'set', value: '0', priority: 1 });
+
+			// set → 0 first, then delta +1 → 1
+			expect(resolveHeroicReactionActionCost(actor, ['defend'])).toBe(1);
+		});
+	});
+
+	describe('rule gating', () => {
+		it('ignores rules that apply to item activations', () => {
+			const actor = createMockActor();
+			addActionCostRule(actor, { applies: 'item', mode: 'set', value: '0' });
+
+			expect(resolveHeroicReactionActionCost(actor, ['defend'])).toBe(1);
+		});
+
+		it('ignores disabled rules', () => {
+			const actor = createMockActor();
+			addActionCostRule(actor, { mode: 'set', value: '0', disabled: true });
+
+			expect(resolveHeroicReactionActionCost(actor, ['defend'])).toBe(1);
+		});
+
+		it('ignores rules whose predicate fails', () => {
+			const actor = createMockActor();
+			addActionCostRule(actor, { mode: 'set', value: '0', predicatePasses: false });
+
+			expect(resolveHeroicReactionActionCost(actor, ['defend'])).toBe(1);
+		});
+
+		it('ignores rules of other types', () => {
+			const actor = createMockActor();
+			actor.rules.push({ type: 'damageBonus' });
+
+			expect(resolveHeroicReactionActionCost(actor, ['defend'])).toBe(1);
+		});
+	});
+});

--- a/src/utils/resolveHeroicReactionActionCost.ts
+++ b/src/utils/resolveHeroicReactionActionCost.ts
@@ -1,0 +1,47 @@
+import type { ActionCostRule } from '../models/rules/actionCost.js';
+import type { HeroicReactionKey } from './heroicActions.js';
+
+interface ActorWithRules {
+	rules?: unknown[];
+}
+
+/**
+ * Resolves the total action cost of using the given heroic reactions, folding
+ * the actor's reaction-scoped `actionCost` rules over each reaction's base cost
+ * of 1 action. Matching rules apply per reaction in `priority` order: `delta`
+ * adds its value, `set` overwrites the running cost. Each reaction's cost is
+ * clamped at 0 before summing, so a discount on one reaction never subsidizes
+ * another used alongside it.
+ *
+ * Cost is orthogonal to the once-per-round use limit — callers must keep
+ * checking the `*Available` flags regardless of the resolved cost.
+ *
+ * The fold semantics intentionally mirror `resolveCharacterItemActionCost`
+ * (second occurrence of the pattern — extract a shared fold helper only if a
+ * third cost surface appears).
+ */
+export default function resolveHeroicReactionActionCost(
+	actor: ActorWithRules | null | undefined,
+	reactionKeys: HeroicReactionKey[],
+): number {
+	const normalizedReactionKeys = Array.from(new Set(reactionKeys));
+
+	const rules = (actor?.rules ?? []) as ActionCostRule[];
+	const applicable = rules
+		.filter((rule) => rule.type === 'actionCost' && rule.appliesTo())
+		.sort((a, b) => a.priority - b.priority);
+
+	let totalCost = 0;
+	for (const reactionKey of normalizedReactionKeys) {
+		let cost = 1;
+		for (const rule of applicable) {
+			if (!rule.matchesReaction(reactionKey)) continue;
+			const value = rule.resolveValue();
+			if (value === null) continue;
+			cost = rule.mode === 'set' ? value : cost + value;
+		}
+		totalCost += Math.max(0, cost);
+	}
+
+	return totalCost;
+}

--- a/src/utils/showInsufficientActionsConfirmation.test.ts
+++ b/src/utils/showInsufficientActionsConfirmation.test.ts
@@ -1,0 +1,74 @@
+import type { Mock } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
+import showInsufficientActionsConfirmation from './showInsufficientActionsConfirmation.js';
+
+function confirmDialog() {
+	return foundry.applications.api.DialogV2.confirm as unknown as Mock;
+}
+
+describe('showInsufficientActionsConfirmation', () => {
+	beforeEach(() => {
+		confirmDialog().mockReset();
+	});
+
+	it('proceeds without prompting when the cost is affordable', async () => {
+		const proceed = await showInsufficientActionsConfirmation({
+			activityName: 'Test Activity',
+			requiredActions: 2,
+			currentActions: 2,
+		});
+
+		expect(proceed).toBe(true);
+		expect(confirmDialog()).not.toHaveBeenCalled();
+	});
+
+	it('proceeds without prompting when force is set, even with insufficient actions', async () => {
+		const proceed = await showInsufficientActionsConfirmation({
+			activityName: 'Test Activity',
+			requiredActions: 2,
+			currentActions: 0,
+			force: true,
+		});
+
+		expect(proceed).toBe(true);
+		expect(confirmDialog()).not.toHaveBeenCalled();
+	});
+
+	it('prompts and proceeds when the player confirms the overspend', async () => {
+		confirmDialog().mockResolvedValue(true);
+
+		const proceed = await showInsufficientActionsConfirmation({
+			activityName: 'Test Activity',
+			requiredActions: 2,
+			currentActions: 1,
+		});
+
+		expect(proceed).toBe(true);
+		expect(confirmDialog()).toHaveBeenCalledTimes(1);
+	});
+
+	it('prompts and blocks when the player cancels', async () => {
+		confirmDialog().mockResolvedValue(false);
+
+		const proceed = await showInsufficientActionsConfirmation({
+			activityName: 'Test Activity',
+			requiredActions: 2,
+			currentActions: 1,
+		});
+
+		expect(proceed).toBe(false);
+		expect(confirmDialog()).toHaveBeenCalledTimes(1);
+	});
+
+	it('blocks when the dialog is dismissed without a choice', async () => {
+		confirmDialog().mockResolvedValue(null);
+
+		const proceed = await showInsufficientActionsConfirmation({
+			activityName: 'Test Activity',
+			requiredActions: 1,
+			currentActions: 0,
+		});
+
+		expect(proceed).toBe(false);
+	});
+});

--- a/src/utils/showInsufficientActionsConfirmation.ts
+++ b/src/utils/showInsufficientActionsConfirmation.ts
@@ -1,0 +1,43 @@
+import localize from './localize.js';
+
+interface InsufficientActionsConfirmationOptions {
+	activityName: string;
+	requiredActions: number;
+	currentActions: number;
+	force?: boolean;
+}
+
+/**
+ * Soft-block gate for uses that would cost more actions than the combatant has
+ * remaining. Resolves `true` when the use may proceed: immediately when the
+ * cost is affordable or `force` is set, otherwise only after the player
+ * confirms the overspend in a dialog.
+ *
+ * @returns true if the use may proceed, false otherwise
+ */
+export default async function showInsufficientActionsConfirmation(
+	options: InsufficientActionsConfirmationOptions,
+): Promise<boolean> {
+	const { activityName, requiredActions, currentActions, force } = options;
+
+	if (force === true) return true;
+	if (currentActions >= requiredActions) return true;
+
+	const confirmKey = 'NIMBLE.ui.confirmInsufficientActions';
+
+	const message = localize(`${confirmKey}.message`, {
+		cost: String(requiredActions),
+		current: String(currentActions),
+	});
+	const confirmQuestion = localize(`${confirmKey}.confirmQuestion`, { name: activityName });
+
+	const confirmed = await foundry.applications.api.DialogV2.confirm({
+		window: { title: localize(`${confirmKey}.title`) },
+		content: `<p>${message}</p><p>${confirmQuestion}</p>`,
+		yes: { label: localize(`${confirmKey}.confirm`) },
+		no: { label: localize(`${confirmKey}.cancel`) },
+		rejectClose: false,
+	});
+
+	return confirmed === true;
+}


### PR DESCRIPTION
## Summary

Extends the `actionCost` rule to heroic reactions and adds a soft-block confirmation when an activation would cost more actions than remain. Cost and use-limit are orthogonal axes per the rulebook ("If you've already Defended this round, you can't use abilities requiring it again *(even for free)*") — this PR changes only the cost axis; the `*Available` flags are untouched, so a free Defend already used this round is still blocked as spent, by construction.

## Changes

- `actionCost` rule gains `applies: 'item' | 'heroicReaction'` (default `'item'`, preserving existing semantics) and `reactions: HeroicReactionKey[]`; scoping fields display conditionally in the Rules Builder; `matchesItem()`/`matchesReaction()` enforce cross-scope isolation in one place.
- `resolveHeroicReactionActionCost` — new util: base 1 action per reaction key, folds reaction-scoped rules per key (delta/set, priority, clamp ≥ 0 per key so a Defend discount never subsidizes a combined Interpose).
- `getHeroicReactionUsageState` derives `requiredActions` from the resolver (usage state is now actor-dependent; every caller already passes a combatant, so no plumbing changes).
- `combat.svelte.ts`: `toggleHeroicReactionAvailability` no longer hardcodes `currentActions - 1` — the pip toggle and the panel button now agree on what a reaction costs (`useHeroicReactions` already flowed through the usage state).
- `showInsufficientActionsConfirmation` — new sibling of `showReactionConfirmation` (that one's option shape and i18n namespace are reaction-specific, so it was not widened). `NimbleCharacter.activateItem` fires it before `super.activateItem(...)` — before any dialogs, rolls, or card creation — only when in a started combat, resolved cost > 0, and remaining actions < cost. Cancel returns `null` with zero side effects; `force: true` bypasses; the `skipActionDeduction` path never prompts (no double-prompt with the opportunity-attack panel).

**Rule-of-Three note:** this is the third near-identical confirm dialog (reaction, move, insufficient actions). Extraction of a shared confirm helper is now warranted — deliberately deferred to a follow-up rather than pre-extracted here.

**Known cosmetic gap:** the reaction confirmation copy still reads "Reactions cost 1 action…" from the raw pip check even when a rule prices the reaction at 0 — the gating itself is cost-aware; only the copy lags. Follow-up candidate.

## Test Plan

- `pnpm check` green; new tests: `resolveHeroicReactionActionCost` (15 cases incl. cross-scope isolation both directions), `showInsufficientActionsConfirmation`, updated usage-state tests (free Defend usable at 0 actions; free-but-spent still blocked).
- Live-verified in Foundry v13 (real UI): with a `{applies:'heroicReaction', reactions:['defend'], mode:'set', value:'0'}` rule and 0 actions, Defend succeeds with no confirmation and no pip change; a second Defend the same round is blocked as already used; the tracker pip toggle agrees with the panel; with the rule disabled the same click raises the insufficient-actions confirmation (control).
- Reviewer repro: add the rule above to a character, drop their actions to 0 off-turn, and Defend from the reactions panel.

## Checklist

- [x] Added or updated unit tests
- [x] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [x] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** yes
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues

Relates to #582. Stacked on #877; retarget as parents merge.
