### PR TITLE
fix(actor): stop cosmetic HP feedback from aborting the update dispatch

### DIFF
--- a/src/documents/actor/base.svelte.ts
+++ b/src/documents/actor/base.svelte.ts
@@ -533,19 +533,33 @@ class NimbleBaseActor<ActorType extends SystemActorTypes = SystemActorTypes> ext
 				hasDynamicRing?: boolean;
 				flashRing?: (ringType: string) => void;
 			};
-			if (ringToken.hasDynamicRing && ringToken.flashRing) {
-				ringToken.flashRing(effectType);
-			}
 
-			void canvasInterface.createScrollingText(
-				tokenObject.center,
-				toSignedIntegerString(effectValue),
-				{
-					anchor: CONST.TEXT_ANCHOR_POINTS.TOP,
-					jitter: 0.25,
-					fill,
-				},
-			);
+			// Ring flashes and scrolling text are purely cosmetic, and both canvas APIs
+			// are frequently wrapped by third-party code. This runs inside `_onUpdate`,
+			// so an error escaping here aborts the core update dispatch mid-flight and
+			// takes the `updateActor` hook down with it — leaving sheets, token bars and
+			// health-state syncs stale. Contain the failure to the token it happened on.
+			try {
+				if (ringToken.hasDynamicRing && ringToken.flashRing) {
+					ringToken.flashRing(effectType);
+				}
+
+				const scrollingText = canvasInterface.createScrollingText(
+					tokenObject.center,
+					toSignedIntegerString(effectValue),
+					{
+						anchor: CONST.TEXT_ANCHOR_POINTS.TOP,
+						jitter: 0.25,
+						fill,
+					},
+				);
+
+				void Promise.resolve(scrollingText).catch((error: unknown) => {
+					console.warn('Nimble | Failed to display HP change feedback', error);
+				});
+			} catch (error) {
+				console.warn('Nimble | Failed to display HP change feedback', error);
+			}
 		}
 	}
 
@@ -1097,11 +1111,18 @@ class NimbleBaseActor<ActorType extends SystemActorTypes = SystemActorTypes> ext
 		const tempDelta = currentHp.temp - previousHp.temp;
 		if (hpDelta === 0 && tempDelta === 0) return;
 
-		this.#emitHpChangeScrollingText({
-			hp: hpDelta,
-			temp: tempDelta,
-			total: hpDelta + tempDelta,
-		});
+		// Belt and braces: the emitter guards each token individually, but everything
+		// around that loop (canvas lookups, token resolution) is patchable too, and
+		// nothing cosmetic is worth aborting the core update dispatch for.
+		try {
+			this.#emitHpChangeScrollingText({
+				hp: hpDelta,
+				temp: tempDelta,
+				total: hpDelta + tempDelta,
+			});
+		} catch (error) {
+			console.warn('Nimble | Failed to emit HP change feedback', error);
+		}
 	}
 }
 

--- a/src/documents/actor/hpChangeFeedback.test.ts
+++ b/src/documents/actor/hpChangeFeedback.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NimbleBaseActor } from './base.svelte.js';
+
+interface TokenStub {
+	object: { visible: boolean; center: { x: number; y: number } };
+	hasDynamicRing?: boolean;
+	flashRing?: ReturnType<typeof vi.fn>;
+}
+
+function makeToken(): TokenStub {
+	return { object: { visible: true, center: { x: 0, y: 0 } } };
+}
+
+function makeActor(tokens: TokenStub[], hpValue: number) {
+	const actor = new NimbleBaseActor({
+		_id: 'actor-1',
+		type: 'npc',
+		system: { attributes: { hp: { value: hpValue, max: 20, temp: 0 } } },
+	} as never);
+
+	Object.assign(actor, {
+		isToken: false,
+		getActiveTokens: vi.fn().mockReturnValue(tokens),
+	});
+
+	return actor;
+}
+
+/** Drives `_onUpdate` with a previous-HP snapshot so an HP delta is emitted. */
+function triggerHpChange(actor: NimbleBaseActor, previousHp: number) {
+	const options = {
+		nimble: { previousHp: { value: previousHp, max: 20, temp: 0 } },
+	} as never;
+
+	actor._onUpdate({} as never, options, 'user-1');
+}
+
+function setCanvas(createScrollingText: ReturnType<typeof vi.fn>) {
+	(globalThis as { canvas?: unknown }).canvas = {
+		ready: true,
+		interface: { createScrollingText },
+	};
+}
+
+describe('HP change scrolling text', () => {
+	let warn: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		warn.mockRestore();
+		(globalThis as { canvas?: unknown }).canvas = undefined;
+	});
+
+	it('emits the signed HP delta over each visible token', () => {
+		const createScrollingText = vi.fn().mockResolvedValue(undefined);
+		setCanvas(createScrollingText);
+
+		triggerHpChange(makeActor([makeToken(), makeToken()], 12), 20);
+
+		expect(createScrollingText).toHaveBeenCalledTimes(2);
+		expect(createScrollingText.mock.calls[0][1]).toBe('-8');
+	});
+
+	// A third-party wrapper around `createScrollingText` that throws used to escape
+	// `_onUpdate`, aborting the core update dispatch before the `updateActor` hook —
+	// which left open sheets, token bars and health-state syncs stale until reload.
+	it('does not let a throwing canvas API escape _onUpdate', () => {
+		const createScrollingText = vi.fn(() => {
+			throw new Error('wrapped by a broken module');
+		});
+		setCanvas(createScrollingText);
+
+		expect(() => triggerHpChange(makeActor([makeToken()], 12), 20)).not.toThrow();
+		expect(warn).toHaveBeenCalled();
+	});
+
+	it('still renders feedback on the remaining tokens when one fails', () => {
+		const createScrollingText = vi
+			.fn()
+			.mockImplementationOnce(() => {
+				throw new Error('wrapped by a broken module');
+			})
+			.mockResolvedValue(undefined);
+		setCanvas(createScrollingText);
+
+		triggerHpChange(makeActor([makeToken(), makeToken()], 12), 20);
+
+		expect(createScrollingText).toHaveBeenCalledTimes(2);
+	});
+
+	it('contains a throwing dynamic ring flash', () => {
+		const createScrollingText = vi.fn().mockResolvedValue(undefined);
+		setCanvas(createScrollingText);
+
+		const token = makeToken();
+		token.hasDynamicRing = true;
+		token.flashRing = vi.fn(() => {
+			throw new Error('wrapped by a broken module');
+		});
+
+		expect(() => triggerHpChange(makeActor([token], 12), 20)).not.toThrow();
+		expect(warn).toHaveBeenCalled();
+	});
+
+	it('handles a rejected scrolling text promise without an unhandled rejection', async () => {
+		const createScrollingText = vi.fn().mockRejectedValue(new Error('rejected downstream'));
+		setCanvas(createScrollingText);
+
+		triggerHpChange(makeActor([makeToken()], 12), 20);
+		await Promise.resolve();
+
+		expect(warn).toHaveBeenCalled();
+	});
+});

--- a/tests/mocks/foundry.ts
+++ b/tests/mocks/foundry.ts
@@ -22,6 +22,8 @@ export const globalFoundryMocks = {
 		}
 
 		prepareData() {}
+
+		_onUpdate(_changed?: any, _options?: any, _userId?: string) {}
 	},
 	Item: class Item {
 		constructor(data?: any, _context?: any) {
@@ -98,6 +100,13 @@ export const globalFoundryMocks = {
 			LIMITED: 1,
 			OBSERVER: 2,
 			OWNER: 3,
+		},
+		TEXT_ANCHOR_POINTS: {
+			CENTER: 0,
+			BOTTOM: 1,
+			TOP: 2,
+			LEFT: 3,
+			RIGHT: 4,
 		},
 	},
 	localize: (key: string) => key,


### PR DESCRIPTION
## Summary

A user reported that HP changes did not show up on open sheets until the sheet was closed and reopened, that the token health bar disagreed with the sheet, and that tokens at 0 HP showed no death indicator. All three come from one cause: cosmetic HP feedback throwing inside `_onUpdate` and aborting the core update dispatch before the `updateActor` hook runs.

The reporter's console showed a broken third-party wrapper (`damage-numbers` 5.0.2 via lib-wrapper) throwing `ReferenceError` out of `InterfaceCanvasGroup#createScrollingText`, called from `#emitHpChangeScrollingText`. The module bug is theirs, but nothing purely cosmetic should be able to break HP automation for the whole system, so this hardens our call site.

## Changes

- Wrap each token's ring flash + scrolling text in `try/catch` inside `#emitHpChangeScrollingText`, so one failing token cannot abort feedback for the rest or escape into `_onUpdate`
- Handle async rejections from `createScrollingText` (`void` discarded the promise but not a rejection)
- Add a backstop `try/catch` around the emitter call in `_onUpdate` for the canvas/token lookups around the loop
- Failures now log `console.warn` instead of propagating
- Add `src/documents/actor/hpChangeFeedback.test.ts` covering the throwing, partially-failing and rejecting cases plus the happy path
- Add `CONST.TEXT_ANCHOR_POINTS` and a no-op `Actor#_onUpdate` to the shared Foundry test mocks

## Test Plan

Unit: `pnpm vitest run src/documents/actor/hpChangeFeedback.test.ts`. Reverting the `base.svelte.ts` change makes 4 of the 5 tests fail, so they pin the regression rather than the implementation.

In Foundry (reproduces the original report on v13.351, no modules required):

1. Open a browser console and break the canvas API the way the module did:
   ```js
   const g = foundry.canvas.groups.InterfaceCanvasGroup.prototype;
   g.createScrollingText = () => { throw new Error("simulated broken module wrapper"); };
   ```
2. Drop an NPC token, open its sheet, and apply damage from a chat card (or edit HP on the sheet).
3. Before this PR: the sheet keeps the old HP until closed and reopened, the token bar keeps its old fill, and no Bloodied/Dead status is applied at the thresholds. After this PR: the sheet, bar and statuses all update, and the console shows a single `Nimble | Failed to display HP change feedback` warning per token.
4. Reload without the console patch and confirm normal damage/healing still shows the floating numbers and dynamic ring flash.

## Checklist

- [x] Added or updated unit tests
- [x] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`) - only `console.warn` diagnostics were added
- [x] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** yes
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues

None filed - reported directly by a user on Foundry 13.351 / Nimble 0.8.8.

## Follow-up (not in this PR)

The same class of fragility exists in the sheet reactivity subscriber in `base.svelte.ts`: the `updateActor` and `updateItem` subscriptions bail on `if (diff === false) return;`, so any actor or item update performed with `{ diff: false }` leaves open sheets stale until reopened. Verified live on v13.351. Happy to fix separately if we agree the guard is not load-bearing.
