### PR TITLE
feat: add a per-item "Skip roll dialog" toggle

### DIFF
--- a/packs/classFeatures/core/oathsworn/oathsworn-progression/lay-on-hands.json
+++ b/packs/classFeatures/core/oathsworn/oathsworn-progression/lay-on-hands.json
@@ -31,6 +31,7 @@
 				}
 			],
 			"showDescription": true,
+			"skipRollDialog": true,
 			"targets": {
 				"count": 1,
 				"restrictions": ""

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -2542,8 +2542,9 @@
 			"targetRestrictions": "Target Restrictions",
 			"attackType": "Attack Type",
 			"distance": "Distance",
+			"activationOptions": "Activation Options",
 			"skipRollDialog": "Skip the roll dialog (activate instantly)",
-			"skipRollDialogHint": "Always activate this item with default roll settings, without opening the roll or upcast dialog. Holding Alt while activating does the same for a single activation.",
+			"skipRollDialogHint": "Always activate this item with default roll settings instead of opening the roll or upcast dialog. Holding Alt while activating inverts this setting for that activation.",
 			"attackTypes": {
 				"none": "None",
 				"melee": "Melee",

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -2542,6 +2542,8 @@
 			"targetRestrictions": "Target Restrictions",
 			"attackType": "Attack Type",
 			"distance": "Distance",
+			"skipRollDialog": "Skip the roll dialog (activate instantly)",
+			"skipRollDialogHint": "Always activate this item with default roll settings, without opening the roll or upcast dialog. Holding Alt while activating does the same for a single activation.",
 			"attackTypes": {
 				"none": "None",
 				"melee": "Melee",

--- a/src/managers/ItemActivationManager.test.ts
+++ b/src/managers/ItemActivationManager.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { EffectNode } from '#types/effectTree.js';
 import { MockRollConstructor } from '../../tests/mocks/foundry.js';
+import { keyPressStore } from '../stores/keyPressStore.js';
 import { findNodesByContexts } from '../utils/treeManipulation/findNodesByContexts.js';
 import { ItemActivationManager, testDependencies } from './ItemActivationManager.js';
 
@@ -77,15 +78,6 @@ const MockDamageRoll = vi.fn(function DamageRollMock(
 const DamageRoll = MockDamageRoll;
 const NimbleRoll = MockNimbleRoll;
 const getRollFormula = mockGetRollFormula;
-
-vi.doMock('../stores/keyPressStore.js', () => ({
-	keyPressStore: {
-		subscribe: vi.fn(() => vi.fn()),
-	},
-}));
-vi.doMock('../documents/dialogs/ItemActivationConfigDialog.svelte.js', () => ({
-	default: vi.fn(),
-}));
 
 // Dialog constructor mocks, injected through testDependencies because module
 // mocks cannot intercept the manager's dialog imports (tests/setup.ts loads
@@ -1299,6 +1291,7 @@ describe('ItemActivationManager.getData (rolls)', () => {
 	describe('Dialog routing', () => {
 		beforeEach(() => {
 			dialogState.result = undefined;
+			keyPressStore.set({ ctrl: false, shift: false, alt: false });
 		});
 
 		it('should skip the config dialog and complete activation when skipRollDialog is set', async () => {
@@ -1410,6 +1403,73 @@ describe('ItemActivationManager.getData (rolls)', () => {
 			expect(MockItemActivationConfigDialog).toHaveBeenCalledTimes(1);
 			expect(result).toEqual({ activation: null, rolls: null });
 			expect(DamageRoll).not.toHaveBeenCalled();
+		});
+
+		it('should open the config dialog when Alt is held and skipRollDialog is set', async () => {
+			keyPressStore.set({ ctrl: false, shift: false, alt: true });
+			dialogState.result = { rollMode: 0 };
+			manager = new ItemActivationManager(
+				mockItem as unknown as ConstructorParameters<typeof ItemActivationManager>[0],
+				{},
+			);
+			const healingNode: EffectNode = {
+				id: 'healing-1',
+				type: 'healing',
+				healingType: 'healing',
+				formula: '1d8',
+				parentContext: null,
+				parentNode: null,
+			} as EffectNode;
+
+			manager.activationData = { effects: [healingNode], skipRollDialog: true };
+			mockReconstructEffectsTree.mockReturnValue([healingNode]);
+
+			const mockRoll = {
+				evaluate: vi.fn().mockResolvedValue(undefined),
+				toJSON: vi.fn().mockReturnValue({ total: 5 }),
+			};
+			MockRoll.mockImplementation(function (this: unknown) {
+				return mockRoll;
+			});
+
+			const result = await manager.getData();
+
+			// Alt inverts the item's dialog default, forcing the dialog open.
+			expect(MockItemActivationConfigDialog).toHaveBeenCalledTimes(1);
+			expect(result.activation).not.toBeNull();
+		});
+
+		it('should skip the config dialog when Alt is held and skipRollDialog is unset', async () => {
+			keyPressStore.set({ ctrl: false, shift: false, alt: true });
+			manager = new ItemActivationManager(
+				mockItem as unknown as ConstructorParameters<typeof ItemActivationManager>[0],
+				{},
+			);
+			const damageNode: EffectNode = {
+				id: 'damage-1',
+				type: 'damage',
+				damageType: 'fire',
+				formula: '1d6',
+				canCrit: true,
+				canMiss: true,
+				parentContext: null,
+				parentNode: null,
+			} as EffectNode;
+
+			manager.activationData = { effects: [damageNode] };
+			mockReconstructEffectsTree.mockReturnValue([damageNode]);
+
+			const mockRoll = {
+				evaluate: vi.fn().mockResolvedValue(undefined),
+				toJSON: vi.fn().mockReturnValue({ total: 4 }),
+			};
+			vi.mocked(DamageRoll).mockImplementation(createMockConstructorImplementation(mockRoll));
+
+			const result = await manager.getData();
+
+			expect(MockItemActivationConfigDialog).not.toHaveBeenCalled();
+			expect(result.activation).not.toBeNull();
+			expect(result.rolls).toHaveLength(1);
 		});
 
 		it('should prefer fastForward options over skipRollDialog defaults when both are set', async () => {

--- a/src/managers/ItemActivationManager.test.ts
+++ b/src/managers/ItemActivationManager.test.ts
@@ -87,6 +87,29 @@ vi.doMock('../documents/dialogs/ItemActivationConfigDialog.svelte.js', () => ({
 	default: vi.fn(),
 }));
 
+// Dialog constructor mocks, injected through testDependencies because module
+// mocks cannot intercept the manager's dialog imports (tests/setup.ts loads
+// the real module graph before any test-file mocks register). The manager
+// awaits `dialog.render(true)` and then `dialog.promise`, so each mock
+// instance provides both; `dialogState.result` controls what the promise
+// resolves to (null/undefined simulates a cancelled dialog).
+const dialogState = { result: undefined as unknown };
+
+function createMockDialogInstance() {
+	return {
+		render: vi.fn().mockResolvedValue(undefined),
+		promise: Promise.resolve(dialogState.result),
+	};
+}
+
+const MockItemActivationConfigDialog = vi.fn(function ItemActivationConfigDialogMock() {
+	return createMockDialogInstance();
+});
+
+const MockSpellUpcastDialog = vi.fn(function SpellUpcastDialogMock() {
+	return createMockDialogInstance();
+});
+
 // Helper function to create a mock implementation that handles 'new' correctly
 // Returns the mockInstance directly since vitest doesn't properly bind 'this' for class mocks
 function createMockConstructorImplementation(mockInstance: MockRollInstance) {
@@ -125,6 +148,8 @@ describe('ItemActivationManager.getData (rolls)', () => {
 			DamageRoll: MockDamageRoll,
 			getRollFormula: mockGetRollFormula,
 			reconstructEffectsTree: mockReconstructEffectsTree,
+			ItemActivationConfigDialog: MockItemActivationConfigDialog,
+			SpellUpcastDialog: MockSpellUpcastDialog,
 		});
 
 		// Create mock actor
@@ -1268,6 +1293,158 @@ describe('ItemActivationManager.getData (rolls)', () => {
 					isVicious: false,
 				},
 			);
+		});
+	});
+
+	describe('Dialog routing', () => {
+		beforeEach(() => {
+			dialogState.result = undefined;
+		});
+
+		it('should skip the config dialog and complete activation when skipRollDialog is set', async () => {
+			manager = new ItemActivationManager(
+				mockItem as unknown as ConstructorParameters<typeof ItemActivationManager>[0],
+				{},
+			);
+			const healingNode: EffectNode = {
+				id: 'healing-1',
+				type: 'healing',
+				healingType: 'healing',
+				formula: '1d8',
+				parentContext: null,
+				parentNode: null,
+			} as EffectNode;
+
+			manager.activationData = { effects: [healingNode], skipRollDialog: true };
+			mockReconstructEffectsTree.mockReturnValue([healingNode]);
+
+			const mockRoll = {
+				evaluate: vi.fn().mockResolvedValue(undefined),
+				toJSON: vi.fn().mockReturnValue({ total: 5 }),
+			};
+			MockRoll.mockImplementation(function (this: unknown) {
+				return mockRoll;
+			});
+
+			const result = await manager.getData();
+
+			expect(result.activation).not.toBeNull();
+			expect(result.rolls).toHaveLength(1);
+			expect(MockItemActivationConfigDialog).not.toHaveBeenCalled();
+		});
+
+		it('should skip the upcast dialog and activate at base tier when skipRollDialog is set on a spell', async () => {
+			mockItem.type = 'spell';
+			manager = new ItemActivationManager(
+				mockItem as unknown as ConstructorParameters<typeof ItemActivationManager>[0],
+				{},
+			);
+
+			manager.activationData = { effects: [], skipRollDialog: true };
+			mockReconstructEffectsTree.mockReturnValue([]);
+
+			const result = await manager.getData();
+
+			expect(MockSpellUpcastDialog).not.toHaveBeenCalled();
+			expect(MockItemActivationConfigDialog).not.toHaveBeenCalled();
+			expect(result.activation).not.toBeNull();
+			// No upcast was applied, so the spell activated at its base tier.
+			expect(manager.upcastResult).toBeNull();
+		});
+
+		it('should open the config dialog when skipRollDialog is unset and the item has rolls', async () => {
+			dialogState.result = { rollMode: 0 };
+			manager = new ItemActivationManager(
+				mockItem as unknown as ConstructorParameters<typeof ItemActivationManager>[0],
+				{},
+			);
+			const damageNode: EffectNode = {
+				id: 'damage-1',
+				type: 'damage',
+				damageType: 'fire',
+				formula: '1d6',
+				canCrit: true,
+				canMiss: true,
+				parentContext: null,
+				parentNode: null,
+			} as EffectNode;
+
+			manager.activationData = { effects: [damageNode] };
+			mockReconstructEffectsTree.mockReturnValue([damageNode]);
+
+			const mockRoll = {
+				evaluate: vi.fn().mockResolvedValue(undefined),
+				toJSON: vi.fn().mockReturnValue({ total: 4 }),
+			};
+			vi.mocked(DamageRoll).mockImplementation(createMockConstructorImplementation(mockRoll));
+
+			const result = await manager.getData();
+
+			expect(MockItemActivationConfigDialog).toHaveBeenCalledTimes(1);
+			expect(result.activation).not.toBeNull();
+			expect(result.rolls).toHaveLength(1);
+		});
+
+		it('should return null activation and rolls when the config dialog is cancelled', async () => {
+			dialogState.result = null;
+			manager = new ItemActivationManager(
+				mockItem as unknown as ConstructorParameters<typeof ItemActivationManager>[0],
+				{},
+			);
+			const damageNode: EffectNode = {
+				id: 'damage-1',
+				type: 'damage',
+				damageType: 'fire',
+				formula: '1d6',
+				canCrit: true,
+				canMiss: true,
+				parentContext: null,
+				parentNode: null,
+			} as EffectNode;
+
+			manager.activationData = { effects: [damageNode] };
+			mockReconstructEffectsTree.mockReturnValue([damageNode]);
+
+			const result = await manager.getData();
+
+			expect(MockItemActivationConfigDialog).toHaveBeenCalledTimes(1);
+			expect(result).toEqual({ activation: null, rolls: null });
+			expect(DamageRoll).not.toHaveBeenCalled();
+		});
+
+		it('should prefer fastForward options over skipRollDialog defaults when both are set', async () => {
+			manager = new ItemActivationManager(
+				mockItem as unknown as ConstructorParameters<typeof ItemActivationManager>[0],
+				{ fastForward: true, rollFormula: '3d12', rollHidden: true },
+			);
+			const damageNode: EffectNode = {
+				id: 'damage-1',
+				type: 'damage',
+				damageType: 'fire',
+				formula: '1d6',
+				canCrit: true,
+				canMiss: true,
+				parentContext: null,
+				parentNode: null,
+			} as EffectNode;
+
+			manager.activationData = { effects: [damageNode], skipRollDialog: true };
+			mockReconstructEffectsTree.mockReturnValue([damageNode]);
+
+			const mockRoll = {
+				evaluate: vi.fn().mockResolvedValue(undefined),
+				toJSON: vi.fn().mockReturnValue({ total: 20 }),
+			};
+			vi.mocked(DamageRoll).mockImplementation(createMockConstructorImplementation(mockRoll));
+
+			const result = await manager.getData();
+
+			expect(MockItemActivationConfigDialog).not.toHaveBeenCalled();
+			// The fastForward rollFormula overrides the node formula; the
+			// skipRollDialog default dialog data would have used '1d6'.
+			expect(DamageRoll).toHaveBeenCalledWith('3d12', expect.anything(), expect.anything());
+			// rollHidden only flows through the fastForward dialog data build.
+			expect(result.rollHidden).toBe(true);
 		});
 	});
 });

--- a/src/managers/ItemActivationManager.ts
+++ b/src/managers/ItemActivationManager.ts
@@ -128,63 +128,10 @@ class ItemActivationManager {
 			rollMode: options.rollMode ?? 0,
 		};
 
-		let dialogData: ItemActivationManager.DialogData;
+		const dialogData = await this.#resolveDialogData(rollOptions);
 
-		if (options.fastForward) {
-			dialogData = {
-				rollMode: options.rollMode ?? 0,
-				rollFormula: options.rollFormula,
-				primaryDieValue: options.primaryDieValue,
-				primaryDieModifier: options.primaryDieModifier,
-				rollHidden: options.rollHidden,
-				conditionalDamages: options.conditionalDamages,
-			};
-		} else {
-			// Check if there are damage or healing effects that require rolling
-			const effects = this.activationData?.effects ?? [];
-			const hasRolls = flattenEffectsTree(effects).some(
-				(node) => node.type === 'damage' || node.type === 'healing',
-			);
-
-			// Check if this is a spell (for upcast dialog)
-			const isSpell = this.#item.type === 'spell';
-
-			if (hasRolls || isSpell) {
-				// Check if Alt is pressed to skip dialog
-				let altPressed = false;
-				const unsubscribe = keyPressStore.subscribe((state) => {
-					altPressed = state.alt;
-				});
-
-				if (altPressed) {
-					// Skip dialog, use default
-					dialogData = this.#getDefaultDialogData(rollOptions);
-				} else {
-					// Use spell dialog for spells, regular dialog for others
-					const DialogClass = isSpell ? SpellUpcastDialog : ItemActivationConfigDialog;
-
-					const dialog = new DialogClass(
-						this.actor,
-						this.#item,
-						`Activate ${this.#item.name}`,
-						rollOptions,
-					);
-					await dialog.render(true);
-					const result = await dialog.promise;
-					if (result) {
-						dialogData = result;
-					} else {
-						// If dialog is cancelled, don't roll
-						return { activation: null, rolls: null };
-					}
-				}
-
-				unsubscribe();
-			} else {
-				// No rolls needed, use default
-				dialogData = this.#getDefaultDialogData(rollOptions);
-			}
-		}
+		// If dialog is cancelled, don't roll
+		if (!dialogData) return { activation: null, rolls: null };
 
 		// Apply upcast deltas if present
 		if (dialogData.upcast && this.#item.type === 'spell') {
@@ -850,6 +797,74 @@ class ItemActivationManager {
 		const newCount = currentCount + bonusDice;
 
 		return formula.replace(/(\d*)d(\d+)/, `${newCount}d${diceSize}`);
+	}
+
+	/**
+	 * Resolves the dialog data for the activation, showing a configuration
+	 * dialog when one is required.
+	 *
+	 * @param rollOptions - The roll options to use as dialog defaults.
+	 * @returns The resolved dialog data, or null if the dialog was cancelled.
+	 */
+	async #resolveDialogData(rollOptions): Promise<ItemActivationManager.DialogData | null> {
+		const options = this.#options;
+
+		if (options.fastForward) {
+			return {
+				rollMode: options.rollMode ?? 0,
+				rollFormula: options.rollFormula,
+				primaryDieValue: options.primaryDieValue,
+				primaryDieModifier: options.primaryDieModifier,
+				rollHidden: options.rollHidden,
+				conditionalDamages: options.conditionalDamages,
+			};
+		}
+
+		if (this.activationData?.skipRollDialog) {
+			return this.#getDefaultDialogData(rollOptions);
+		}
+
+		// Check if there are damage or healing effects that require rolling
+		const effects = this.activationData?.effects ?? [];
+		const hasRolls = flattenEffectsTree(effects).some(
+			(node) => node.type === 'damage' || node.type === 'healing',
+		);
+
+		// Check if this is a spell (for upcast dialog)
+		const isSpell = this.#item.type === 'spell';
+
+		if (!hasRolls && !isSpell) {
+			// No rolls needed, use default
+			return this.#getDefaultDialogData(rollOptions);
+		}
+
+		// Check if Alt is pressed to skip dialog
+		let altPressed = false;
+		const unsubscribe = keyPressStore.subscribe((state) => {
+			altPressed = state.alt;
+		});
+		unsubscribe();
+
+		if (altPressed) {
+			// Skip dialog, use default
+			return this.#getDefaultDialogData(rollOptions);
+		}
+
+		// Use spell dialog for spells, regular dialog for others
+		const DialogClass = isSpell ? SpellUpcastDialog : ItemActivationConfigDialog;
+
+		const dialog = new DialogClass(
+			this.actor,
+			this.#item,
+			`Activate ${this.#item.name}`,
+			rollOptions,
+		);
+		await dialog.render(true);
+		const result = await dialog.promise;
+		if (result) return result;
+
+		// If dialog is cancelled, don't roll
+		return null;
 	}
 
 	/**

--- a/src/managers/ItemActivationManager.ts
+++ b/src/managers/ItemActivationManager.ts
@@ -808,7 +808,9 @@ class ItemActivationManager {
 	 * @param rollOptions - The roll options to use as dialog defaults.
 	 * @returns The resolved dialog data, or null if the dialog was cancelled.
 	 */
-	async #resolveDialogData(rollOptions): Promise<ItemActivationManager.DialogData | null> {
+	async #resolveDialogData(
+		rollOptions: ItemActivationManager.RollOptions,
+	): Promise<ItemActivationManager.DialogData | null> {
 		const options = this.#options;
 
 		if (options.fastForward) {
@@ -820,10 +822,6 @@ class ItemActivationManager {
 				rollHidden: options.rollHidden,
 				conditionalDamages: options.conditionalDamages,
 			};
-		}
-
-		if (this.activationData?.skipRollDialog) {
-			return this.#getDefaultDialogData(rollOptions);
 		}
 
 		// Check if there are damage or healing effects that require rolling
@@ -840,15 +838,16 @@ class ItemActivationManager {
 			return this.#getDefaultDialogData(rollOptions);
 		}
 
-		// Check if Alt is pressed to skip dialog
+		// Holding Alt inverts the item's default dialog behavior
 		let altPressed = false;
 		const unsubscribe = keyPressStore.subscribe((state) => {
 			altPressed = state.alt;
 		});
 		unsubscribe();
 
-		if (altPressed) {
-			// Skip dialog, use default
+		const skipDialog = this.activationData?.skipRollDialog ? !altPressed : altPressed;
+
+		if (skipDialog) {
 			return this.#getDefaultDialogData(rollOptions);
 		}
 
@@ -877,7 +876,9 @@ class ItemActivationManager {
 	 * @param options - The roll options to use as defaults.
 	 * @returns Default dialog data based on the provided options.
 	 */
-	#getDefaultDialogData(options): ItemActivationManager.DialogData {
+	#getDefaultDialogData(
+		options: ItemActivationManager.RollOptions,
+	): ItemActivationManager.DialogData {
 		return {
 			...options,
 		};
@@ -1051,6 +1052,18 @@ namespace ItemActivationManager {
 		rollHidden?: boolean;
 		/** Typed conditional-bonus damage to roll as its own effect (see DialogData). */
 		conditionalDamages?: Array<{ formula: string; damageType: string; label: string }>;
+	}
+
+	/**
+	 * Resolved roll options used as dialog defaults.
+	 */
+	export interface RollOptions {
+		/** Domain tags describing the item being activated. */
+		domain: Set<string>;
+		/** Whether to execute the item's custom macro after activation. */
+		executeMacro: boolean;
+		/** Roll mode: positive for advantage, negative for disadvantage, 0 for normal. */
+		rollMode: number;
 	}
 
 	/**

--- a/src/managers/ItemActivationManager.ts
+++ b/src/managers/ItemActivationManager.ts
@@ -43,6 +43,8 @@ const dependencies = {
 	DamageRoll,
 	getRollFormula,
 	reconstructEffectsTree,
+	ItemActivationConfigDialog,
+	SpellUpcastDialog,
 };
 
 export const testDependencies = dependencies;
@@ -851,7 +853,9 @@ class ItemActivationManager {
 		}
 
 		// Use spell dialog for spells, regular dialog for others
-		const DialogClass = isSpell ? SpellUpcastDialog : ItemActivationConfigDialog;
+		const DialogClass = isSpell
+			? dependencies.SpellUpcastDialog
+			: dependencies.ItemActivationConfigDialog;
 
 		const dialog = new DialogClass(
 			this.actor,

--- a/src/models/item/FeatureDataModel.ts
+++ b/src/models/item/FeatureDataModel.ts
@@ -109,6 +109,7 @@ class NimbleFeatureData extends NimbleBaseItemData<
 
 	declare activation: {
 		showDescription: boolean;
+		skipRollDialog: boolean;
 		acquireTargetsFromTemplate: boolean;
 		cost: { details: string; quantity: number; type: string; isReaction: boolean };
 		duration: { details: string; quantity: number; type: string };

--- a/src/models/item/ObjectDataModel.ts
+++ b/src/models/item/ObjectDataModel.ts
@@ -115,6 +115,7 @@ class NimbleObjectData extends NimbleBaseItemData<
 	// Schema-defined properties
 	declare activation: {
 		showDescription: boolean;
+		skipRollDialog: boolean;
 		acquireTargetsFromTemplate: boolean;
 		cost: { details: string; quantity: number; type: string; isReaction: boolean };
 		duration: { details: string; quantity: number; type: string };

--- a/src/models/item/SpellDataModel.ts
+++ b/src/models/item/SpellDataModel.ts
@@ -191,6 +191,7 @@ class NimbleSpellData extends NimbleBaseItemData<
 > {
 	declare activation: {
 		showDescription: boolean;
+		skipRollDialog: boolean;
 		acquireTargetsFromTemplate: boolean;
 		cost: { details: string; quantity: number; type: string; isReaction: boolean };
 		duration: { details: string; quantity: number; type: string };

--- a/src/models/item/common.ts
+++ b/src/models/item/common.ts
@@ -64,6 +64,11 @@ export const activation = () => ({
 			nullable: false,
 			initial: true,
 		}),
+		skipRollDialog: new fields.BooleanField({
+			required: true,
+			nullable: false,
+			initial: false,
+		}),
 		targets: new fields.SchemaField({
 			count: new fields.NumberField({
 				required: true,

--- a/src/view/sheets/pages/ItemActivationCoreConfigTab.svelte
+++ b/src/view/sheets/pages/ItemActivationCoreConfigTab.svelte
@@ -21,7 +21,9 @@
 
 <section>
 	<header class="nimble-section-header">
-		<h4 class="nimble-heading" data-heading-variant="section">Description</h4>
+		<h4 class="nimble-heading" data-heading-variant="section">
+			{localize('NIMBLE.itemConfig.activationOptions')}
+		</h4>
 	</header>
 
 	<label class="nimble-field">
@@ -36,12 +38,6 @@
 
 		<span class="nimble-field__label"> Output item description on activation </span>
 	</label>
-</section>
-
-<section>
-	<header class="nimble-section-header">
-		<h4 class="nimble-heading" data-heading-variant="section">Roll Dialog</h4>
-	</header>
 
 	<label class="nimble-field">
 		<input

--- a/src/view/sheets/pages/ItemActivationCoreConfigTab.svelte
+++ b/src/view/sheets/pages/ItemActivationCoreConfigTab.svelte
@@ -1,6 +1,8 @@
 <script>
 	import { getContext } from 'svelte';
 
+	import localize from '#utils/localize.js';
+
 	const { activationCostTypes, durationTypes } = CONFIG.NIMBLE;
 
 	let document = getContext('document');
@@ -33,6 +35,31 @@
 		/>
 
 		<span class="nimble-field__label"> Output item description on activation </span>
+	</label>
+</section>
+
+<section>
+	<header class="nimble-section-header">
+		<h4 class="nimble-heading" data-heading-variant="section">Roll Dialog</h4>
+	</header>
+
+	<label class="nimble-field">
+		<input
+			type="checkbox"
+			checked={activationData.skipRollDialog}
+			onchange={({ target }) =>
+				document.update({
+					'system.activation.skipRollDialog': target.checked,
+				})}
+		/>
+
+		<span class="nimble-field__label"> {localize('NIMBLE.itemConfig.skipRollDialog')} </span>
+
+		<i
+			class="nimble-field__hint-icon fa-solid fa-circle-info"
+			data-tooltip={localize('NIMBLE.itemConfig.skipRollDialogHint')}
+			data-tooltip-direction="UP"
+		></i>
 	</label>
 </section>
 


### PR DESCRIPTION
## Summary

Adds a per-item `system.activation.skipRollDialog` toggle that unconditionally suppresses the activation/upcast dialog, so authors can build one-click abilities like Lay on Hands. Closes the gap where the only skip was the undiscoverable per-click Alt hold.

## Changes

- New `skipRollDialog` boolean (initial `false`, no migration needed) on the shared `activation()` schema, so all four activatable item types get it from one definition.
- `ItemActivationManager#getData` dialog decision extracted into `#resolveDialogData` with precedence: `fastForward` option → item flag → Alt held → existing `hasRolls || isSpell` dialog gate. A flagged spell skips `SpellUpcastDialog` and casts at base tier. Also fixes a pre-existing leak where cancelling the dialog skipped the `keyPressStore` unsubscribe.
- One "Roll Dialog" checkbox in the shared `ItemActivationCoreConfigTab`, so it appears on all four item sheets (object, feature, monster feature, spell) with no per-sheet edits. **Placement deviates from #868's proposal** (Config-tab "General Configuration" section): the Activation > Core tab already hosts the analogous `showDescription` toggle and is a single shared component, so the shared-section component is deferred until a second cross-type setting exists.
- Two new English strings under `NIMBLE.itemConfig` (label + hint noting Alt-click as the one-shot equivalent) — flagged for human review per AGENTS.md.
- Shipped Lay on Hands now sets the flag.
- Dialog classes are now routed through the manager's existing `testDependencies` injection (behavior-identical) because module mocks cannot intercept imports preloaded by `tests/setup.ts`.

## Test Plan

- `pnpm test` — 5 new routing tests in `ItemActivationManager.test.ts` (flag on item, flag on spell, flag unset opens dialog, dialog cancel, fastForward precedence); full suite green.
- In Foundry: import Lay on Hands onto a character; on Activation > Core its "Skip the roll dialog" checkbox is pre-checked; activating posts the healing card with no dialog. Uncheck it and the config dialog returns; Alt-click still skips. Set the flag on any spell and it casts without the upcast dialog at base tier. A charge-consuming feature with the flag still decrements its pool on activation.
- Verified live on v13 via Playwright driving the real UI (checkbox clicks, sheet activation clicks); all cases above pass with no system console errors.

## Checklist

- [x] Added or updated unit tests
- [x] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [x] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** yes
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues

Closes #868
