### PR TITLE
fix(pdfExport): print document link labels instead of raw UUIDs

### DIFF
--- a/src/utils/resolveContentLinks.test.ts
+++ b/src/utils/resolveContentLinks.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import resolveContentLinks from './resolveContentLinks.ts';
+
+const globals = globalThis as unknown as { fromUuidSync?: unknown };
+const originalFromUuidSync = globals.fromUuidSync;
+
+afterEach(() => {
+	globals.fromUuidSync = originalFromUuidSync;
+});
+
+describe('resolveContentLinks', () => {
+	it('replaces a labelled link with its label', () => {
+		expect(
+			resolveContentLinks(
+				'<p>@UUID[Compendium.nimble.nimble-spells.Item.9TNPdOXlCcGgxw6r]{Shadow Blast}</p>',
+			),
+		).toBe('<p>Shadow Blast</p>');
+	});
+
+	it('replaces every link in a description', () => {
+		const description =
+			'<p>Your Patron grants you knowledge of:</p>' +
+			'<p>@UUID[Compendium.nimble.nimble-spells.Item.9TNPdOXlCcGgxw6r]{Shadow Blast}</p>' +
+			'<p>@UUID[Compendium.nimble.nimble-spells.Item.ho2KADcmQWWTeYR0]{Summon Shadow}</p>';
+
+		expect(resolveContentLinks(description)).toBe(
+			'<p>Your Patron grants you knowledge of:</p><p>Shadow Blast</p><p>Summon Shadow</p>',
+		);
+	});
+
+	it('falls back to the referenced document name when the link has no label', () => {
+		globals.fromUuidSync = vi.fn(() => ({ name: 'Summon Shadow' }));
+
+		expect(
+			resolveContentLinks('@UUID[Compendium.nimble.nimble-spells.Item.ho2KADcmQWWTeYR0]'),
+		).toBe('Summon Shadow');
+	});
+
+	it('leaves an unlabelled link alone when the document cannot be resolved', () => {
+		globals.fromUuidSync = vi.fn(() => null);
+
+		const description = '@UUID[Compendium.nimble.nimble-spells.Item.missing]';
+		expect(resolveContentLinks(description)).toBe(description);
+	});
+
+	it('prefers the label over the referenced document name', () => {
+		globals.fromUuidSync = vi.fn(() => ({ name: 'Shadow Blast' }));
+
+		expect(
+			resolveContentLinks('@UUID[Compendium.nimble.nimble-spells.Item.9TNPdOXlCcGgxw6r]{Blast}'),
+		).toBe('Blast');
+		expect(globals.fromUuidSync).not.toHaveBeenCalled();
+	});
+
+	it('returns content without links unchanged', () => {
+		const description = '<p>Gain <strong>1 mana</strong> at the start of each round.</p>';
+		expect(resolveContentLinks(description)).toBe(description);
+	});
+
+	it('handles empty content', () => {
+		expect(resolveContentLinks('')).toBe('');
+	});
+});

--- a/src/utils/resolveContentLinks.ts
+++ b/src/utils/resolveContentLinks.ts
@@ -1,0 +1,18 @@
+/** Matches Foundry's document-link syntax: `@UUID[uuid]` with an optional `{Label}`. */
+const documentLinkPattern = /@UUID\[([^\]]+)\](?:\{([^}]*)\})?/g;
+
+/**
+ * Replaces Foundry document links with the text they display, for output that cannot
+ * render an enriched link (the PDF export). Unlabelled links resolve to the referenced
+ * document's name, and stay untouched when that document cannot be found.
+ */
+export default function resolveContentLinks(content: string): string {
+	if (!content) return '';
+
+	return content.replace(documentLinkPattern, (link, uuid: string, label?: string) => {
+		if (label) return label;
+
+		const referencedDocument = fromUuidSync(uuid, { strict: false }) as { name?: string } | null;
+		return referencedDocument?.name ?? link;
+	});
+}

--- a/src/view/sheets/character/pdfExport/generatePdfContent.test.ts
+++ b/src/view/sheets/character/pdfExport/generatePdfContent.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import type { NimbleCharacter } from '#documents/actor/character.js';
+import { generateInitialColumnContentHtml } from './generatePdfContent.ts';
+
+const CONDUIT_OF_SHADOW_DESCRIPTION =
+	'<p>Your Patron grants you knowledge of:</p>' +
+	'<p>@UUID[Compendium.nimble.nimble-spells.Item.9TNPdOXlCcGgxw6r]{Shadow Blast}</p>' +
+	'<p>@UUID[Compendium.nimble.nimble-spells.Item.ho2KADcmQWWTeYR0]{Summon Shadow}</p>';
+
+function createCharacterWithFeature(description: string): NimbleCharacter {
+	const feature = {
+		id: 'conduitOfShadow01',
+		type: 'feature',
+		name: 'Conduit of Shadow',
+		isType: (type: string) => type === 'feature',
+		system: {
+			description,
+			class: 'shadowmancer',
+			group: 'shadowmancer-progression',
+			subclass: false,
+			gainedAtLevel: 1,
+			gainedAtLevels: [1],
+		},
+	};
+
+	return {
+		items: [feature],
+		classes: {
+			shadowmancer: {
+				name: 'Shadowmancer',
+				identifier: 'shadowmancer',
+				system: { groupIdentifiers: ['shadowmancer-progression'] },
+			},
+		},
+		system: {
+			currency: { gp: { value: 0 }, sp: { value: 0 }, cp: { value: 0 } },
+		},
+	} as unknown as NimbleCharacter;
+}
+
+describe('generateInitialColumnContentHtml', () => {
+	it('renders a feature description that links to spells with the spell names', () => {
+		const columns = generateInitialColumnContentHtml(
+			createCharacterWithFeature(CONDUIT_OF_SHADOW_DESCRIPTION),
+		);
+		const content = columns.join('');
+
+		expect(content).toContain('Shadow Blast');
+		expect(content).toContain('Summon Shadow');
+		expect(content).not.toContain('@UUID');
+		expect(content).not.toContain('9TNPdOXlCcGgxw6r');
+		expect(content).not.toContain('ho2KADcmQWWTeYR0');
+	});
+});

--- a/src/view/sheets/character/pdfExport/generatePdfContent.ts
+++ b/src/view/sheets/character/pdfExport/generatePdfContent.ts
@@ -5,6 +5,7 @@ import type { NimbleObjectItem } from '#documents/item/object.js';
 import type { NimbleSpellItem } from '#documents/item/spell.js';
 import type { NimbleSubclassItem } from '#documents/item/subclass.js';
 import formatActivationCostLabel from '#utils/formatActivationCostLabel.js';
+import resolveContentLinks from '#utils/resolveContentLinks.js';
 
 /** Estimated characters per column based on PDF config */
 const CHARS_PER_COLUMN = 1150;
@@ -33,7 +34,7 @@ interface SelectableItem {
  */
 function stripHtml(html: string): string {
 	if (!html) return '';
-	const processed = html
+	const processed = resolveContentLinks(html)
 		.replace(/<\/p>/gi, '\n')
 		.replace(/<br\s*\/?>/gi, '\n')
 		.replace(/<\/div>/gi, '\n')
@@ -55,8 +56,9 @@ function stripHtml(html: string): string {
 function extractMechanicalAbilities(html: string): string {
 	if (!html) return '';
 
-	const hrParts = html.split(/<hr\s*\/?>/i);
-	const mechanicalPart = hrParts.length > 1 ? hrParts.slice(1).join('') : html;
+	const resolved = resolveContentLinks(html);
+	const hrParts = resolved.split(/<hr\s*\/?>/i);
+	const mechanicalPart = hrParts.length > 1 ? hrParts.slice(1).join('') : resolved;
 
 	const processed = mechanicalPart
 		.replace(/<\/p>/gi, '\n')
@@ -82,8 +84,9 @@ function extractMechanicalAbilities(html: string): string {
 function extractMechanicalAbilitiesHtml(html: string): string {
 	if (!html) return '';
 
-	const hrParts = html.split(/<hr\s*\/?>/i);
-	const mechanicalPart = hrParts.length > 1 ? hrParts.slice(1).join('') : html;
+	const resolved = resolveContentLinks(html);
+	const hrParts = resolved.split(/<hr\s*\/?>/i);
+	const mechanicalPart = hrParts.length > 1 ? hrParts.slice(1).join('') : resolved;
 
 	// Clean up HTML but preserve <strong> tags
 	const temp = document.createElement('div');
@@ -864,7 +867,7 @@ function getSelectableItems(actor: NimbleCharacter): SelectableItem[] {
 			category: 'character',
 			label: 'Character Notes',
 			content: stripHtml(notes) || notes,
-			contentHtml: notes,
+			contentHtml: resolveContentLinks(notes),
 		});
 	}
 


### PR DESCRIPTION
## Summary

Exported character PDFs printed Foundry document links verbatim, so the Shadowmancer's *Conduit of Shadow* read `@UUID[Compendium.nimble.nimble-spells.Item.9TNPdOXlCcGgxw6r]{Shadow Blast}` instead of `Shadow Blast`. The PDF pipeline strips HTML tags, but the enricher syntax is plain text and survived untouched. Links are now resolved to their display text before the content is laid out.

## Changes

- New `src/utils/resolveContentLinks.ts`: replaces `@UUID[uuid]{Label}` with `Label`; an unlabelled link resolves through `fromUuidSync(uuid, { strict: false })` to the referenced document's name, and is left as-is when that lookup fails, so a broken link is never silently dropped.
- `generatePdfContent.ts` resolves links at the four points where document HTML enters the export: `stripHtml` (features, spells, inventory), both `extractMechanicalAbilities*` extractors (ancestry/background), and the raw `contentHtml` pass-through for character notes. Resolving at extraction rather than at draw time also cleans up the export dialog's column text and its character-count/over-limit warnings.
- Unit tests for the new utility, plus a regression test through `generateInitialColumnContentHtml` using a Shadowmancer *Conduit of Shadow* feature.

Custom `[[/check ...]]` / `[[/savingThrow ...]]` / `[[/condition ...]]` enrichers and inline rolls still print verbatim in the PDF — out of scope here. No pack data changed; the authored `@UUID` links are correct.

## Test Plan

1. Create or open a Shadowmancer with **Conduit of Shadow** (level 1).
2. Open the character sheet → PDF export dialog.
3. The Shadowmancer Features column should read `Conduit of Shadow (Lvl 1): Your Patron grants you knowledge of: | Shadow Blast | Summon Shadow` — no `@UUID[...]` text and no compendium ids.
4. Export/preview the PDF and confirm the same in the rendered sheet.

Automated: `src/view/sheets/character/pdfExport/generatePdfContent.test.ts` fails on `dev` with the raw `@UUID[...]` string in the column content and passes with this change; `src/utils/resolveContentLinks.test.ts` covers label precedence, multiple links, the `fromUuidSync` fallback, an unresolvable link, link-free content, and empty input.

## Checklist

- [x] Added or updated unit tests
- [x] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`) — no new user-facing strings
- [ ] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** yes
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues

None — reported in conversation.
