### PR TITLE
fix(ui): stop warning about level data the features tab cannot expect

### DIFF
--- a/src/utils/featureLevelData.test.ts
+++ b/src/utils/featureLevelData.test.ts
@@ -1,0 +1,135 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { globSync } from 'glob';
+import { describe, expect, it } from 'vitest';
+
+type PackSource = {
+	_id?: string;
+	name: string;
+	type: string;
+	system?: {
+		class?: string;
+		group?: string;
+		gainedAtLevel?: number | null;
+		gainedAtLevels?: number[];
+		rules?: unknown[];
+		levelUpOptions?: { rules?: unknown[] }[];
+	};
+};
+
+const COMPENDIUM_ITEM_UUID = /^Compendium\.[^.]+\.[^.]+\.Item\.(?<id>[A-Za-z0-9]+)$/;
+
+function readPackSources(): { file: string; source: PackSource }[] {
+	return globSync('packs/**/*.json', { cwd: process.cwd() })
+		.filter((file) => !file.endsWith('ids.json'))
+		.map((file) => {
+			const raw = readFileSync(path.resolve(process.cwd(), file), 'utf-8');
+			return { file, source: JSON.parse(raw) as PackSource };
+		});
+}
+
+/** Every rule on an item, including those nested under its level-up options. */
+function collectRules(source: PackSource): Record<string, unknown>[] {
+	const own = Array.isArray(source.system?.rules) ? source.system.rules : [];
+	const fromOptions = (source.system?.levelUpOptions ?? []).flatMap((option) =>
+		Array.isArray(option?.rules) ? option.rules : [],
+	);
+	return [...own, ...fromOptions].filter(
+		(rule): rule is Record<string, unknown> => !!rule && typeof rule === 'object',
+	);
+}
+
+/**
+ * Ids of items that some other item's rule hands out (`grantItem.uuid`,
+ * `poolMaxBonus.grantItemUuid`, and anything else naming an item uuid).
+ */
+function collectGrantedItemIds(sources: { source: PackSource }[]): Set<string> {
+	const granted = new Set<string>();
+
+	for (const { source } of sources) {
+		for (const rule of collectRules(source)) {
+			for (const value of Object.values(rule)) {
+				if (typeof value !== 'string') continue;
+				const id = COMPENDIUM_ITEM_UUID.exec(value)?.groups?.id;
+				if (id) granted.add(id);
+			}
+		}
+	}
+
+	return granted;
+}
+
+function hasLevelData(source: PackSource): boolean {
+	const { gainedAtLevel, gainedAtLevels } = source.system ?? {};
+	if (gainedAtLevel !== null && gainedAtLevel !== undefined) return true;
+	return Array.isArray(gainedAtLevels) && gainedAtLevels.length > 0;
+}
+
+function describeItem({ file, source }: { file: string; source: PackSource }): string {
+	return `${source.name} (${file})`;
+}
+
+/**
+ * Level data is what makes a feature grantable, so which items carry it is a
+ * correctness question rather than a completeness one.
+ *
+ * `getClassFeaturesFromIndex` indexes features by level, then auto-grants the
+ * ones in a `-progression` group and offers the rest as selections within their
+ * group. A feature that another feature already hands out through a rule must
+ * therefore carry no level data: with it, the class progression would surface a
+ * second copy at that level alongside the granted one. A feature that nothing
+ * grants must carry it, or levelling never hands it out at all.
+ *
+ * This replaces a runtime `console.warn` on the features tab, which fired on
+ * every sort for cards that legitimately have no level, including class and
+ * subclass cards whose data models have no such field.
+ */
+describe('feature pack level data', () => {
+	const sources = readPackSources();
+	const features = sources.filter(({ source }) => source.type === 'feature');
+	const grantedItemIds = collectGrantedItemIds(sources);
+
+	it('reads a non-empty set of feature items', () => {
+		expect(features.length).toBeGreaterThan(0);
+	});
+
+	it('finds items granted by another feature rule', () => {
+		// Guards the derivation itself: if uuid parsing broke, every feature would
+		// look ungranted and the next assertion would pass for the wrong reason.
+		expect(grantedItemIds.size).toBeGreaterThan(0);
+	});
+
+	it('records a level on every feature that levelling has to grant', () => {
+		const missing = features
+			.filter(({ source }) => !hasLevelData(source))
+			.filter(({ source }) => !(source._id && grantedItemIds.has(source._id)))
+			.map(describeItem);
+
+		expect(missing).toEqual([]);
+	});
+
+	it('leaves a level off every feature another rule already grants', () => {
+		const overSpecified = features
+			.filter(({ source }) => source._id && grantedItemIds.has(source._id))
+			.filter(({ source }) => hasLevelData(source))
+			.map(describeItem);
+
+		expect(overSpecified).toEqual([]);
+	});
+
+	it('agrees between the two level fields when both are set', () => {
+		// `gainedAtLevel` is the primary; the sheet falls back to the minimum of
+		// the list. A primary above that minimum would badge the card one level
+		// and sort it at another.
+		const inconsistent = features
+			.filter(({ source }) => {
+				const { gainedAtLevel, gainedAtLevels } = source.system ?? {};
+				if (gainedAtLevel === null || gainedAtLevel === undefined) return false;
+				if (!Array.isArray(gainedAtLevels) || gainedAtLevels.length < 1) return false;
+				return gainedAtLevel !== Math.min(...gainedAtLevels);
+			})
+			.map(describeItem);
+
+		expect(inconsistent).toEqual([]);
+	});
+});

--- a/src/view/sheets/pages/PlayerCharacterFeaturesTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterFeaturesTab.svelte
@@ -78,14 +78,24 @@
 		sheet.clearDroppedItemFlash(itemId);
 	}
 
+	/**
+	 * The level an item sorts at within its group. Items with no level sort last.
+	 *
+	 * Deliberately silent about a missing level. Most cards on this tab are types
+	 * that carry no level fields at all (a class or subclass card cannot have
+	 * one), and a feature that another feature's rule grants must have none:
+	 * level data is what makes the class progression surface an item, so adding
+	 * it there would offer a second copy alongside the granted one.
+	 *
+	 * Reporting either at runtime puts a message in every player's console about
+	 * pack data they cannot act on, once per sort. Which items should carry level
+	 * data is asserted by `featureLevelData.test.ts` instead, before it ships.
+	 */
 	function getEffectiveLevel(item): number {
 		const explicit = item.reactive.system?.gainedAtLevel;
 		if (explicit != null) return explicit;
 		const levels = item.reactive.system?.gainedAtLevels;
 		if (levels?.length) return Math.min(...levels);
-		console.warn(
-			`[Nimble] Feature "${item.reactive.name}" has no level data — gainedAtLevel: ${explicit}, gainedAtLevels: ${JSON.stringify(levels)}`,
-		);
 		return Infinity;
 	}
 


### PR DESCRIPTION
## Summary

Removes a console warning on the features tab that fires for cards which cannot have level data,
and replaces it with a pack test that asserts the real invariant before anything ships.

## Changes

- **Dropped the `has no level data` warning** from `getEffectiveLevel`. The `Infinity` fallback
  stays, so a levelless card still sorts last.
- **Added `featureLevelData.test.ts`**, which derives which items must carry level data instead of
  listing them: any item id named by another item's rule must have none, and every other feature
  must have some.

## Why the warning could not be made clean

It fired on two kinds of card, and neither is a data gap:

- **Class and subclass cards.** `gainedAtLevel` and `gainedAtLevels` are declared only on
  `FeatureDataModel`. A class card has no such fields, so it reports `undefined` for both and
  warns on every sort. Every character with a class and a subclass produced two of these per
  re-render, which is most of the volume.
- **Features that another feature grants.** Level data is what makes the class progression
  surface an item: `getClassFeaturesFromIndex` indexes by level, auto-grants what is in a
  `-progression` group and offers the rest as selections in their group. So an item that is
  already handed out by a rule must carry *no* level data, or a second copy appears alongside the
  granted one. Two items are in this position, both correctly levelless:
  - **Coordinated Strike!** is granted by Commander's Orders' `grantItem` rule.
  - **+1 Max Combat Die** is granted by the `max-combat-die` level-up option's `poolMaxBonus`
    rule on Fit for Any Battlefield.

So the message was unactionable in both cases, printed once per sort, in every player's console.

## The test that replaces it

The invariant runs in both directions, and both are load-bearing:

- a feature nothing grants must record a level, or levelling never hands it out;
- a feature something grants must not, or the progression offers a duplicate.

A third assertion guards the derivation itself: if uuid parsing broke, every feature would look
ungranted and the main assertion would pass for the wrong reason. A fourth checks `gainedAtLevel`
matches the minimum of `gainedAtLevels` where both are set, since the sheet badges from one and
falls back to the other.

## Test Plan

`pnpm check` passes (220 files, 3496 tests).

I verified the new test fails on the real defects rather than passing trivially, by breaking each
direction in turn and confirming the matching assertion fails and names the file:

1. Set `gainedAtLevel: 1` on Coordinated Strike (a granted feature) → *"leaves a level off every
   feature another rule already grants"* fails.
2. Clear the level data on Master Commander (an ungranted feature) → *"records a level on every
   feature that levelling has to grant"* fails.

To check the warning is gone in Foundry:

1. Open a character sheet with a class and a subclass on the Features tab, console open.
2. Sort or filter to force a re-render. No `[Nimble] Feature "..." has no level data` lines
   should appear.
3. Confirm the tab still orders features by level, with any levelless card last.

## Checklist

- [x] Added or updated unit tests
- [x] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [ ] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** yes
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

The Foundry box is unchecked honestly: verified at unit level, plus the reproduction above.

## Worth flagging

My first attempt at this was to *give* Coordinated Strike `gainedAtLevel: 1`, on the reasoning
that a level 1 feature should say so. That was wrong, and `commander.test.ts` caught it: three
assertions failed, because it made the level 1 Commander offer Coordinated Strike as a selection
in the `commanders-orders` group when level 1 should auto-grant Commander's Orders and offer no
pools at all. The pack data was right and the warning was wrong. The test in this PR encodes that
lesson so the same mistake fails immediately rather than looking like a fix.

No pack data or migration is touched here as a result.

## Related Issues

None filed; the warning was reported from a dev build console.
