### PR TITLE
fix(rules): move per-level maxHpBonus with the class level

### DIFF
--- a/src/documents/item/class.test.ts
+++ b/src/documents/item/class.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { NimbleClassItem } from './class.js';
+
+/**
+ * `NimbleClassItem._preUpdate` ends in `super._preUpdate(...)`. The shared `Item` mock has no
+ * such method, so stand one up for the duration of this file rather than reaching into the
+ * shared mocks.
+ */
+const itemPrototype = (globalThis as unknown as { Item: { prototype: Record<string, unknown> } })
+	.Item.prototype;
+
+beforeEach(() => {
+	itemPrototype._preUpdate = vi.fn(async () => undefined);
+});
+
+afterEach(() => {
+	delete itemPrototype._preUpdate;
+	vi.restoreAllMocks();
+});
+
+interface MaxHpBonusSource {
+	value: number;
+	perLevel?: boolean;
+	disabled?: boolean;
+	type?: string;
+}
+
+/** An item carrying rules, in the `Map` shape `NimbleBaseItem#rules` exposes. */
+function createRuleHost(rules: MaxHpBonusSource[]) {
+	return {
+		rules: new Map(
+			rules.map((rule, index) => [
+				`rule-${index}`,
+				{ type: rule.type ?? 'maxHpBonus', value: rule.value, perLevel: rule.perLevel ?? false },
+			]),
+		),
+	};
+}
+
+function createActor(hpBonus: number, items: ReturnType<typeof createRuleHost>[]) {
+	return {
+		classes: {},
+		items,
+		system: {
+			attributes: { hp: { bonus: hpBonus }, hitDice: {} },
+			classData: { levels: [], startingClass: 'shepherd' },
+		},
+		update: vi.fn(async (_data: Record<string, unknown>) => undefined),
+	};
+}
+
+function createClassItem(actor: unknown, classLevel: number) {
+	return {
+		identifier: 'shepherd',
+		isEmbedded: true,
+		parent: actor,
+		rules: new Map(),
+		system: { classLevel, hitDieSize: 8 },
+	};
+}
+
+async function runClassPreUpdate(classItem: unknown, changed: Record<string, unknown>) {
+	return NimbleClassItem.prototype._preUpdate.call(
+		classItem as NimbleClassItem,
+		changed,
+		{} as never,
+		{} as never,
+	);
+}
+
+/** The single `actor.update()` payload the hook builds. */
+function updatePayload(actor: ReturnType<typeof createActor>): Record<string, unknown> {
+	return actor.update.mock.calls.at(-1)?.[0] ?? {};
+}
+
+describe('NimbleClassItem._preUpdate: per-level maxHpBonus rules', () => {
+	it('raises the stored HP bonus for a rule carried by a non-class item', async () => {
+		// The reported case: a feature grants +2 max HP per level. Only the class item
+		// receives the level update, so the feature's rule has to be totalled here.
+		const actor = createActor(4, [createRuleHost([{ value: 2, perLevel: true }])]);
+		const classItem = createClassItem(actor, 2);
+
+		await runClassPreUpdate(classItem, { system: { classLevel: 3 } });
+
+		expect(updatePayload(actor)['system.attributes.hp.bonus']).toBe(6);
+	});
+
+	it('lowers the stored HP bonus when a level up is reverted', async () => {
+		const actor = createActor(6, [createRuleHost([{ value: 2, perLevel: true }])]);
+		const classItem = createClassItem(actor, 3);
+
+		await runClassPreUpdate(classItem, { system: { classLevel: 2 } });
+
+		expect(updatePayload(actor)['system.attributes.hp.bonus']).toBe(4);
+	});
+
+	it('scales by the full difference when the level moves more than one step', async () => {
+		// Level history validation resets a corrupt character straight back to 1.
+		const actor = createActor(8, [createRuleHost([{ value: 2, perLevel: true }])]);
+		const classItem = createClassItem(actor, 4);
+
+		await runClassPreUpdate(classItem, { system: { classLevel: 1 } });
+
+		expect(updatePayload(actor)['system.attributes.hp.bonus']).toBe(2);
+	});
+
+	it('totals every per-level rule on the actor, including the class item’s own', async () => {
+		const actor = createActor(9, [
+			createRuleHost([{ value: 2, perLevel: true }]),
+			createRuleHost([{ value: 1, perLevel: true }]),
+		]);
+		const classItem = createClassItem(actor, 3);
+		classItem.rules = new Map([
+			['class-rule', { type: 'maxHpBonus', value: 3, perLevel: true }],
+		]) as never;
+		actor.items.push(classItem as never);
+
+		await runClassPreUpdate(classItem, { system: { classLevel: 4 } });
+
+		expect(updatePayload(actor)['system.attributes.hp.bonus']).toBe(15);
+	});
+
+	it('leaves the stored HP bonus alone for a flat maxHpBonus rule', async () => {
+		// A flat bonus is worth the same at every level, so a level change must not move it.
+		const actor = createActor(4, [createRuleHost([{ value: 2, perLevel: false }])]);
+		const classItem = createClassItem(actor, 2);
+
+		await runClassPreUpdate(classItem, { system: { classLevel: 3 } });
+
+		expect(updatePayload(actor)).not.toHaveProperty('system.attributes.hp.bonus');
+	});
+
+	it('ignores rules of other types', async () => {
+		const actor = createActor(4, [
+			createRuleHost([{ type: 'maxWounds', value: 2, perLevel: true }]),
+		]);
+		const classItem = createClassItem(actor, 2);
+
+		await runClassPreUpdate(classItem, { system: { classLevel: 3 } });
+
+		expect(updatePayload(actor)).not.toHaveProperty('system.attributes.hp.bonus');
+	});
+
+	it('leaves the stored HP bonus alone when the class level does not change', async () => {
+		const actor = createActor(4, [createRuleHost([{ value: 2, perLevel: true }])]);
+		const classItem = createClassItem(actor, 2);
+
+		await runClassPreUpdate(classItem, { system: { classLevel: 2 } });
+
+		expect(updatePayload(actor)).not.toHaveProperty('system.attributes.hp.bonus');
+	});
+});

--- a/src/documents/item/class.ts
+++ b/src/documents/item/class.ts
@@ -3,6 +3,7 @@ import {
 	ClassResourceManager,
 } from '../../managers/ClassResourceManager.js';
 import type { NimbleClassData } from '../../models/item/ClassDataModel.js';
+import { getMaxHpBonusPerLevel } from '../../models/rules/maxHpBonus.js';
 import type { NimbleCharacter } from '../actor/character.js';
 import { NimbleBaseItem } from './base.svelte.js';
 
@@ -193,8 +194,31 @@ export class NimbleClassItem extends NimbleBaseItem<'class'> {
 		// Type the changed object for this method's usage
 		const changedData = changed as {
 			name?: string & { slugify: (options: { strict: boolean }) => string };
-			system?: { hitDieSize?: number };
+			system?: { hitDieSize?: number; classLevel?: number };
 		};
+
+		// A `maxHpBonus` rule set `perLevel` is worth `value * classLevel`, and that
+		// figure is written into the actor's stored HP bonus once, when the rule's
+		// item is added. Only the class item is told the level moved, so rules living
+		// on features, boons and objects never hear about it — move the stored bonus
+		// by the level difference here, on behalf of every rule on the actor.
+		const nextClassLevel = changedData.system?.classLevel;
+
+		if (typeof nextClassLevel === 'number') {
+			// Signed, so a reverted level up gives the bonus back, and a jump of more
+			// than one level (a level history reset) moves it by the full difference.
+			const levelDifference = nextClassLevel - this.system.classLevel;
+			const hpBonusPerLevel = getMaxHpBonusPerLevel(actor);
+
+			if (levelDifference !== 0 && hpBonusPerLevel !== 0) {
+				const currentHpBonus =
+					(foundry.utils.getProperty(actor, 'system.attributes.hp.bonus') as number | undefined) ??
+					0;
+
+				actorUpdates['system.attributes.hp.bonus'] =
+					currentHpBonus + hpBonusPerLevel * levelDifference;
+			}
+		}
 
 		if (changedData.name) {
 			const existingLevels =

--- a/src/models/rules/maxHpBonus.test.ts
+++ b/src/models/rules/maxHpBonus.test.ts
@@ -1,5 +1,21 @@
 import { describe, expect, it } from 'vitest';
-import { MaxHpBonusRule } from './maxHpBonus.js';
+import { getMaxHpBonusPerLevel, MaxHpBonusRule } from './maxHpBonus.js';
+
+interface RuleSource {
+	type?: string;
+	value?: number;
+	perLevel?: boolean;
+	disabled?: boolean;
+	invalid?: boolean;
+}
+
+function actorCarrying(...items: RuleSource[][]) {
+	return {
+		items: items.map((rules) => ({
+			rules: new Map(rules.map((rule, index) => [`rule-${index}`, rule])),
+		})),
+	};
+}
 
 describe('MaxHpBonusRule', () => {
 	describe('schema', () => {
@@ -15,6 +31,49 @@ describe('MaxHpBonusRule', () => {
 		it('exposes the picker group and i18n description key', () => {
 			expect(MaxHpBonusRule.group).toBe('bonuses');
 			expect(MaxHpBonusRule.description).toBe('NIMBLE.rules.maxHpBonus.description');
+		});
+	});
+
+	describe('getMaxHpBonusPerLevel', () => {
+		it('totals the per-level rules across every item on the actor', () => {
+			const actor = actorCarrying(
+				[{ type: 'maxHpBonus', value: 2, perLevel: true }],
+				[{ type: 'maxHpBonus', value: 3, perLevel: true }],
+			);
+
+			expect(getMaxHpBonusPerLevel(actor)).toBe(5);
+		});
+
+		it('ignores flat bonuses and rules of other types', () => {
+			const actor = actorCarrying([
+				{ type: 'maxHpBonus', value: 5, perLevel: false },
+				{ type: 'maxWounds', value: 7, perLevel: true },
+			]);
+
+			expect(getMaxHpBonusPerLevel(actor)).toBe(0);
+		});
+
+		it('counts a disabled rule, because its bonus is still in the stored total', () => {
+			// `preCreate` adds the bonus without consulting `disabled`, so leaving a
+			// disabled rule out here would strand its contribution at the old level.
+			const actor = actorCarrying([
+				{ type: 'maxHpBonus', value: 2, perLevel: true, disabled: true },
+			]);
+
+			expect(getMaxHpBonusPerLevel(actor)).toBe(2);
+		});
+
+		it('skips an invalid rule, which never contributed in the first place', () => {
+			// `preCreate` bails on `invalid`, so there is nothing stored to move.
+			const actor = actorCarrying([
+				{ type: 'maxHpBonus', value: 2, perLevel: true, invalid: true },
+			]);
+
+			expect(getMaxHpBonusPerLevel(actor)).toBe(0);
+		});
+
+		it('returns nothing for an actor with no items', () => {
+			expect(getMaxHpBonusPerLevel({})).toBe(0);
 		});
 	});
 });

--- a/src/models/rules/maxHpBonus.ts
+++ b/src/models/rules/maxHpBonus.ts
@@ -10,9 +10,42 @@ interface ActorSystemWithHp {
 	};
 }
 
-/** Class item system data */
-interface ClassItemSystem {
-	classLevel: number;
+/** The parts of an actor the helper below reads, kept structural so this module never imports a document class. */
+interface ActorWithRuleItems {
+	items?: Iterable<{ rules?: Map<string, unknown> }>;
+}
+
+/** The fields the helper below reads off a rule. */
+interface MaxHpBonusLike {
+	type?: string;
+	perLevel?: boolean;
+	value?: number;
+	invalid?: boolean;
+}
+
+/**
+ * Max HP every `maxHpBonus` rule on the actor contributes for a single class level.
+ *
+ * A `perLevel` rule folds `value * level` into the actor's stored
+ * `attributes.hp.bonus` when its item is added and takes the same amount back
+ * out when the item is deleted. Nothing re-derives that figure in between, so a
+ * class level change has to move it by this much per level gained or lost.
+ * Counts rules exactly as `preCreate` and `afterDelete` do — disabled ones in,
+ * invalid ones out — so the stored total stays symmetric with what they wrote.
+ */
+function getMaxHpBonusPerLevel(actor: ActorWithRuleItems): number {
+	let perLevel = 0;
+
+	for (const item of actor.items ?? []) {
+		for (const rule of (item.rules?.values() ?? []) as Iterable<MaxHpBonusLike>) {
+			if (rule.type !== 'maxHpBonus') continue;
+			if (!rule.perLevel || rule.invalid) continue;
+
+			perLevel += rule.value ?? 0;
+		}
+	}
+
+	return perLevel;
 }
 
 function schema() {
@@ -86,36 +119,6 @@ class MaxHpBonusRule extends NimbleBaseRule<MaxHpBonusRule.Schema> {
 		>);
 	}
 
-	async preUpdate(changes: Record<string, unknown>): Promise<void> {
-		if (this.invalid) return;
-
-		const { actor, item } = this;
-		if (!actor || !item) return;
-		if (item.type !== 'class') return;
-
-		if (!this.perLevel) return;
-
-		// Return if update doesn't pertain to level
-		const keys = Object.keys(foundry.utils.flattenObject(changes));
-		const itemSystem = item.system as unknown as ClassItemSystem;
-		if (
-			!keys.includes('system.classLevel') ||
-			changes['system.classLevel'] === itemSystem.classLevel
-		)
-			return;
-
-		const formula = this.value;
-		const addedHp = getDeterministicBonus(formula, actor.getRollData());
-		if (addedHp === null) return;
-
-		const actorSystem = actor.system as unknown as ActorSystemWithHp;
-		const { bonus } = actorSystem.attributes.hp;
-		await actor.update({ system: { attributes: { hp: { bonus: bonus + addedHp } } } } as Record<
-			string,
-			unknown
-		>);
-	}
-
 	async afterDelete(): Promise<void> {
 		if (this.invalid) return;
 
@@ -136,4 +139,4 @@ class MaxHpBonusRule extends NimbleBaseRule<MaxHpBonusRule.Schema> {
 	}
 }
 
-export { MaxHpBonusRule };
+export { getMaxHpBonusPerLevel, MaxHpBonusRule };


### PR DESCRIPTION
This PR proposes a fix for the per-level `maxHpBonus` rule, so a rule carried by a feature moves with the character's class level instead of staying frozen at the level its item was added on. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/469. You can sign in with your GitHub ID to claim ownership of the project.

## Summary

A `maxHpBonus` rule with `perLevel: true` folds `value * classLevel` into the actor's stored `system.attributes.hp.bonus` once, in `preCreate`, and takes the same amount back out in `afterDelete`. Nothing re-derived it in between. The only level-change handler was `MaxHpBonusRule#preUpdate`, and rule `preUpdate` is dispatched by `NimbleBaseItem#_preUpdate` on the item being updated — so it fired only when the rule happened to sit on the class item itself. The rule in #499 lives on a feature, so leveling up never moved the stored bonus. That is why the HP Overview's "from rules" total, which `EditHitPointsDialog.svelte` recomputes live off `system.rules`, read correctly while the stored bonus did not.

It also explains the "does not fix itself even after deleting+adding the item again" part of that report. With `value: 2, perLevel: true` added at level 2, `preCreate` stores 4; leveling to 3 stores nothing, so 4 stands where 6 is due; deleting the item runs `afterDelete`, which subtracts `2 * @level` at the *current* level — 6 — leaving −2; re-adding puts 6 back and lands on 4 again. The stored bonus stays exactly one level's worth short, permanently. Separately, on the class item where `preUpdate` did run, it added a flat `this.value` whenever `system.classLevel` appeared in the change, unsigned and unscaled: `NimbleCharacter#revertLevelUp` writes `classLevel - 1`, so reverting a level *added* HP instead of giving it back, and the reset to level 1 in `validateLevelHistory` moved the bonus by one level rather than the full difference.

## Changes

- `src/models/rules/maxHpBonus.ts` — add `getMaxHpBonusPerLevel(actor)`, totalling the per-level `maxHpBonus` rules across every item on the actor. It counts disabled rules and skips invalid ones, matching what `preCreate` and `afterDelete` actually wrote, so the stored total stays symmetric with them.
- `src/models/rules/maxHpBonus.ts` — remove `MaxHpBonusRule#preUpdate`. It only ever covered class-hosted rules, and leaving it in would double-count them.
- `src/documents/item/class.ts` — in `NimbleClassItem#_preUpdate`, the one hook that is told the class level moved, fold `perLevelTotal * (newLevel - oldLevel)` into the `actorUpdates` object the method already builds. Being signed, it gives the bonus back on a revert and moves the full amount on a multi-level jump.

The new import runs one way only, from the document into the rule module; the rule module still imports no document, and `pnpm circular-deps` reports no violations.

## Test Plan

`src/documents/item/class.test.ts` is new and drives the real `_preUpdate` hook. With only that file applied on top of `dev`:

```
$ npx vitest run src/documents/item/class.test.ts
 FAIL  src/documents/item/class.test.ts > raises the stored HP bonus for a rule carried by a non-class item
 FAIL  src/documents/item/class.test.ts > lowers the stored HP bonus when a level up is reverted
 FAIL  src/documents/item/class.test.ts > scales by the full difference when the level moves more than one step
 FAIL  src/documents/item/class.test.ts > totals every per-level rule on the actor, including the class item's own
 Test Files  1 failed (1)
      Tests  4 failed | 3 passed (7)
```

The three already passing are the controls that must stay green: a flat `perLevel: false` rule, a rule of another type, and an update where the level does not change. With the fix, all seven pass. `src/models/rules/maxHpBonus.test.ts` adds five cases for the helper itself (totalling across items, flat and other-type rules excluded, disabled counted, invalid skipped).

Whole-suite comparison: `pnpm test` on `dev` is 245 files / 3784 tests passing; on this branch it is 246 / 3796 — the twelve added tests, no new failures. `pnpm type-check` is clean, `biome check` is clean on the touched files, and the repo's own pre-push hook (biome check, type-check, full suite) passes.

`tests/integration` needs a licensed Foundry instance, so I could not run it here. Its `maxHpBonus` case exercises a flat `perLevel: false` add and delete, which this change does not touch. To replay the fix by hand in a world: give a level 2 character a feature carrying `{"type": "maxHpBonus", "value": 2, "perLevel": true}`, open Edit Hit Points and note Bonus HP reads 4; level to 3 and it should now read 6, matching the "from rules" total beside it; revert the level up and it should return to 4.

## Related Issues

Fixes #499

## How this was managed

This work was tracked as a single story on a live board imported from this repository's own issues and pull requests — 837 stories in all: [maxHPBonus Rule is not recalculated on Level-Up](https://eastagiletracker.com/projects/469/stories/419217), on the [Nimble for FoundryVTT board](https://eastagiletracker.com/projects/469).

![board](https://raw.githubusercontent.com/eastagiletracker/FoundryVTT-Nimble/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
