### PR TITLE
fix(levelUp): stop duplicate feature copies from crashing the level-up dialog

### DIFF
--- a/src/view/dialogs/spellGrantUtils.test.ts
+++ b/src/view/dialogs/spellGrantUtils.test.ts
@@ -629,4 +629,63 @@ describe('collectSpellGrants', () => {
 			expect(result.spellSelections[0].ruleId).toBe('spell-choice-1-ice');
 		});
 	});
+
+	describe('duplicate rule ids', () => {
+		it('collapses selectSpell groups from duplicate copies of the same rules', () => {
+			const index = buildTestIndex();
+			const rules: RulesArray = [
+				{
+					id: 'spell-choice-1',
+					type: 'grantSpells',
+					schools: ['fire', 'ice'],
+					tiers: [0],
+					mode: 'selectSpell',
+					count: 1,
+					predicate: { level: { min: 4 } },
+				},
+			];
+
+			// The same feature present twice (e.g. a world copy alongside the pack
+			// original) supplies its rules array twice
+			const result = collectSpellGrants(
+				[rules, [...rules]],
+				index,
+				'mage',
+				4,
+				new Set(),
+				new Set(),
+			);
+
+			const ruleIds = result.spellSelections.map((s) => s.ruleId);
+			expect(ruleIds).toEqual(['spell-choice-1-fire', 'spell-choice-1-ice']);
+			expect(new Set(ruleIds).size).toBe(ruleIds.length);
+		});
+
+		it('collapses selectSchool groups from duplicate copies of the same rules', () => {
+			const index = buildTestIndex();
+			const rules: RulesArray = [
+				{
+					id: 'school-choice-1',
+					type: 'grantSpells',
+					schools: ['fire', 'ice'],
+					tiers: [0],
+					mode: 'selectSchool',
+					count: 1,
+					predicate: { level: { min: 4 } },
+				},
+			];
+
+			const result = collectSpellGrants(
+				[rules, [...rules]],
+				index,
+				'mage',
+				4,
+				new Set(),
+				new Set(),
+			);
+
+			expect(result.schoolSelections).toHaveLength(1);
+			expect(result.schoolSelections[0].ruleId).toBe('school-choice-1');
+		});
+	});
 });

--- a/src/view/dialogs/spellGrantUtils.ts
+++ b/src/view/dialogs/spellGrantUtils.ts
@@ -103,6 +103,11 @@ export function collectSpellGrants(
 	const schoolSelections: SchoolSelectionGroup[] = [];
 	const spellSelections: SpellSelectionGroup[] = [];
 	const seenUuids = new Set<string>();
+	// Selection groups are rendered in keyed each-blocks, so every emitted ruleId must be
+	// unique. Duplicate copies of a feature (a world item alongside its pack original, two
+	// customized copies, etc.) supply identical rules, and a repeated key would crash the
+	// dialog — collapse repeats into the first occurrence instead.
+	const seenSelectionKeys = new Set<string>();
 	const uuidLookup = buildUuidLookup(spellIndex);
 
 	for (const rules of rulesArrays) {
@@ -146,9 +151,11 @@ export function collectSpellGrants(
 					return schoolSpells.some((s) => !ownedSpellUuids.has(s.uuid));
 				});
 
-				if (availableSchools.length > 0) {
+				const schoolRuleId = (rule.id as string) ?? '';
+				if (availableSchools.length > 0 && !seenSelectionKeys.has(schoolRuleId)) {
+					seenSelectionKeys.add(schoolRuleId);
 					schoolSelections.push({
-						ruleId: (rule.id as string) ?? '',
+						ruleId: schoolRuleId,
 						label: (rule.label as string) || localize('NIMBLE.spellGrants.chooseSchoolsFallback'),
 						availableSchools,
 						tiers,
@@ -170,7 +177,8 @@ export function collectSpellGrants(
 						forClass: classIdentifier,
 					}).filter((s) => !ownedSpellUuids.has(s.uuid));
 
-					if (availableSpells.length > 0) {
+					if (availableSpells.length > 0 && !seenSelectionKeys.has(`${ruleId}-${school}`)) {
+						seenSelectionKeys.add(`${ruleId}-${school}`);
 						spellSelections.push({
 							ruleId: `${ruleId}-${school}`,
 							label,


### PR DESCRIPTION
## Summary

When two copies of the same class feature are visible to the level-up dialog (for example a world item alongside its compendium original), their identical grantSpells rules produced spell/school selection groups with duplicate ruleIds. The dialog renders those groups in keyed each blocks, so the duplicate key threw svelte's `each_key_duplicate` and froze the whole dialog. This is what made leveling a Shepherd from 2 to 3 impossible in #906: Master of Twilight is the only feature at that level that emits keyed selection groups, which is why other classes appeared unaffected.

`collectSpellGrants` now collapses repeated selection keys into their first occurrence, so no data condition can crash the dialog. Same-named or source-linked duplicates are already presented as a "keep one or all" comparison by #854; this covers copies that clustering cannot match (renamed or unlinked hand copies) and acts as a safety net for the general case.

## Changes

- `collectSpellGrants` tracks emitted selection keys and skips repeats for both `selectSchool` and `selectSpell` groups
- Added unit tests covering duplicated rules arrays for both selection modes

## Test Plan

1. Import "Master of Twilight" from the class features compendium into the world Items directory, then rename the copy (renaming breaks the duplicate-source clustering, simulating a hand-made copy)
2. Create a character with the Shepherd class and level it to 2
3. Click Level Up on the sheet
4. Before this fix: the dialog freezes with `Uncaught Error: https://svelte.dev/e/each_key_duplicate` in the console. After: the dialog renders fully, each utility spell choice appears once, and the level-up completes
5. `pnpm vitest run src/view/dialogs/spellGrantUtils.test.ts`

Verified live on Foundry v13 (build 351) via scripted real-UI clicks for both the renamed-copy case (crashed before, works after) and the same-name case (unchanged, still shows the #854 comparison UI).

## Checklist

- [x] Added or updated unit tests
- [x] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [x] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** yes
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues

Fixes #906
