### PR TITLE
feat(combat): actionDelta rule and pending grants

### DIFF
--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -1469,6 +1469,7 @@ export const myStore = writable<MyStoreState>(initialState);
 | `isCombatantDead()` | `src/utils/isCombatantDead.ts` | Check if a combatant is dead based on HP/wounds |
 | `combatantActionMutationQueue` | `src/utils/combatantActionMutationQueue.ts` | Serialize combatant action/reaction updates and clear combat-scoped pending entries |
 | `queueCombatantMutationWithFreshDocument()` | `src/utils/queueCombatantMutationWithFreshDocument.ts` | Queue a mutation and re-resolve the combatant document to avoid stale references |
+| `requestCombatantActionDelta()` | `src/utils/requestCombatantActionDelta.ts` | Apply a combined current/pending action adjustment to a character combatant — direct for GMs/owners, relayed to the active GM over the system socket otherwise |
 | `getActorHpValue()` | `src/utils/isCombatantDead.ts` | Get an actor's current HP value |
 | `getActorWoundsValueAndMax()` | `src/utils/isCombatantDead.ts` | Get an actor's wounds value and max |
 | `calculateRollMode()` | `src/utils/calculateRollMode.ts` | Determine roll mode based on modifier keys |

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -654,6 +654,7 @@
 		"ruleTypes": {
 			"abilityBonus": "Stat Bonus",
 			"actionCost": "Action Cost",
+			"actionDelta": "Action Adjustment",
 			"applyCondition": "Apply Condition",
 			"armorClass": "Armor Class",
 			"chargeConsumer": "Charge Consumer",
@@ -732,6 +733,25 @@
 				"reactions": {
 					"label": "Heroic reactions",
 					"hint": "Only these heroic reactions are affected. Leave empty to affect every heroic reaction."
+				}
+			},
+			"actionDelta": {
+				"description": "Grant or remove raw actions when this item is used — immediately or at the recipient's next turn. Can also borrow: gain actions now and start the next turn with that many fewer. Applies to character combatants only.",
+				"value": {
+					"label": "Actions",
+					"hint": "How many actions to grant. A flat number or formula (e.g. @level). Negative values remove actions."
+				},
+				"timing": {
+					"label": "Timing",
+					"hint": "now: adjust the current action pool immediately (may exceed the usual maximum). nextTurn: apply when the recipient's actions next refill."
+				},
+				"target": {
+					"label": "Target",
+					"hint": "self: the actor using the item. targeted: the currently targeted tokens. allAllies: every allied hero in the combat."
+				},
+				"borrowFromNextTurn": {
+					"label": "Borrow from next turn",
+					"hint": "Also start the next turn with that many fewer actions, applied together with the immediate gain as a single adjustment."
 				}
 			},
 			"applyCondition": {
@@ -1692,6 +1712,8 @@
 				"endTurn": "End Turn",
 				"rollInitiative": "Roll Initiative",
 				"useActionsFirst": "Use your actions first",
+				"pendingActionsGain": "Gains {count} additional actions at the next action refill",
+				"pendingActionsLoss": "Starts the next turn with {count} fewer actions",
 				"confirmEndTurnEarlyTitle": "End Turn Early?",
 				"confirmEndTurnEarlyBody": "You haven't used all your actions yet. Are you sure you want to end your turn?",
 				"noPermissionEndTurn": "You do not have permission to end turns.",

--- a/src/config/registerRulesConfig.ts
+++ b/src/config/registerRulesConfig.ts
@@ -1,5 +1,6 @@
 import { AbilityBonusRule } from '../models/rules/abilityBonus.js';
 import { ActionCostRule } from '../models/rules/actionCost.js';
+import { ActionDeltaRule } from '../models/rules/actionDelta.js';
 import { ApplyConditionRule } from '../models/rules/applyCondition.js';
 import { ArmorClassRule } from '../models/rules/armorClass.js';
 import { ChargeConsumerRule } from '../models/rules/chargeConsumer.js';
@@ -45,6 +46,7 @@ export default function registerRulesConfig() {
 	const ruleTypes = {
 		abilityBonus: 'NIMBLE.ruleTypes.abilityBonus',
 		actionCost: 'NIMBLE.ruleTypes.actionCost',
+		actionDelta: 'NIMBLE.ruleTypes.actionDelta',
 		applyCondition: 'NIMBLE.ruleTypes.applyCondition',
 		armorClass: 'NIMBLE.ruleTypes.armorClass',
 		chargeConsumer: 'NIMBLE.ruleTypes.chargeConsumer',
@@ -90,6 +92,7 @@ export default function registerRulesConfig() {
 	const ruleDataModels = {
 		abilityBonus: AbilityBonusRule,
 		actionCost: ActionCostRule,
+		actionDelta: ActionDeltaRule,
 		applyCondition: ApplyConditionRule,
 		armorClass: ArmorClassRule,
 		chargeConsumer: ChargeConsumerRule,

--- a/src/documents/combat/combat.svelte.test.ts
+++ b/src/documents/combat/combat.svelte.test.ts
@@ -3722,6 +3722,7 @@ describe('NimbleCombat', () => {
 		expect(combatant.update).toHaveBeenCalledWith({
 			'system.actions.base.current': 3,
 			'system.actions.base.additional': 0,
+			'system.actions.pendingDelta': 0,
 			'system.actions.heroic.defendAvailable': true,
 			'system.actions.heroic.interposeAvailable': true,
 			'system.actions.heroic.opportunityAttackAvailable': true,

--- a/src/documents/combat/combat.svelte.ts
+++ b/src/documents/combat/combat.svelte.ts
@@ -9,6 +9,7 @@ import {
 } from '#utils/getHeroicReactionUsageState.js';
 import {
 	canOwnerUseHeroicReaction,
+	getAllHeroicReactionAvailabilityUpdate,
 	getHeroicReactionAvailability,
 	getHeroicReactionAvailabilityUpdate,
 	HEROIC_REACTIONS,
@@ -20,7 +21,11 @@ import { getMinionGroupId, getMinionGroupSummaries } from '#utils/minionGrouping
 import { queueCombatantMutationWithFreshDocument } from '#utils/queueCombatantMutationWithFreshDocument.js';
 import resolveHeroicReactionActionCost from '#utils/resolveHeroicReactionActionCost.js';
 import { isCombatConvenienceAutomationEnabled } from '../../settings/automationSettings.js';
-import { getCombatantManualSortValue, getCombatantResetActions } from './combatantSystem.js';
+import {
+	buildCharacterTurnRefillUpdate,
+	getCombatantManualSortValue,
+	getCombatantResetActions,
+} from './combatantSystem.js';
 import { getCombatantCurrentActions, logMinionGroupingCombat } from './combatCommon.js';
 import { rollInitiativeForCombatant } from './combatInitiative.js';
 import { performMinionGroupAttack } from './combatMinionAttacks.js';
@@ -601,18 +606,6 @@ class NimbleCombat extends Combat {
 		await this.updateEmbeddedDocuments('Combatant', updates);
 	}
 
-	#buildHeroicReactionAvailabilityUpdate(available: boolean): Record<string, unknown> {
-		const update: Record<string, unknown> = {};
-		for (const reactionKey of HEROIC_REACTIONS) {
-			for (const [path, value] of Object.entries(
-				getHeroicReactionAvailabilityUpdate(reactionKey, available),
-			)) {
-				update[path] = value;
-			}
-		}
-		return update;
-	}
-
 	async #refreshCharacterHeroicReactions(): Promise<void> {
 		const updates = this.combatants.contents.reduce<Record<string, unknown>[]>((acc, combatant) => {
 			if (combatant.type !== 'character' || !combatant.id) return acc;
@@ -622,7 +615,7 @@ class NimbleCombat extends Combat {
 			if (!needsRefresh) return acc;
 			acc.push({
 				_id: combatant.id,
-				...this.#buildHeroicReactionAvailabilityUpdate(true),
+				...getAllHeroicReactionAvailabilityUpdate(true),
 			});
 			return acc;
 		}, []);
@@ -798,10 +791,10 @@ class NimbleCombat extends Combat {
 
 	/**
 	 * Refill an outgoing character's turn-end state: fire the Nimble end-of-turn hook (charge-pool
-	 * recovery, etc.), reset base actions to max (capped by Dying), clear additional actions, and
-	 * restore heroic reactions. Callers claim `#endingTurnRefilledCharacterId` synchronously
-	 * before invoking this so a single forward advance never refills — or fires the hook for —
-	 * the same hero twice.
+	 * recovery, etc.), reset base actions to max (capped by Dying, adjusted by any pending action
+	 * delta), clear additional actions, and restore heroic reactions. Callers claim
+	 * `#endingTurnRefilledCharacterId` synchronously before invoking this so a single forward
+	 * advance never refills — or fires the hook for — the same hero twice.
 	 */
 	async #applyCharacterTurnEndRefill(combatant: Combatant.Implementation): Promise<void> {
 		if (combatant.type !== 'character') return;
@@ -809,11 +802,7 @@ class NimbleCombat extends Combat {
 		// @ts-expect-error Custom hook
 		Hooks.call('nimbleCombatTurnEnd', combatant);
 
-		await combatant.update({
-			'system.actions.base.current': getCombatantResetActions(combatant),
-			'system.actions.base.additional': 0,
-			...this.#buildHeroicReactionAvailabilityUpdate(true),
-		} as Record<string, unknown>);
+		await combatant.update(buildCharacterTurnRefillUpdate(combatant));
 	}
 
 	/**
@@ -1273,9 +1262,7 @@ class NimbleCombat extends Combat {
 		await this.updateEmbeddedDocuments('Combatant', [
 			{
 				_id: combatantId,
-				'system.actions.base.current': getCombatantResetActions(combatant),
-				'system.actions.base.additional': 0,
-				...this.#buildHeroicReactionAvailabilityUpdate(true),
+				...buildCharacterTurnRefillUpdate(combatant),
 			} as Record<string, unknown>,
 		]);
 	}

--- a/src/documents/combat/combatInitiative.test.ts
+++ b/src/documents/combat/combatInitiative.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { createCombatantFixture } from '../../../tests/fixtures/combat.js';
 import { applyCharacterInitiativeActionUpdate } from './combatInitiative.js';
 
 function createCharacter() {
@@ -38,6 +39,32 @@ describe('applyCharacterInitiativeActionUpdate', () => {
 		applyCharacterInitiativeActionUpdate(createCharacter(), updates, 20);
 
 		expect(updates['system.actions.base.current']).toBe(3);
+	});
+
+	it('folds a positive pending grant into the round-1 seed and zeroes it', () => {
+		const combatant = createCombatantFixture({ type: 'character', actionsPendingDelta: 2 });
+		const updates: Record<string, unknown> = {};
+		applyCharacterInitiativeActionUpdate(combatant, updates, 14);
+
+		expect(updates['system.actions.base.current']).toBe(4);
+		expect(updates['system.actions.pendingDelta']).toBe(0);
+	});
+
+	it('folds a negative pending debt into the round-1 seed, clamping at 0', () => {
+		const combatant = createCombatantFixture({ type: 'character', actionsPendingDelta: -3 });
+		const updates: Record<string, unknown> = {};
+		applyCharacterInitiativeActionUpdate(combatant, updates, 7);
+
+		expect(updates['system.actions.base.current']).toBe(0);
+		expect(updates['system.actions.pendingDelta']).toBe(0);
+	});
+
+	it('does not write the pending delta path when no pending delta exists', () => {
+		const updates: Record<string, unknown> = {};
+		applyCharacterInitiativeActionUpdate(createCharacter(), updates, 14);
+
+		expect(updates['system.actions.base.current']).toBe(2);
+		expect(updates).not.toHaveProperty('system.actions.pendingDelta');
 	});
 
 	it('does not modify actions for non-character combatants', () => {

--- a/src/documents/combat/combatInitiative.ts
+++ b/src/documents/combat/combatInitiative.ts
@@ -1,5 +1,12 @@
+import { getCombatantPendingActionDelta } from './combatantSystem.js';
 import type { InitiativeRollOutcome } from './combatTypes.js';
 import { handleInitiativeRules } from './handleInitiativeRules.js';
+
+function getInitiativeStartingActions(rollTotal: number): number {
+	if (rollTotal >= 20) return 3;
+	if (rollTotal >= 10) return 2;
+	return 1;
+}
 
 export function applyCharacterInitiativeActionUpdate(
 	combatant: Combatant.Implementation,
@@ -12,16 +19,19 @@ export function applyCharacterInitiativeActionUpdate(
 	// first round. Their max stays at 3 — per-turn restoration always refills
 	// to max (reduced only by the Dying condition), so we must not touch max
 	// here or low-initiative heroes would be permanently capped below 3.
+	//
+	// The round-1 seed is a `current`-reset site like the per-turn refill, so
+	// any pending action adjustment folds in here too (and is cleared) — else a
+	// pre-roll grant or debt would be silently eaten by the absolute set.
 	const actionPath = 'system.actions.base.current';
-	if (rollTotal >= 20) {
-		combatantUpdates[actionPath] = 3;
-		return;
+	const pendingDelta = getCombatantPendingActionDelta(combatant);
+	combatantUpdates[actionPath] = Math.max(
+		0,
+		getInitiativeStartingActions(rollTotal) + pendingDelta,
+	);
+	if (pendingDelta !== 0) {
+		combatantUpdates['system.actions.pendingDelta'] = 0;
 	}
-	if (rollTotal >= 10) {
-		combatantUpdates[actionPath] = 2;
-		return;
-	}
-	combatantUpdates[actionPath] = 1;
 }
 
 export async function buildInitiativeChatData(params: {

--- a/src/documents/combat/combatantSystem.test.ts
+++ b/src/documents/combat/combatantSystem.test.ts
@@ -3,7 +3,12 @@ import {
 	createCombatActorFixture,
 	createCombatantFixture,
 } from '../../../tests/fixtures/combat.js';
-import { getCombatantResetActions, isCombatantDying } from './combatantSystem.js';
+import {
+	buildCharacterTurnRefillUpdate,
+	getCombatantPendingActionDelta,
+	getCombatantResetActions,
+	isCombatantDying,
+} from './combatantSystem.js';
 
 function createDyingActor(dyingActionLimit?: number) {
 	return Object.assign(createCombatActorFixture({ type: 'character', dyingActionLimit }), {
@@ -52,5 +57,95 @@ describe('getCombatantResetActions', () => {
 	it('never resets above the combatant base max even with a higher dying limit', () => {
 		const combatant = createCombatantFixture({ actionsMax: 1, actor: createDyingActor(2) });
 		expect(getCombatantResetActions(combatant)).toBe(1);
+	});
+});
+
+describe('getCombatantPendingActionDelta', () => {
+	it('reads the pending delta from a character combatant', () => {
+		const combatant = createCombatantFixture({ type: 'character', actionsPendingDelta: 2 });
+		expect(getCombatantPendingActionDelta(combatant)).toBe(2);
+	});
+
+	it('preserves negative pending deltas (action debt)', () => {
+		const combatant = createCombatantFixture({ type: 'character', actionsPendingDelta: -3 });
+		expect(getCombatantPendingActionDelta(combatant)).toBe(-3);
+	});
+
+	it('is always 0 for non-character combatants', () => {
+		const combatant = createCombatantFixture({ type: 'npc', actionsPendingDelta: 2 });
+		expect(getCombatantPendingActionDelta(combatant)).toBe(0);
+	});
+
+	it('is 0 when the field is absent', () => {
+		const combatant = {
+			type: 'character',
+			system: { actions: {} },
+		} as unknown as Combatant.Implementation;
+		expect(getCombatantPendingActionDelta(combatant)).toBe(0);
+	});
+});
+
+describe('buildCharacterTurnRefillUpdate', () => {
+	const HEROIC_AVAILABILITY_PATHS = [
+		'system.actions.heroic.defendAvailable',
+		'system.actions.heroic.interposeAvailable',
+		'system.actions.heroic.opportunityAttackAvailable',
+		'system.actions.heroic.helpAvailable',
+	];
+
+	it('refills to the base max when no pending delta exists', () => {
+		const combatant = createCombatantFixture({
+			type: 'character',
+			actionsMax: 3,
+			actor: createCombatActorFixture({ type: 'character' }),
+		});
+		const update = buildCharacterTurnRefillUpdate(combatant);
+
+		expect(update['system.actions.base.current']).toBe(3);
+		expect(update['system.actions.base.additional']).toBe(0);
+		expect(update['system.actions.pendingDelta']).toBe(0);
+		for (const path of HEROIC_AVAILABILITY_PATHS) {
+			expect(update[path]).toBe(true);
+		}
+	});
+
+	it('folds a positive pending grant into the refill and zeroes it', () => {
+		const combatant = createCombatantFixture({
+			type: 'character',
+			actionsMax: 3,
+			actionsPendingDelta: 2,
+			actor: createCombatActorFixture({ type: 'character' }),
+		});
+		const update = buildCharacterTurnRefillUpdate(combatant);
+
+		expect(update['system.actions.base.current']).toBe(5);
+		expect(update['system.actions.pendingDelta']).toBe(0);
+	});
+
+	it('folds a negative pending debt into the refill, clamping at 0', () => {
+		const combatant = createCombatantFixture({
+			type: 'character',
+			actionsMax: 3,
+			actionsPendingDelta: -5,
+			actor: createCombatActorFixture({ type: 'character' }),
+		});
+		const update = buildCharacterTurnRefillUpdate(combatant);
+
+		expect(update['system.actions.base.current']).toBe(0);
+		expect(update['system.actions.pendingDelta']).toBe(0);
+	});
+
+	it('applies the pending delta on top of the Dying-capped reset', () => {
+		const combatant = createCombatantFixture({
+			type: 'character',
+			actionsMax: 3,
+			actionsPendingDelta: 1,
+			actor: createDyingActor(),
+		});
+		const update = buildCharacterTurnRefillUpdate(combatant);
+
+		// Dying caps the reset at 1; the pending grant still lands on top.
+		expect(update['system.actions.base.current']).toBe(2);
+		expect(update['system.actions.pendingDelta']).toBe(0);
 	});
 });

--- a/src/documents/combat/combatantSystem.ts
+++ b/src/documents/combat/combatantSystem.ts
@@ -1,4 +1,5 @@
 import { getActorDyingActionLimit, isActorDying } from '#utils/actorHealthState.js';
+import { getAllHeroicReactionAvailabilityUpdate } from '#utils/heroicActions.js';
 import type { CombatantBaseActions, NimbleCombatantSystem } from './combatTypes.js';
 
 function getCombatantSystem(combatant: Combatant.Implementation): NimbleCombatantSystem | null {
@@ -53,4 +54,40 @@ export function getCombatantBaseActionMax(combatant: Combatant.Implementation): 
 
 export function getCombatantManualSortValue(combatant: Combatant.Implementation): number {
 	return Number(getCombatantSystem(combatant)?.sort ?? 0);
+}
+
+/**
+ * The character combatant's pending action adjustment: an amount folded into
+ * `current` at their next action refill, then zeroed. May be negative (an
+ * action debt owed to the next turn). Always 0 for non-character combatants,
+ * whose models don't carry the field.
+ */
+export function getCombatantPendingActionDelta(combatant: Combatant.Implementation): number {
+	if (combatant.type !== 'character') return 0;
+	const actions = getCombatantSystem(combatant)?.actions as
+		| { pendingDelta?: unknown }
+		| undefined
+		| null;
+	const normalized = Number(actions?.pendingDelta ?? 0);
+	if (!Number.isFinite(normalized)) return 0;
+	return Math.trunc(normalized);
+}
+
+/**
+ * The update object that refills a character combatant's turn state: base
+ * actions reset to max (capped by Dying) with any pending action adjustment
+ * folded in and cleared, additional actions cleared, and heroic reactions
+ * restored. Shared by every character `current`-reset site so the refill
+ * semantics can never drift between them.
+ */
+export function buildCharacterTurnRefillUpdate(
+	combatant: Combatant.Implementation,
+): Record<string, unknown> {
+	const pendingDelta = getCombatantPendingActionDelta(combatant);
+	return {
+		'system.actions.base.current': Math.max(0, getCombatantResetActions(combatant) + pendingDelta),
+		'system.actions.base.additional': 0,
+		'system.actions.pendingDelta': 0,
+		...getAllHeroicReactionAvailabilityUpdate(true),
+	};
 }

--- a/src/hooks/actionEconomySystem.ts
+++ b/src/hooks/actionEconomySystem.ts
@@ -1,0 +1,171 @@
+import { systemHookName } from '#system';
+import { isCombatantDead } from '#utils/isCombatantDead.js';
+import { requestCombatantActionDelta } from '#utils/requestCombatantActionDelta.js';
+import type { ActionDeltaApplication, ActionDeltaRule } from '../models/rules/actionDelta.js';
+
+type HookFn = (...args: unknown[]) => unknown;
+
+interface UseItemTarget {
+	id?: string | null;
+	document?: { id?: string | null } | null;
+	actor?: { id?: string | null } | null;
+}
+
+interface UseItemContext {
+	targets?: UseItemTarget[];
+}
+
+interface RuleBearingItem {
+	uuid?: string;
+	isEmbedded?: boolean;
+	actor?: { id?: string | null } | null;
+	rules?: Map<string, { type?: string }> | null;
+}
+
+function registerCustomHook(eventName: string, fn: HookFn): void {
+	(Hooks.on as (event: string, fn: HookFn) => number)(eventName, fn);
+}
+
+function toRuleBearingItem(item: unknown): RuleBearingItem | null {
+	if (!item || typeof item !== 'object') return null;
+	const typedItem = item as RuleBearingItem;
+	if (!typedItem.isEmbedded || !typedItem.actor) return null;
+	return typedItem;
+}
+
+function getActionDeltaRules(item: RuleBearingItem): ActionDeltaRule[] {
+	const rules = item.rules;
+	if (!rules || typeof rules.values !== 'function') return [];
+	return [...rules.values()].filter(
+		(rule): rule is ActionDeltaRule =>
+			rule?.type === 'actionDelta' && (rule as ActionDeltaRule).appliesTo(),
+	);
+}
+
+function getCombatantDisposition(combatant: Combatant.Implementation): number | null {
+	const disposition = Number(
+		combatant.token?.disposition ?? combatant.token?.object?.document?.disposition ?? Number.NaN,
+	);
+	return Number.isFinite(disposition) ? disposition : null;
+}
+
+function findCombatantForActorId(
+	combat: Combat,
+	actorId: string | null | undefined,
+): Combatant.Implementation | null {
+	if (!actorId) return null;
+	return combat.combatants.find((combatant) => combatant.actorId === actorId) ?? null;
+}
+
+function findCombatantForTarget(
+	combat: Combat,
+	target: UseItemTarget,
+): Combatant.Implementation | null {
+	const tokenId = target.document?.id ?? target.id ?? null;
+	if (tokenId) {
+		const tokenCombatant =
+			combat.combatants.find((combatant) => combatant.tokenId === tokenId) ?? null;
+		if (tokenCombatant) return tokenCombatant;
+	}
+	return findCombatantForActorId(combat, target.actor?.id ?? null);
+}
+
+/**
+ * The living character combatants a rule affects, per its `target` field:
+ * the activating actor's combatant, the user's current targets, or every
+ * character combatant sharing the source's token disposition.
+ */
+function resolveTargetCombatants(params: {
+	combat: Combat;
+	rule: ActionDeltaRule;
+	sourceCombatant: Combatant.Implementation | null;
+	targets: UseItemTarget[];
+}): Combatant.Implementation[] {
+	const { combat, rule, sourceCombatant, targets } = params;
+
+	let candidates: Array<Combatant.Implementation | null>;
+	if (rule.target === 'self') {
+		candidates = [sourceCombatant];
+	} else if (rule.target === 'targeted') {
+		candidates = targets.map((target) => findCombatantForTarget(combat, target));
+	} else {
+		const sourceDisposition = sourceCombatant ? getCombatantDisposition(sourceCombatant) : null;
+		candidates = combat.combatants.contents.filter(
+			(combatant) =>
+				combatant.type === 'character' &&
+				(sourceDisposition === null || getCombatantDisposition(combatant) === sourceDisposition),
+		);
+	}
+
+	return candidates.filter(
+		(combatant): combatant is Combatant.Implementation =>
+			combatant !== null && combatant.type === 'character' && !isCombatantDead(combatant),
+	);
+}
+
+function accumulateApplication(
+	accumulator: Map<string, ActionDeltaApplication>,
+	combatantId: string,
+	application: ActionDeltaApplication,
+): void {
+	const existing = accumulator.get(combatantId) ?? { currentDelta: 0, pendingDelta: 0 };
+	accumulator.set(combatantId, {
+		currentDelta: existing.currentDelta + application.currentDelta,
+		pendingDelta: existing.pendingDelta + application.pendingDelta,
+	});
+}
+
+/**
+ * Applies the action adjustments declared by the used item's rules. All of an
+ * item's adjustments for the same combatant are merged into one combined
+ * request so paired current/pending changes land as a single atomic update.
+ * Like charge consumption, this runs regardless of the rule-automation setting
+ * — it is resource bookkeeping, not condition automation.
+ */
+function handleUseItem(item: unknown, _chatMessage: unknown, context: unknown): void {
+	const typedItem = toRuleBearingItem(item);
+	if (!typedItem) return;
+
+	const combat = (game.combat as Combat | null) ?? null;
+	if (!combat?.started) return;
+
+	const rules = getActionDeltaRules(typedItem);
+	if (rules.length < 1) return;
+
+	const targets = ((context as UseItemContext | null)?.targets ?? []).filter(
+		(target): target is UseItemTarget => Boolean(target),
+	);
+	const sourceCombatant = findCombatantForActorId(combat, typedItem.actor?.id ?? null);
+
+	const applications = new Map<string, ActionDeltaApplication>();
+	for (const rule of rules) {
+		const application = rule.resolveApplication();
+		if (!application) continue;
+
+		for (const combatant of resolveTargetCombatants({ combat, rule, sourceCombatant, targets })) {
+			if (!combatant.id) continue;
+			accumulateApplication(applications, combatant.id, application);
+		}
+	}
+
+	// Negative accumulations persist unclamped — the refill and the write path
+	// clamp `current` at zero, so a large pending debt simply floors there.
+	for (const [combatantId, deltas] of applications) {
+		if (deltas.currentDelta === 0 && deltas.pendingDelta === 0) continue;
+		void requestCombatantActionDelta({
+			combat,
+			combatantId,
+			sourceItemUuid: typedItem.uuid ?? '',
+			deltas,
+		});
+	}
+}
+
+let didRegisterActionEconomySystemHooks = false;
+
+export default function registerActionEconomySystemHooks(): void {
+	if (didRegisterActionEconomySystemHooks) return;
+	didRegisterActionEconomySystemHooks = true;
+
+	registerCustomHook(systemHookName('useItem'), handleUseItem as HookFn);
+}

--- a/src/hooks/ready.ts
+++ b/src/hooks/ready.ts
@@ -12,6 +12,7 @@ import {
 import { registerCombatTurnSocketListener } from '../utils/combatTurnActions.js';
 import { registerIncomingReactionSocketListener } from '../utils/incomingAttackReactions.js';
 import { registerMarkTargetSocketListener } from '../utils/markTargetEffects.js';
+import { registerCombatantActionDeltaSocketListener } from '../utils/requestCombatantActionDelta.js';
 import CanvasConditionsPanel from '../view/ui/CanvasConditionsPanel.svelte';
 import CtTopTracker from '../view/ui/CtTopTracker.svelte';
 import registerAdjacencySync from './combatantHooks/adjacencySync.js';
@@ -61,6 +62,7 @@ export default async function ready() {
 	registerCombatTurnSocketListener();
 	registerIncomingReactionSocketListener();
 	registerMarkTargetSocketListener();
+	registerCombatantActionDeltaSocketListener();
 
 	const target = document.body;
 	const anchor = document.querySelector('#notifications');

--- a/src/models/combatant/CharacterCombatantDataModel.ts
+++ b/src/models/combatant/CharacterCombatantDataModel.ts
@@ -25,6 +25,14 @@ const nimbleCharacterCombatantSchema = () => ({
 				min: 0,
 			}),
 		}),
+		// Action adjustment folded into `current` at the next refill, then zeroed.
+		// May be negative (an action debt owed to the next turn), so no `min`.
+		pendingDelta: new fields.NumberField({
+			required: true,
+			initial: 0,
+			nullable: false,
+			integer: true,
+		}),
 		heroic: new fields.SchemaField({
 			interposeAvailable: new fields.BooleanField({
 				required: true,

--- a/src/models/rules/actionDelta.test.ts
+++ b/src/models/rules/actionDelta.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import { ActionDeltaRule } from './actionDelta.js';
+
+describe('ActionDeltaRule', () => {
+	describe('schema', () => {
+		it('defines the expected fields', () => {
+			const schema = ActionDeltaRule.defineSchema();
+			expect(schema).toHaveProperty('type');
+			expect(schema).toHaveProperty('value');
+			expect(schema).toHaveProperty('timing');
+			expect(schema).toHaveProperty('target');
+			expect(schema).toHaveProperty('borrowFromNextTurn');
+		});
+
+		it('declares closed timing and target choice sets', () => {
+			const schema = ActionDeltaRule.defineSchema();
+			const timing = schema.timing as unknown as { choices: string[] };
+			expect(timing.choices).toEqual(['now', 'nextTurn']);
+
+			const target = schema.target as unknown as { choices: string[] };
+			expect(target.choices).toEqual(['self', 'targeted', 'allAllies']);
+		});
+
+		it('defaults to an immediate self-grant of 1 that does not borrow', () => {
+			const schema = ActionDeltaRule.defineSchema();
+			const value = schema.value as unknown as { options: { initial: string } };
+			expect(value.options.initial).toBe('1');
+
+			const timing = schema.timing as unknown as { options: { initial: string } };
+			expect(timing.options.initial).toBe('now');
+
+			const target = schema.target as unknown as { options: { initial: string } };
+			expect(target.options.initial).toBe('self');
+
+			const borrowFromNextTurn = schema.borrowFromNextTurn as unknown as {
+				options: { initial: boolean };
+			};
+			expect(borrowFromNextTurn.options.initial).toBe(false);
+		});
+	});
+
+	describe('class metadata', () => {
+		it('exposes the picker group and i18n description key', () => {
+			expect(ActionDeltaRule.group).toBe('resource');
+			expect(ActionDeltaRule.description).toBe('NIMBLE.rules.actionDelta.description');
+		});
+
+		it('declares no lifecycle hooks', () => {
+			// A pure action-adjustment descriptor must never run during data preparation.
+			expect(ActionDeltaRule.appliesInPrePrepareData).toBe(false);
+			expect(Object.getOwnPropertyNames(ActionDeltaRule.prototype)).not.toContain(
+				'afterPrepareData',
+			);
+		});
+	});
+
+	function createRule(
+		config: {
+			timing?: 'now' | 'nextTurn';
+			target?: 'self' | 'targeted' | 'allAllies';
+			borrowFromNextTurn?: boolean;
+			resolvedValue?: number | null;
+		} = {},
+	) {
+		const rule = new ActionDeltaRule(
+			{ type: 'actionDelta' } as foundry.data.fields.SchemaField.CreateData<
+				ActionDeltaRule['schema']['fields']
+			>,
+			{ strict: false },
+		) as ActionDeltaRule;
+
+		rule.timing = config.timing ?? 'now';
+		rule.target = config.target ?? 'self';
+		rule.borrowFromNextTurn = config.borrowFromNextTurn ?? false;
+		// Bypass the actor-backed formula resolution — resolveApplication's
+		// timing/borrow arithmetic is the unit under test.
+		Object.defineProperty(rule, 'resolveValue', {
+			value: () => config.resolvedValue ?? null,
+		});
+		return rule;
+	}
+
+	describe('resolveApplication', () => {
+		it('applies an immediate grant to the current pool only', () => {
+			const rule = createRule({ timing: 'now', resolvedValue: 2 });
+			expect(rule.resolveApplication()).toEqual({ currentDelta: 2, pendingDelta: 0 });
+		});
+
+		it('applies a next-turn grant to the pending delta only', () => {
+			const rule = createRule({ timing: 'nextTurn', resolvedValue: 2 });
+			expect(rule.resolveApplication()).toEqual({ currentDelta: 0, pendingDelta: 2 });
+		});
+
+		it('supports negative values (action denial)', () => {
+			const rule = createRule({ timing: 'now', resolvedValue: -1 });
+			expect(rule.resolveApplication()).toEqual({ currentDelta: -1, pendingDelta: 0 });
+		});
+
+		it('borrowing grants now and owes the same amount next turn as one combined adjustment', () => {
+			const rule = createRule({ timing: 'now', borrowFromNextTurn: true, resolvedValue: 2 });
+			expect(rule.resolveApplication()).toEqual({ currentDelta: 2, pendingDelta: -2 });
+		});
+
+		it('ignores borrowing for next-turn grants', () => {
+			const rule = createRule({ timing: 'nextTurn', borrowFromNextTurn: true, resolvedValue: 2 });
+			expect(rule.resolveApplication()).toEqual({ currentDelta: 0, pendingDelta: 2 });
+		});
+
+		it('is null for an unresolvable value', () => {
+			const rule = createRule({ resolvedValue: null });
+			expect(rule.resolveApplication()).toBeNull();
+		});
+
+		it('is null for a zero value', () => {
+			const rule = createRule({ resolvedValue: 0 });
+			expect(rule.resolveApplication()).toBeNull();
+		});
+
+		it('truncates fractional values', () => {
+			const rule = createRule({ timing: 'now', borrowFromNextTurn: true, resolvedValue: 2.7 });
+			expect(rule.resolveApplication()).toEqual({ currentDelta: 2, pendingDelta: -2 });
+		});
+	});
+});

--- a/src/models/rules/actionDelta.ts
+++ b/src/models/rules/actionDelta.ts
@@ -1,0 +1,135 @@
+import { withWidget } from './_widgetOption.js';
+import { NimbleBaseRule } from './base.js';
+
+type ActionDeltaTiming = 'now' | 'nextTurn';
+
+type ActionDeltaTarget = 'self' | 'targeted' | 'allAllies';
+
+/**
+ * The change an `actionDelta` rule makes to a combatant's action pools when it
+ * fires, expressed as a single combined adjustment: `currentDelta` applies to
+ * the current pool immediately, `pendingDelta` accumulates into the amount
+ * folded in at the recipient's next action refill.
+ */
+interface ActionDeltaApplication {
+	currentDelta: number;
+	pendingDelta: number;
+}
+
+function schema() {
+	const { fields } = foundry.data;
+
+	return {
+		value: new fields.StringField(
+			withWidget({
+				required: true,
+				nullable: false,
+				initial: '1',
+				label: 'NIMBLE.rules.actionDelta.value.label',
+				hint: 'NIMBLE.rules.actionDelta.value.hint',
+				widget: 'formula',
+			}),
+		),
+		timing: new fields.StringField({
+			required: true,
+			nullable: false,
+			initial: 'now',
+			label: 'NIMBLE.rules.actionDelta.timing.label',
+			hint: 'NIMBLE.rules.actionDelta.timing.hint',
+			choices: ['now', 'nextTurn'],
+		}),
+		target: new fields.StringField({
+			required: true,
+			nullable: false,
+			initial: 'self',
+			label: 'NIMBLE.rules.actionDelta.target.label',
+			hint: 'NIMBLE.rules.actionDelta.target.hint',
+			choices: ['self', 'targeted', 'allAllies'],
+		}),
+		borrowFromNextTurn: new fields.BooleanField({
+			required: true,
+			nullable: false,
+			initial: false,
+			label: 'NIMBLE.rules.actionDelta.borrowFromNextTurn.label',
+			hint: 'NIMBLE.rules.actionDelta.borrowFromNextTurn.hint',
+			showWhen: (data: Record<string, unknown>) => data.timing !== 'nextTurn',
+		} as unknown as never),
+		type: new fields.StringField({ required: true, nullable: false, initial: 'actionDelta' }),
+	};
+}
+
+declare namespace ActionDeltaRule {
+	type Schema = NimbleBaseRule.Schema & ReturnType<typeof schema>;
+}
+
+/**
+ * Grants (or removes) raw actions when the owning item is used. Carries no
+ * lifecycle hooks — the item-use hook (`src/hooks/actionEconomySystem.ts`)
+ * collects matching rules and applies their resolved deltas to the affected
+ * character combatants.
+ *
+ * `timing` picks when the change lands: `now` adjusts the current action pool
+ * immediately (overflow past the pool maximum is allowed), `nextTurn`
+ * accumulates into the pending adjustment folded in at the recipient's next
+ * refill. `borrowFromNextTurn` combines the two: gain the value now and start
+ * the next turn with that many fewer, as one atomic adjustment. `target` picks
+ * who is affected — the activating actor, the user's current targets, or every
+ * allied character combatant.
+ */
+class ActionDeltaRule extends NimbleBaseRule<ActionDeltaRule.Schema> {
+	static override group = 'resource';
+	static override description = 'NIMBLE.rules.actionDelta.description';
+
+	declare value: string;
+
+	declare timing: ActionDeltaTiming;
+
+	declare target: ActionDeltaTarget;
+
+	declare borrowFromNextTurn: boolean;
+
+	static override defineSchema(): ActionDeltaRule.Schema {
+		return {
+			...NimbleBaseRule.defineSchema(),
+			...schema(),
+		};
+	}
+
+	override tooltipInfo(): string {
+		return super.tooltipInfo(
+			new Map([
+				['value', 'string'],
+				['timing', '"now" | "nextTurn"'],
+				['target', '"self" | "targeted" | "allAllies"'],
+				['borrowFromNextTurn', 'boolean'],
+			]),
+		);
+	}
+
+	/** Resolves the configured value against the actor's roll data. */
+	resolveValue(): number | null {
+		return this.resolveFormula(this.value);
+	}
+
+	/**
+	 * The combined current/pending adjustment this rule makes when it fires, or
+	 * `null` when the resolved value is invalid or zero (a no-op).
+	 */
+	resolveApplication(): ActionDeltaApplication | null {
+		const value = this.resolveValue();
+		if (value === null) return null;
+		const normalizedValue = Math.trunc(value);
+		if (normalizedValue === 0) return null;
+
+		if (this.timing === 'nextTurn') {
+			return { currentDelta: 0, pendingDelta: normalizedValue };
+		}
+
+		return {
+			currentDelta: normalizedValue,
+			pendingDelta: this.borrowFromNextTurn ? -normalizedValue : 0,
+		};
+	}
+}
+
+export { ActionDeltaRule, type ActionDeltaApplication };

--- a/src/nimble.ts
+++ b/src/nimble.ts
@@ -1,3 +1,4 @@
+import registerActionEconomySystemHooks from './hooks/actionEconomySystem.js';
 import { handleAutomaticConditionApplication } from './hooks/automaticConditions.js';
 import registerBabeleHooks from './hooks/babeleInit.js';
 import registerBabeleInstallNotice from './hooks/babeleInstallNotice.js';
@@ -119,6 +120,7 @@ registerCombatantDefeatSync();
 registerCombatantHealthStateSync();
 registerDyingActionLimitSync();
 registerChargeSystemHooks();
+registerActionEconomySystemHooks();
 registerDicePoolSystemHooks();
 registerWoundTriggerHooks();
 registerTurnTriggerHooks();

--- a/src/utils/heroicActions.ts
+++ b/src/utils/heroicActions.ts
@@ -78,6 +78,16 @@ export function getHeroicReactionAvailabilityUpdate(
 	};
 }
 
+export function getAllHeroicReactionAvailabilityUpdate(
+	available: boolean,
+): Record<string, unknown> {
+	const update: Record<string, unknown> = {};
+	for (const reactionKey of HEROIC_REACTIONS) {
+		Object.assign(update, getHeroicReactionAvailabilityUpdate(reactionKey, available));
+	}
+	return update;
+}
+
 export function getHeroicReactionAvailabilityTitle(
 	reactionKey: HeroicReactionKey,
 	available: boolean,

--- a/src/utils/requestCombatantActionDelta.test.ts
+++ b/src/utils/requestCombatantActionDelta.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { createCombatantFixture } from '../../tests/fixtures/combat.js';
+import { buildCombatantActionDeltaUpdate } from './requestCombatantActionDelta.js';
+
+describe('buildCombatantActionDeltaUpdate', () => {
+	it('applies an immediate grant, allowing overflow past the pool max', () => {
+		const combatant = createCombatantFixture({
+			type: 'character',
+			actionsCurrent: 3,
+			actionsMax: 3,
+		});
+		const update = buildCombatantActionDeltaUpdate(combatant, {
+			currentDelta: 2,
+			pendingDelta: 0,
+		});
+
+		expect(update).toEqual({ 'system.actions.base.current': 5 });
+	});
+
+	it('clamps an immediate removal at 0', () => {
+		const combatant = createCombatantFixture({
+			type: 'character',
+			actionsCurrent: 1,
+			actionsMax: 3,
+		});
+		const update = buildCombatantActionDeltaUpdate(combatant, {
+			currentDelta: -4,
+			pendingDelta: 0,
+		});
+
+		expect(update).toEqual({ 'system.actions.base.current': 0 });
+	});
+
+	it('accumulates a pending grant onto the stored pending delta', () => {
+		const combatant = createCombatantFixture({
+			type: 'character',
+			actionsPendingDelta: 1,
+		});
+		const update = buildCombatantActionDeltaUpdate(combatant, {
+			currentDelta: 0,
+			pendingDelta: 2,
+		});
+
+		expect(update).toEqual({ 'system.actions.pendingDelta': 3 });
+	});
+
+	it('writes a paired gain-now/owe-next-turn adjustment as one atomic update', () => {
+		const combatant = createCombatantFixture({
+			type: 'character',
+			actionsCurrent: 1,
+			actionsMax: 3,
+			actionsPendingDelta: 0,
+		});
+		const update = buildCombatantActionDeltaUpdate(combatant, {
+			currentDelta: 2,
+			pendingDelta: -2,
+		});
+
+		expect(update).toEqual({
+			'system.actions.base.current': 3,
+			'system.actions.pendingDelta': -2,
+		});
+	});
+
+	it('is null for non-character combatants', () => {
+		const combatant = createCombatantFixture({ type: 'npc', actionsCurrent: 1 });
+		expect(buildCombatantActionDeltaUpdate(combatant, { currentDelta: 2, pendingDelta: 0 })).toBe(
+			null,
+		);
+	});
+
+	it('is null for an all-zero adjustment', () => {
+		const combatant = createCombatantFixture({ type: 'character' });
+		expect(buildCombatantActionDeltaUpdate(combatant, { currentDelta: 0, pendingDelta: 0 })).toBe(
+			null,
+		);
+	});
+
+	it('normalizes non-finite deltas to no-ops', () => {
+		const combatant = createCombatantFixture({ type: 'character' });
+		expect(
+			buildCombatantActionDeltaUpdate(combatant, {
+				currentDelta: Number.NaN,
+				pendingDelta: Number.POSITIVE_INFINITY,
+			}),
+		).toBe(null);
+	});
+});

--- a/src/utils/requestCombatantActionDelta.ts
+++ b/src/utils/requestCombatantActionDelta.ts
@@ -1,0 +1,221 @@
+import {
+	getCombatantBaseActionMax,
+	getCombatantPendingActionDelta,
+} from '#documents/combat/combatantSystem.js';
+import { SYSTEM_ID } from '#system';
+import {
+	getCombatantCurrentActions,
+	resolveCombatantCurrentActionsAfterDelta,
+} from './combatTurnActions.js';
+import { isActiveGM } from './isActiveGM.js';
+import { queueCombatantMutationWithFreshDocument } from './queueCombatantMutationWithFreshDocument.js';
+
+/**
+ * Foundry system socket channel. Must be `system.<id>` so the request reaches the GM's
+ * client, and derived from SYSTEM_ID so the emitter and listener stay in lockstep across
+ * the stable (`nimble`) and dev (`nimble-dev`) installs.
+ */
+const ACTION_DELTA_SOCKET_NAME = `system.${SYSTEM_ID}`;
+const ACTION_DELTA_REQUEST_TYPE = 'actionDelta';
+
+/** A combined adjustment to a character combatant's action pools. */
+interface CombatantActionDeltas {
+	/** Change to the current action pool, applied immediately. Overflow past max is allowed. */
+	currentDelta: number;
+	/** Change to the pending adjustment folded in at the combatant's next action refill. */
+	pendingDelta: number;
+}
+
+interface CombatantActionDeltaRequest extends CombatantActionDeltas {
+	type: typeof ACTION_DELTA_REQUEST_TYPE;
+	combatId: string;
+	combatantId: string;
+	userId: string;
+	sourceItemUuid: string;
+}
+
+function normalizeDelta(value: unknown): number {
+	const numericValue = Number(value);
+	if (!Number.isFinite(numericValue)) return 0;
+	return Math.trunc(numericValue);
+}
+
+/**
+ * The update object applying a combined current/pending action adjustment to a
+ * character combatant, or `null` when nothing would change (non-character
+ * combatant or an all-zero adjustment). Both pools are written in one update so
+ * paired adjustments (e.g. gain now, owe next turn) can never half-apply.
+ */
+export function buildCombatantActionDeltaUpdate(
+	combatant: Combatant.Implementation,
+	deltas: CombatantActionDeltas,
+): Record<string, unknown> | null {
+	if (combatant.type !== 'character') return null;
+
+	const currentDelta = normalizeDelta(deltas.currentDelta);
+	const pendingDelta = normalizeDelta(deltas.pendingDelta);
+	if (currentDelta === 0 && pendingDelta === 0) return null;
+
+	const update: Record<string, unknown> = {};
+	if (currentDelta !== 0) {
+		update['system.actions.base.current'] = resolveCombatantCurrentActionsAfterDelta({
+			currentActions: getCombatantCurrentActions(combatant),
+			maxActions: getCombatantBaseActionMax(combatant),
+			delta: currentDelta,
+			allowOverflow: true,
+		});
+	}
+	if (pendingDelta !== 0) {
+		update['system.actions.pendingDelta'] =
+			getCombatantPendingActionDelta(combatant) + pendingDelta;
+	}
+	return update;
+}
+
+async function applyCombatantActionDelta(params: {
+	combat: Combat;
+	combatantId: string;
+	deltas: CombatantActionDeltas;
+}): Promise<boolean> {
+	return (
+		(await queueCombatantMutationWithFreshDocument({
+			combat: params.combat,
+			combatantId: params.combatantId,
+			mutation: async (combatant) => {
+				const update = buildCombatantActionDeltaUpdate(combatant, params.deltas);
+				if (!update) return false;
+				await combatant.update(update);
+				return true;
+			},
+		})) ?? false
+	);
+}
+
+/** Whether this client may write the combatant's action pools directly, without a GM relay. */
+function canModifyCombatant(combatant: Combatant.Implementation): boolean {
+	return Boolean(game.user?.isGM) || Boolean(combatant.actor?.isOwner);
+}
+
+function getSocket():
+	| {
+			on?: (eventName: string, listener: (payload: unknown) => void) => void;
+			emit?: (eventName: string, payload: unknown) => void;
+	  }
+	| undefined {
+	return game.socket as ReturnType<typeof getSocket>;
+}
+
+/**
+ * Applies a combined current/pending action adjustment to a character combatant. The
+ * activating client owns the granting item but often not the affected combatant (an ally's
+ * grant, a hostile denial), so it cannot write the combatant directly. GMs and combatant
+ * owners apply the adjustment locally; everyone else relays the request to the active GM,
+ * mirroring the mark-target socket proxy.
+ *
+ * Returns whether the adjustment was applied (direct) or successfully relayed.
+ */
+export async function requestCombatantActionDelta(params: {
+	combat: Combat;
+	combatantId: string;
+	sourceItemUuid: string;
+	deltas: CombatantActionDeltas;
+}): Promise<boolean> {
+	const { combat, combatantId, sourceItemUuid, deltas } = params;
+	const combatant = combat.combatants.get(combatantId) ?? null;
+	if (!combatant || combatant.type !== 'character') return false;
+
+	if (canModifyCombatant(combatant)) {
+		return applyCombatantActionDelta({ combat, combatantId, deltas });
+	}
+
+	if (!game.user?.id) return false;
+	const socket = getSocket();
+	if (!socket?.emit) return false;
+
+	const request: CombatantActionDeltaRequest = {
+		type: ACTION_DELTA_REQUEST_TYPE,
+		combatId: combat.id ?? combat._id ?? '',
+		combatantId,
+		userId: game.user.id,
+		sourceItemUuid,
+		currentDelta: normalizeDelta(deltas.currentDelta),
+		pendingDelta: normalizeDelta(deltas.pendingDelta),
+	};
+	socket.emit(ACTION_DELTA_SOCKET_NAME, request);
+	return true;
+}
+
+function getUserById(userId: string | null | undefined): User.Implementation | null {
+	if (!userId) return null;
+	const usersCollection = game.users as unknown as {
+		get?: (id: string) => User.Implementation | null;
+	};
+	return usersCollection.get?.(userId) ?? null;
+}
+
+/**
+ * A relayed request is honored only if the requesting user still owns the granting item's
+ * actor — the same authorization the activation itself required — so a client cannot ask
+ * the GM to rewrite the action pools of combatants it has no claim to affect.
+ */
+function isRequestAuthorized(userId: string, sourceItemUuid: string): boolean {
+	const user = getUserById(userId);
+	if (!user) return false;
+	if (user.isGM) return true;
+
+	const item = fromUuidSync(sourceItemUuid as Parameters<typeof fromUuidSync>[0]) as {
+		actor?: { testUserPermission?: (user: unknown, level: unknown) => boolean } | null;
+	} | null;
+	return Boolean(item?.actor?.testUserPermission?.(user, CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER));
+}
+
+function getCombatById(combatId: string | null | undefined): Combat | null {
+	if (!combatId) return null;
+	const combatsCollection = game.combats as unknown as {
+		get?: (id: string) => Combat | null;
+	};
+	return combatsCollection.get?.(combatId) ?? null;
+}
+
+async function handleCombatantActionDeltaRequest(payload: unknown): Promise<void> {
+	// The active GM is the single client that performs the privileged write.
+	if (!isActiveGM()) return;
+	if (!payload || typeof payload !== 'object') return;
+
+	const request = payload as Partial<CombatantActionDeltaRequest>;
+	if (request.type !== ACTION_DELTA_REQUEST_TYPE) return;
+	if (!request.combatId || !request.combatantId || !request.userId || !request.sourceItemUuid) {
+		return;
+	}
+	if (!isRequestAuthorized(request.userId, request.sourceItemUuid)) return;
+
+	const combat = getCombatById(request.combatId);
+	if (!combat) return;
+	const combatant = combat.combatants.get(request.combatantId) ?? null;
+	if (!combatant || combatant.type !== 'character') return;
+
+	await applyCombatantActionDelta({
+		combat,
+		combatantId: request.combatantId,
+		deltas: {
+			currentDelta: normalizeDelta(request.currentDelta),
+			pendingDelta: normalizeDelta(request.pendingDelta),
+		},
+	});
+}
+
+let hasRegisteredCombatantActionDeltaSocketListener = false;
+
+/**
+ * Registers the GM-side listener for relayed action-adjustment requests. Idempotent, so it
+ * is safe to call once from the `ready` hook.
+ */
+export function registerCombatantActionDeltaSocketListener(): void {
+	if (hasRegisteredCombatantActionDeltaSocketListener) return;
+	hasRegisteredCombatantActionDeltaSocketListener = true;
+
+	const socket = getSocket();
+	socket?.on?.(ACTION_DELTA_SOCKET_NAME, (payload) => {
+		void handleCombatantActionDeltaRequest(payload);
+	});
+}

--- a/src/view/rulesBuilder/components/RuleTypePicker.svelte.ts
+++ b/src/view/rulesBuilder/components/RuleTypePicker.svelte.ts
@@ -12,6 +12,7 @@ interface PickerEntry {
 const RULE_ICONS: Record<string, string> = {
 	abilityBonus: 'fa-solid fa-dumbbell',
 	actionCost: 'fa-solid fa-stopwatch',
+	actionDelta: 'fa-solid fa-plus-minus',
 	applyCondition: 'fa-solid fa-bolt-lightning',
 	armorClass: 'fa-solid fa-shield-halved',
 	chargeConsumer: 'fa-solid fa-arrow-down-from-line',

--- a/src/view/sheets/components/ActionTracker.svelte
+++ b/src/view/sheets/components/ActionTracker.svelte
@@ -35,9 +35,10 @@
 				</button>
 			{:else if state.hasInitiative}
 				<div class="action-tracker__pips">
-					{#each { length: state.actionsData.effectiveMax }, i}
+					{#each { length: state.actionsData.pipCount }, i}
 						{@const isAvailable = i < state.actionsData.current}
 						{@const isAdditional = i >= state.actionsData.max}
+						{@const isOverflow = i >= state.actionsData.effectiveMax}
 						{@const isJustSpent = state.justSpentPips.has(i)}
 						{@const diceIcon = getDiceIcon(i)}
 
@@ -46,6 +47,7 @@
 							class:action-tracker__pip--available={isAvailable}
 							class:action-tracker__pip--spent={!isAvailable}
 							class:action-tracker__pip--additional={isAdditional}
+							class:action-tracker__pip--overflow={isOverflow}
 							class:action-tracker__pip--just-spent={isJustSpent}
 							type="button"
 							aria-label={state.getPipAriaLabel(i, isAvailable)}
@@ -72,6 +74,18 @@
 						>
 							<i class="fa-solid fa-plus"></i>
 						</button>
+					{/if}
+
+					{#if state.pendingActionsBadge}
+						<span
+							class="action-tracker__pending"
+							class:action-tracker__pending--negative={state.pendingActionsBadge.isNegative}
+							aria-label={state.pendingActionsBadge.tooltip}
+							data-tooltip={state.pendingActionsBadge.tooltip}
+							data-tooltip-direction="RIGHT"
+						>
+							{state.pendingActionsBadge.text}
+						</span>
 					{/if}
 				</div>
 
@@ -211,6 +225,23 @@
 				}
 			}
 
+			// Overflow pips: granted actions beyond the effective max. Only ever
+			// rendered filled (there is no empty slot past the max to restore into).
+			&--overflow.action-tracker__pip--available {
+				border-color: hsl(45, 70%, 50%);
+
+				i,
+				.action-tracker__pip-number {
+					color: hsl(45, 70%, 50%);
+				}
+
+				&:hover i,
+				&:hover .action-tracker__pip-number {
+					color: hsl(45, 70%, 60%);
+					filter: drop-shadow(0 0 4px hsl(45, 70%, 50%));
+				}
+			}
+
 			&--just-spent {
 				animation: pip-spent 0.6s ease-out;
 
@@ -224,6 +255,25 @@
 			font-size: 0.75rem;
 			font-weight: 700;
 			line-height: 1;
+		}
+
+		&__pending {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			width: 1.625rem;
+			height: 1rem;
+			font-size: 0.625rem;
+			font-weight: 700;
+			line-height: 1;
+			color: hsl(139, 47%, 44%);
+			border: 1px dashed currentcolor;
+			border-radius: 4px;
+			cursor: help;
+
+			&--negative {
+				color: hsl(0, 55%, 55%);
+			}
 		}
 
 		&__add-additional {

--- a/src/view/sheets/components/ActionTracker.svelte.ts
+++ b/src/view/sheets/components/ActionTracker.svelte.ts
@@ -4,6 +4,7 @@ import type { NimbleCharacter } from '#documents/actor/character.js';
 import {
 	getCombatantAdditionalActions,
 	getCombatantBaseActions,
+	getCombatantPendingActionDelta,
 	isCombatantDying,
 } from '#documents/combat/combatantSystem.js';
 import type { PromptedInitiativeOptions } from '#types/combat.js';
@@ -24,6 +25,12 @@ interface ActionsData {
 	max: number;
 	additional: number;
 	effectiveMax: number;
+	/** How far `current` exceeds `effectiveMax` (granted actions beyond the usual pool). */
+	overflow: number;
+	/** How many pips to render: the effective max plus any overflow. */
+	pipCount: number;
+	/** Adjustment folded into `current` at the next action refill. May be negative. */
+	pendingDelta: number;
 }
 
 // ============================================================================
@@ -88,7 +95,17 @@ export function createActionTrackerState(getActor: () => NimbleCharacter) {
 
 	function getActionsData(): ActionsData {
 		const combatant = getCombatantInCombat();
-		if (!combatant) return { current: 0, max: 3, additional: 0, effectiveMax: 3 };
+		if (!combatant) {
+			return {
+				current: 0,
+				max: 3,
+				additional: 0,
+				effectiveMax: 3,
+				overflow: 0,
+				pipCount: 3,
+				pendingDelta: 0,
+			};
+		}
 
 		const actions = getCombatantBaseActions(combatant);
 		const additional = getCombatantAdditionalActions(combatant);
@@ -98,11 +115,18 @@ export function createActionTrackerState(getActor: () => NimbleCharacter) {
 		const max = isCombatantDying(combatant)
 			? Math.min(actions.max || 3, getActorDyingActionLimit(combatant.actor))
 			: actions.max || 3;
+		const effectiveMax = max + additional;
+		// Granted actions may push `current` past the effective max; render the
+		// surplus as extra overflow pips rather than silently truncating it.
+		const overflow = Math.max(0, actions.current - effectiveMax);
 		return {
 			current: actions.current,
 			max,
 			additional,
-			effectiveMax: max + additional,
+			effectiveMax,
+			overflow,
+			pipCount: effectiveMax + overflow,
+			pendingDelta: getCombatantPendingActionDelta(combatant),
 		};
 	}
 
@@ -257,6 +281,22 @@ export function createActionTrackerState(getActor: () => NimbleCharacter) {
 
 	const showCombatBar = $derived(hasInitiative || needsInitiative || initiativePending);
 
+	// Badge surfacing a pending action adjustment ("+2" / "−1") so players see
+	// at a glance that their next refill will differ from the usual maximum.
+	const pendingActionsBadge = $derived.by(() => {
+		const delta = actionsData.pendingDelta;
+		if (delta === 0) return null;
+		const isNegative = delta < 0;
+		const count = String(Math.abs(delta));
+		return {
+			text: `${isNegative ? '−' : '+'}${count}`,
+			tooltip: isNegative
+				? localize('NIMBLE.ui.heroicActions.pendingActionsLoss', { count })
+				: localize('NIMBLE.ui.heroicActions.pendingActionsGain', { count }),
+			isNegative,
+		};
+	});
+
 	// ============================================================================
 	// Pip Interaction
 	// ============================================================================
@@ -341,6 +381,9 @@ export function createActionTrackerState(getActor: () => NimbleCharacter) {
 		},
 		get showCombatBar() {
 			return showCombatBar;
+		},
+		get pendingActionsBadge() {
+			return pendingActionsBadge;
 		},
 		get justSpentPips() {
 			return justSpentPips;

--- a/tests/fixtures/combat.ts
+++ b/tests/fixtures/combat.ts
@@ -27,6 +27,7 @@ export type CombatantFixtureOptions = {
 	tokenId?: string;
 	actionsCurrent?: number;
 	actionsMax?: number;
+	actionsPendingDelta?: number;
 };
 
 type CombatantsCollectionFixture = Combatant.Implementation[] & {
@@ -96,6 +97,7 @@ export function createCombatantFixture({
 	tokenId = '',
 	actionsCurrent = 1,
 	actionsMax = 2,
+	actionsPendingDelta = 0,
 }: CombatantFixtureOptions = {}): Combatant.Implementation {
 	const resolvedActorId = actorId || actor?.id || '';
 
@@ -119,6 +121,7 @@ export function createCombatantFixture({
 					current: actionsCurrent,
 					max: actionsMax,
 				},
+				pendingDelta: actionsPendingDelta,
 				heroic: {
 					defendAvailable: true,
 					interposeAvailable: true,


### PR DESCRIPTION
## Summary

New `actionDelta` rule for features that grant or dock raw actions — "+1 action", "an ally gains 1 action", "gain 2 now but start your next turn with 2 fewer", hostile action denial — plus the `pendingDelta` machinery that makes next-turn grants survive every refill path. Character combatants only (NPC/Solo models don't carry the pool; the Companion shares the hero's pool).

## Changes

- `CharacterCombatantDataModel` gains `actions.pendingDelta` (integer, initial 0, **no min** — debts are negative). Semantic: folded into `current` at the next refill, then zeroed. Not stored in `additional`, which is wiped per-turn and feeds `effectiveMax` — a next-turn grant there would misrender the current pool. No migration (the migration runner never visits combatants; Foundry fills `initial: 0` on read).
- All three character `current`-reset sites fold the delta: turn-end refill and the depleted-handoff path now share a `buildCharacterTurnRefillUpdate()` helper (they had already drifted as inline copies), and the round-1 initiative seed folds it too so a round-1 grant isn't eaten. `current = max(0, resetActions + pendingDelta)`, then `pendingDelta` zeroed in the same update. The two non-character reset sites are untouched. `dyingActionLimitSync` intentionally does not clear `pendingDelta` — Dying clamps `current` now; a pending grant lands next turn when the character may no longer be Dying.
- `src/models/rules/actionDelta.ts` — fields: `value` (formula), `timing: 'now' | 'nextTurn'`, `target: 'self' | 'targeted' | 'allAllies'`, `borrowFromNextTurn`. Borrow = +N now and −N pending in ONE atomic combatant update. Registered in all four places.
- `src/hooks/actionEconomySystem.ts` — listens on `systemHookName('useItem')` (chargeSystem shape), resolves targets, merges applications per combatant, dispatches one write each.
- `src/utils/requestCombatantActionDelta.ts` — GM socket relay on the system channel (players can't update combatants they don't own; hostile denial targets an enemy). Direct write for GM/owner; executor authorizes by source-item-actor ownership; writes go through `queueCombatantMutationWithFreshDocument` with overflow allowed.
- ActionTracker renders overflow pips (`current` may exceed `effectiveMax`) and a pending badge ("+2 / −1 next turn") so players aren't blindsided at refill.

## Test Plan

- `pnpm check` green; new tests cover the refill fold (positive grant, negative debt clamped at 0, zeroed after fold, Dying interplay, round-1 path), rule schema/semantics (borrow = one atomic update), relay guards (non-character → null, clamp, overflow).
- Live-verified in Foundry v13 (real UI): a `nextTurn +1` grant sets `pendingDelta` 1, and after ending the turn via the real End Turn control the pool refills to max+1 with `pendingDelta` zeroed; borrow `+2 now` overflows to 5 with 2 visually distinct overflow pips and the pending badge, and the next refill lands at max−2; a pre-initiative `pendingDelta` survives the round-1 seed (roll via the real initiative dialog).
- Reviewer repro: put an `actionDelta` rule on a feature, activate it mid-combat, watch the tracker and then the next refill.

## Checklist

- [x] Added or updated unit tests
- [x] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [x] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** yes
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues

Relates to #582. Stacked on #878; retarget as parents merge.

