### PR TITLE
feat(dice): distinct Dice So Nice color for the primary die with per-user customization

### DIFF
--- a/docs/documentation/gm/settings.md
+++ b/docs/documentation/gm/settings.md
@@ -51,6 +51,15 @@ Want the system to carry as much as possible? Leave every Automation toggle **on
 Prefer to stay hands-on? Open Configure Automation and turn **off** Apply Conditions and Effects from Rules (conditions become one-click suggestions on chat cards instead), plus any other family you'd rather track yourself, such as Resource Spending or Action Tracking. Leave **off** Auto-Add Character To Combat On Initiative Roll and Auto-Track Token Adjacency. Consider turning **on** Hide Rolls by Default on your own client so GM rolls stay behind the screen. The system still rolls the dice and does the math. It just asks before changing anything.
 :::
 
+## 3D dice
+
+If your table uses the **Dice So Nice** module, the **Configure 3D Dice** button in the system settings tab opens a window where each player chooses how the primary die of their damage rolls looks. The primary die is drawn in its own colors so it reads apart from the rest of the pool, and the colors travel with the roll: everyone at the table sees the roller's choice, not their own.
+
+- **Distinct Primary Die** is on by default. Turn it off to have the primary die use your normal Dice So Nice theme.
+- **Primary Die Color** and **Primary Die Number Color** set the body and the numerals. **Reset Colors** puts both back to the crimson and gold defaults.
+
+All three are per-user, so every player sets their own. Without Dice So Nice installed and enabled, the button is greyed out: these settings only change 3D dice, and there is nothing for them to affect.
+
 ## The combat tracker has its own settings
 
 The combat tracker at the top of the screen isn't configured from the settings menu. Instead, click the gear button on the tracker itself to open the **Combat Tracker Settings** window. Size, colors, hit point bar display, and what players are allowed to see all live there, and every option is listed in the [Settings Reference](../reference/settings.md).

--- a/docs/system/dice-engine.md
+++ b/docs/system/dice-engine.md
@@ -144,7 +144,7 @@ Content authors can leave `weaponType` blank (nothing breaks) or set it for weap
 ## What the engine does NOT do
 
 - **It doesn't render the chat card.** That lives in `src/view/chat/components/` and consumes the finalized roll.
-- **It doesn't integrate with Dice So Nice.** DSN visualizes whatever dice are on the roll; the engine has already decided the outcome before DSN sees anything. One current quirk: the vicious explosion path manually rerolls the primary die to avoid DSN preempting the crit chain. Don't touch that without talking to whoever owns DSN integration.
+- **It doesn't take results from Dice So Nice.** DSN visualizes whatever dice are on the roll; the engine has already decided the outcome before DSN sees anything. The one thing the engine hands DSN is cosmetic: `_extractPrimaryDie` and the `c`/`cv` modifier handlers tag the primary term with an `appearance` option so the primary die renders in the roller's own colors (`src/dice/diceSoNiceIntegration.ts`). Those options are inert without the module. One current quirk: the vicious explosion path manually rerolls the primary die to avoid DSN preempting the crit chain. Don't touch that without talking to whoever owns DSN integration.
 - **It doesn't do targeting.** Target selection is upstream in the activation flow; the engine just receives a target count.
 - **It doesn't validate rule compliance.** If you pass it a mixed-type primary pool (`d6 + d8`), it will roll it. The rules say you shouldn't, but the engine doesn't police that — that's on the content layer.
 
@@ -155,6 +155,7 @@ Content authors can leave `weaponType` blank (nothing breaks) or set it for weap
 | The roll formula preprocessing | `src/dice/DamageRoll.ts` (`_preProcessFormula`, `_applyRollMode`) |
 | The primary die logic | `src/dice/terms/PrimaryDie.ts` |
 | Tie-aware adv/dis handlers | `src/dice/nimbleDieModifiers.ts` |
+| Dice So Nice primary die styling | `src/dice/diceSoNiceIntegration.ts`, `src/settings/registerDiceSoNiceSettings.ts` |
 | Die modifier metadata (`c`, `cv`, `v`, `n`) | `src/dice/nimbleDieModifiers.ts` (`getNimbleMods()`, `NIMBLE_MODS`) |
 | Where custom modifiers get registered | `src/hooks/init.ts` (calls `registerNimbleDieModifiers()`) |
 | Roll construction from an item | `src/managers/ItemActivationManager.ts` |

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -2768,16 +2768,30 @@
 				"name": "Auto-Add Character To Combat On Initiative Roll",
 				"hint": "When enabled, rolling initiative from a character sheet adds that character to the current scene combat before rolling, if they are not already in combat."
 			},
+			"diceSoNiceMenu": {
+				"name": "3D Dice",
+				"manageButton": "Configure 3D Dice",
+				"hint": "Choose how the primary die of your damage rolls looks in Dice So Nice. Each player sets this for themselves.",
+				"title": "3D Dice Settings",
+				"intro": "These settings apply to the rolls you make, and every player sees them on their own screen.",
+				"sectionPrimaryDie": "Primary Die",
+				"preview": "Preview",
+				"moduleMissing": "Install and enable the Dice So Nice module to use these settings.",
+				"reset": "Reset Colors",
+				"save": "Save Changes",
+				"saved": "3D dice settings saved.",
+				"saveError": "Could not save the 3D dice settings. See the console for details."
+			},
 			"dsnPrimaryDieStyleEnabled": {
-				"name": "3D Dice: Distinct Primary Die",
-				"hint": "When Dice So Nice is active, render the primary die of your damage rolls with a distinct appearance so it stands out from the rest of the dice. Applies to rolls you make, on every player's screen."
+				"name": "Distinct Primary Die",
+				"hint": "Render the primary die of your damage rolls with a distinct appearance so it stands out from the rest of the dice."
 			},
 			"dsnPrimaryDieColor": {
-				"name": "3D Dice: Primary Die Color",
+				"name": "Primary Die Color",
 				"hint": "Body color for the primary die of your damage rolls."
 			},
 			"dsnPrimaryDieLabelColor": {
-				"name": "3D Dice: Primary Die Number Color",
+				"name": "Primary Die Number Color",
 				"hint": "Number color for the primary die of your damage rolls."
 			},
 			"autoTrackTokenAdjacency": {

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -414,6 +414,10 @@
 			"thunder": "Thunder",
 			"unknown": "Unknown Type"
 		},
+		"diceSoNice": {
+			"category": "Nimble",
+			"primaryDieColorset": "Nimble Primary Die"
+		},
 		"durations": {
 			"action": "Action",
 			"minute": "Minute",
@@ -2763,6 +2767,18 @@
 			"autoAddCharacterToCombatOnInitiativeRoll": {
 				"name": "Auto-Add Character To Combat On Initiative Roll",
 				"hint": "When enabled, rolling initiative from a character sheet adds that character to the current scene combat before rolling, if they are not already in combat."
+			},
+			"dsnPrimaryDieStyleEnabled": {
+				"name": "3D Dice: Distinct Primary Die",
+				"hint": "When Dice So Nice is active, render the primary die of your damage rolls with a distinct appearance so it stands out from the rest of the dice. Applies to rolls you make, on every player's screen."
+			},
+			"dsnPrimaryDieColor": {
+				"name": "3D Dice: Primary Die Color",
+				"hint": "Body color for the primary die of your damage rolls."
+			},
+			"dsnPrimaryDieLabelColor": {
+				"name": "3D Dice: Primary Die Number Color",
+				"hint": "Number color for the primary die of your damage rolls."
 			},
 			"autoTrackTokenAdjacency": {
 				"name": "Auto-Track Token Adjacency",

--- a/scripts/docs/generateReference.gen.ts
+++ b/scripts/docs/generateReference.gen.ts
@@ -20,6 +20,7 @@ import { registerAdjacencySettings } from '../../src/settings/adjacencySettings.
 import { registerCombatTrackerSettings } from '../../src/settings/combatTrackerSettings.js';
 import registerSystemSettings from '../../src/settings/index.js';
 import { registerNcswSettings } from '../../src/settings/ncswSettings.js';
+import { registerDiceSoNiceSettings } from '../../src/settings/registerDiceSoNiceSettings.js';
 
 const OUT_DIR = path.resolve(process.cwd(), 'docs/documentation/reference');
 const PARTIALS_DIR = path.join(OUT_DIR, '_partials');
@@ -495,6 +496,8 @@ function captureSettings(): CapturedSetting[] {
 	registerCombatTrackerSettings();
 	currentCategory = 'Nimble Character Widget';
 	registerNcswSettings();
+	currentCategory = '3D Dice';
+	registerDiceSoNiceSettings();
 	currentCategory = 'General';
 	registerSystemSettings();
 
@@ -506,17 +509,28 @@ function describeSettingDefault(setting: CapturedSetting): string {
 		const choiceLabel = setting.choices[String(setting.default)];
 		if (choiceLabel) return localize(choiceLabel);
 	}
+	// DataField-typed settings (e.g. ColorField) carry their default as the
+	// field's `initial` rather than a sibling `default`.
+	if (setting.default === undefined && setting.type?.initial !== undefined) {
+		return resolveInitial(setting.type.initial);
+	}
 	return resolveInitial(setting.default);
 }
 
 function generateSettingsPage(): void {
 	const captured = captureSettings();
 
-	const categories = ['General', 'Token Adjacency', 'Combat Tracker', 'Nimble Character Widget'];
+	const categories = [
+		'General',
+		'Token Adjacency',
+		'Combat Tracker',
+		'Nimble Character Widget',
+		'3D Dice',
+	];
 
 	// Categories whose config:false settings are still user-facing because they
 	// are edited from a dedicated in-app dialog rather than the settings window.
-	const dialogManagedCategories = new Set(['Combat Tracker', 'Nimble Character Widget']);
+	const dialogManagedCategories = new Set(['Combat Tracker', 'Nimble Character Widget', '3D Dice']);
 
 	const sections = categories
 		.map((category) => {

--- a/src/dice/DamageRoll.test.ts
+++ b/src/dice/DamageRoll.test.ts
@@ -3,6 +3,7 @@ import type { EffectNode } from '#types/effectTree.js';
 import { ItemActivationManager, testDependencies } from '../managers/ItemActivationManager.js';
 import { hasWeaponProficiency } from '../utils/attackUtils.js';
 import { DamageRoll } from './DamageRoll.js';
+import { PRIMARY_DIE_COLORSET } from './diceSoNiceIntegration.js';
 import {
 	getNimbleMods,
 	nimbleCrit,
@@ -61,6 +62,11 @@ function stubBaseRollEvaluate() {
  * Stage evaluated state on a DamageRoll so that calling `_evaluate` exercises
  * the post-evaluation logic (isCritical / isMiss / total adjustments).
  */
+/** The 3D dice appearance a term carries, if any. */
+function appearanceOf(term: foundry.dice.terms.RollTerm | undefined) {
+	return (term?.options as { appearance?: unknown } | undefined)?.appearance;
+}
+
 function stagePrimaryDieResults(roll: DamageRoll, results: DieResult[], total: number) {
 	if (!roll.primaryDie) throw new Error('roll has no primaryDie — cannot stage results');
 	roll.primaryDie.results = results as any;
@@ -203,6 +209,30 @@ describe('DamageRoll preprocessing', () => {
 
 			expect(roll.formula).toBe('1d6');
 			expect(roll.primaryDie).toBeDefined();
+		});
+
+		it('should tag the primary die of a single die formula for 3D dice', () => {
+			const roll = new DamageRoll(
+				'1d6',
+				{},
+				{ canCrit: true, canMiss: true, rollMode: 0, primaryDieValue: 0, primaryDieModifier: 0 },
+			);
+
+			expect(appearanceOf(roll.primaryDie)).toEqual({ colorset: PRIMARY_DIE_COLORSET });
+		});
+
+		it('should tag the primary die of a multi-die formula for 3D dice', () => {
+			const roll = new DamageRoll(
+				'2d6',
+				{},
+				{ canCrit: true, canMiss: true, rollMode: 0, primaryDieValue: 0, primaryDieModifier: 0 },
+			);
+
+			expect(appearanceOf(roll.primaryDie)).toEqual({ colorset: PRIMARY_DIE_COLORSET });
+			const damageTerm = roll.terms.find(
+				(term) => term instanceof foundry.dice.terms.Die && term !== roll.primaryDie,
+			);
+			expect(appearanceOf(damageTerm)).toBeUndefined();
 		});
 	});
 

--- a/src/dice/DamageRoll.ts
+++ b/src/dice/DamageRoll.ts
@@ -1,6 +1,6 @@
 import type { AnyObject, FixedInstanceType } from 'fvtt-types/utils';
 import type { InexactPartial } from '#types/utils.js';
-import { getPrimaryDieAppearance } from './diceSoNiceIntegration.js';
+import { getPrimaryDieDiceOptions } from './diceSoNiceIntegration.js';
 import { getNimbleMods } from './nimbleDieModifiers.js';
 import { PrimaryDie } from './terms/PrimaryDie.js';
 
@@ -327,7 +327,7 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 		if (!firstDieTerm) return;
 
 		const { number = 1, faces } = firstDieTerm;
-		const appearance = getPrimaryDieAppearance();
+		const diceSoNiceOptions = getPrimaryDieDiceOptions();
 		let primaryTerm: PrimaryDie;
 
 		if (number > 1) {
@@ -341,7 +341,7 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 				number: 1,
 				faces: faces ?? 6,
 				modifiers: [],
-				options: { flavor: 'Primary Die', isVicious, appearance },
+				options: { flavor: 'Primary Die', isVicious, ...diceSoNiceOptions },
 			});
 
 			// Apply advantage/disadvantage to primary die only (keeps 1)
@@ -359,7 +359,7 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 				number: 1,
 				faces: firstDieTerm.faces ?? 6,
 				modifiers: [],
-				options: { isVicious, appearance },
+				options: { isVicious, ...diceSoNiceOptions },
 			});
 
 			// Apply advantage/disadvantage (keeps 1)

--- a/src/dice/DamageRoll.ts
+++ b/src/dice/DamageRoll.ts
@@ -1,6 +1,6 @@
 import type { AnyObject, FixedInstanceType } from 'fvtt-types/utils';
 import type { InexactPartial } from '#types/utils.js';
-
+import { getPrimaryDieAppearance } from './diceSoNiceIntegration.js';
 import { getNimbleMods } from './nimbleDieModifiers.js';
 import { PrimaryDie } from './terms/PrimaryDie.js';
 
@@ -327,6 +327,7 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 		if (!firstDieTerm) return;
 
 		const { number = 1, faces } = firstDieTerm;
+		const appearance = getPrimaryDieAppearance();
 		let primaryTerm: PrimaryDie;
 
 		if (number > 1) {
@@ -340,7 +341,7 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 				number: 1,
 				faces: faces ?? 6,
 				modifiers: [],
-				options: { flavor: 'Primary Die', isVicious },
+				options: { flavor: 'Primary Die', isVicious, appearance },
 			});
 
 			// Apply advantage/disadvantage to primary die only (keeps 1)
@@ -358,7 +359,7 @@ class DamageRoll extends foundry.dice.Roll<DamageRoll.Data> {
 				number: 1,
 				faces: firstDieTerm.faces ?? 6,
 				modifiers: [],
-				options: { isVicious },
+				options: { isVicious, appearance },
 			});
 
 			// Apply advantage/disadvantage (keeps 1)

--- a/src/dice/diceSoNiceIntegration.test.ts
+++ b/src/dice/diceSoNiceIntegration.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SYSTEM_ID } from '#system';
+import {
+	DEFAULT_PRIMARY_DIE_COLOR,
+	DEFAULT_PRIMARY_DIE_LABEL_COLOR,
+	DSN_PRIMARY_DIE_COLOR_SETTING_KEY,
+	DSN_PRIMARY_DIE_LABEL_COLOR_SETTING_KEY,
+	DSN_PRIMARY_DIE_STYLE_ENABLED_SETTING_KEY,
+} from '../settings/diceSoNiceSettings.js';
+import { getPrimaryDieAppearance, PRIMARY_DIE_COLORSET } from './diceSoNiceIntegration.js';
+
+type SettingsMock = {
+	settings: { has: (id: string) => boolean };
+	get: ReturnType<typeof vi.fn>;
+};
+
+function installSettingsMock(values: Record<string, unknown>): SettingsMock {
+	const registeredIds = new Set(Object.keys(values).map((key) => `${SYSTEM_ID}.${key}`));
+	const mock: SettingsMock = {
+		settings: { has: (id: string) => registeredIds.has(id) },
+		get: vi.fn((_namespace: string, key: string) => values[key]),
+	};
+	(game as unknown as { settings: SettingsMock }).settings = mock;
+	return mock;
+}
+
+describe('getPrimaryDieAppearance', () => {
+	beforeEach(() => {
+		installSettingsMock({});
+	});
+
+	it('returns only the colorset when no settings are registered', () => {
+		expect(getPrimaryDieAppearance()).toEqual({ colorset: PRIMARY_DIE_COLORSET });
+	});
+
+	it('returns undefined when the user has disabled primary die styling', () => {
+		installSettingsMock({ [DSN_PRIMARY_DIE_STYLE_ENABLED_SETTING_KEY]: false });
+
+		expect(getPrimaryDieAppearance()).toBeUndefined();
+	});
+
+	it('returns only the colorset when settings hold the default colors', () => {
+		installSettingsMock({
+			[DSN_PRIMARY_DIE_STYLE_ENABLED_SETTING_KEY]: true,
+			[DSN_PRIMARY_DIE_COLOR_SETTING_KEY]: DEFAULT_PRIMARY_DIE_COLOR,
+			[DSN_PRIMARY_DIE_LABEL_COLOR_SETTING_KEY]: DEFAULT_PRIMARY_DIE_LABEL_COLOR,
+		});
+
+		expect(getPrimaryDieAppearance()).toEqual({ colorset: PRIMARY_DIE_COLORSET });
+	});
+
+	it('includes a custom background with a matching edge', () => {
+		installSettingsMock({ [DSN_PRIMARY_DIE_COLOR_SETTING_KEY]: '#123456' });
+
+		expect(getPrimaryDieAppearance()).toEqual({
+			colorset: PRIMARY_DIE_COLORSET,
+			background: '#123456',
+			edge: '#123456',
+		});
+	});
+
+	it('includes a custom foreground without touching the background', () => {
+		installSettingsMock({ [DSN_PRIMARY_DIE_LABEL_COLOR_SETTING_KEY]: '#ffffff' });
+
+		expect(getPrimaryDieAppearance()).toEqual({
+			colorset: PRIMARY_DIE_COLORSET,
+			foreground: '#ffffff',
+		});
+	});
+
+	it('expands three-digit hex colors', () => {
+		installSettingsMock({ [DSN_PRIMARY_DIE_COLOR_SETTING_KEY]: '#a1c' });
+
+		expect(getPrimaryDieAppearance()).toMatchObject({ background: '#aa11cc' });
+	});
+
+	it('stringifies Color-like setting values', () => {
+		installSettingsMock({
+			[DSN_PRIMARY_DIE_COLOR_SETTING_KEY]: { toString: () => '#654321' },
+		});
+
+		expect(getPrimaryDieAppearance()).toMatchObject({ background: '#654321' });
+	});
+
+	it('falls back to the default for invalid color values', () => {
+		installSettingsMock({ [DSN_PRIMARY_DIE_COLOR_SETTING_KEY]: 'not-a-color' });
+
+		expect(getPrimaryDieAppearance()).toEqual({ colorset: PRIMARY_DIE_COLORSET });
+	});
+});

--- a/src/dice/diceSoNiceIntegration.test.ts
+++ b/src/dice/diceSoNiceIntegration.test.ts
@@ -7,7 +7,7 @@ import {
 	DSN_PRIMARY_DIE_LABEL_COLOR_SETTING_KEY,
 	DSN_PRIMARY_DIE_STYLE_ENABLED_SETTING_KEY,
 } from '../settings/diceSoNiceSettings.js';
-import { getPrimaryDieAppearance, PRIMARY_DIE_COLORSET } from './diceSoNiceIntegration.js';
+import { getPrimaryDieDiceOptions, PRIMARY_DIE_COLORSET } from './diceSoNiceIntegration.js';
 
 type SettingsMock = {
 	settings: { has: (id: string) => boolean };
@@ -24,19 +24,22 @@ function installSettingsMock(values: Record<string, unknown>): SettingsMock {
 	return mock;
 }
 
-describe('getPrimaryDieAppearance', () => {
+describe('getPrimaryDieDiceOptions', () => {
 	beforeEach(() => {
 		installSettingsMock({});
 	});
 
 	it('returns only the colorset when no settings are registered', () => {
-		expect(getPrimaryDieAppearance()).toEqual({ colorset: PRIMARY_DIE_COLORSET });
+		expect(getPrimaryDieDiceOptions()).toEqual({
+			appearance: { colorset: PRIMARY_DIE_COLORSET },
+			dsnDamageTypeManaged: true,
+		});
 	});
 
 	it('returns undefined when the user has disabled primary die styling', () => {
 		installSettingsMock({ [DSN_PRIMARY_DIE_STYLE_ENABLED_SETTING_KEY]: false });
 
-		expect(getPrimaryDieAppearance()).toBeUndefined();
+		expect(getPrimaryDieDiceOptions()).toBeUndefined();
 	});
 
 	it('returns only the colorset when settings hold the default colors', () => {
@@ -46,23 +49,24 @@ describe('getPrimaryDieAppearance', () => {
 			[DSN_PRIMARY_DIE_LABEL_COLOR_SETTING_KEY]: DEFAULT_PRIMARY_DIE_LABEL_COLOR,
 		});
 
-		expect(getPrimaryDieAppearance()).toEqual({ colorset: PRIMARY_DIE_COLORSET });
+		expect(getPrimaryDieDiceOptions()?.appearance).toEqual({ colorset: PRIMARY_DIE_COLORSET });
 	});
 
-	it('includes a custom background with a matching edge', () => {
+	it('derives a matching edge and a darkened outline from a custom background', () => {
 		installSettingsMock({ [DSN_PRIMARY_DIE_COLOR_SETTING_KEY]: '#123456' });
 
-		expect(getPrimaryDieAppearance()).toEqual({
+		expect(getPrimaryDieDiceOptions()?.appearance).toEqual({
 			colorset: PRIMARY_DIE_COLORSET,
 			background: '#123456',
 			edge: '#123456',
+			outline: '#06121e',
 		});
 	});
 
 	it('includes a custom foreground without touching the background', () => {
 		installSettingsMock({ [DSN_PRIMARY_DIE_LABEL_COLOR_SETTING_KEY]: '#ffffff' });
 
-		expect(getPrimaryDieAppearance()).toEqual({
+		expect(getPrimaryDieDiceOptions()?.appearance).toEqual({
 			colorset: PRIMARY_DIE_COLORSET,
 			foreground: '#ffffff',
 		});
@@ -71,7 +75,7 @@ describe('getPrimaryDieAppearance', () => {
 	it('expands three-digit hex colors', () => {
 		installSettingsMock({ [DSN_PRIMARY_DIE_COLOR_SETTING_KEY]: '#a1c' });
 
-		expect(getPrimaryDieAppearance()).toMatchObject({ background: '#aa11cc' });
+		expect(getPrimaryDieDiceOptions()?.appearance).toMatchObject({ background: '#aa11cc' });
 	});
 
 	it('stringifies Color-like setting values', () => {
@@ -79,12 +83,18 @@ describe('getPrimaryDieAppearance', () => {
 			[DSN_PRIMARY_DIE_COLOR_SETTING_KEY]: { toString: () => '#654321' },
 		});
 
-		expect(getPrimaryDieAppearance()).toMatchObject({ background: '#654321' });
+		expect(getPrimaryDieDiceOptions()?.appearance).toMatchObject({ background: '#654321' });
 	});
 
 	it('falls back to the default for invalid color values', () => {
 		installSettingsMock({ [DSN_PRIMARY_DIE_COLOR_SETTING_KEY]: 'not-a-color' });
 
-		expect(getPrimaryDieAppearance()).toEqual({ colorset: PRIMARY_DIE_COLORSET });
+		expect(getPrimaryDieDiceOptions()?.appearance).toEqual({ colorset: PRIMARY_DIE_COLORSET });
+	});
+
+	it('marks the damage type as system-managed so a flavor cannot override the colorset', () => {
+		installSettingsMock({});
+
+		expect(getPrimaryDieDiceOptions()?.dsnDamageTypeManaged).toBe(true);
 	});
 });

--- a/src/dice/diceSoNiceIntegration.ts
+++ b/src/dice/diceSoNiceIntegration.ts
@@ -19,6 +19,16 @@ export const PRIMARY_DIE_COLORSET = `${SYSTEM_ID}-primary`;
 /** Gold edge used when the die body is the default color. */
 const DEFAULT_PRIMARY_DIE_EDGE_COLOR = '#d4af37';
 
+/** Dark red numeral outline paired with the default crimson body. */
+const DEFAULT_PRIMARY_DIE_OUTLINE_COLOR = '#310606';
+
+/**
+ * How much of the body color is kept in the numeral outline derived from a
+ * custom body, matching how dark the default outline sits against the default
+ * crimson body.
+ */
+const OUTLINE_DARKENING_FACTOR = 0.35;
+
 /**
  * Per-term appearance override read by Dice So Nice. The colorset is
  * resolved first; any explicit color fields are then merged over it.
@@ -28,15 +38,45 @@ export interface PrimaryDieAppearance {
 	background?: string;
 	foreground?: string;
 	edge?: string;
+	outline?: string;
 }
 
 /**
- * Builds the appearance override for a primary die from the rolling user's
- * preferences, or `undefined` when the user has disabled distinct primary
- * die styling. Called at roll construction, so the roller's own settings
- * determine how their primary die renders on every client.
+ * Die term options that make Dice So Nice render the term as a primary die.
  */
-export function getPrimaryDieAppearance(): PrimaryDieAppearance | undefined {
+export interface PrimaryDieDiceOptions {
+	appearance: PrimaryDieAppearance;
+	/**
+	 * Stops Dice So Nice deriving a colorset from the term's `type`/`flavor`,
+	 * which resolves before `appearance.colorset` and would otherwise let a
+	 * damage-type mapping override the primary die styling.
+	 */
+	dsnDamageTypeManaged: true;
+}
+
+/** Darkens an `#rrggbb` color towards black by `factor`. */
+function darkenHexColor(color: string, factor: number): string {
+	const channels = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(color);
+	if (!channels) return color;
+
+	const darkened = channels
+		.slice(1)
+		.map((channel) =>
+			Math.round(Number.parseInt(channel, 16) * factor)
+				.toString(16)
+				.padStart(2, '0'),
+		)
+		.join('');
+	return `#${darkened}`;
+}
+
+/**
+ * Builds the Dice So Nice term options for a primary die from the rolling
+ * user's preferences, or `undefined` when the user has disabled distinct
+ * primary die styling. Called at roll construction, so the roller's own
+ * settings determine how their primary die renders on every client.
+ */
+export function getPrimaryDieDiceOptions(): PrimaryDieDiceOptions | undefined {
 	const preferences = getPrimaryDiePreferences();
 	if (!preferences.enabled) return undefined;
 
@@ -44,16 +84,17 @@ export function getPrimaryDieAppearance(): PrimaryDieAppearance | undefined {
 
 	if (preferences.background !== DEFAULT_PRIMARY_DIE_COLOR) {
 		appearance.background = preferences.background;
-		// The default gold edge only suits the default body color; a custom
-		// body looks best with a matching edge.
+		// The default gold edge and dark red numeral outline only suit the
+		// default body color, so derive both from a custom body instead.
 		appearance.edge = preferences.background;
+		appearance.outline = darkenHexColor(preferences.background, OUTLINE_DARKENING_FACTOR);
 	}
 
 	if (preferences.foreground !== DEFAULT_PRIMARY_DIE_LABEL_COLOR) {
 		appearance.foreground = preferences.foreground;
 	}
 
-	return appearance;
+	return { appearance, dsnDamageTypeManaged: true };
 }
 
 /**
@@ -73,22 +114,29 @@ interface Dice3D {
  * construction are inert.
  */
 export default function registerDiceSoNiceIntegration() {
-	(Hooks.once as (event: string, fn: (dice3d: Dice3D) => void) => number)(
+	(Hooks.once as (event: string, fn: (dice3d: Dice3D) => Promise<void>) => number)(
 		'diceSoNiceReady',
-		(dice3d) => {
-			dice3d.addColorset(
-				{
-					name: PRIMARY_DIE_COLORSET,
-					description: localize('NIMBLE.diceSoNice.primaryDieColorset'),
-					category: localize('NIMBLE.diceSoNice.category'),
-					foreground: DEFAULT_PRIMARY_DIE_LABEL_COLOR,
-					background: DEFAULT_PRIMARY_DIE_COLOR,
-					outline: '#310606',
-					edge: DEFAULT_PRIMARY_DIE_EDGE_COLOR,
-					material: 'metal',
-				},
-				'default',
-			);
+		async (dice3d) => {
+			try {
+				await dice3d.addColorset(
+					{
+						name: PRIMARY_DIE_COLORSET,
+						description: localize('NIMBLE.diceSoNice.primaryDieColorset'),
+						category: localize('NIMBLE.diceSoNice.category'),
+						foreground: DEFAULT_PRIMARY_DIE_LABEL_COLOR,
+						background: DEFAULT_PRIMARY_DIE_COLOR,
+						outline: DEFAULT_PRIMARY_DIE_OUTLINE_COLOR,
+						edge: DEFAULT_PRIMARY_DIE_EDGE_COLOR,
+						material: 'metal',
+						// Keeps the colorset out of the player-facing theme list;
+						// it is only meant to be applied per term by the system.
+						visibility: 'hidden',
+					},
+					'default',
+				);
+			} catch (error) {
+				console.error(`${SYSTEM_ID} | Failed to register the primary die colorset`, error);
+			}
 		},
 	);
 }

--- a/src/dice/diceSoNiceIntegration.ts
+++ b/src/dice/diceSoNiceIntegration.ts
@@ -1,0 +1,94 @@
+import { SYSTEM_ID } from '#system';
+import {
+	DEFAULT_PRIMARY_DIE_COLOR,
+	DEFAULT_PRIMARY_DIE_LABEL_COLOR,
+	getPrimaryDiePreferences,
+} from '../settings/diceSoNiceSettings.js';
+import localize from '../utils/localize.js';
+
+/**
+ * Name of the Dice So Nice colorset applied to primary dice so they stand
+ * out from the rest of the dice pool in 3D rolls.
+ *
+ * Referenced from term construction via `options.appearance.colorset`, which
+ * Dice So Nice reads per die term when rendering a roll. Term options are
+ * serialized with the roll, so the appearance travels to all clients.
+ */
+export const PRIMARY_DIE_COLORSET = `${SYSTEM_ID}-primary`;
+
+/** Gold edge used when the die body is the default color. */
+const DEFAULT_PRIMARY_DIE_EDGE_COLOR = '#d4af37';
+
+/**
+ * Per-term appearance override read by Dice So Nice. The colorset is
+ * resolved first; any explicit color fields are then merged over it.
+ */
+export interface PrimaryDieAppearance {
+	colorset: string;
+	background?: string;
+	foreground?: string;
+	edge?: string;
+}
+
+/**
+ * Builds the appearance override for a primary die from the rolling user's
+ * preferences, or `undefined` when the user has disabled distinct primary
+ * die styling. Called at roll construction, so the roller's own settings
+ * determine how their primary die renders on every client.
+ */
+export function getPrimaryDieAppearance(): PrimaryDieAppearance | undefined {
+	const preferences = getPrimaryDiePreferences();
+	if (!preferences.enabled) return undefined;
+
+	const appearance: PrimaryDieAppearance = { colorset: PRIMARY_DIE_COLORSET };
+
+	if (preferences.background !== DEFAULT_PRIMARY_DIE_COLOR) {
+		appearance.background = preferences.background;
+		// The default gold edge only suits the default body color; a custom
+		// body looks best with a matching edge.
+		appearance.edge = preferences.background;
+	}
+
+	if (preferences.foreground !== DEFAULT_PRIMARY_DIE_LABEL_COLOR) {
+		appearance.foreground = preferences.foreground;
+	}
+
+	return appearance;
+}
+
+/**
+ * Minimal surface of the Dice So Nice module API used by this integration.
+ * The module publishes no type definitions.
+ */
+interface Dice3D {
+	addColorset(colorset: Record<string, string>, mode?: string): Promise<void>;
+}
+
+/**
+ * Registers the system's Dice So Nice colorsets.
+ *
+ * The `diceSoNiceReady` hook only fires when the module is installed and
+ * active, so no module guard is needed: without the module the colorset is
+ * never registered, and the per-term `appearance` options set during roll
+ * construction are inert.
+ */
+export default function registerDiceSoNiceIntegration() {
+	(Hooks.once as (event: string, fn: (dice3d: Dice3D) => void) => number)(
+		'diceSoNiceReady',
+		(dice3d) => {
+			dice3d.addColorset(
+				{
+					name: PRIMARY_DIE_COLORSET,
+					description: localize('NIMBLE.diceSoNice.primaryDieColorset'),
+					category: localize('NIMBLE.diceSoNice.category'),
+					foreground: DEFAULT_PRIMARY_DIE_LABEL_COLOR,
+					background: DEFAULT_PRIMARY_DIE_COLOR,
+					outline: '#310606',
+					edge: DEFAULT_PRIMARY_DIE_EDGE_COLOR,
+					material: 'metal',
+				},
+				'default',
+			);
+		},
+	);
+}

--- a/src/dice/nimbleDieModifiers.test.ts
+++ b/src/dice/nimbleDieModifiers.test.ts
@@ -1,4 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SYSTEM_ID } from '#system';
+import { DSN_PRIMARY_DIE_STYLE_ENABLED_SETTING_KEY } from '../settings/diceSoNiceSettings.js';
+import { PRIMARY_DIE_COLORSET } from './diceSoNiceIntegration.js';
 import {
 	_resetVWarned,
 	getNimbleMods,
@@ -19,6 +22,7 @@ type DieResult = {
 interface MockDie {
 	results: DieResult[];
 	modifiers: string[];
+	options?: Record<string, unknown>;
 }
 
 function createMockDie(overrides?: Partial<MockDie>): MockDie {
@@ -236,5 +240,55 @@ describe('NIMBLE_MODS', () => {
 
 		const raw = (die as unknown as Record<symbol, unknown>)[NIMBLE_MODS];
 		expect(raw).toEqual({ canCrit: true, explosionStyle: 'standard' });
+	});
+});
+
+// ─── Primary die appearance (3D dice) ───────────────────────────────
+
+describe('primary die appearance', () => {
+	function installSettingsMock(values: Record<string, unknown>) {
+		const registeredIds = new Set(Object.keys(values).map((key) => `${SYSTEM_ID}.${key}`));
+		(game as unknown as { settings: unknown }).settings = {
+			settings: { has: (id: string) => registeredIds.has(id) },
+			get: vi.fn((_namespace: string, key: string) => values[key]),
+		};
+	}
+
+	beforeEach(() => {
+		installSettingsMock({});
+	});
+
+	it('should tag a die crit-capable through the c modifier', () => {
+		const die = createMockDie();
+
+		nimbleCrit.call(die, 'c');
+
+		expect(die.options?.appearance).toEqual({ colorset: PRIMARY_DIE_COLORSET });
+		expect(die.options?.dsnDamageTypeManaged).toBe(true);
+	});
+
+	it('should tag a die crit-capable through the cv modifier', () => {
+		const die = createMockDie();
+
+		nimbleCritVicious.call(die, 'cv');
+
+		expect(die.options?.appearance).toEqual({ colorset: PRIMARY_DIE_COLORSET });
+	});
+
+	it('should preserve an appearance already set on the term', () => {
+		const die = createMockDie({ options: { appearance: { colorset: 'custom' } } });
+
+		nimbleCrit.call(die, 'c');
+
+		expect(die.options?.appearance).toEqual({ colorset: 'custom' });
+	});
+
+	it('should leave options untouched when the user disabled primary die styling', () => {
+		installSettingsMock({ [DSN_PRIMARY_DIE_STYLE_ENABLED_SETTING_KEY]: false });
+		const die = createMockDie();
+
+		nimbleCrit.call(die, 'c');
+
+		expect(die.options).toBeUndefined();
 	});
 });

--- a/src/dice/nimbleDieModifiers.ts
+++ b/src/dice/nimbleDieModifiers.ts
@@ -31,7 +31,7 @@
  *   - `kln3`   → keep 3 lowest
  */
 
-import { getPrimaryDieAppearance, type PrimaryDieAppearance } from './diceSoNiceIntegration.js';
+import { getPrimaryDieDiceOptions, type PrimaryDieDiceOptions } from './diceSoNiceIntegration.js';
 
 // ─── Die Modifier Metadata ──────────────────────────────────────────
 
@@ -74,7 +74,7 @@ type DieResult = {
 interface DieLike {
 	results: DieResult[];
 	modifiers?: string[];
-	options?: { appearance?: PrimaryDieAppearance };
+	options?: Partial<PrimaryDieDiceOptions>;
 }
 
 /**
@@ -82,12 +82,17 @@ interface DieLike {
  * render it distinctly from the rest of the pool. Preserves any appearance
  * already set on the term, and does nothing when the rolling user has
  * disabled distinct primary die styling.
+ *
+ * A 3D dice appearance is per term, and in modifier mode the whole tagged term
+ * is the primary pool: every die in `4d4cv` crits and explodes on its own, so
+ * there is no single die within it to single out.
  */
 function applyPrimaryDieAppearance(die: DieLike): void {
-	const appearance = getPrimaryDieAppearance();
-	if (!appearance) return;
+	const diceSoNiceOptions = getPrimaryDieDiceOptions();
+	if (!diceSoNiceOptions) return;
 	die.options ??= {};
-	die.options.appearance ??= appearance;
+	if (die.options.appearance) return;
+	Object.assign(die.options, diceSoNiceOptions);
 }
 
 function parseCount(modifier: string, prefix: 'khn' | 'kln'): number {

--- a/src/dice/nimbleDieModifiers.ts
+++ b/src/dice/nimbleDieModifiers.ts
@@ -31,6 +31,8 @@
  *   - `kln3`   → keep 3 lowest
  */
 
+import { getPrimaryDieAppearance, type PrimaryDieAppearance } from './diceSoNiceIntegration.js';
+
 // ─── Die Modifier Metadata ──────────────────────────────────────────
 
 /**
@@ -72,6 +74,20 @@ type DieResult = {
 interface DieLike {
 	results: DieResult[];
 	modifiers?: string[];
+	options?: { appearance?: PrimaryDieAppearance };
+}
+
+/**
+ * Tag a crit-capable die with the primary-die appearance so 3D dice modules
+ * render it distinctly from the rest of the pool. Preserves any appearance
+ * already set on the term, and does nothing when the rolling user has
+ * disabled distinct primary die styling.
+ */
+function applyPrimaryDieAppearance(die: DieLike): void {
+	const appearance = getPrimaryDieAppearance();
+	if (!appearance) return;
+	die.options ??= {};
+	die.options.appearance ??= appearance;
 }
 
 function parseCount(modifier: string, prefix: 'khn' | 'kln'): number {
@@ -160,6 +176,7 @@ export function nimbleCrit(this: DieLike, _modifier: string): boolean {
 	if (this.modifiers && !this.modifiers.includes('x')) {
 		this.modifiers.push('x');
 	}
+	applyPrimaryDieAppearance(this);
 	return true;
 }
 
@@ -177,6 +194,7 @@ export function nimbleCritVicious(this: DieLike, _modifier: string): boolean {
 		canCrit: true,
 		explosionStyle: 'vicious',
 	} satisfies NimbleDieMetadata;
+	applyPrimaryDieAppearance(this);
 	return true;
 }
 

--- a/src/dice/terms/PrimaryDie.ts
+++ b/src/dice/terms/PrimaryDie.ts
@@ -1,4 +1,5 @@
 import type { InexactPartial } from 'fvtt-types/utils';
+import type { PrimaryDieAppearance } from '../diceSoNiceIntegration.js';
 
 declare namespace PrimaryDie {
 	/** Options for PrimaryDie that extend standard die options. */
@@ -7,6 +8,8 @@ declare namespace PrimaryDie {
 		isVicious?: boolean;
 		/** Optional flavor text for the die. */
 		flavor?: string;
+		/** Per-term appearance override read by Dice So Nice when active. */
+		appearance?: PrimaryDieAppearance;
 	}
 
 	/** Term data for configuring a PrimaryDie. */

--- a/src/dice/terms/PrimaryDie.ts
+++ b/src/dice/terms/PrimaryDie.ts
@@ -1,5 +1,5 @@
 import type { InexactPartial } from 'fvtt-types/utils';
-import type { PrimaryDieAppearance } from '../diceSoNiceIntegration.js';
+import type { PrimaryDieDiceOptions } from '../diceSoNiceIntegration.js';
 
 declare namespace PrimaryDie {
 	/** Options for PrimaryDie that extend standard die options. */
@@ -9,7 +9,9 @@ declare namespace PrimaryDie {
 		/** Optional flavor text for the die. */
 		flavor?: string;
 		/** Per-term appearance override read by Dice So Nice when active. */
-		appearance?: PrimaryDieAppearance;
+		appearance?: PrimaryDieDiceOptions['appearance'];
+		/** Marks the term's damage type as system-managed for Dice So Nice. */
+		dsnDamageTypeManaged?: boolean;
 	}
 
 	/** Term data for configuring a PrimaryDie. */

--- a/src/nimble.ts
+++ b/src/nimble.ts
@@ -1,3 +1,4 @@
+import registerDiceSoNiceIntegration from './dice/diceSoNiceIntegration.js';
 import registerActionEconomySystemHooks from './hooks/actionEconomySystem.js';
 import { handleAutomaticConditionApplication } from './hooks/automaticConditions.js';
 import registerBabeleHooks from './hooks/babeleInit.js';
@@ -147,6 +148,7 @@ registerTokenCombatantSync();
 registerRuleEventDispatch();
 registerBabeleHooks();
 registerBabeleInstallNotice();
+registerDiceSoNiceIntegration();
 
 // Refresh tokens when combat ends to remove turn indicators
 Hooks.on('deleteCombat', async (combat: Combat) => {

--- a/src/settings/diceSoNiceSettings.ts
+++ b/src/settings/diceSoNiceSettings.ts
@@ -7,6 +7,9 @@ export const DSN_PRIMARY_DIE_LABEL_COLOR_SETTING_KEY = 'dsnPrimaryDieLabelColor'
 export const DEFAULT_PRIMARY_DIE_COLOR = '#8a1c1c';
 export const DEFAULT_PRIMARY_DIE_LABEL_COLOR = '#f5e7c1';
 
+/** Module id of Dice So Nice, the only consumer of these preferences. */
+export const DICE_SO_NICE_MODULE_ID = 'dice-so-nice';
+
 /** User preferences controlling the primary die's 3D dice appearance. */
 export interface PrimaryDiePreferences {
 	enabled: boolean;
@@ -14,7 +17,12 @@ export interface PrimaryDiePreferences {
 	foreground: string;
 }
 
-function normalizeHexColor(value: unknown, fallback: string): string {
+/** Whether Dice So Nice is installed and enabled in this world. */
+export function isDiceSoNiceActive(): boolean {
+	return Boolean(game.modules?.get(DICE_SO_NICE_MODULE_ID)?.active);
+}
+
+export function normalizeHexColor(value: unknown, fallback: string): string {
 	if (value === null || value === undefined) return fallback;
 	// ColorField-backed settings return a Color instance; its toString() is
 	// the css hex form. Plain strings pass through unchanged.
@@ -26,10 +34,6 @@ function normalizeHexColor(value: unknown, fallback: string): string {
 		return `#${red}${red}${green}${green}${blue}${blue}`;
 	}
 	return fallback;
-}
-
-function colorSettingField(initial: string) {
-	return new foundry.data.fields.ColorField({ nullable: false, initial });
 }
 
 /**
@@ -61,41 +65,21 @@ export function getPrimaryDiePreferences(): PrimaryDiePreferences {
 	};
 }
 
-export function registerDiceSoNiceSettings() {
-	game.settings.register(
+/** Stores the current user's primary die appearance preferences. */
+export async function setPrimaryDiePreferences(preferences: PrimaryDiePreferences): Promise<void> {
+	await game.settings.set(
 		SYSTEM_ID as 'core',
 		DSN_PRIMARY_DIE_STYLE_ENABLED_SETTING_KEY as 'rollMode',
-		{
-			name: 'NIMBLE.settings.dsnPrimaryDieStyleEnabled.name',
-			hint: 'NIMBLE.settings.dsnPrimaryDieStyleEnabled.hint',
-			scope: 'user',
-			config: true,
-			type: Boolean,
-			default: true,
-		} as unknown as Parameters<typeof game.settings.register>[2],
+		preferences.enabled as never,
 	);
-
-	game.settings.register(
+	await game.settings.set(
 		SYSTEM_ID as 'core',
 		DSN_PRIMARY_DIE_COLOR_SETTING_KEY as 'rollMode',
-		{
-			name: 'NIMBLE.settings.dsnPrimaryDieColor.name',
-			hint: 'NIMBLE.settings.dsnPrimaryDieColor.hint',
-			scope: 'user',
-			config: true,
-			type: colorSettingField(DEFAULT_PRIMARY_DIE_COLOR),
-		} as unknown as Parameters<typeof game.settings.register>[2],
+		normalizeHexColor(preferences.background, DEFAULT_PRIMARY_DIE_COLOR) as never,
 	);
-
-	game.settings.register(
+	await game.settings.set(
 		SYSTEM_ID as 'core',
 		DSN_PRIMARY_DIE_LABEL_COLOR_SETTING_KEY as 'rollMode',
-		{
-			name: 'NIMBLE.settings.dsnPrimaryDieLabelColor.name',
-			hint: 'NIMBLE.settings.dsnPrimaryDieLabelColor.hint',
-			scope: 'user',
-			config: true,
-			type: colorSettingField(DEFAULT_PRIMARY_DIE_LABEL_COLOR),
-		} as unknown as Parameters<typeof game.settings.register>[2],
+		normalizeHexColor(preferences.foreground, DEFAULT_PRIMARY_DIE_LABEL_COLOR) as never,
 	);
 }

--- a/src/settings/diceSoNiceSettings.ts
+++ b/src/settings/diceSoNiceSettings.ts
@@ -1,0 +1,101 @@
+import { SYSTEM_ID } from '#system';
+
+export const DSN_PRIMARY_DIE_STYLE_ENABLED_SETTING_KEY = 'dsnPrimaryDieStyleEnabled';
+export const DSN_PRIMARY_DIE_COLOR_SETTING_KEY = 'dsnPrimaryDieColor';
+export const DSN_PRIMARY_DIE_LABEL_COLOR_SETTING_KEY = 'dsnPrimaryDieLabelColor';
+
+export const DEFAULT_PRIMARY_DIE_COLOR = '#8a1c1c';
+export const DEFAULT_PRIMARY_DIE_LABEL_COLOR = '#f5e7c1';
+
+/** User preferences controlling the primary die's 3D dice appearance. */
+export interface PrimaryDiePreferences {
+	enabled: boolean;
+	background: string;
+	foreground: string;
+}
+
+function normalizeHexColor(value: unknown, fallback: string): string {
+	if (value === null || value === undefined) return fallback;
+	// ColorField-backed settings return a Color instance; its toString() is
+	// the css hex form. Plain strings pass through unchanged.
+	const normalized = String(value).trim().toLowerCase();
+	if (/^#[0-9a-f]{6}$/.test(normalized)) return normalized;
+	const shortHexMatch = /^#([0-9a-f]{3})$/.exec(normalized);
+	if (shortHexMatch) {
+		const [red, green, blue] = [...shortHexMatch[1]];
+		return `#${red}${red}${green}${green}${blue}${blue}`;
+	}
+	return fallback;
+}
+
+function colorSettingField(initial: string) {
+	return new foundry.data.fields.ColorField({ nullable: false, initial });
+}
+
+/**
+ * Read a system setting, returning `undefined` when the settings registry is
+ * unavailable or the key is not registered (e.g. in unit tests or before the
+ * setup hook has run).
+ */
+function getSettingSafe(key: string): unknown {
+	const settingsMap = game.settings?.settings as { has: (key: string) => boolean } | undefined;
+	if (!settingsMap?.has(`${SYSTEM_ID}.${key}`)) return undefined;
+	return game.settings.get(SYSTEM_ID as 'core', key as 'rollMode');
+}
+
+/**
+ * The current user's primary die appearance preferences, falling back to the
+ * system defaults when the settings are unavailable.
+ */
+export function getPrimaryDiePreferences(): PrimaryDiePreferences {
+	return {
+		enabled: getSettingSafe(DSN_PRIMARY_DIE_STYLE_ENABLED_SETTING_KEY) !== false,
+		background: normalizeHexColor(
+			getSettingSafe(DSN_PRIMARY_DIE_COLOR_SETTING_KEY),
+			DEFAULT_PRIMARY_DIE_COLOR,
+		),
+		foreground: normalizeHexColor(
+			getSettingSafe(DSN_PRIMARY_DIE_LABEL_COLOR_SETTING_KEY),
+			DEFAULT_PRIMARY_DIE_LABEL_COLOR,
+		),
+	};
+}
+
+export function registerDiceSoNiceSettings() {
+	game.settings.register(
+		SYSTEM_ID as 'core',
+		DSN_PRIMARY_DIE_STYLE_ENABLED_SETTING_KEY as 'rollMode',
+		{
+			name: 'NIMBLE.settings.dsnPrimaryDieStyleEnabled.name',
+			hint: 'NIMBLE.settings.dsnPrimaryDieStyleEnabled.hint',
+			scope: 'user',
+			config: true,
+			type: Boolean,
+			default: true,
+		} as unknown as Parameters<typeof game.settings.register>[2],
+	);
+
+	game.settings.register(
+		SYSTEM_ID as 'core',
+		DSN_PRIMARY_DIE_COLOR_SETTING_KEY as 'rollMode',
+		{
+			name: 'NIMBLE.settings.dsnPrimaryDieColor.name',
+			hint: 'NIMBLE.settings.dsnPrimaryDieColor.hint',
+			scope: 'user',
+			config: true,
+			type: colorSettingField(DEFAULT_PRIMARY_DIE_COLOR),
+		} as unknown as Parameters<typeof game.settings.register>[2],
+	);
+
+	game.settings.register(
+		SYSTEM_ID as 'core',
+		DSN_PRIMARY_DIE_LABEL_COLOR_SETTING_KEY as 'rollMode',
+		{
+			name: 'NIMBLE.settings.dsnPrimaryDieLabelColor.name',
+			hint: 'NIMBLE.settings.dsnPrimaryDieLabelColor.hint',
+			scope: 'user',
+			config: true,
+			type: colorSettingField(DEFAULT_PRIMARY_DIE_LABEL_COLOR),
+		} as unknown as Parameters<typeof game.settings.register>[2],
+	);
+}

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -6,11 +6,11 @@ import LanguageCustomizationDialog from '#view/dialogs/LanguageCustomizationDial
 import { MigrationRunnerBase } from '../migration/MigrationRunnerBase.js';
 import { registerAdjacencySettings } from './adjacencySettings.js';
 import { registerCombatTrackerSettings } from './combatTrackerSettings.js';
-import { registerDiceSoNiceSettings } from './diceSoNiceSettings.js';
 import { AUTO_ADD_CHARACTER_TO_COMBAT_ON_INITIATIVE_ROLL_SETTING_KEY } from './initiativeSettings.js';
 import { registerLanguageSettings } from './languageSettings.js';
 import { registerNcswSettings } from './ncswSettings.js';
 import { registerAutomationSettings } from './registerAutomationSettings.js';
+import { registerDiceSoNiceSettings } from './registerDiceSoNiceSettings.js';
 import { registerSpellSchoolSettings } from './registerSpellSchoolSettings.js';
 import { registerSpellScrollSettings } from './spellScrollSettings.js';
 

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -6,6 +6,7 @@ import LanguageCustomizationDialog from '#view/dialogs/LanguageCustomizationDial
 import { MigrationRunnerBase } from '../migration/MigrationRunnerBase.js';
 import { registerAdjacencySettings } from './adjacencySettings.js';
 import { registerCombatTrackerSettings } from './combatTrackerSettings.js';
+import { registerDiceSoNiceSettings } from './diceSoNiceSettings.js';
 import { AUTO_ADD_CHARACTER_TO_COMBAT_ON_INITIATIVE_ROLL_SETTING_KEY } from './initiativeSettings.js';
 import { registerLanguageSettings } from './languageSettings.js';
 import { registerNcswSettings } from './ncswSettings.js';
@@ -90,6 +91,7 @@ export default function registerSystemSettings() {
 	registerAutomationSettings();
 
 	registerCombatTrackerSettings();
+	registerDiceSoNiceSettings();
 	registerNcswSettings();
 	registerLanguageSettings();
 	registerSpellSchoolSettings();

--- a/src/settings/registerDiceSoNiceSettings.test.ts
+++ b/src/settings/registerDiceSoNiceSettings.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SYSTEM_ID } from '#system';
+import {
+	DSN_PRIMARY_DIE_COLOR_SETTING_KEY,
+	DSN_PRIMARY_DIE_LABEL_COLOR_SETTING_KEY,
+	DSN_PRIMARY_DIE_STYLE_ENABLED_SETTING_KEY,
+} from './diceSoNiceSettings.js';
+import { registerDiceSoNiceSettings } from './registerDiceSoNiceSettings.js';
+
+// The settings menu class extends an ApplicationV2-based dialog and pulls in a
+// Svelte component; neither is exercised by registration itself, so both are
+// replaced with inert stand-ins to keep this suite node-safe.
+vi.mock('#documents/dialogs/GenericDialog.svelte.js', () => ({
+	default: class GenericDialogMock {
+		async render(): Promise<this> {
+			return this;
+		}
+	},
+}));
+
+vi.mock('#view/settings/DiceSoNiceSettingsDialog.svelte', () => ({ default: {} }));
+
+type SettingsMock = {
+	register: ReturnType<typeof vi.fn>;
+	registerMenu: ReturnType<typeof vi.fn>;
+};
+
+type RegisteredSettingConfig = { scope?: string; config?: boolean };
+
+function setupSettingsMock(): SettingsMock {
+	const settingsMock: SettingsMock = { register: vi.fn(), registerMenu: vi.fn() };
+	(game as unknown as { settings: SettingsMock }).settings = settingsMock;
+	return settingsMock;
+}
+
+function getRegisteredConfig(
+	settingsMock: SettingsMock,
+	settingKey: string,
+): RegisteredSettingConfig | undefined {
+	const call = settingsMock.register.mock.calls.find(([, key]) => key === settingKey);
+	return call?.[2] as RegisteredSettingConfig | undefined;
+}
+
+describe('registerDiceSoNiceSettings', () => {
+	let settingsMock: SettingsMock;
+
+	beforeEach(() => {
+		settingsMock = setupSettingsMock();
+		registerDiceSoNiceSettings();
+	});
+
+	it('hides every primary die setting from the flat settings list', () => {
+		const settingKeys = [
+			DSN_PRIMARY_DIE_STYLE_ENABLED_SETTING_KEY,
+			DSN_PRIMARY_DIE_COLOR_SETTING_KEY,
+			DSN_PRIMARY_DIE_LABEL_COLOR_SETTING_KEY,
+		];
+
+		expect(settingsMock.register).toHaveBeenCalledTimes(settingKeys.length);
+		for (const settingKey of settingKeys) {
+			expect(getRegisteredConfig(settingsMock, settingKey)).toMatchObject({
+				scope: 'user',
+				config: false,
+			});
+		}
+	});
+
+	it('registers an unrestricted submenu so every player can reach their own settings', () => {
+		expect(settingsMock.registerMenu).toHaveBeenCalledTimes(1);
+		expect(settingsMock.registerMenu).toHaveBeenCalledWith(
+			SYSTEM_ID,
+			'diceSoNiceMenu',
+			expect.objectContaining({ restricted: false }),
+		);
+	});
+});

--- a/src/settings/registerDiceSoNiceSettings.ts
+++ b/src/settings/registerDiceSoNiceSettings.ts
@@ -1,0 +1,122 @@
+import type { Component } from 'svelte';
+import GenericDialog from '#documents/dialogs/GenericDialog.svelte.js';
+import { SYSTEM_ID } from '#system';
+import DiceSoNiceSettingsDialog from '#view/settings/DiceSoNiceSettingsDialog.svelte';
+import {
+	DEFAULT_PRIMARY_DIE_COLOR,
+	DEFAULT_PRIMARY_DIE_LABEL_COLOR,
+	DSN_PRIMARY_DIE_COLOR_SETTING_KEY,
+	DSN_PRIMARY_DIE_LABEL_COLOR_SETTING_KEY,
+	DSN_PRIMARY_DIE_STYLE_ENABLED_SETTING_KEY,
+	isDiceSoNiceActive,
+} from './diceSoNiceSettings.js';
+
+const MENU_ICON = 'fa-solid fa-dice-d20';
+const MENU_KEY = 'diceSoNiceMenu';
+
+/** Tracks the open dialog so repeated submenu clicks focus it instead of stacking copies. */
+let openEditor: DiceSoNiceSettingsMenu | null = null;
+
+/**
+ * No-argument ApplicationV2 wrapper so the Svelte dialog can be registered as a
+ * Foundry settings submenu, which renders the native title + button + hint row
+ * and instantiates the menu via `new type()`.
+ */
+class DiceSoNiceSettingsMenu extends GenericDialog {
+	constructor() {
+		super(
+			game.i18n.localize('NIMBLE.settings.diceSoNiceMenu.title'),
+			DiceSoNiceSettingsDialog as unknown as Component<Record<string, never>>,
+			{},
+			{ uniqueId: 'nimble-dice-so-nice-settings', icon: MENU_ICON, width: 460, resizable: true },
+		);
+	}
+
+	override async render(...args: Parameters<GenericDialog['render']>): Promise<this> {
+		if (openEditor?.rendered && openEditor !== this) {
+			openEditor.bringToFront();
+			return openEditor as this;
+		}
+		openEditor = this;
+		return super.render(...args);
+	}
+}
+
+function colorSettingField(initial: string) {
+	return new foundry.data.fields.ColorField({ nullable: false, initial });
+}
+
+/**
+ * Disables the submenu button while Dice So Nice is absent and replaces the
+ * row's hint with an explanation, so the settings tab says why the button
+ * cannot be used instead of opening a dialog that controls nothing.
+ */
+function registerModuleAvailabilityNotice(): void {
+	Hooks.on('renderSettingsConfig', (_app: unknown, html: HTMLElement | JQuery) => {
+		if (isDiceSoNiceActive()) return;
+
+		const element = html instanceof HTMLElement ? html : html[0];
+		const button = element?.querySelector<HTMLButtonElement>(
+			`button[data-key="${SYSTEM_ID}.${MENU_KEY}"]`,
+		);
+		if (!button) return;
+
+		button.disabled = true;
+		button.dataset.tooltip = game.i18n.localize('NIMBLE.settings.diceSoNiceMenu.moduleMissing');
+
+		const hint = button.closest('.form-group')?.querySelector('.hint');
+		if (hint) hint.textContent = game.i18n.localize('NIMBLE.settings.diceSoNiceMenu.moduleMissing');
+	});
+}
+
+export function registerDiceSoNiceSettings(): void {
+	game.settings.register(
+		SYSTEM_ID as 'core',
+		DSN_PRIMARY_DIE_STYLE_ENABLED_SETTING_KEY as 'rollMode',
+		{
+			name: 'NIMBLE.settings.dsnPrimaryDieStyleEnabled.name',
+			hint: 'NIMBLE.settings.dsnPrimaryDieStyleEnabled.hint',
+			scope: 'user',
+			config: false,
+			type: Boolean,
+			default: true,
+		} as unknown as Parameters<typeof game.settings.register>[2],
+	);
+
+	game.settings.register(
+		SYSTEM_ID as 'core',
+		DSN_PRIMARY_DIE_COLOR_SETTING_KEY as 'rollMode',
+		{
+			name: 'NIMBLE.settings.dsnPrimaryDieColor.name',
+			hint: 'NIMBLE.settings.dsnPrimaryDieColor.hint',
+			scope: 'user',
+			config: false,
+			type: colorSettingField(DEFAULT_PRIMARY_DIE_COLOR),
+		} as unknown as Parameters<typeof game.settings.register>[2],
+	);
+
+	game.settings.register(
+		SYSTEM_ID as 'core',
+		DSN_PRIMARY_DIE_LABEL_COLOR_SETTING_KEY as 'rollMode',
+		{
+			name: 'NIMBLE.settings.dsnPrimaryDieLabelColor.name',
+			hint: 'NIMBLE.settings.dsnPrimaryDieLabelColor.hint',
+			scope: 'user',
+			config: false,
+			type: colorSettingField(DEFAULT_PRIMARY_DIE_LABEL_COLOR),
+		} as unknown as Parameters<typeof game.settings.register>[2],
+	);
+
+	// Not restricted: the settings behind this menu are per-user, so every
+	// player needs the button.
+	game.settings.registerMenu(SYSTEM_ID, MENU_KEY, {
+		name: 'NIMBLE.settings.diceSoNiceMenu.name',
+		label: 'NIMBLE.settings.diceSoNiceMenu.manageButton',
+		hint: 'NIMBLE.settings.diceSoNiceMenu.hint',
+		icon: MENU_ICON,
+		type: DiceSoNiceSettingsMenu as unknown as new () => foundry.applications.api.ApplicationV2.Any,
+		restricted: false,
+	});
+
+	registerModuleAvailabilityNotice();
+}

--- a/src/view/settings/DiceSoNiceSettingsDialog.svelte
+++ b/src/view/settings/DiceSoNiceSettingsDialog.svelte
@@ -1,0 +1,248 @@
+<script lang="ts">
+	import type { DiceSoNiceSettingsDialogProps } from './DiceSoNiceSettingsDialog.types.ts';
+
+	import localize from '#utils/localize.js';
+	import {
+		DEFAULT_PRIMARY_DIE_COLOR,
+		DEFAULT_PRIMARY_DIE_LABEL_COLOR,
+		getPrimaryDiePreferences,
+		isDiceSoNiceActive,
+		setPrimaryDiePreferences,
+	} from '../../settings/diceSoNiceSettings.js';
+
+	let { dialog }: DiceSoNiceSettingsDialogProps = $props();
+
+	const t = (key: string) => localize(`NIMBLE.settings.diceSoNiceMenu.${key}`);
+
+	const moduleActive = isDiceSoNiceActive();
+
+	const preferences = $state(getPrimaryDiePreferences());
+
+	const colorRows = [
+		{ shortKey: 'dsnPrimaryDieColor', field: 'background' },
+		{ shortKey: 'dsnPrimaryDieLabelColor', field: 'foreground' },
+	] as const;
+
+	function resetToDefaults() {
+		preferences.background = DEFAULT_PRIMARY_DIE_COLOR;
+		preferences.foreground = DEFAULT_PRIMARY_DIE_LABEL_COLOR;
+	}
+
+	async function save() {
+		try {
+			await setPrimaryDiePreferences({ ...preferences });
+		} catch (error) {
+			console.error(error);
+			ui.notifications?.error(t('saveError'));
+			return;
+		}
+
+		ui.notifications?.info(t('saved'));
+		dialog.close();
+	}
+</script>
+
+<article class="nimble-sheet__body nimble-dsn-settings">
+	<p class="nimble-dsn-settings__intro">{t('intro')}</p>
+
+	{#if !moduleActive}
+		<p class="nimble-dsn-settings__warning">{t('moduleMissing')}</p>
+	{/if}
+
+	<fieldset class="nimble-dsn-settings__section">
+		<legend class="nimble-dsn-settings__section-title">{t('sectionPrimaryDie')}</legend>
+
+		<div class="nimble-dsn-settings__rows">
+			<div class="nimble-dsn-settings__row">
+				<div class="nimble-dsn-settings__text">
+					<label class="nimble-dsn-settings__label" for="nimble-dsn-enabled">
+						{localize('NIMBLE.settings.dsnPrimaryDieStyleEnabled.name')}
+					</label>
+					<p class="nimble-dsn-settings__hint">
+						{localize('NIMBLE.settings.dsnPrimaryDieStyleEnabled.hint')}
+					</p>
+				</div>
+
+				<input
+					id="nimble-dsn-enabled"
+					type="checkbox"
+					checked={preferences.enabled}
+					onchange={({ currentTarget }) => {
+						preferences.enabled = currentTarget.checked;
+					}}
+				/>
+			</div>
+
+			{#each colorRows as row (row.shortKey)}
+				<div class="nimble-dsn-settings__row">
+					<div class="nimble-dsn-settings__text">
+						<label class="nimble-dsn-settings__label" for={`nimble-dsn-${row.shortKey}`}>
+							{localize(`NIMBLE.settings.${row.shortKey}.name`)}
+						</label>
+						<p class="nimble-dsn-settings__hint">
+							{localize(`NIMBLE.settings.${row.shortKey}.hint`)}
+						</p>
+					</div>
+
+					<input
+						id={`nimble-dsn-${row.shortKey}`}
+						type="color"
+						class="nimble-dsn-settings__color-picker"
+						disabled={!preferences.enabled}
+						value={preferences[row.field]}
+						oninput={({ currentTarget }) => {
+							preferences[row.field] = currentTarget.value;
+						}}
+					/>
+				</div>
+			{/each}
+		</div>
+
+		<div
+			class="nimble-dsn-settings__preview"
+			class:nimble-dsn-settings__preview--muted={!preferences.enabled}
+			style={`--nimble-dsn-preview-background: ${preferences.background}; --nimble-dsn-preview-foreground: ${preferences.foreground};`}
+		>
+			<span class="nimble-dsn-settings__preview-die">20</span>
+			<span class="nimble-dsn-settings__preview-label">{t('preview')}</span>
+		</div>
+	</fieldset>
+</article>
+
+<footer class="nimble-sheet__footer">
+	<button class="nimble-button" data-button-variant="basic" type="button" onclick={resetToDefaults}>
+		{t('reset')}
+	</button>
+
+	<button class="nimble-button" data-button-variant="basic" type="button" onclick={save}>
+		{t('save')}
+	</button>
+</footer>
+
+<style lang="scss">
+	.nimble-dsn-settings {
+		--nimble-sheet-body-padding-block-start: 0.5rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+
+		&__intro,
+		&__warning {
+			margin: 0;
+			font-size: var(--nimble-sm-text);
+			line-height: 1.4;
+			color: var(--nimble-medium-text-color);
+		}
+
+		&__warning {
+			padding: 0.5rem 0.625rem;
+			font-weight: 700;
+			color: var(--nimble-dark-text-color);
+			background: var(--nimble-box-background-color);
+			border: 1px solid var(--nimble-card-border-color);
+			border-inline-start: 3px solid var(--nimble-attack-roll-color, #8a1c1c);
+			border-radius: 6px;
+		}
+
+		&__section {
+			margin: 0;
+			min-width: 0;
+			display: flex;
+			flex-direction: column;
+			gap: 0.5rem;
+			padding: 0.625rem;
+			background: var(--nimble-box-background-color);
+			border: 1px solid var(--nimble-card-border-color);
+			border-radius: 6px;
+		}
+
+		&__section-title {
+			margin-inline-start: 0.3rem;
+			padding-inline: 0.3rem;
+			font-size: var(--nimble-sm-text);
+			line-height: 1;
+			font-weight: 700;
+			color: var(--nimble-dark-text-color);
+		}
+
+		&__rows {
+			display: flex;
+			flex-direction: column;
+			gap: 0.625rem;
+		}
+
+		&__row {
+			display: grid;
+			grid-template-columns: minmax(0, 1fr) auto;
+			align-items: start;
+			gap: 0.75rem;
+		}
+
+		&__text {
+			display: flex;
+			flex-direction: column;
+			gap: 0.1875rem;
+			min-width: 0;
+		}
+
+		&__label {
+			font-weight: 700;
+			font-size: var(--nimble-sm-text);
+			color: var(--nimble-dark-text-color);
+		}
+
+		&__hint {
+			margin: 0;
+			font-size: var(--nimble-xs-text);
+			line-height: 1.4;
+			color: var(--nimble-medium-text-color);
+		}
+
+		&__color-picker {
+			inline-size: 2.5rem;
+			block-size: 1.75rem;
+			padding: 0;
+			border: 1px solid var(--nimble-card-border-color);
+			border-radius: 4px;
+			cursor: pointer;
+
+			&:disabled {
+				cursor: not-allowed;
+				opacity: 0.5;
+			}
+		}
+
+		&__preview {
+			display: flex;
+			align-items: center;
+			gap: 0.5rem;
+
+			&--muted {
+				opacity: 0.4;
+			}
+		}
+
+		&__preview-die {
+			display: grid;
+			place-items: center;
+			inline-size: 2rem;
+			block-size: 2rem;
+			font-weight: 700;
+			font-size: var(--nimble-sm-text);
+			color: var(--nimble-dsn-preview-foreground);
+			background: var(--nimble-dsn-preview-background);
+			border-radius: 6px;
+		}
+
+		&__preview-label {
+			font-size: var(--nimble-xs-text);
+			color: var(--nimble-medium-text-color);
+		}
+	}
+
+	.nimble-sheet__footer {
+		--nimble-button-padding: 0.5rem 1rem;
+		display: flex;
+		gap: 0.5rem;
+	}
+</style>

--- a/src/view/settings/DiceSoNiceSettingsDialog.types.ts
+++ b/src/view/settings/DiceSoNiceSettingsDialog.types.ts
@@ -1,0 +1,5 @@
+import type GenericDialog from '#documents/dialogs/GenericDialog.svelte.js';
+
+export interface DiceSoNiceSettingsDialogProps {
+	dialog: GenericDialog;
+}

--- a/tests/mocks/foundry.ts
+++ b/tests/mocks/foundry.ts
@@ -605,6 +605,11 @@ export const foundryApiMocks = {
 						assignWithOptions(this, options);
 					}
 				},
+				ColorField: class ColorField {
+					constructor(options?: any) {
+						assignWithOptions(this, options);
+					}
+				},
 				NumberField: class NumberField {
 					constructor(options?: any) {
 						assignWithOptions(this, options);


### PR DESCRIPTION
## Summary

When Dice So Nice is active, the primary die of a damage roll now renders with a distinct appearance (crimson body, gold numerals and edge by default) so it stands out from the rest of the dice pool, and each user can customize or disable the styling for their own rolls.

<img width="1027" height="483" alt="image" src="https://github.com/user-attachments/assets/ece57ca1-c88a-4749-9bf9-55848e36b6e8" />
DSN not enabled/installed
<br />
<img width="582" height="128" alt="image" src="https://github.com/user-attachments/assets/440930f9-8fa3-4a50-a07b-11287cefa0ab" />

Rolling
<img width="677" height="906" alt="image" src="https://github.com/user-attachments/assets/cb304a0f-181d-4f69-bff7-f8b5545ceb44" />

## Changes

- New `src/dice/diceSoNiceIntegration.ts`: registers a system colorset on the `diceSoNiceReady` hook and builds the per-term appearance override from the rolling user's preferences. Without the module active, the hook never fires and the term options are inert.
- `DamageRoll._extractPrimaryDie` (both branches) and the `c`/`cv` die modifier handlers tag their dice with `options.appearance`, which Dice So Nice reads per term. Term options serialize with the roll, so the roller's colors show on every client. Vicious explosion dice inherit the styling because their results live on the primary term.
- New `src/settings/diceSoNiceSettings.ts`: three user-scoped settings (v14 `scope: 'user'`, stored per account) with an enable toggle plus `ColorField`-backed color pickers for the die body and numerals. A custom body color also recolors the edge to match; invalid values fall back to the defaults.
- Unit tests for the appearance builder (defaults, disabled, custom colors, short hex expansion, Color instance stringification, invalid input fallback).

## Test Plan

1. Install and enable Dice So Nice in a v14 world, then roll damage from a weapon or attack feature. The leftmost primary die should be crimson with gold numerals while the remaining dice use your normal DSN theme. Crit explosion dice (including vicious chains) keep the primary color.
2. Open Configure Settings, Nimble tab: change "3D Dice: Primary Die Color" and "3D Dice: Primary Die Number Color" via the color pickers, roll again, and confirm the new colors. Confirm both settings render as color pickers, not text inputs.
3. Toggle "3D Dice: Distinct Primary Die" off and confirm the primary die reverts to your regular DSN dice theme.
4. Roll as a second user with different colors and confirm each player's rolls carry their own colors on both screens.
5. Modifier-mode formulas (e.g. `4d4cv` via the dice testbench) should color every crit-capable die.
6. `pnpm test` covers the appearance-building logic in `src/dice/diceSoNiceIntegration.test.ts`.

## Checklist

- [x] Added or updated unit tests
- [x] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [x] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** yes
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues

None.
