### PR TITLE
feat(chat): granted activation offers

### DIFF
--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -1470,6 +1470,8 @@ export const myStore = writable<MyStoreState>(initialState);
 | `combatantActionMutationQueue` | `src/utils/combatantActionMutationQueue.ts` | Serialize combatant action/reaction updates and clear combat-scoped pending entries |
 | `queueCombatantMutationWithFreshDocument()` | `src/utils/queueCombatantMutationWithFreshDocument.ts` | Queue a mutation and re-resolve the combatant document to avoid stale references |
 | `requestCombatantActionDelta()` | `src/utils/requestCombatantActionDelta.ts` | Apply a combined current/pending action adjustment to a character combatant — direct for GMs/owners, relayed to the active GM over the system socket otherwise |
+| `getPrimaryActiveGmId()` | `src/utils/getPrimaryActiveGmId.ts` | User id of the single GM client that executes relayed socket requests (designated active GM, falling back to any connected GM), or `null` when no GM is connected |
+| `collectGrantedActionOffers()`, `requestGrantedActionOfferUse()` | `src/utils/grantedActionOffers.ts` | Granted-activation offers on activation chat cards — build offers from an item's `grantActivation` rules at use time, and consume an offer (direct for GMs, relayed to the active GM over the system socket otherwise) |
 | `getActorHpValue()` | `src/utils/isCombatantDead.ts` | Get an actor's current HP value |
 | `getActorWoundsValueAndMax()` | `src/utils/isCombatantDead.ts` | Get an actor's wounds value and max |
 | `calculateRollMode()` | `src/utils/calculateRollMode.ts` | Determine roll mode based on modifier keys |

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -90,6 +90,13 @@
 			"healingAlreadyApplied": "Healing has already been applied",
 			"healingUndone": "Healing has been undone",
 			"noHealingRecord": "No healing record found to undo",
+			"grantedActionOffers": {
+				"heading": "Granted Actions",
+				"weaponAttack": "Weapon Attack",
+				"noEligibleItems": "No eligible items to use.",
+				"usedBy": "Granted action used by {name}",
+				"usedByVia": "Granted action used by {name} via {label}"
+			},
 			"incomingReactions": {
 				"heading": "Reactions",
 				"forceReroll": "Force Reroll",
@@ -665,6 +672,7 @@
 			"damageBonus": "Damage Bonus",
 			"damageReduction": "Damage Reduction",
 			"dyingActionLimit": "Dying Action Limit",
+			"grantActivation": "Grant Activation",
 			"grantMovement": "Grant Movement",
 			"diceConsumer": "Dice Consumer",
 			"dicePool": "Dice Pool",
@@ -944,6 +952,13 @@
 						"label": "Condition",
 						"hint": "Optional condition tested when the trigger fires (e.g. self: raging). Leave empty to always apply."
 					}
+				}
+			},
+			"grantActivation": {
+				"description": "Offer the currently targeted tokens an immediate activation (e.g. a weapon attack) via a button on this item's chat card. Any action cost for the recipient is governed by other rules, such as an Action Cost or Action Adjustment rule.",
+				"activationType": {
+					"label": "Granted activation",
+					"hint": "What the recipient is offered. Weapon attack: the recipient picks one of their weapons and makes a normal attack."
 				}
 			},
 			"grantMovement": {

--- a/src/config/registerRulesConfig.ts
+++ b/src/config/registerRulesConfig.ts
@@ -13,6 +13,7 @@ import { DamageReductionRule } from '../models/rules/damageReduction.js';
 import { DiceConsumerRule } from '../models/rules/diceConsumer.js';
 import { DicePoolRule } from '../models/rules/dicePool.js';
 import { DyingActionLimitRule } from '../models/rules/dyingActionLimit.js';
+import { GrantActivationRule } from '../models/rules/grantActivation.js';
 import { ItemGrantRule } from '../models/rules/grantItem.js';
 import { GrantMovementRule } from '../models/rules/grantMovement.js';
 import { GrantProficiencyRule } from '../models/rules/grantProficiencies.ts';
@@ -57,6 +58,7 @@ export default function registerRulesConfig() {
 		damageBonus: 'NIMBLE.ruleTypes.damageBonus',
 		damageReduction: 'NIMBLE.ruleTypes.damageReduction',
 		dyingActionLimit: 'NIMBLE.ruleTypes.dyingActionLimit',
+		grantActivation: 'NIMBLE.ruleTypes.grantActivation',
 		grantMovement: 'NIMBLE.ruleTypes.grantMovement',
 		diceConsumer: 'NIMBLE.ruleTypes.diceConsumer',
 		dicePool: 'NIMBLE.ruleTypes.dicePool',
@@ -103,6 +105,7 @@ export default function registerRulesConfig() {
 		damageBonus: DamageBonusRule,
 		damageReduction: DamageReductionRule,
 		dyingActionLimit: DyingActionLimitRule,
+		grantActivation: GrantActivationRule,
 		grantMovement: GrantMovementRule,
 		diceConsumer: DiceConsumerRule,
 		dicePool: DicePoolRule,

--- a/src/hooks/actionEconomySystem.ts
+++ b/src/hooks/actionEconomySystem.ts
@@ -1,4 +1,5 @@
 import { systemHookName } from '#system';
+import { collectGrantedActionOffers } from '#utils/grantedActionOffers.js';
 import { isCombatantDead } from '#utils/isCombatantDead.js';
 import { requestCombatantActionDelta } from '#utils/requestCombatantActionDelta.js';
 import type { ActionDeltaApplication, ActionDeltaRule } from '../models/rules/actionDelta.js';
@@ -8,7 +9,7 @@ type HookFn = (...args: unknown[]) => unknown;
 interface UseItemTarget {
 	id?: string | null;
 	document?: { id?: string | null } | null;
-	actor?: { id?: string | null } | null;
+	actor?: { id?: string | null; uuid?: string } | null;
 }
 
 interface UseItemContext {
@@ -17,8 +18,9 @@ interface UseItemContext {
 
 interface RuleBearingItem {
 	uuid?: string;
+	name?: string;
 	isEmbedded?: boolean;
-	actor?: { id?: string | null } | null;
+	actor?: { id?: string | null; uuid?: string } | null;
 	rules?: Map<string, { type?: string }> | null;
 }
 
@@ -161,6 +163,37 @@ function handleUseItem(item: unknown, _chatMessage: unknown, context: unknown): 
 	}
 }
 
+/**
+ * Stamps the used item's granted-activation offers onto its chat card, where
+ * the recipients' owners (or a GM) can accept them. Runs on the activating
+ * client, which authored the message and may therefore update it. Unlike the
+ * action-delta handler, this does not require an active combat — an offered
+ * activation works anywhere, and any in-combat action cost is resolved by the
+ * recipient's normal activation flow.
+ */
+function handleUseItemGrantedOffers(item: unknown, chatMessage: unknown, context: unknown): void {
+	const typedItem = toRuleBearingItem(item);
+	if (!typedItem) return;
+
+	const message = chatMessage as {
+		system?: { grantedActionOffers?: unknown };
+		update?: (data: Record<string, unknown>) => Promise<unknown>;
+	} | null;
+	// Only card types whose schema carries the offers field can persist them.
+	if (!message?.update || !Array.isArray(message.system?.grantedActionOffers)) return;
+
+	const targets = ((context as UseItemContext | null)?.targets ?? []).filter(
+		(target): target is UseItemTarget => Boolean(target),
+	);
+	const offers = collectGrantedActionOffers(
+		typedItem as Parameters<typeof collectGrantedActionOffers>[0],
+		targets,
+	);
+	if (offers.length < 1) return;
+
+	void message.update({ system: { grantedActionOffers: offers } });
+}
+
 let didRegisterActionEconomySystemHooks = false;
 
 export default function registerActionEconomySystemHooks(): void {
@@ -168,4 +201,5 @@ export default function registerActionEconomySystemHooks(): void {
 	didRegisterActionEconomySystemHooks = true;
 
 	registerCustomHook(systemHookName('useItem'), handleUseItem as HookFn);
+	registerCustomHook(systemHookName('useItem'), handleUseItemGrantedOffers as HookFn);
 }

--- a/src/hooks/ready.ts
+++ b/src/hooks/ready.ts
@@ -10,6 +10,7 @@ import {
 	loadAncestryLanguageDefaults,
 } from '../settings/languageSettings.js';
 import { registerCombatTurnSocketListener } from '../utils/combatTurnActions.js';
+import { registerGrantedActionOfferSocketListener } from '../utils/grantedActionOffers.js';
 import { registerIncomingReactionSocketListener } from '../utils/incomingAttackReactions.js';
 import { registerMarkTargetSocketListener } from '../utils/markTargetEffects.js';
 import { registerCombatantActionDeltaSocketListener } from '../utils/requestCombatantActionDelta.js';
@@ -60,6 +61,7 @@ export default async function ready() {
 		if (actor?.type === 'character') actor.prepareData?.();
 	}
 	registerCombatTurnSocketListener();
+	registerGrantedActionOfferSocketListener();
 	registerIncomingReactionSocketListener();
 	registerMarkTargetSocketListener();
 	registerCombatantActionDeltaSocketListener();

--- a/src/models/chat/FeatureCardDataModel.ts
+++ b/src/models/chat/FeatureCardDataModel.ts
@@ -1,5 +1,11 @@
 import { activation } from '../item/common.js';
-import { appliedHealing, incomingReactions, metadata, targets } from './common.js';
+import {
+	appliedHealing,
+	grantedActionOffers,
+	incomingReactions,
+	metadata,
+	targets,
+} from './common.js';
 
 const { fields } = foundry.data;
 
@@ -30,6 +36,7 @@ declare namespace NimbleFeatureCardData {
 	type Schema = DataSchema &
 		ReturnType<typeof activation> &
 		ReturnType<typeof appliedHealing> &
+		ReturnType<typeof grantedActionOffers> &
 		ReturnType<typeof incomingReactions> &
 		ReturnType<typeof metadata> &
 		ReturnType<typeof featureCardSchema> &
@@ -48,6 +55,7 @@ class NimbleFeatureCardData extends foundry.abstract.TypeDataModel<
 		return {
 			...activation(),
 			...appliedHealing(),
+			...grantedActionOffers(),
 			...incomingReactions(),
 			...featureCardSchema(),
 			...metadata(),

--- a/src/models/chat/ObjectCardDataModel.ts
+++ b/src/models/chat/ObjectCardDataModel.ts
@@ -1,5 +1,11 @@
 import { activation } from '../item/common.js';
-import { appliedHealing, incomingReactions, metadata, targets } from './common.js';
+import {
+	appliedHealing,
+	grantedActionOffers,
+	incomingReactions,
+	metadata,
+	targets,
+} from './common.js';
 
 const { fields } = foundry.data;
 
@@ -26,6 +32,7 @@ declare namespace NimbleObjectCardData {
 	type Schema = DataSchema &
 		ReturnType<typeof activation> &
 		ReturnType<typeof appliedHealing> &
+		ReturnType<typeof grantedActionOffers> &
 		ReturnType<typeof incomingReactions> &
 		ReturnType<typeof metadata> &
 		ReturnType<typeof objectCardSchema> &
@@ -44,6 +51,7 @@ class NimbleObjectCardData extends foundry.abstract.TypeDataModel<
 		return {
 			...activation(),
 			...appliedHealing(),
+			...grantedActionOffers(),
 			...incomingReactions(),
 			...objectCardSchema(),
 			...metadata(),

--- a/src/models/chat/SpellCardDataModel.ts
+++ b/src/models/chat/SpellCardDataModel.ts
@@ -1,5 +1,11 @@
 import { activation } from '../item/common.js';
-import { appliedHealing, incomingReactions, metadata, targets } from './common.js';
+import {
+	appliedHealing,
+	grantedActionOffers,
+	incomingReactions,
+	metadata,
+	targets,
+} from './common.js';
 
 const { fields } = foundry.data;
 
@@ -31,6 +37,7 @@ declare namespace NimbleSpellCardData {
 	type Schema = DataSchema &
 		ReturnType<typeof activation> &
 		ReturnType<typeof appliedHealing> &
+		ReturnType<typeof grantedActionOffers> &
 		ReturnType<typeof incomingReactions> &
 		ReturnType<typeof metadata> &
 		ReturnType<typeof spellCardSchema> &
@@ -49,6 +56,7 @@ class NimbleSpellCardData extends foundry.abstract.TypeDataModel<
 		return {
 			...activation(),
 			...appliedHealing(),
+			...grantedActionOffers(),
 			...incomingReactions(),
 			...spellCardSchema(),
 			...metadata(),

--- a/src/models/chat/common.test.ts
+++ b/src/models/chat/common.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { grantedActionOffers } from './common.js';
+
+describe('grantedActionOffers schema factory', () => {
+	it('defines an offers array that is empty by default', () => {
+		const schema = grantedActionOffers();
+		const field = schema.grantedActionOffers as unknown as { options: { initial: unknown } };
+		expect(schema).toHaveProperty('grantedActionOffers');
+		expect(field.options.initial).toEqual([]);
+	});
+
+	it('defines the per-offer fields the executor revalidates against', () => {
+		const schema = grantedActionOffers();
+		const element = (schema.grantedActionOffers as unknown as { element: { fields: object } })
+			.element;
+		const fieldNames = Object.keys(element.fields);
+
+		expect(fieldNames).toEqual([
+			'id',
+			'targetActorUuid',
+			'label',
+			'activationType',
+			'ruleId',
+			'sourceItemUuid',
+			'used',
+			'usedBy',
+		]);
+	});
+
+	it('starts offers unused with no consuming user', () => {
+		const schema = grantedActionOffers();
+		const element = (
+			schema.grantedActionOffers as unknown as {
+				element: { fields: Record<string, { options: { initial: unknown } }> };
+			}
+		).element;
+
+		expect(element.fields.used.options.initial).toBe(false);
+		expect(element.fields.usedBy.options.initial).toBeNull();
+	});
+
+	it('constrains the activation type to the closed weaponAttack set', () => {
+		const schema = grantedActionOffers();
+		const element = (
+			schema.grantedActionOffers as unknown as {
+				element: { fields: Record<string, { choices?: string[]; options: { initial: unknown } }> };
+			}
+		).element;
+
+		expect(element.fields.activationType.choices).toEqual(['weaponAttack']);
+		expect(element.fields.activationType.options.initial).toBe('weaponAttack');
+	});
+});

--- a/src/models/chat/common.ts
+++ b/src/models/chat/common.ts
@@ -22,6 +22,33 @@ export const appliedHealing = () => ({
 });
 
 /**
+ * Pending granted-activation offers (e.g. "a targeted ally may immediately
+ * make a weapon attack"). Stamped onto the card by the activating client from
+ * the used item's grantActivation rules. Offers carry no expiry — like the
+ * incoming reactions below, they remain available until used.
+ */
+export const grantedActionOffers = () => ({
+	grantedActionOffers: new fields.ArrayField(
+		new fields.SchemaField({
+			id: new fields.StringField({ required: true, nullable: false, initial: '' }),
+			targetActorUuid: new fields.StringField({ required: true, nullable: false, initial: '' }),
+			label: new fields.StringField({ required: true, nullable: false, initial: '' }),
+			activationType: new fields.StringField({
+				required: true,
+				nullable: false,
+				initial: 'weaponAttack',
+				choices: ['weaponAttack'],
+			}),
+			ruleId: new fields.StringField({ required: true, nullable: false, initial: '' }),
+			sourceItemUuid: new fields.StringField({ required: true, nullable: false, initial: '' }),
+			used: new fields.BooleanField({ required: true, nullable: false, initial: false }),
+			usedBy: new fields.StringField({ required: false, nullable: true, initial: null }),
+		}),
+		{ required: true, nullable: false, initial: [] },
+	),
+});
+
+/**
  * Pending interactive incoming-attack reactions (force reroll, redirect to
  * self). Snapshotted at card creation by the attacker's client; `kind` is an
  * open extension point for future reaction types.

--- a/src/models/rules/grantActivation.test.ts
+++ b/src/models/rules/grantActivation.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { GrantActivationRule } from './grantActivation.js';
+
+describe('GrantActivationRule', () => {
+	describe('schema', () => {
+		it('defines the expected fields', () => {
+			const schema = GrantActivationRule.defineSchema();
+			expect(schema).toHaveProperty('type');
+			expect(schema).toHaveProperty('activationType');
+		});
+
+		it('declares a closed activation-type choice set defaulting to weaponAttack', () => {
+			const schema = GrantActivationRule.defineSchema();
+			const activationType = schema.activationType as unknown as {
+				choices: string[];
+				options: { initial: string };
+			};
+			expect(activationType.choices).toEqual(['weaponAttack']);
+			expect(activationType.options.initial).toBe('weaponAttack');
+		});
+	});
+
+	describe('class metadata', () => {
+		it('exposes the picker group and i18n description key', () => {
+			expect(GrantActivationRule.group).toBe('resource');
+			expect(GrantActivationRule.description).toBe('NIMBLE.rules.grantActivation.description');
+		});
+
+		it('declares no lifecycle hooks', () => {
+			// A pure offer descriptor must never run during data preparation.
+			expect(GrantActivationRule.appliesInPrePrepareData).toBe(false);
+			expect(Object.getOwnPropertyNames(GrantActivationRule.prototype)).not.toContain(
+				'afterPrepareData',
+			);
+		});
+	});
+});

--- a/src/models/rules/grantActivation.ts
+++ b/src/models/rules/grantActivation.ts
@@ -1,0 +1,60 @@
+import { NimbleBaseRule } from './base.js';
+
+/**
+ * The kinds of activation a recipient can be offered. A closed set so the
+ * chat card knows how to build the recipient's item list.
+ */
+const GRANTED_ACTIVATION_TYPES = ['weaponAttack'] as const;
+
+type GrantedActivationType = (typeof GRANTED_ACTIVATION_TYPES)[number];
+
+function schema() {
+	const { fields } = foundry.data;
+
+	return {
+		activationType: new fields.StringField({
+			required: true,
+			nullable: false,
+			initial: 'weaponAttack',
+			label: 'NIMBLE.rules.grantActivation.activationType.label',
+			hint: 'NIMBLE.rules.grantActivation.activationType.hint',
+			choices: [...GRANTED_ACTIVATION_TYPES],
+		}),
+		type: new fields.StringField({ required: true, nullable: false, initial: 'grantActivation' }),
+	};
+}
+
+declare namespace GrantActivationRule {
+	type Schema = NimbleBaseRule.Schema & ReturnType<typeof schema>;
+}
+
+/**
+ * Offers the user's current targets an immediate activation (e.g. a weapon
+ * attack) when the owning item is used. Carries no lifecycle hooks — the
+ * item-use hook (`src/hooks/actionEconomySystem.ts`) collects matching rules
+ * and stamps granted-activation offers onto the item's chat card, where the
+ * recipient's owner (or a GM) can accept them.
+ *
+ * The offer only opens the recipient's normal activation flow; any action
+ * cost for the recipient is governed by the granting feature's other rules
+ * (e.g. an action-cost or action-adjustment rule), not by the offer itself.
+ */
+class GrantActivationRule extends NimbleBaseRule<GrantActivationRule.Schema> {
+	static override group = 'resource';
+	static override description = 'NIMBLE.rules.grantActivation.description';
+
+	declare activationType: GrantedActivationType;
+
+	static override defineSchema(): GrantActivationRule.Schema {
+		return {
+			...NimbleBaseRule.defineSchema(),
+			...schema(),
+		};
+	}
+
+	override tooltipInfo(): string {
+		return super.tooltipInfo(new Map([['activationType', '"weaponAttack"']]));
+	}
+}
+
+export { GrantActivationRule, type GrantedActivationType };

--- a/src/utils/combatTurnActions.ts
+++ b/src/utils/combatTurnActions.ts
@@ -1,6 +1,7 @@
 import { isActionTrackingAutomationEnabled } from '../settings/automationSettings.js';
 import { getActorDyingActionLimit, isActorDying } from './actorHealthState.js';
 import { combatantActionMutationQueue } from './combatantActionMutationQueue.js';
+import { getPrimaryActiveGmId } from './getPrimaryActiveGmId.js';
 import { isCombatantDead } from './isCombatantDead.js';
 import { queueCombatantMutationWithFreshDocument } from './queueCombatantMutationWithFreshDocument.js';
 
@@ -110,18 +111,6 @@ export function canUserTakeCombatTurn(
 	const activeCombatant = combat.combatant ?? null;
 	if (!activeCombatant || activeCombatant.type !== 'character') return false;
 	return !isCombatantDead(activeCombatant);
-}
-
-function getPrimaryActiveGmId(): string | null {
-	const usersCollection = game.users as unknown as {
-		activeGM?: { id?: string | null } | null;
-		contents?: Array<{ active?: boolean; id?: string | null; isGM?: boolean }>;
-	};
-	const activeGmId = usersCollection.activeGM?.id ?? null;
-	if (activeGmId) return activeGmId;
-	return (
-		usersCollection.contents?.find((user) => user.isGM === true && user.active === true)?.id ?? null
-	);
 }
 
 function getUserById(userId: string | null | undefined): User.Implementation | null {

--- a/src/utils/getPrimaryActiveGmId.ts
+++ b/src/utils/getPrimaryActiveGmId.ts
@@ -1,0 +1,17 @@
+/**
+ * The user id of the single GM client designated to execute relayed socket
+ * requests, or `null` when no GM is connected. Prefers Foundry's designated
+ * active GM and falls back to any connected GM, so emitters and listeners
+ * agree on one executor.
+ */
+export function getPrimaryActiveGmId(): string | null {
+	const usersCollection = game.users as unknown as {
+		activeGM?: { id?: string | null } | null;
+		contents?: Array<{ active?: boolean; id?: string | null; isGM?: boolean }>;
+	};
+	const activeGmId = usersCollection.activeGM?.id ?? null;
+	if (activeGmId) return activeGmId;
+	return (
+		usersCollection.contents?.find((user) => user.isGM === true && user.active === true)?.id ?? null
+	);
+}

--- a/src/utils/grantedActionOffers.test.ts
+++ b/src/utils/grantedActionOffers.test.ts
@@ -1,0 +1,401 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { GrantedActionOffer } from './grantedActionOffers.js';
+
+type OffersModule = typeof import('./grantedActionOffers.js');
+
+interface MockMessage {
+	system: { grantedActionOffers: GrantedActionOffer[] };
+	update: ReturnType<typeof vi.fn>;
+}
+
+type TestGlobals = {
+	game: {
+		user: { id: string | null; isGM: boolean } | null;
+		users: {
+			activeGM: { id: string } | null;
+			contents: Array<{ id: string; isGM: boolean; active: boolean }>;
+			get: (id: string) => { id: string; isGM: boolean } | null;
+		};
+		socket: { on?: ReturnType<typeof vi.fn>; emit?: ReturnType<typeof vi.fn> };
+		messages: { get: ReturnType<typeof vi.fn> };
+	};
+	fromUuidSync: ReturnType<typeof vi.fn>;
+};
+
+function globals(): TestGlobals {
+	return globalThis as unknown as TestGlobals;
+}
+
+function createOffer(overrides: Partial<GrantedActionOffer> = {}): GrantedActionOffer {
+	return {
+		id: 'offer-1',
+		targetActorUuid: 'Actor.ally',
+		label: 'Granting Feature',
+		activationType: 'weaponAttack',
+		ruleId: 'rule-1',
+		sourceItemUuid: 'Item.granting-item',
+		used: false,
+		usedBy: null,
+		...overrides,
+	};
+}
+
+function createMessage(offers: GrantedActionOffer[]): MockMessage {
+	return {
+		system: { grantedActionOffers: offers },
+		update: vi.fn().mockResolvedValue(undefined),
+	};
+}
+
+function setUser(user: { id: string | null; isGM: boolean } | null): void {
+	globals().game.user = user;
+}
+
+function setUsers(users: Array<{ id: string; isGM: boolean; active?: boolean }>): void {
+	const gm = users.find((user) => user.isGM && user.active !== false) ?? null;
+	globals().game.users = {
+		activeGM: gm ? { id: gm.id } : null,
+		contents: users.map((user) => ({ ...user, active: user.active !== false })),
+		get: (id: string) => users.find((user) => user.id === id) ?? null,
+	};
+}
+
+function setMessages(messagesById: Record<string, MockMessage>): void {
+	globals().game.messages = {
+		get: vi.fn((id: string) => messagesById[id] ?? null),
+	};
+}
+
+/**
+ * Route fromUuidSync by uuid: the ally actor for ownership checks, the
+ * granting item for rule revalidation.
+ */
+function setDocuments(options: { allyIsOwnedByRequester?: boolean; ruleDisabled?: boolean } = {}) {
+	globals().fromUuidSync = vi.fn((uuid: string) => {
+		if (uuid === 'Actor.ally') {
+			return {
+				name: 'Sir Brannon',
+				testUserPermission: () => options.allyIsOwnedByRequester ?? true,
+			};
+		}
+		if (uuid === 'Item.granting-item') {
+			return {
+				rules: new Map([['key', { id: 'rule-1', disabled: options.ruleDisabled ?? false }]]),
+			};
+		}
+		return null;
+	});
+}
+
+// The module keeps a "listener already registered" flag at module scope, so
+// every test needs a fresh module instance to register its own socket spy.
+async function loadModule(): Promise<OffersModule> {
+	vi.resetModules();
+	return import('./grantedActionOffers.js');
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	setUsers([
+		{ id: 'gm-user', isGM: true },
+		{ id: 'player-1', isGM: false },
+	]);
+	setMessages({});
+	setDocuments();
+	globals().game.socket = { on: vi.fn(), emit: vi.fn() };
+});
+
+describe('collectGrantedActionOffers', () => {
+	function createGrantingItem(
+		rules: Array<{ type: string; id: string; label?: string; appliesTo?: () => boolean }>,
+	) {
+		return {
+			uuid: 'Item.granting-item',
+			name: 'Granting Item',
+			actor: { uuid: 'Actor.commander' },
+			rules: new Map(rules.map((rule) => [rule.id, { appliesTo: () => true, ...rule }])),
+		};
+	}
+
+	it('builds one offer per grantActivation rule and target actor', async () => {
+		const { collectGrantedActionOffers } = await loadModule();
+		const item = createGrantingItem([{ type: 'grantActivation', id: 'rule-1', label: 'Strike' }]);
+
+		const offers = collectGrantedActionOffers(item, [
+			{ actor: { uuid: 'Actor.ally' } },
+			{ actor: { uuid: 'Actor.other-ally' } },
+		]);
+
+		expect(offers).toHaveLength(2);
+		expect(offers[0]).toMatchObject({
+			targetActorUuid: 'Actor.ally',
+			label: 'Strike',
+			activationType: 'weaponAttack',
+			ruleId: 'rule-1',
+			sourceItemUuid: 'Item.granting-item',
+			used: false,
+			usedBy: null,
+		});
+	});
+
+	it('never offers the activating actor their own grant', async () => {
+		const { collectGrantedActionOffers } = await loadModule();
+		const item = createGrantingItem([{ type: 'grantActivation', id: 'rule-1' }]);
+
+		const offers = collectGrantedActionOffers(item, [{ actor: { uuid: 'Actor.commander' } }]);
+
+		expect(offers).toHaveLength(0);
+	});
+
+	it('deduplicates multiple targeted tokens of the same actor', async () => {
+		const { collectGrantedActionOffers } = await loadModule();
+		const item = createGrantingItem([{ type: 'grantActivation', id: 'rule-1' }]);
+
+		const offers = collectGrantedActionOffers(item, [
+			{ actor: { uuid: 'Actor.ally' } },
+			{ actor: { uuid: 'Actor.ally' } },
+		]);
+
+		expect(offers).toHaveLength(1);
+	});
+
+	it('falls back to the item name when the rule has no label', async () => {
+		const { collectGrantedActionOffers } = await loadModule();
+		const item = createGrantingItem([{ type: 'grantActivation', id: 'rule-1' }]);
+
+		const offers = collectGrantedActionOffers(item, [{ actor: { uuid: 'Actor.ally' } }]);
+
+		expect(offers[0]?.label).toBe('Granting Item');
+	});
+
+	it('ignores rules of other types and rules whose predicate does not apply', async () => {
+		const { collectGrantedActionOffers } = await loadModule();
+		const item = createGrantingItem([
+			{ type: 'actionDelta', id: 'rule-1' },
+			{ type: 'grantActivation', id: 'rule-2', appliesTo: () => false },
+		]);
+
+		const offers = collectGrantedActionOffers(item, [{ actor: { uuid: 'Actor.ally' } }]);
+
+		expect(offers).toHaveLength(0);
+	});
+});
+
+describe('requestGrantedActionOfferUse', () => {
+	it('stamps the offer used directly for a GM user without emitting a socket request', async () => {
+		const { requestGrantedActionOfferUse } = await loadModule();
+		const message = createMessage([createOffer()]);
+		setMessages({ 'message-1': message });
+		setUser({ id: 'gm-user', isGM: true });
+
+		await expect(
+			requestGrantedActionOfferUse({ messageId: 'message-1', offerId: 'offer-1' }),
+		).resolves.toBe(true);
+
+		expect(message.update).toHaveBeenCalledWith({
+			system: {
+				grantedActionOffers: [
+					expect.objectContaining({ id: 'offer-1', used: true, usedBy: 'gm-user' }),
+				],
+			},
+		});
+		expect(globals().game.socket.emit).not.toHaveBeenCalled();
+	});
+
+	it('emits a socket request with the expected payload for a non-GM user', async () => {
+		const { requestGrantedActionOfferUse } = await loadModule();
+		const message = createMessage([createOffer()]);
+		setMessages({ 'message-1': message });
+		setUser({ id: 'player-1', isGM: false });
+
+		await expect(
+			requestGrantedActionOfferUse({ messageId: 'message-1', offerId: 'offer-1' }),
+		).resolves.toBe(true);
+
+		expect(globals().game.socket.emit).toHaveBeenCalledWith('system.nimble', {
+			type: 'grantedActionOffer',
+			messageId: 'message-1',
+			offerId: 'offer-1',
+			userId: 'player-1',
+		});
+		expect(message.update).not.toHaveBeenCalled();
+	});
+
+	it('returns false for a non-GM user when no GM is active', async () => {
+		const { requestGrantedActionOfferUse } = await loadModule();
+		setUser({ id: 'player-1', isGM: false });
+		setUsers([{ id: 'player-1', isGM: false }]);
+
+		await expect(
+			requestGrantedActionOfferUse({ messageId: 'message-1', offerId: 'offer-1' }),
+		).resolves.toBe(false);
+		expect(globals().game.socket.emit).not.toHaveBeenCalled();
+	});
+
+	it('returns false when there is no logged-in user', async () => {
+		const { requestGrantedActionOfferUse } = await loadModule();
+		setUser(null);
+
+		await expect(
+			requestGrantedActionOfferUse({ messageId: 'message-1', offerId: 'offer-1' }),
+		).resolves.toBe(false);
+	});
+
+	it('does not stamp an already-used offer again', async () => {
+		const { requestGrantedActionOfferUse } = await loadModule();
+		const message = createMessage([createOffer({ used: true, usedBy: 'player-1' })]);
+		setMessages({ 'message-1': message });
+		setUser({ id: 'gm-user', isGM: true });
+
+		await requestGrantedActionOfferUse({ messageId: 'message-1', offerId: 'offer-1' });
+
+		expect(message.update).not.toHaveBeenCalled();
+	});
+
+	it('rejects when the granting rule has been disabled since the offer was made', async () => {
+		const { requestGrantedActionOfferUse } = await loadModule();
+		const message = createMessage([createOffer()]);
+		setMessages({ 'message-1': message });
+		setDocuments({ ruleDisabled: true });
+		setUser({ id: 'gm-user', isGM: true });
+
+		await requestGrantedActionOfferUse({ messageId: 'message-1', offerId: 'offer-1' });
+
+		expect(message.update).not.toHaveBeenCalled();
+	});
+});
+
+describe('registerGrantedActionOfferSocketListener', () => {
+	async function registerAndGetListener(): Promise<(payload: unknown) => void> {
+		const { registerGrantedActionOfferSocketListener } = await loadModule();
+		registerGrantedActionOfferSocketListener();
+
+		const socketOn = globals().game.socket.on;
+		expect(socketOn).toHaveBeenCalledWith('system.nimble', expect.any(Function));
+		return socketOn?.mock.calls[0]?.[1] as (payload: unknown) => void;
+	}
+
+	async function flushAsync(): Promise<void> {
+		await Promise.resolve();
+		await Promise.resolve();
+	}
+
+	function relayedRequest(overrides: Record<string, unknown> = {}) {
+		return {
+			type: 'grantedActionOffer',
+			messageId: 'message-1',
+			offerId: 'offer-1',
+			userId: 'player-1',
+			...overrides,
+		};
+	}
+
+	it('lets the primary active GM stamp a relayed request from an owning player', async () => {
+		setUser({ id: 'gm-user', isGM: true });
+		const message = createMessage([createOffer()]);
+		setMessages({ 'message-1': message });
+		const listener = await registerAndGetListener();
+
+		listener(relayedRequest());
+		await flushAsync();
+
+		expect(message.update).toHaveBeenCalledWith({
+			system: {
+				grantedActionOffers: [
+					expect.objectContaining({ id: 'offer-1', used: true, usedBy: 'player-1' }),
+				],
+			},
+		});
+	});
+
+	it('rejects a relayed request whose user does not own the recipient actor', async () => {
+		setUser({ id: 'gm-user', isGM: true });
+		setDocuments({ allyIsOwnedByRequester: false });
+		const message = createMessage([createOffer()]);
+		setMessages({ 'message-1': message });
+		const listener = await registerAndGetListener();
+
+		listener(relayedRequest());
+		await flushAsync();
+
+		expect(message.update).not.toHaveBeenCalled();
+	});
+
+	it('rejects a relayed request that claims GM identity (spoof guard)', async () => {
+		setUser({ id: 'gm-user', isGM: true });
+		setUsers([
+			{ id: 'gm-user', isGM: true },
+			{ id: 'other-gm', isGM: true },
+		]);
+		const message = createMessage([createOffer()]);
+		setMessages({ 'message-1': message });
+		const listener = await registerAndGetListener();
+
+		listener(relayedRequest({ userId: 'other-gm' }));
+		await flushAsync();
+
+		expect(message.update).not.toHaveBeenCalled();
+	});
+
+	it('ignores requests of a different type', async () => {
+		setUser({ id: 'gm-user', isGM: true });
+		const message = createMessage([createOffer()]);
+		setMessages({ 'message-1': message });
+		const listener = await registerAndGetListener();
+
+		listener(relayedRequest({ type: 'incomingAttackReaction' }));
+		await flushAsync();
+
+		expect(message.update).not.toHaveBeenCalled();
+	});
+
+	it('ignores requests on non-GM clients', async () => {
+		setUser({ id: 'player-2', isGM: false });
+		const message = createMessage([createOffer()]);
+		setMessages({ 'message-1': message });
+		const listener = await registerAndGetListener();
+
+		listener(relayedRequest());
+		await flushAsync();
+
+		expect(message.update).not.toHaveBeenCalled();
+	});
+
+	it('only executes on the primary active GM client', async () => {
+		setUser({ id: 'secondary-gm', isGM: true });
+		setUsers([
+			{ id: 'gm-user', isGM: true },
+			{ id: 'secondary-gm', isGM: true },
+		]);
+		const message = createMessage([createOffer()]);
+		setMessages({ 'message-1': message });
+		const listener = await registerAndGetListener();
+
+		listener(relayedRequest());
+		await flushAsync();
+
+		expect(message.update).not.toHaveBeenCalled();
+	});
+
+	it('ignores malformed payloads missing required fields', async () => {
+		setUser({ id: 'gm-user', isGM: true });
+		const message = createMessage([createOffer()]);
+		setMessages({ 'message-1': message });
+		const listener = await registerAndGetListener();
+
+		listener({ type: 'grantedActionOffer', messageId: 'message-1' });
+		listener(null);
+		listener('not-an-object');
+		await flushAsync();
+
+		expect(message.update).not.toHaveBeenCalled();
+	});
+
+	it('registers the socket listener only once per module instance', async () => {
+		const { registerGrantedActionOfferSocketListener } = await loadModule();
+		registerGrantedActionOfferSocketListener();
+		registerGrantedActionOfferSocketListener();
+
+		expect(globals().game.socket.on).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/utils/grantedActionOffers.ts
+++ b/src/utils/grantedActionOffers.ts
@@ -1,0 +1,260 @@
+import { SYSTEM_ID } from '#system';
+import type { GrantedActivationType } from '../models/rules/grantActivation.js';
+import { getPrimaryActiveGmId } from './getPrimaryActiveGmId.js';
+
+/**
+ * Foundry system socket channel. Must be `system.<id>` so the request reaches the GM's
+ * client, and derived from SYSTEM_ID so the emitter and listener stay in lockstep across
+ * the stable (`nimble`) and dev (`nimble-dev`) installs.
+ */
+const GRANTED_ACTION_OFFER_SOCKET_NAME = `system.${SYSTEM_ID}`;
+const GRANTED_ACTION_OFFER_REQUEST_TYPE = 'grantedActionOffer';
+
+const GRANT_ACTIVATION_RULE_TYPE = 'grantActivation';
+
+/**
+ * A pending granted-activation offer stamped onto the granting item's chat
+ * card. Snapshotted on the activating client at card creation so every client
+ * sees the same offer; the executing GM revalidates lightly on use. Offers
+ * carry no expiry — like the incoming-attack reaction entries, they simply
+ * remain available until used.
+ */
+interface GrantedActionOffer {
+	id: string;
+	/** Recipient actor (token-actor uuid, so unlinked tokens resolve) */
+	targetActorUuid: string;
+	/** Rule label or granting item name, surfaced for chat attribution */
+	label: string;
+	/** What the recipient is offered (drives their selectable item list) */
+	activationType: GrantedActivationType;
+	ruleId: string;
+	/** The granting item, for revalidating that the rule still exists and is enabled */
+	sourceItemUuid: string;
+	used: boolean;
+	/** Id of the user who consumed the offer */
+	usedBy: string | null;
+}
+
+interface GrantedActionOfferRequest {
+	type: typeof GRANTED_ACTION_OFFER_REQUEST_TYPE;
+	messageId: string;
+	offerId: string;
+	userId: string;
+}
+
+interface GrantActivationRuleLike {
+	type?: string;
+	id?: string;
+	label?: string;
+	activationType?: GrantedActivationType;
+	appliesTo?: () => boolean;
+}
+
+interface OfferGrantingItem {
+	uuid?: string;
+	name?: string;
+	actor?: { uuid?: string } | null;
+	rules?: Map<string, GrantActivationRuleLike> | null;
+}
+
+interface OfferTargetToken {
+	actor?: { uuid?: string } | null;
+}
+
+/**
+ * Build the granted-activation offers a used item extends to the user's
+ * current targets, one offer per (rule, target actor). The activating actor
+ * never receives an offer from their own activation.
+ */
+export function collectGrantedActionOffers(
+	item: OfferGrantingItem,
+	targets: OfferTargetToken[],
+): GrantedActionOffer[] {
+	const rules =
+		item.rules && typeof item.rules.values === 'function' ? [...item.rules.values()] : [];
+	const grantRules = rules.filter(
+		(rule) => rule?.type === GRANT_ACTIVATION_RULE_TYPE && rule.appliesTo?.(),
+	);
+	if (grantRules.length < 1) return [];
+
+	const sourceActorUuid = item.actor?.uuid ?? '';
+	const offersByKey = new Map<string, GrantedActionOffer>();
+
+	for (const rule of grantRules) {
+		for (const target of targets) {
+			const targetActorUuid = target.actor?.uuid ?? '';
+			if (!targetActorUuid || targetActorUuid === sourceActorUuid) continue;
+
+			const key = `${rule.id ?? ''}:${targetActorUuid}`;
+			if (offersByKey.has(key)) continue;
+
+			offersByKey.set(key, {
+				id: foundry.utils.randomID(),
+				targetActorUuid,
+				label: rule.label || item.name || '',
+				activationType: rule.activationType ?? 'weaponAttack',
+				ruleId: rule.id ?? '',
+				sourceItemUuid: item.uuid ?? '',
+				used: false,
+				usedBy: null,
+			});
+		}
+	}
+
+	return Array.from(offersByKey.values());
+}
+
+interface OfferBearingMessage {
+	system?: { grantedActionOffers?: GrantedActionOffer[] };
+	update?: (data: Record<string, unknown>) => Promise<unknown>;
+}
+
+function getMessageById(messageId: string | null | undefined): OfferBearingMessage | null {
+	if (!messageId) return null;
+	return (game.messages?.get(messageId) as unknown as OfferBearingMessage | null) ?? null;
+}
+
+/**
+ * Validate a pending offer before stamping it used. Eligibility was
+ * snapshotted at card creation; this is a light revalidation only: the offer
+ * must exist and be unused, the requesting user must be a GM or own the
+ * recipient actor, and the granting rule must still exist and be enabled.
+ *
+ * `viaSocket` marks a player-relayed request, whose `requestingUserId` is
+ * client-supplied and therefore unauthenticated over the base socket. A
+ * genuine GM always executes on their own client (the direct path), so a
+ * relayed request that claims GM identity is a spoof and is rejected.
+ */
+function validateGrantedActionOffer(
+	message: OfferBearingMessage,
+	offerId: string,
+	requestingUserId: string,
+	viaSocket: boolean,
+): { offers: GrantedActionOffer[]; offer: GrantedActionOffer } | null {
+	const offers = message.system?.grantedActionOffers ?? [];
+	const offer = offers.find((entry) => entry.id === offerId);
+	if (!offer || offer.used) return null;
+
+	const requestingUser = game.users?.get(requestingUserId) ?? null;
+	if (!requestingUser) return null;
+	if (viaSocket && requestingUser.isGM) return null;
+	if (!requestingUser.isGM) {
+		const targetActor = fromUuidSync(
+			offer.targetActorUuid as Parameters<typeof fromUuidSync>[0],
+		) as Actor.Implementation | null;
+		const isOwner = targetActor?.testUserPermission?.(
+			requestingUser,
+			CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER,
+		);
+		if (!isOwner) return null;
+	}
+
+	if (offer.sourceItemUuid) {
+		const item = fromUuidSync(offer.sourceItemUuid as Parameters<typeof fromUuidSync>[0]) as {
+			rules?: Map<string, { id?: string; disabled?: boolean }>;
+		} | null;
+		const rule = item?.rules
+			? [...item.rules.values()].find((entry) => entry.id === offer.ruleId)
+			: null;
+		if (!rule || rule.disabled) return null;
+	}
+
+	return { offers, offer };
+}
+
+/**
+ * Stamp an offer as used on the executing GM's client. The stamp is the whole
+ * execution — the recipient's activation itself runs on the requesting client
+ * through the normal activation flow. `used` is written in a single message
+ * update, so a second request for the same offer fails the `used` check.
+ */
+async function executeGrantedActionOfferUse(
+	messageId: string,
+	offerId: string,
+	requestingUserId: string,
+	viaSocket: boolean,
+): Promise<void> {
+	if (!game.user?.isGM) return;
+
+	const message = getMessageById(messageId);
+	if (!message?.update) return;
+
+	const found = validateGrantedActionOffer(message, offerId, requestingUserId, viaSocket);
+	if (!found) return;
+
+	const updatedOffers = found.offers.map((entry) =>
+		entry.id === offerId ? { ...entry, used: true, usedBy: requestingUserId } : entry,
+	);
+	await message.update({
+		system: { grantedActionOffers: updatedOffers },
+	});
+}
+
+async function handleGrantedActionOfferRequest(payload: unknown): Promise<void> {
+	if (!game.user?.isGM) return;
+	if ((game.user.id ?? null) !== getPrimaryActiveGmId()) return;
+	if (!payload || typeof payload !== 'object') return;
+
+	const request = payload as Partial<GrantedActionOfferRequest>;
+	if (request.type !== GRANTED_ACTION_OFFER_REQUEST_TYPE) return;
+	if (!request.messageId || !request.offerId || !request.userId) return;
+
+	await executeGrantedActionOfferUse(request.messageId, request.offerId, request.userId, true);
+}
+
+let hasRegisteredGrantedActionOfferSocketListener = false;
+
+/**
+ * Registers the GM-side listener for relayed granted-activation offer
+ * requests. Idempotent, so it is safe to call once from the `ready` hook.
+ */
+export function registerGrantedActionOfferSocketListener(): void {
+	if (hasRegisteredGrantedActionOfferSocketListener) return;
+	hasRegisteredGrantedActionOfferSocketListener = true;
+
+	const socket = game.socket as
+		| {
+				on?: (eventName: string, listener: (payload: unknown) => void) => void;
+		  }
+		| undefined;
+	socket?.on?.(GRANTED_ACTION_OFFER_SOCKET_NAME, (payload) => {
+		void handleGrantedActionOfferRequest(payload);
+	});
+}
+
+/**
+ * Consume a granted-activation offer on a chat card. GMs stamp the offer
+ * directly; players relay the request to the primary active GM, who owns the
+ * message mutation. Call after the recipient's activation completed, so a
+ * cancelled activation leaves the offer available.
+ */
+export async function requestGrantedActionOfferUse(params: {
+	messageId: string;
+	offerId: string;
+}): Promise<boolean> {
+	if (!game.user?.id) return false;
+
+	if (game.user.isGM) {
+		await executeGrantedActionOfferUse(params.messageId, params.offerId, game.user.id, false);
+		return true;
+	}
+
+	if (!getPrimaryActiveGmId()) return false;
+
+	const socket = game.socket as
+		| {
+				emit?: (eventName: string, payload: GrantedActionOfferRequest) => void;
+		  }
+		| undefined;
+	if (!socket?.emit) return false;
+
+	socket.emit(GRANTED_ACTION_OFFER_SOCKET_NAME, {
+		type: GRANTED_ACTION_OFFER_REQUEST_TYPE,
+		messageId: params.messageId,
+		offerId: params.offerId,
+		userId: game.user.id,
+	});
+	return true;
+}
+
+export type { GrantedActionOffer };

--- a/src/utils/incomingAttackReactions.ts
+++ b/src/utils/incomingAttackReactions.ts
@@ -1,3 +1,4 @@
+import { getPrimaryActiveGmId } from './getPrimaryActiveGmId.js';
 import type { IncomingReactionEntry } from './incomingAttackModifiers.js';
 
 const INCOMING_REACTION_SOCKET_NAME = 'system.nimble';
@@ -22,18 +23,6 @@ interface ReactionCapableMessage {
 		viaSocket?: boolean,
 	) => Promise<void>;
 	system?: { incomingReactions?: IncomingReactionEntry[] };
-}
-
-function getPrimaryActiveGmId(): string | null {
-	const usersCollection = game.users as unknown as {
-		activeGM?: { id?: string | null } | null;
-		contents?: Array<{ active?: boolean; id?: string | null; isGM?: boolean }>;
-	};
-	const activeGmId = usersCollection.activeGM?.id ?? null;
-	if (activeGmId) return activeGmId;
-	return (
-		usersCollection.contents?.find((user) => user.isGM === true && user.active === true)?.id ?? null
-	);
 }
 
 function getMessageById(messageId: string | null | undefined): ReactionCapableMessage | null {

--- a/src/view/chat/FeatureCard.svelte
+++ b/src/view/chat/FeatureCard.svelte
@@ -5,6 +5,7 @@
 	import CardBodyHeader from './components/CardBodyHeader.svelte';
 	import CardHeader from './components/CardHeader.svelte';
 	import ChargeConsumptionNode from './components/ChargeConsumptionNode.svelte';
+	import GrantedActionOffers from './components/GrantedActionOffers.svelte';
 	import IncomingReactionPrompts from './components/IncomingReactionPrompts.svelte';
 	import ItemCardEffects from './components/ItemCardEffects.svelte';
 	import Targets from './components/Targets.svelte';
@@ -84,6 +85,8 @@
 	{#if featureType === 'feature' || featureType === 'monsterFeature'}
 		<ItemCardEffects />
 	{/if}
+
+	<GrantedActionOffers />
 
 	<IncomingReactionPrompts />
 

--- a/src/view/chat/ObjectCard.svelte
+++ b/src/view/chat/ObjectCard.svelte
@@ -5,6 +5,7 @@
 	import CardHeader from './components/CardHeader.svelte';
 	import CardBodyHeader from './components/CardBodyHeader.svelte';
 	import ChargeConsumptionNode from './components/ChargeConsumptionNode.svelte';
+	import GrantedActionOffers from './components/GrantedActionOffers.svelte';
 	import IncomingReactionPrompts from './components/IncomingReactionPrompts.svelte';
 	import ItemCardEffects from './components/ItemCardEffects.svelte';
 	import Targets from './components/Targets.svelte';
@@ -62,6 +63,8 @@
 	{/if}
 
 	<ItemCardEffects />
+
+	<GrantedActionOffers />
 
 	<IncomingReactionPrompts />
 

--- a/src/view/chat/SpellCard.svelte
+++ b/src/view/chat/SpellCard.svelte
@@ -5,6 +5,7 @@
 	import CardBodyHeader from './components/CardBodyHeader.svelte';
 	import CardHeader from './components/CardHeader.svelte';
 	import ChargeConsumptionNode from './components/ChargeConsumptionNode.svelte';
+	import GrantedActionOffers from './components/GrantedActionOffers.svelte';
 	import IncomingReactionPrompts from './components/IncomingReactionPrompts.svelte';
 	import ItemCardEffects from './components/ItemCardEffects.svelte';
 	import Targets from './components/Targets.svelte';
@@ -106,6 +107,8 @@
 	{/if}
 
 	<ItemCardEffects />
+
+	<GrantedActionOffers />
 
 	<IncomingReactionPrompts />
 

--- a/src/view/chat/components/GrantedActionOffers.svelte
+++ b/src/view/chat/components/GrantedActionOffers.svelte
@@ -1,0 +1,227 @@
+<script lang="ts">
+	import type { NimbleChatMessage } from '#documents/chatMessage.ts';
+	import type { GrantedActionOffer } from '#utils/grantedActionOffers.ts';
+
+	import { getContext } from 'svelte';
+	import { requestGrantedActionOfferUse } from '#utils/grantedActionOffers.js';
+	import localize from '../../../utils/localize.js';
+
+	interface OfferRecipientActor {
+		name?: string;
+		isOwner?: boolean;
+		items?: Iterable<OfferRecipientItem>;
+		activateItem?: (id: string) => Promise<unknown>;
+	}
+
+	interface OfferRecipientItem {
+		id: string | null;
+		name: string;
+		type: string;
+		system?: { objectType?: string };
+	}
+
+	function getRecipientActor(offer: GrantedActionOffer): OfferRecipientActor | null {
+		return (fromUuidSync(offer.targetActorUuid as Parameters<typeof fromUuidSync>[0]) ??
+			null) as OfferRecipientActor | null;
+	}
+
+	function canUseOffer(offer: GrantedActionOffer): boolean {
+		if (game.user?.isGM) return true;
+		const actor = getRecipientActor(offer);
+		return !!actor?.isOwner;
+	}
+
+	function getOfferHeading(offer: GrantedActionOffer): string {
+		return localize(`NIMBLE.chat.grantedActionOffers.${offer.activationType}`);
+	}
+
+	function getOfferLabel(offer: GrantedActionOffer): string {
+		const heading = getOfferHeading(offer);
+		const actorName = getRecipientActor(offer)?.name ?? '';
+		const source = offer.label ? `: ${offer.label}` : '';
+		return `${heading}${source} — ${actorName}`;
+	}
+
+	function getOfferTooltip(offer: GrantedActionOffer): string | null {
+		if (!offer.sourceItemUuid) return null;
+		const item = fromUuidSync(offer.sourceItemUuid as Parameters<typeof fromUuidSync>[0]) as {
+			name?: string;
+		} | null;
+		return item?.name ?? null;
+	}
+
+	function getUsedAttribution(offer: GrantedActionOffer): string {
+		const actorName = getRecipientActor(offer)?.name ?? '';
+		return offer.label
+			? localize('NIMBLE.chat.grantedActionOffers.usedByVia', {
+					name: actorName,
+					label: offer.label,
+				})
+			: localize('NIMBLE.chat.grantedActionOffers.usedBy', { name: actorName });
+	}
+
+	/** The recipient's items the offer allows them to activate. */
+	function getEligibleItems(offer: GrantedActionOffer): OfferRecipientItem[] {
+		const actor = getRecipientActor(offer);
+		if (!actor?.items) return [];
+		// weaponAttack is the only activation type; extend here alongside the
+		// rule's choice set.
+		return [...actor.items].filter(
+			(item) => item.type === 'object' && item.system?.objectType === 'weapon',
+		);
+	}
+
+	function toggleOffer(offerId: string): void {
+		expandedOfferId = expandedOfferId === offerId ? null : offerId;
+	}
+
+	/**
+	 * Run the recipient's normal activation flow, then consume the offer. The
+	 * activation resolves its own costs (including any adjustments the granting
+	 * feature's rules declared), so the offer itself carries none. A cancelled
+	 * activation returns null and leaves the offer available.
+	 */
+	async function useOfferWithItem(offer: GrantedActionOffer, itemId: string | null) {
+		if (busy || !itemId) return;
+		busy = true;
+
+		try {
+			const actor = getRecipientActor(offer);
+			if (!actor?.activateItem) return;
+
+			const activationCard = await actor.activateItem(itemId);
+			if (!activationCard) return;
+
+			await requestGrantedActionOfferUse({
+				messageId: messageDocument.id ?? '',
+				offerId: offer.id,
+			});
+			expandedOfferId = null;
+		} finally {
+			busy = false;
+		}
+	}
+
+	let messageDocument = getContext<NimbleChatMessage>('messageDocument');
+	let busy = $state(false);
+	let expandedOfferId = $state<string | null>(null);
+
+	let offers = $derived(
+		(messageDocument?.reactive?.system as { grantedActionOffers?: GrantedActionOffer[] })
+			?.grantedActionOffers ?? [],
+	);
+	let pendingOffers = $derived(offers.filter((offer) => !offer.used && canUseOffer(offer)));
+	let usedOffers = $derived(offers.filter((offer) => offer.used));
+</script>
+
+{#if pendingOffers.length > 0 || usedOffers.length > 0}
+	<section class="nimble-card-section nimble-card-section--granted-action-offers">
+		{#if pendingOffers.length > 0}
+			<header class="nimble-section-header">
+				<h3 class="nimble-heading" data-heading-variant="section">
+					{localize('NIMBLE.chat.grantedActionOffers.heading')}
+				</h3>
+			</header>
+
+			<ul class="nimble-granted-action-offer-list">
+				{#each pendingOffers as offer (offer.id)}
+					<li>
+						<button
+							class="nimble-button nimble-granted-action-offer-button"
+							type="button"
+							disabled={busy}
+							data-tooltip={getOfferTooltip(offer)}
+							onclick={() => toggleOffer(offer.id)}
+						>
+							<i class="nimble-button__icon fa-solid fa-hand-point-right"></i>
+							{getOfferLabel(offer)}
+						</button>
+
+						{#if expandedOfferId === offer.id}
+							{@const eligibleItems = getEligibleItems(offer)}
+
+							{#if eligibleItems.length > 0}
+								<ul
+									class="nimble-granted-action-offer-list nimble-granted-action-offer-list--items"
+								>
+									{#each eligibleItems as item (item.id)}
+										<li>
+											<button
+												class="nimble-button nimble-granted-action-offer-button"
+												type="button"
+												disabled={busy}
+												onclick={() => useOfferWithItem(offer, item.id)}
+											>
+												<i class="nimble-button__icon fa-solid fa-dice-d20"></i>
+												{item.name}
+											</button>
+										</li>
+									{/each}
+								</ul>
+							{:else}
+								<p class="nimble-granted-action-offer-empty">
+									{localize('NIMBLE.chat.grantedActionOffers.noEligibleItems')}
+								</p>
+							{/if}
+						{/if}
+					</li>
+				{/each}
+			</ul>
+		{/if}
+
+		{#each usedOffers as offer (offer.id)}
+			<p class="nimble-granted-action-offer-attribution">
+				<i class="fa-solid fa-hand-point-right"></i>
+				{getUsedAttribution(offer)}
+			</p>
+		{/each}
+	</section>
+{/if}
+
+<style lang="scss">
+	.nimble-card-section {
+		padding: var(--nimble-card-section-padding, 0.5rem);
+
+		&:not(:last-of-type) {
+			border-bottom: 1px solid var(--nimble-card-border-color);
+		}
+	}
+
+	.nimble-granted-action-offer-list {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+		list-style: none;
+		padding: 0;
+		margin: 0;
+
+		&--items {
+			margin-block-start: 0.25rem;
+			margin-inline-start: 1rem;
+		}
+	}
+
+	.nimble-granted-action-offer-button {
+		display: flex;
+		align-items: center;
+		gap: 0.375rem;
+		width: 100%;
+		padding: 0.25rem 0.5rem;
+		font-size: var(--nimble-sm-text);
+		text-align: left;
+	}
+
+	.nimble-granted-action-offer-empty {
+		margin: 0.25rem 0 0 1rem;
+		font-size: var(--nimble-xs-text);
+		font-style: italic;
+		color: var(--nimble-medium-text-color);
+	}
+
+	.nimble-granted-action-offer-attribution {
+		margin: 0.25rem 0 0 0;
+		font-size: var(--nimble-xs-text);
+		font-style: italic;
+		color: var(--nimble-medium-text-color);
+	}
+</style>

--- a/src/view/chat/components/GrantedActionOffers.test.ts
+++ b/src/view/chat/components/GrantedActionOffers.test.ts
@@ -1,0 +1,126 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import GrantedActionOffersTestHarness from './GrantedActionOffers.testHarness.svelte';
+
+interface OfferOptions {
+	id?: string;
+	label?: string;
+	used?: boolean;
+}
+
+function createOffer(options: OfferOptions = {}) {
+	return {
+		id: options.id ?? 'offer-1',
+		targetActorUuid: 'Actor.ally',
+		label: options.label ?? 'Granting Feature',
+		activationType: 'weaponAttack',
+		ruleId: 'rule-1',
+		sourceItemUuid: '',
+		used: options.used ?? false,
+		usedBy: options.used ? 'player-1' : null,
+	};
+}
+
+function createMessage(offers: ReturnType<typeof createOffer>[]) {
+	const message = {
+		id: 'message-1',
+		system: { grantedActionOffers: offers },
+		reactive: null as unknown,
+	};
+	message.reactive = message;
+	return message;
+}
+
+let previousFromUuidSync: unknown;
+let previousGameUser: unknown;
+
+beforeEach(() => {
+	const g = globalThis as Record<string, any>;
+	previousFromUuidSync = g.fromUuidSync;
+	previousGameUser = g.game?.user;
+	g.fromUuidSync = vi.fn(() => ({ name: 'Sir Brannon', isOwner: true, items: [] }));
+	g.game = g.game ?? {};
+	g.game.user = { isGM: true, id: 'gm' };
+});
+
+afterEach(() => {
+	const g = globalThis as Record<string, any>;
+	g.fromUuidSync = previousFromUuidSync;
+	if (g.game) g.game.user = previousGameUser;
+});
+
+describe('GrantedActionOffers', () => {
+	it('renders a labeled button for a pending offer', () => {
+		render(GrantedActionOffersTestHarness, {
+			props: { messageDocument: createMessage([createOffer()]) },
+		});
+
+		const button = screen.getByRole('button');
+		expect(button.textContent).toContain('Weapon Attack');
+		expect(button.textContent).toContain('Granting Feature');
+		expect(button.textContent).toContain('Sir Brannon');
+	});
+
+	it('expands into the recipient item list on click, with an empty state when no items qualify', async () => {
+		render(GrantedActionOffersTestHarness, {
+			props: { messageDocument: createMessage([createOffer()]) },
+		});
+
+		await fireEvent.click(screen.getByRole('button'));
+
+		expect(screen.getByText('No eligible items to use.')).toBeTruthy();
+	});
+
+	it('lists the recipient weapons when the offer is expanded', async () => {
+		const g = globalThis as Record<string, any>;
+		g.fromUuidSync = vi.fn(() => ({
+			name: 'Sir Brannon',
+			isOwner: true,
+			items: [
+				{ id: 'sword', name: 'Longsword', type: 'object', system: { objectType: 'weapon' } },
+				{ id: 'rope', name: 'Rope', type: 'object', system: { objectType: 'gear' } },
+				{ id: 'rage', name: 'Rage', type: 'feature', system: {} },
+			],
+		}));
+
+		render(GrantedActionOffersTestHarness, {
+			props: { messageDocument: createMessage([createOffer()]) },
+		});
+
+		await fireEvent.click(screen.getByRole('button'));
+
+		const buttons = screen.getAllByRole('button');
+		const buttonLabels = buttons.map((button) => button.textContent ?? '');
+		expect(buttonLabels.some((label) => label.includes('Longsword'))).toBe(true);
+		expect(buttonLabels.some((label) => label.includes('Rope'))).toBe(false);
+		expect(buttonLabels.some((label) => label.includes('Rage'))).toBe(false);
+	});
+
+	it('renders an attribution line instead of a button for used offers', () => {
+		render(GrantedActionOffersTestHarness, {
+			props: { messageDocument: createMessage([createOffer({ used: true })]) },
+		});
+
+		expect(screen.queryByRole('button')).toBeNull();
+		expect(screen.getByText(/Sir Brannon/)).toBeTruthy();
+	});
+
+	it('renders nothing when there are no offers', () => {
+		const { container } = render(GrantedActionOffersTestHarness, {
+			props: { messageDocument: createMessage([]) },
+		});
+
+		expect(container.querySelector('section')).toBeNull();
+	});
+
+	it('hides pending offers from non-owners who are not GMs', () => {
+		const g = globalThis as Record<string, any>;
+		g.game.user = { isGM: false, id: 'player' };
+		g.fromUuidSync = vi.fn(() => ({ name: 'Sir Brannon', isOwner: false, items: [] }));
+
+		render(GrantedActionOffersTestHarness, {
+			props: { messageDocument: createMessage([createOffer()]) },
+		});
+
+		expect(screen.queryByRole('button')).toBeNull();
+	});
+});

--- a/src/view/chat/components/GrantedActionOffers.testHarness.svelte
+++ b/src/view/chat/components/GrantedActionOffers.testHarness.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import { setContext, untrack } from 'svelte';
+	import GrantedActionOffers from './GrantedActionOffers.svelte';
+
+	let { messageDocument } = $props();
+
+	setContext(
+		'messageDocument',
+		untrack(() => messageDocument),
+	);
+</script>
+
+<GrantedActionOffers />

--- a/src/view/rulesBuilder/components/RuleTypePicker.svelte.ts
+++ b/src/view/rulesBuilder/components/RuleTypePicker.svelte.ts
@@ -21,6 +21,7 @@ const RULE_ICONS: Record<string, string> = {
 	conditionImmunity: 'fa-solid fa-shield-virus',
 	damageBonus: 'fa-solid fa-explosion',
 	dyingActionLimit: 'fa-solid fa-skull',
+	grantActivation: 'fa-solid fa-hand-point-right',
 	grantItem: 'fa-solid fa-gift',
 	grantProficiency: 'fa-solid fa-graduation-cap',
 	grantSpells: 'fa-solid fa-wand-magic-sparkles',


### PR DESCRIPTION
## Summary

New `grantActivation` rule and chat-card offer channel for "an ally immediately makes a weapon attack" features. Pool grants (previous PR) apply silently — an activation grant needs a prompt on the ally's client because the ally picks the weapon and target. Built as a parallel sibling of the incoming-reaction prompts, not a widening of `IncomingReactionEntry` (that union is attack-specific and built from a roll this feature doesn't have).

## Changes

- `src/models/rules/grantActivation.ts` — minimal declarative rule (`activationType`, currently `weaponAttack` only; extension points marked). Registered in all four places.
- `grantedActionOffers()` schema factory in `src/models/chat/common.ts`, mixed into the Feature/Spell/Object card models exactly like `incomingReactions` (initial `[]`, no migration).
- Offer stamping on the existing `useItem` hook path: the activating client (message author) writes offers for the user's targeted allies onto the just-created card.
- `GrantedActionOffers.svelte` — buttons filtered per viewer like `canUseEntry`: visible only to owners of the target actor and to GMs (so a GM can act for an offline player). Clicking expands the recipient's eligible weapons; picking one runs the ally's normal `activateItem` flow — action costs resolve through the `actionCost` machinery, closing the gap noted in `IncomingReactionPrompts` that rule-granted offers had no way to declare a cost. A cancelled activation leaves the offer available.
- `src/utils/grantedActionOffers.ts` — socket type on the system channel with executor-side revalidation mirroring the incoming-reaction checks (offer exists and unused, requester may act for the target actor, anti-spoof guard) and a single-update `used`/`usedBy` stamp. Used offers render as attribution lines.
- `getPrimaryActiveGmId` promoted to a shared util (this was its third private copy — Rule of Three; both existing call sites migrated, Shared Code Inventory updated).
- **No expiry** — offers sit unused indefinitely, consistent with the reaction system; documented in the offer type. Two owners racing the same offer on different clients could both roll before the stamp lands (same fire-and-forget property as the reaction relay); the GM adjudicates that rare case.

## Test Plan

- `pnpm check` green; 19 socket/collection tests (visibility, spoof guard, non-owner rejection, idempotency, malformed payloads), component tests, schema tests.
- Live-verified in Foundry v13 with **two simultaneous clients** (GM + a player owning the ally), real UI clicks throughout: activating the granting feature stamps the offer onto its card; the button renders on the ally-owner's client and the GM's but not on a third non-owner client; the player clicks the offer → weapon → roll and the attack card posts while the offer stamps `used` on both clients via the GM relay; the button cannot be pressed again; with the player disconnected, the GM presses a fresh offer on the ally's behalf successfully.
- Reviewer repro: two browser sessions, target an ally token, activate a feature carrying a `grantActivation` rule.

## Checklist

- [x] Added or updated unit tests
- [x] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [x] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** yes
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues

Relates to #582. Stacked on #879; retarget as parents merge.
