### PR TITLE
fix(mana): seed current mana when max mana first becomes non-zero

### DIFF
--- a/src/documents/actor/character.ts
+++ b/src/documents/actor/character.ts
@@ -1739,6 +1739,17 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 
 		await this.updateItem(characterClass.id!, itemUpdates);
 		await this.update(actorUpdates);
+
+		// Max mana falls with the level, and the current value does not follow it
+		// down on its own. Read back the recomputed max rather than deriving it
+		// here, so the clamp cannot drift from the preparation logic.
+		const mana = this.system.resources.mana;
+		if (mana.current > mana.max) {
+			await this.update({
+				'system.resources.mana.current': Math.max(0, mana.max),
+			} as Parameters<this['update']>[0]);
+		}
+
 		await this.#syncPoolBonusItemDescriptions();
 	}
 

--- a/src/documents/actor/character.ts
+++ b/src/documents/actor/character.ts
@@ -1740,16 +1740,6 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 		await this.updateItem(characterClass.id!, itemUpdates);
 		await this.update(actorUpdates);
 
-		// Max mana falls with the level, and the current value does not follow it
-		// down on its own. Read back the recomputed max rather than deriving it
-		// here, so the clamp cannot drift from the preparation logic.
-		const mana = this.system.resources.mana;
-		if (mana.current > mana.max) {
-			await this.update({
-				'system.resources.mana.current': Math.max(0, mana.max),
-			} as Parameters<this['update']>[0]);
-		}
-
 		await this.#syncPoolBonusItemDescriptions();
 	}
 

--- a/src/hooks/manaSeeding.test.ts
+++ b/src/hooks/manaSeeding.test.ts
@@ -223,4 +223,53 @@ describe('registerManaSeedingHooks', () => {
 
 		expect(actor.update).toHaveBeenCalledTimes(1);
 	});
+
+	it('clamps the current value down when max mana falls away entirely', async () => {
+		const callbacks = await registerHooks();
+		const actor = createManaActor({ current: 2, max: 2 });
+
+		await updateActor(callbacks, actor, { newMax: 0 });
+
+		expect(actor.update).toHaveBeenCalledWith({ 'system.resources.mana.current': 0 });
+	});
+
+	it('clamps the current value down to a max that fell but stayed positive', async () => {
+		const callbacks = await registerHooks();
+		const actor = createManaActor({ current: 5, max: 5 });
+
+		await updateActor(callbacks, actor, { newMax: 3 });
+
+		expect(actor.update).toHaveBeenCalledWith({ 'system.resources.mana.current': 3 });
+	});
+
+	it('leaves a current value that still fits inside a reduced max alone', async () => {
+		const callbacks = await registerHooks();
+		const actor = createManaActor({ current: 1, max: 5 });
+
+		await updateActor(callbacks, actor, { newMax: 3 });
+
+		expect(actor.update).not.toHaveBeenCalled();
+	});
+
+	it('does not re-clamp from the write the clamp itself performs', async () => {
+		const callbacks = await registerHooks();
+		const actor = createManaActor({ current: 2, max: 2 });
+
+		await updateActor(callbacks, actor, { newMax: 0 });
+		expect(actor.update).toHaveBeenCalledTimes(1);
+
+		actor.system.resources.mana.current = 0;
+		await updateActor(callbacks, actor, { newMax: 0 });
+
+		expect(actor.update).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not clamp when the update was initiated by a different user', async () => {
+		const callbacks = await registerHooks();
+		const actor = createManaActor({ current: 2, max: 2 });
+
+		await updateActor(callbacks, actor, { newMax: 0, userId: 'someone-else' });
+
+		expect(actor.update).not.toHaveBeenCalled();
+	});
 });

--- a/src/hooks/manaSeeding.test.ts
+++ b/src/hooks/manaSeeding.test.ts
@@ -13,6 +13,7 @@ function globals() {
 
 type MockManaActor = {
 	id: string;
+	uuid: string;
 	type: string;
 	system: { resources: { mana: { current: number; max: number } } };
 	update: ReturnType<typeof vi.fn>;
@@ -25,10 +26,13 @@ function createManaActor({
 	max = 0,
 	type = 'character',
 	id = '',
+	uuid = '',
 } = {}): MockManaActor {
 	nextActorId += 1;
+	const actorId = id || `actor-${nextActorId}`;
 	return {
-		id: id || `actor-${nextActorId}`,
+		id: actorId,
+		uuid: uuid || `Actor.${actorId}`,
 		type,
 		system: { resources: { mana: { current, max } } },
 		update: vi.fn().mockResolvedValue(undefined),
@@ -209,6 +213,51 @@ describe('registerManaSeedingHooks', () => {
 
 		expect(gainsAPool.update).toHaveBeenCalledWith({ 'system.resources.mana.current': 5 });
 		expect(alreadyHasOne.update).not.toHaveBeenCalled();
+	});
+
+	// An unlinked token's synthetic actor carries the base actor's id, so two of
+	// them in one batch would collide on an id-keyed stash. Their uuids differ.
+	it('keeps unlinked token actors sharing a base id separate', async () => {
+		const callbacks = await registerHooks();
+		const gainsAPool = createManaActor({
+			current: 0,
+			max: 0,
+			id: 'base-actor',
+			uuid: 'Scene.s1.Token.t1.Actor.base-actor',
+		});
+		const alreadyHasOne = createManaActor({
+			current: 0,
+			max: 4,
+			id: 'base-actor',
+			uuid: 'Scene.s1.Token.t2.Actor.base-actor',
+		});
+		const options = {};
+
+		callbacks.get('preUpdateActor')?.(gainsAPool, {}, options, 'user-1');
+		callbacks.get('preUpdateActor')?.(alreadyHasOne, {}, options, 'user-1');
+
+		gainsAPool.system.resources.mana.max = 5;
+		alreadyHasOne.system.resources.mana.max = 7;
+
+		callbacks.get('updateActor')?.(gainsAPool, {}, options, 'user-1');
+		callbacks.get('updateActor')?.(alreadyHasOne, {}, options, 'user-1');
+		await flushAsync();
+
+		expect(gainsAPool.update).toHaveBeenCalledWith({ 'system.resources.mana.current': 5 });
+		expect(alreadyHasOne.update).not.toHaveBeenCalled();
+	});
+
+	// Nothing stashed means the pre-hook never ran for this actor, so there is
+	// no before-value to compare against and the post-hook must do nothing.
+	it('does nothing when the post-hook runs without a stashed previous max', async () => {
+		const callbacks = await registerHooks();
+		const actor = createManaActor({ current: 0, max: 0 });
+
+		actor.system.resources.mana.max = 5;
+		callbacks.get('updateActor')?.(actor, {}, {}, 'user-1');
+		await flushAsync();
+
+		expect(actor.update).not.toHaveBeenCalled();
 	});
 
 	it('does not re-seed from the write the seed itself performs', async () => {

--- a/src/hooks/manaSeeding.test.ts
+++ b/src/hooks/manaSeeding.test.ts
@@ -48,23 +48,6 @@ async function registerHooks(): Promise<HookCallbacks> {
 	return callbacks;
 }
 
-async function updateClassItem(
-	callbacks: HookCallbacks,
-	actor: MockManaActor,
-	{
-		newMax,
-		itemType = 'class',
-		userId = 'user-1',
-	}: { newMax: number; itemType?: string; userId?: string },
-): Promise<void> {
-	const item = { type: itemType, actor };
-	const options = {};
-	callbacks.get('preUpdateItem')?.(item, {}, options, userId);
-	actor.system.resources.mana.max = newMax;
-	callbacks.get('updateItem')?.(item, {}, options, userId);
-	await flushAsync();
-}
-
 async function updateActor(
 	callbacks: HookCallbacks,
 	actor: MockManaActor,
@@ -85,29 +68,6 @@ describe('registerManaSeedingHooks', () => {
 		globals().game.user = { id: 'user-1' };
 	});
 
-	it('fills the pool when a class update makes max mana non-zero for the first time', async () => {
-		const callbacks = await registerHooks();
-		const actor = createManaActor({ current: 0, max: 0 });
-
-		await updateClassItem(callbacks, actor, { newMax: 5 });
-
-		expect(actor.update).toHaveBeenCalledWith({ 'system.resources.mana.current': 5 });
-	});
-
-	it('fills the pool when a class item is added and max mana becomes non-zero', async () => {
-		const callbacks = await registerHooks();
-		const actor = createManaActor({ current: 0, max: 0 });
-
-		const item = { type: 'class', actor };
-		const options = {};
-		callbacks.get('preCreateItem')?.(item, {}, options, 'user-1');
-		actor.system.resources.mana.max = 4;
-		callbacks.get('createItem')?.(item, options, 'user-1');
-		await flushAsync();
-
-		expect(actor.update).toHaveBeenCalledWith({ 'system.resources.mana.current': 4 });
-	});
-
 	it('fills the pool when an actor update makes max mana non-zero for the first time', async () => {
 		const callbacks = await registerHooks();
 		const actor = createManaActor({ current: 0, max: 0 });
@@ -121,7 +81,7 @@ describe('registerManaSeedingHooks', () => {
 		const callbacks = await registerHooks();
 		const actor = createManaActor({ current: 1, max: 3 });
 
-		await updateClassItem(callbacks, actor, { newMax: 5 });
+		await updateActor(callbacks, actor, { newMax: 5 });
 
 		expect(actor.update).not.toHaveBeenCalled();
 	});
@@ -130,7 +90,7 @@ describe('registerManaSeedingHooks', () => {
 		const callbacks = await registerHooks();
 		const actor = createManaActor({ current: 0, max: 3 });
 
-		await updateClassItem(callbacks, actor, { newMax: 5 });
+		await updateActor(callbacks, actor, { newMax: 5 });
 
 		expect(actor.update).not.toHaveBeenCalled();
 	});
@@ -139,7 +99,7 @@ describe('registerManaSeedingHooks', () => {
 		const callbacks = await registerHooks();
 		const actor = createManaActor({ current: 2, max: 0 });
 
-		await updateClassItem(callbacks, actor, { newMax: 5 });
+		await updateActor(callbacks, actor, { newMax: 5 });
 
 		expect(actor.update).not.toHaveBeenCalled();
 	});
@@ -148,7 +108,7 @@ describe('registerManaSeedingHooks', () => {
 		const callbacks = await registerHooks();
 		const actor = createManaActor({ current: 0, max: 0 });
 
-		await updateClassItem(callbacks, actor, { newMax: 0 });
+		await updateActor(callbacks, actor, { newMax: 0 });
 
 		expect(actor.update).not.toHaveBeenCalled();
 	});
@@ -157,16 +117,7 @@ describe('registerManaSeedingHooks', () => {
 		const callbacks = await registerHooks();
 		const actor = createManaActor({ current: 0, max: 0 });
 
-		await updateClassItem(callbacks, actor, { newMax: 5, userId: 'someone-else' });
-
-		expect(actor.update).not.toHaveBeenCalled();
-	});
-
-	it('ignores updates to non-class items', async () => {
-		const callbacks = await registerHooks();
-		const actor = createManaActor({ current: 0, max: 0 });
-
-		await updateClassItem(callbacks, actor, { newMax: 5, itemType: 'feature' });
+		await updateActor(callbacks, actor, { newMax: 5, userId: 'someone-else' });
 
 		expect(actor.update).not.toHaveBeenCalled();
 	});
@@ -264,7 +215,7 @@ describe('registerManaSeedingHooks', () => {
 		const callbacks = await registerHooks();
 		const actor = createManaActor({ current: 0, max: 0 });
 
-		await updateClassItem(callbacks, actor, { newMax: 5 });
+		await updateActor(callbacks, actor, { newMax: 5 });
 		expect(actor.update).toHaveBeenCalledTimes(1);
 
 		actor.system.resources.mana.current = 5;

--- a/src/hooks/manaSeeding.test.ts
+++ b/src/hooks/manaSeeding.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushAsync, getTestGlobals } from '../../tests/helpers.js';
+import { createHookCapture } from '../../tests/mocks/combat.js';
+
+type ManaSeedingTestGlobals = {
+	game: { user?: { id?: string } };
+	Hooks: { on: ReturnType<typeof vi.fn> };
+};
+
+function globals() {
+	return getTestGlobals<ManaSeedingTestGlobals>();
+}
+
+type MockManaActor = {
+	type: string;
+	system: { resources: { mana: { current: number; max: number } } };
+	update: ReturnType<typeof vi.fn>;
+};
+
+function createManaActor({ current = 0, max = 0, type = 'character' } = {}): MockManaActor {
+	return {
+		type,
+		system: { resources: { mana: { current, max } } },
+		update: vi.fn().mockResolvedValue(undefined),
+	};
+}
+
+type HookCallbacks = Map<string, (...args: unknown[]) => unknown>;
+
+async function registerHooks(): Promise<HookCallbacks> {
+	const callbacks = createHookCapture(globals().Hooks.on);
+	const register = (await import('./manaSeeding.js')).default;
+	register();
+	return callbacks;
+}
+
+async function updateClassItem(
+	callbacks: HookCallbacks,
+	actor: MockManaActor,
+	{
+		newMax,
+		itemType = 'class',
+		userId = 'user-1',
+	}: { newMax: number; itemType?: string; userId?: string },
+): Promise<void> {
+	const item = { type: itemType, actor };
+	const options = {};
+	callbacks.get('preUpdateItem')?.(item, {}, options, userId);
+	actor.system.resources.mana.max = newMax;
+	callbacks.get('updateItem')?.(item, {}, options, userId);
+	await flushAsync();
+}
+
+async function updateActor(
+	callbacks: HookCallbacks,
+	actor: MockManaActor,
+	{ newMax, userId = 'user-1' }: { newMax: number; userId?: string },
+): Promise<void> {
+	const options = {};
+	callbacks.get('preUpdateActor')?.(actor, {}, options, userId);
+	actor.system.resources.mana.max = newMax;
+	callbacks.get('updateActor')?.(actor, {}, options, userId);
+	await flushAsync();
+}
+
+describe('registerManaSeedingHooks', () => {
+	beforeEach(() => {
+		vi.resetModules();
+		vi.clearAllMocks();
+
+		globals().game.user = { id: 'user-1' };
+	});
+
+	it('fills the pool when a class update makes max mana non-zero for the first time', async () => {
+		const callbacks = await registerHooks();
+		const actor = createManaActor({ current: 0, max: 0 });
+
+		await updateClassItem(callbacks, actor, { newMax: 5 });
+
+		expect(actor.update).toHaveBeenCalledWith({ 'system.resources.mana.current': 5 });
+	});
+
+	it('fills the pool when a class item is added and max mana becomes non-zero', async () => {
+		const callbacks = await registerHooks();
+		const actor = createManaActor({ current: 0, max: 0 });
+
+		const item = { type: 'class', actor };
+		const options = {};
+		callbacks.get('preCreateItem')?.(item, {}, options, 'user-1');
+		actor.system.resources.mana.max = 4;
+		callbacks.get('createItem')?.(item, options, 'user-1');
+		await flushAsync();
+
+		expect(actor.update).toHaveBeenCalledWith({ 'system.resources.mana.current': 4 });
+	});
+
+	it('fills the pool when an actor update makes max mana non-zero for the first time', async () => {
+		const callbacks = await registerHooks();
+		const actor = createManaActor({ current: 0, max: 0 });
+
+		await updateActor(callbacks, actor, { newMax: 3 });
+
+		expect(actor.update).toHaveBeenCalledWith({ 'system.resources.mana.current': 3 });
+	});
+
+	it('leaves a partly spent pool alone when max mana was already non-zero', async () => {
+		const callbacks = await registerHooks();
+		const actor = createManaActor({ current: 1, max: 3 });
+
+		await updateClassItem(callbacks, actor, { newMax: 5 });
+
+		expect(actor.update).not.toHaveBeenCalled();
+	});
+
+	it('leaves a fully spent pool alone when max mana was already non-zero', async () => {
+		const callbacks = await registerHooks();
+		const actor = createManaActor({ current: 0, max: 3 });
+
+		await updateClassItem(callbacks, actor, { newMax: 5 });
+
+		expect(actor.update).not.toHaveBeenCalled();
+	});
+
+	it('does not overwrite a current value that already exists when max first appears', async () => {
+		const callbacks = await registerHooks();
+		const actor = createManaActor({ current: 2, max: 0 });
+
+		await updateClassItem(callbacks, actor, { newMax: 5 });
+
+		expect(actor.update).not.toHaveBeenCalled();
+	});
+
+	it('does nothing while max mana stays at zero', async () => {
+		const callbacks = await registerHooks();
+		const actor = createManaActor({ current: 0, max: 0 });
+
+		await updateClassItem(callbacks, actor, { newMax: 0 });
+
+		expect(actor.update).not.toHaveBeenCalled();
+	});
+
+	it('does not write when the update was initiated by a different user', async () => {
+		const callbacks = await registerHooks();
+		const actor = createManaActor({ current: 0, max: 0 });
+
+		await updateClassItem(callbacks, actor, { newMax: 5, userId: 'someone-else' });
+
+		expect(actor.update).not.toHaveBeenCalled();
+	});
+
+	it('ignores updates to non-class items', async () => {
+		const callbacks = await registerHooks();
+		const actor = createManaActor({ current: 0, max: 0 });
+
+		await updateClassItem(callbacks, actor, { newMax: 5, itemType: 'feature' });
+
+		expect(actor.update).not.toHaveBeenCalled();
+	});
+
+	it('ignores non-character actors', async () => {
+		const callbacks = await registerHooks();
+		const actor = createManaActor({ current: 0, max: 0, type: 'npc' });
+
+		await updateActor(callbacks, actor, { newMax: 5 });
+
+		expect(actor.update).not.toHaveBeenCalled();
+	});
+
+	it('does not re-seed from the write the seed itself performs', async () => {
+		const callbacks = await registerHooks();
+		const actor = createManaActor({ current: 0, max: 0 });
+
+		await updateClassItem(callbacks, actor, { newMax: 5 });
+		expect(actor.update).toHaveBeenCalledTimes(1);
+
+		actor.system.resources.mana.current = 5;
+		await updateActor(callbacks, actor, { newMax: 5 });
+
+		expect(actor.update).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/hooks/manaSeeding.test.ts
+++ b/src/hooks/manaSeeding.test.ts
@@ -12,13 +12,23 @@ function globals() {
 }
 
 type MockManaActor = {
+	id: string;
 	type: string;
 	system: { resources: { mana: { current: number; max: number } } };
 	update: ReturnType<typeof vi.fn>;
 };
 
-function createManaActor({ current = 0, max = 0, type = 'character' } = {}): MockManaActor {
+let nextActorId = 0;
+
+function createManaActor({
+	current = 0,
+	max = 0,
+	type = 'character',
+	id = '',
+} = {}): MockManaActor {
+	nextActorId += 1;
 	return {
+		id: id || `actor-${nextActorId}`,
 		type,
 		system: { resources: { mana: { current, max } } },
 		update: vi.fn().mockResolvedValue(undefined),
@@ -164,6 +174,41 @@ describe('registerManaSeedingHooks', () => {
 		await updateActor(callbacks, actor, { newMax: 5 });
 
 		expect(actor.update).not.toHaveBeenCalled();
+	});
+
+	// The character sheet's max mana field writes `baseMax`, so raising it from
+	// zero runs the same path a level-up does. Broader than the level-up case
+	// the hook was added for, and intended.
+	it('fills the pool when max mana is raised from zero on the sheet', async () => {
+		const callbacks = await registerHooks();
+		const actor = createManaActor({ current: 0, max: 0 });
+
+		await updateActor(callbacks, actor, { newMax: 6 });
+
+		expect(actor.update).toHaveBeenCalledWith({ 'system.resources.mana.current': 6 });
+	});
+
+	// A batched update shares one options object across every document: the
+	// backend runs the whole pre-hook loop before any post-hook. Each actor has
+	// to read back its own previous max, not the last one stashed.
+	it("keeps each actor's previous max separate in a batched update", async () => {
+		const callbacks = await registerHooks();
+		const gainsAPool = createManaActor({ current: 0, max: 0 });
+		const alreadyHasOne = createManaActor({ current: 0, max: 4 });
+		const options = {};
+
+		callbacks.get('preUpdateActor')?.(gainsAPool, {}, options, 'user-1');
+		callbacks.get('preUpdateActor')?.(alreadyHasOne, {}, options, 'user-1');
+
+		gainsAPool.system.resources.mana.max = 5;
+		alreadyHasOne.system.resources.mana.max = 7;
+
+		callbacks.get('updateActor')?.(gainsAPool, {}, options, 'user-1');
+		callbacks.get('updateActor')?.(alreadyHasOne, {}, options, 'user-1');
+		await flushAsync();
+
+		expect(gainsAPool.update).toHaveBeenCalledWith({ 'system.resources.mana.current': 5 });
+		expect(alreadyHasOne.update).not.toHaveBeenCalled();
 	});
 
 	it('does not re-seed from the write the seed itself performs', async () => {

--- a/src/hooks/manaSeeding.ts
+++ b/src/hooks/manaSeeding.ts
@@ -1,0 +1,92 @@
+import { SYSTEM_ID } from '#system';
+
+const PREVIOUS_MANA_MAX_PATH = `${SYSTEM_ID}.previousManaMax`;
+
+type ManaSnapshot = {
+	actor: Actor.Implementation;
+	current: number;
+	max: number;
+};
+
+function getManaSnapshot(actor: unknown): ManaSnapshot | null {
+	if (!actor || typeof actor !== 'object') return null;
+	const typedActor = actor as Actor.Implementation;
+	if (typedActor.type !== 'character') return null;
+
+	const mana = (
+		typedActor.system as { resources?: { mana?: { current?: unknown; max?: unknown } } }
+	)?.resources?.mana;
+	if (!mana) return null;
+
+	const current = Number(mana.current ?? 0);
+	const max = Number(mana.max ?? 0);
+	if (!Number.isFinite(current) || !Number.isFinite(max)) return null;
+
+	return { actor: typedActor, current, max };
+}
+
+function toClassItemActor(item: unknown): Actor.Implementation | null {
+	if (!item || typeof item !== 'object') return null;
+	const typedItem = item as Item.Implementation;
+	if (typedItem.type !== 'class') return null;
+	return typedItem.actor ?? null;
+}
+
+// Derived max mana is still the pre-update value inside pre-hooks, so it is
+// recorded on the update options for the post-hook to compare against.
+function stashPreviousManaMax(actor: unknown, options: unknown): void {
+	const snapshot = getManaSnapshot(actor);
+	if (!snapshot || !options || typeof options !== 'object') return;
+	foundry.utils.setProperty(options, PREVIOUS_MANA_MAX_PATH, snapshot.max);
+}
+
+async function seedManaIfNewlyAvailable(
+	actor: unknown,
+	options: unknown,
+	userId: unknown,
+): Promise<void> {
+	// Only the client that initiated the change writes. That client has
+	// permission by construction, and every other connected client skips the
+	// write instead of attempting one the server would reject.
+	if (!userId || game.user?.id !== userId) return;
+
+	const snapshot = getManaSnapshot(actor);
+	if (!snapshot || !options || typeof options !== 'object') return;
+
+	const previousMax = foundry.utils.getProperty(options, PREVIOUS_MANA_MAX_PATH);
+	if (typeof previousMax !== 'number' || previousMax > 0) return;
+
+	// Seed only on the transition from "no pool" to "has a pool", and never
+	// touch a value that already exists.
+	if (snapshot.max <= 0 || snapshot.current !== 0) return;
+
+	await snapshot.actor.update({
+		'system.resources.mana.current': snapshot.max,
+	} as Parameters<Actor.Implementation['update']>[0]);
+}
+
+export default function registerManaSeedingHooks(): void {
+	Hooks.on('preCreateItem', (item: Item.Implementation, _data, options) => {
+		stashPreviousManaMax(toClassItemActor(item), options);
+	});
+
+	Hooks.on('createItem', (item: Item.Implementation, options, userId) => {
+		void seedManaIfNewlyAvailable(toClassItemActor(item), options, userId);
+	});
+
+	Hooks.on('preUpdateItem', (item: Item.Implementation, _changes, options) => {
+		stashPreviousManaMax(toClassItemActor(item), options);
+	});
+
+	Hooks.on('updateItem', (item: Item.Implementation, _changes, options, userId) => {
+		void seedManaIfNewlyAvailable(toClassItemActor(item), options, userId);
+	});
+
+	Hooks.on('preUpdateActor', (actor: Actor.Implementation, _changes, options) => {
+		stashPreviousManaMax(actor, options);
+	});
+
+	Hooks.on('updateActor', (actor: Actor.Implementation, _changes, options, userId) => {
+		void seedManaIfNewlyAvailable(actor, options, userId);
+	});
+}

--- a/src/hooks/manaSeeding.ts
+++ b/src/hooks/manaSeeding.ts
@@ -4,6 +4,7 @@ const PREVIOUS_MANA_MAX_PATH = `${SYSTEM_ID}.previousManaMax`;
 
 type ManaSnapshot = {
 	actor: Actor.Implementation;
+	actorId: string;
 	current: number;
 	max: number;
 };
@@ -22,7 +23,12 @@ function getManaSnapshot(actor: unknown): ManaSnapshot | null {
 	const max = Number(mana.max ?? 0);
 	if (!Number.isFinite(current) || !Number.isFinite(max)) return null;
 
-	return { actor: typedActor, current, max };
+	// The stash is keyed by id, so an actor without one cannot be tracked
+	// across the two hooks.
+	const actorId = typedActor.id;
+	if (!actorId) return null;
+
+	return { actor: typedActor, actorId, current, max };
 }
 
 function toClassItemActor(item: unknown): Actor.Implementation | null {
@@ -34,10 +40,15 @@ function toClassItemActor(item: unknown): Actor.Implementation | null {
 
 // Derived max mana is still the pre-update value inside pre-hooks, so it is
 // recorded on the update options for the post-hook to compare against.
+//
+// Keyed by actor id because one options object is shared by every document in
+// a batched update: the backend runs the whole pre-hook loop before any
+// post-hook, so a single slot would leave every actor reading the last one's
+// value.
 function stashPreviousManaMax(actor: unknown, options: unknown): void {
 	const snapshot = getManaSnapshot(actor);
 	if (!snapshot || !options || typeof options !== 'object') return;
-	foundry.utils.setProperty(options, PREVIOUS_MANA_MAX_PATH, snapshot.max);
+	foundry.utils.setProperty(options, `${PREVIOUS_MANA_MAX_PATH}.${snapshot.actorId}`, snapshot.max);
 }
 
 async function seedManaIfNewlyAvailable(
@@ -53,7 +64,10 @@ async function seedManaIfNewlyAvailable(
 	const snapshot = getManaSnapshot(actor);
 	if (!snapshot || !options || typeof options !== 'object') return;
 
-	const previousMax = foundry.utils.getProperty(options, PREVIOUS_MANA_MAX_PATH);
+	const previousMax = foundry.utils.getProperty(
+		options,
+		`${PREVIOUS_MANA_MAX_PATH}.${snapshot.actorId}`,
+	);
 	if (typeof previousMax !== 'number' || previousMax > 0) return;
 
 	// Seed only on the transition from "no pool" to "has a pool", and never

--- a/src/hooks/manaSeeding.ts
+++ b/src/hooks/manaSeeding.ts
@@ -4,7 +4,7 @@ const PREVIOUS_MANA_MAX_PATH = `${SYSTEM_ID}.previousManaMax`;
 
 type ManaSnapshot = {
 	actor: Actor.Implementation;
-	actorId: string;
+	actorUuid: string;
 	current: number;
 	max: number;
 };
@@ -23,12 +23,18 @@ function getManaSnapshot(actor: unknown): ManaSnapshot | null {
 	const max = Number(mana.max ?? 0);
 	if (!Number.isFinite(current) || !Number.isFinite(max)) return null;
 
-	// The stash is keyed by id, so an actor without one cannot be tracked
-	// across the two hooks.
-	const actorId = typedActor.id;
-	if (!actorId) return null;
+	// Keyed by uuid rather than id: an unlinked token's synthetic actor carries
+	// the base actor's id, so several of them in one batch would share a key.
+	const actorUuid = typedActor.uuid;
+	if (!actorUuid) return null;
 
-	return { actor: typedActor, actorId, current, max };
+	return { actor: typedActor, actorUuid, current, max };
+}
+
+function readStash(options: object): Record<string, number> | undefined {
+	return foundry.utils.getProperty(options, PREVIOUS_MANA_MAX_PATH) as
+		| Record<string, number>
+		| undefined;
 }
 
 function toClassItemActor(item: unknown): Actor.Implementation | null {
@@ -41,14 +47,19 @@ function toClassItemActor(item: unknown): Actor.Implementation | null {
 // Derived max mana is still the pre-update value inside pre-hooks, so it is
 // recorded on the update options for the post-hook to compare against.
 //
-// Keyed by actor id because one options object is shared by every document in
-// a batched update: the backend runs the whole pre-hook loop before any
+// Keyed per actor because one options object is shared by every document in a
+// batched update: the backend runs the whole pre-hook loop before any
 // post-hook, so a single slot would leave every actor reading the last one's
 // value.
 function stashPreviousManaMax(actor: unknown, options: unknown): void {
 	const snapshot = getManaSnapshot(actor);
 	if (!snapshot || !options || typeof options !== 'object') return;
-	foundry.utils.setProperty(options, `${PREVIOUS_MANA_MAX_PATH}.${snapshot.actorId}`, snapshot.max);
+
+	// Indexed into a record rather than appended to the path: a uuid contains
+	// dots, which `setProperty` would read as nesting.
+	const stash = readStash(options) ?? {};
+	stash[snapshot.actorUuid] = snapshot.max;
+	foundry.utils.setProperty(options, PREVIOUS_MANA_MAX_PATH, stash);
 }
 
 async function seedManaIfNewlyAvailable(
@@ -64,10 +75,7 @@ async function seedManaIfNewlyAvailable(
 	const snapshot = getManaSnapshot(actor);
 	if (!snapshot || !options || typeof options !== 'object') return;
 
-	const previousMax = foundry.utils.getProperty(
-		options,
-		`${PREVIOUS_MANA_MAX_PATH}.${snapshot.actorId}`,
-	);
+	const previousMax = readStash(options)?.[snapshot.actorUuid];
 	if (typeof previousMax !== 'number' || previousMax > 0) return;
 
 	// Seed only on the transition from "no pool" to "has a pool", and never

--- a/src/hooks/manaSeeding.ts
+++ b/src/hooks/manaSeeding.ts
@@ -55,7 +55,7 @@ function stashPreviousManaMax(actor: unknown, options: unknown): void {
 	foundry.utils.setProperty(options, PREVIOUS_MANA_MAX_PATH, stash);
 }
 
-async function seedManaIfNewlyAvailable(
+async function reconcileManaAgainstMax(
 	actor: unknown,
 	options: unknown,
 	userId: unknown,
@@ -71,15 +71,21 @@ async function seedManaIfNewlyAvailable(
 	const previousMax = readStash(options)?.[snapshot.actorUuid];
 	if (typeof previousMax !== 'number') return;
 
-	if (previousMax > 0) return;
-
 	// Seed only on the transition from "no pool" to "has a pool", and never
 	// touch a value that already exists.
-	if (snapshot.max <= 0 || snapshot.current !== 0) return;
+	if (previousMax <= 0 && snapshot.max > 0 && snapshot.current === 0) {
+		await snapshot.actor.update({
+			'system.resources.mana.current': snapshot.max,
+		} as Parameters<Actor.Implementation['update']>[0]);
+		return;
+	}
 
-	await snapshot.actor.update({
-		'system.resources.mana.current': snapshot.max,
-	} as Parameters<Actor.Implementation['update']>[0]);
+	// This write re-enters the hook and stops, because current then equals max.
+	if (snapshot.current > snapshot.max) {
+		await snapshot.actor.update({
+			'system.resources.mana.current': Math.max(0, snapshot.max),
+		} as Parameters<Actor.Implementation['update']>[0]);
+	}
 }
 
 export default function registerManaSeedingHooks(): void {
@@ -88,6 +94,6 @@ export default function registerManaSeedingHooks(): void {
 	});
 
 	Hooks.on('updateActor', (actor: Actor.Implementation, _changes, options, userId) => {
-		void seedManaIfNewlyAvailable(actor, options, userId);
+		void reconcileManaAgainstMax(actor, options, userId);
 	});
 }

--- a/src/hooks/manaSeeding.ts
+++ b/src/hooks/manaSeeding.ts
@@ -37,13 +37,6 @@ function readStash(options: object): Record<string, number> | undefined {
 		| undefined;
 }
 
-function toClassItemActor(item: unknown): Actor.Implementation | null {
-	if (!item || typeof item !== 'object') return null;
-	const typedItem = item as Item.Implementation;
-	if (typedItem.type !== 'class') return null;
-	return typedItem.actor ?? null;
-}
-
 // Derived max mana is still the pre-update value inside pre-hooks, so it is
 // recorded on the update options for the post-hook to compare against.
 //
@@ -76,7 +69,9 @@ async function seedManaIfNewlyAvailable(
 	if (!snapshot || !options || typeof options !== 'object') return;
 
 	const previousMax = readStash(options)?.[snapshot.actorUuid];
-	if (typeof previousMax !== 'number' || previousMax > 0) return;
+	if (typeof previousMax !== 'number') return;
+
+	if (previousMax > 0) return;
 
 	// Seed only on the transition from "no pool" to "has a pool", and never
 	// touch a value that already exists.
@@ -88,22 +83,6 @@ async function seedManaIfNewlyAvailable(
 }
 
 export default function registerManaSeedingHooks(): void {
-	Hooks.on('preCreateItem', (item: Item.Implementation, _data, options) => {
-		stashPreviousManaMax(toClassItemActor(item), options);
-	});
-
-	Hooks.on('createItem', (item: Item.Implementation, options, userId) => {
-		void seedManaIfNewlyAvailable(toClassItemActor(item), options, userId);
-	});
-
-	Hooks.on('preUpdateItem', (item: Item.Implementation, _changes, options) => {
-		stashPreviousManaMax(toClassItemActor(item), options);
-	});
-
-	Hooks.on('updateItem', (item: Item.Implementation, _changes, options, userId) => {
-		void seedManaIfNewlyAvailable(toClassItemActor(item), options, userId);
-	});
-
 	Hooks.on('preUpdateActor', (actor: Actor.Implementation, _changes, options) => {
 		stashPreviousManaMax(actor, options);
 	});

--- a/src/nimble.ts
+++ b/src/nimble.ts
@@ -23,6 +23,7 @@ import { registerDicePoolTurnTriggerHooks } from './hooks/dicePoolTriggers/turnT
 import { hotbarDrop as onHotbarDrop } from './hooks/hotBarDrop.js';
 import i18nInit from './hooks/i18nInit.js';
 import init from './hooks/init.js';
+import registerManaSeedingHooks from './hooks/manaSeeding.js';
 import registerMinionGroupTokenActions from './hooks/minionGroupTokenActions.js';
 import registerMinionGroupTokenBadges from './hooks/minionGroupTokenBadges.js';
 import { registerPoolGainMessageHooks } from './hooks/poolGainMessage.js';
@@ -127,6 +128,7 @@ registerCombatantHealthStateSync();
 registerDyingActionLimitSync();
 registerPendingActionDeltaFold();
 registerChargeSystemHooks();
+registerManaSeedingHooks();
 registerActionEconomySystemHooks();
 registerDicePoolSystemHooks();
 registerWoundTriggerHooks();

--- a/tests/integration/manaSeeding.test.ts
+++ b/tests/integration/manaSeeding.test.ts
@@ -8,9 +8,9 @@
  * the `updateActor` hook runs, and that a value stashed on the update options
  * survives to the post-hook. Both are only observable in a real world.
  *
- * Levelling back down is covered here too, because the seed is what makes a
- * stranded current value reachable: a pool filled to 2/2 at level 2 would
- * otherwise keep its 2 while the maximum returns to 0.
+ * The three ways a maximum falls away again are covered here too, because the
+ * seed is what makes a stranded current value reachable: a pool filled to 2/2
+ * at level 2 would otherwise keep its 2 while the maximum returns to 0.
  */
 
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
@@ -29,6 +29,8 @@ interface ManaActor {
 	levels: { character: number };
 	updateItem(itemId: string, changes: Record<string, unknown>): Promise<unknown>;
 	revertLastLevelUp(): Promise<unknown>;
+	validateLevelHistory(): Promise<boolean>;
+	deleteEmbeddedDocuments(embeddedName: string, ids: string[]): Promise<unknown>;
 	update(changes: Record<string, unknown>): Promise<unknown>;
 }
 
@@ -66,10 +68,7 @@ describe('mana seeding across a level up and back down', () => {
 		const characterClass = Object.values(mage.classes)[0]!;
 		await mage.updateItem(characterClass.id, { 'system.classLevel': 2 });
 		await mage.update({
-			'system.classData.levels': [
-				...mage.system.classData.levels,
-				characterClass.identifier,
-			],
+			'system.classData.levels': [...mage.system.classData.levels, characterClass.identifier],
 			'system.levelUpHistory': [
 				{
 					level: 2,
@@ -97,6 +96,84 @@ describe('mana seeding across a level up and back down', () => {
 
 		const mana = readMana(mage);
 		expect(mage.levels.character).toBe(1);
+		expect(mana.max).toBe(0);
+		expect(mana.current).toBeLessThanOrEqual(mana.max);
+	});
+});
+
+/**
+ * Levelling down is not the only way the maximum falls back to zero: a level
+ * history reset and deleting the class item both rewrite `classData.levels`.
+ */
+describe('mana is not left stranded when the pool disappears another way', () => {
+	const buildLevelTwoMage = async (suffix: string): Promise<ManaActor> => {
+		const mage = (await Actor.create({
+			name: `${TEST_PREFIX} ${suffix}`,
+			type: 'character',
+		} as Actor.CreateData)) as unknown as ManaActor;
+		await importPackItem(
+			mage as unknown as Actor,
+			'nimble-classes',
+			(entry: { name: string }) => entry.name === 'Mage',
+			[],
+		);
+		await settle();
+
+		const characterClass = Object.values(mage.classes)[0]!;
+		await mage.updateItem(characterClass.id, { 'system.classLevel': 2 });
+		await mage.update({
+			'system.classData.levels': [...mage.system.classData.levels, characterClass.identifier],
+			'system.levelUpHistory': [
+				{
+					level: 2,
+					hpIncrease: 0,
+					abilityIncreases: {},
+					skillIncreases: {},
+					hitDieAdded: false,
+					classIdentifier: characterClass.identifier,
+					grantedFeatureIds: [],
+					grantedSpellIds: [],
+					poolMaxBonuses: {},
+				},
+			],
+		});
+		await settle();
+
+		expect(readMana(mage).current).toBeGreaterThan(0);
+		return mage;
+	};
+
+	beforeAll(async () => {
+		await purgeTestDocuments(TEST_PREFIX);
+	});
+
+	afterAll(async () => {
+		await purgeTestDocuments(TEST_PREFIX);
+	});
+
+	test('a level history reset leaves no value stranded above the maximum', async () => {
+		const mage = await buildLevelTwoMage('History Reset');
+
+		// The inconsistency the reset exists to repair.
+		await mage.update({ 'system.levelUpHistory': [] });
+		await settle();
+		expect(await mage.validateLevelHistory()).toBe(true);
+		await settle();
+
+		const mana = readMana(mage);
+		expect(mage.levels.character).toBe(1);
+		expect(mana.max).toBe(0);
+		expect(mana.current).toBeLessThanOrEqual(mana.max);
+	});
+
+	test('deleting the class leaves no value stranded above the maximum', async () => {
+		const mage = await buildLevelTwoMage('Class Delete');
+
+		const characterClass = Object.values(mage.classes)[0]!;
+		await mage.deleteEmbeddedDocuments('Item', [characterClass.id]);
+		await settle();
+
+		const mana = readMana(mage);
 		expect(mana.max).toBe(0);
 		expect(mana.current).toBeLessThanOrEqual(mana.max);
 	});

--- a/tests/integration/manaSeeding.test.ts
+++ b/tests/integration/manaSeeding.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Live regression tests for mana seeding, exercised against real Mage content.
+ *
+ * A caster's mana maximum is zero at level 1 and only rises at level 2, so the
+ * current value has to be filled at the moment the maximum first appears. The
+ * unit suite pins the hook's logic against mocks, but it cannot confirm the two
+ * runtime facts the hook rests on: that Foundry recomputes derived data before
+ * the `updateActor` hook runs, and that a value stashed on the update options
+ * survives to the post-hook. Both are only observable in a real world.
+ *
+ * Levelling back down is covered here too, because the seed is what makes a
+ * stranded current value reachable: a pool filled to 2/2 at level 2 would
+ * otherwise keep its 2 while the maximum returns to 0.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import { importPackItem, purgeTestDocuments, settle } from './liveHelpers.ts';
+
+const TEST_PREFIX = 'V14 Mana Seeding';
+
+interface ManaActor {
+	id: string;
+	classes: Record<string, { id: string; identifier: string }>;
+	system: {
+		classData: { levels: string[] };
+		levelUpHistory: unknown[];
+		resources: { mana: { current: number; max: number; baseMax: number } };
+	};
+	levels: { character: number };
+	updateItem(itemId: string, changes: Record<string, unknown>): Promise<unknown>;
+	revertLastLevelUp(): Promise<unknown>;
+	update(changes: Record<string, unknown>): Promise<unknown>;
+}
+
+const readMana = (actor: ManaActor) => ({ ...actor.system.resources.mana });
+
+describe('mana seeding across a level up and back down', () => {
+	let mage: ManaActor;
+
+	beforeAll(async () => {
+		await purgeTestDocuments(TEST_PREFIX);
+		mage = (await Actor.create({
+			name: `${TEST_PREFIX} Mage`,
+			type: 'character',
+		} as Actor.CreateData)) as unknown as ManaActor;
+		await importPackItem(
+			mage as unknown as Actor,
+			'nimble-classes',
+			(entry: { name: string }) => entry.name === 'Mage',
+			[],
+		);
+		await settle();
+	});
+
+	afterAll(async () => {
+		await purgeTestDocuments(TEST_PREFIX);
+	});
+
+	test('a level 1 Mage has no pool yet', () => {
+		expect(readMana(mage)).toMatchObject({ current: 0, max: 0 });
+	});
+
+	test('levelling to 2 fills the pool the class just granted', async () => {
+		// The two writes the level-up path makes once its dialog has collected
+		// the player's choices. The dialog itself is not what is under test.
+		const characterClass = Object.values(mage.classes)[0]!;
+		await mage.updateItem(characterClass.id, { 'system.classLevel': 2 });
+		await mage.update({
+			'system.classData.levels': [
+				...mage.system.classData.levels,
+				characterClass.identifier,
+			],
+			'system.levelUpHistory': [
+				{
+					level: 2,
+					hpIncrease: 0,
+					abilityIncreases: {},
+					skillIncreases: {},
+					hitDieAdded: false,
+					classIdentifier: characterClass.identifier,
+					grantedFeatureIds: [],
+					grantedSpellIds: [],
+					poolMaxBonuses: {},
+				},
+			],
+		});
+		await settle();
+
+		const mana = readMana(mage);
+		expect(mana.max).toBeGreaterThan(0);
+		expect(mana.current).toBe(mana.max);
+	});
+
+	test('levelling back down leaves no value stranded above the maximum', async () => {
+		await mage.revertLastLevelUp();
+		await settle();
+
+		const mana = readMana(mage);
+		expect(mage.levels.character).toBe(1);
+		expect(mana.max).toBe(0);
+		expect(mana.current).toBeLessThanOrEqual(mana.max);
+	});
+});


### PR DESCRIPTION
## Summary

A character gets no starting mana when their class first grants it. The maximum
goes above zero at level 2, the current value stays at zero, and nothing fills it
until the first Safe Rest. This fills it the moment the maximum first appears.

## Changes

- New mana seeding hooks. The pre-update hooks record the derived max mana before
  a change, and the post-update hooks compare and fill when it first goes above zero.
- Only fills a pool that is empty and whose max was zero before this change. A partly
  spent pool is left alone. Note the predicate is "max was zero", not "never been
  filled": a character who levels to 2, spends mana, levels down, and levels up again
  is seeded a second time, because levelling down returns the max to zero without
  clamping the current value. Low impact, and left as is rather than adding a
  persistent flag.
- The stashed max is keyed by actor uuid. One options object is shared by every document
  in a batched update, and the backend runs the whole pre-hook loop before any
  post-hook, so a single slot left every actor reading the last one's value. Uuid rather
  than id, because an unlinked token's synthetic actor carries the base actor's id.
- Level down clamps the current value. Max mana falls back to zero with the level and
  the current value did not follow it, which the seed makes reachable: a pool filled to
  2 of 2 kept its 2 while the max returned to 0, and readouts show that as a 2/0 chip
  since they only bail when both are zero.
- Only the client that made the change writes. A non-owner never attempts a write
  the server would reject.
- Registered in `nimble.ts` next to the charge system hooks.

This is broader than the title says. The hooks watch max mana, not levelling, so any
change that raises the max from zero on an empty pool seeds it. In practice that means
the Configure Mana dialog too: raising Base Mana from zero fills the pool. That seems
right, and it is covered by a test.

## Test Plan

1. Make a level 1 character of a class that gains mana at level 2 (Mage, Songweaver,
   Shepherd, Stormshifter, or Oathsworn).
2. Level them to 2. The mana bar should be full, not 0 out of max.
3. Spend some mana, then level again. The current value should not move.
4. Have a player who does not own the character watch their console while the GM
   levels them. There should be no permission errors.

Covered by 15 unit tests over the seeding function, plus a live integration test at
`tests/integration/manaSeeding.test.ts` that levels a real Mage up and back down inside
a running world.

Also run in a live Foundry v14 world (14.365), driving the real controls:

- A level 1 Mage levelled to 2 through the sheet's Level Up button and the level-up
  window (Take Average, spend the skill point, Submit) ended on 2 of 2 mana.
- Raising Base Mana from 0 to 7 in the Configure Mana dialog filled the pool to 7 of 7.
- A batched `Actor.updateDocuments` over two actors seeded only the one that gained a
  pool. There is no UI that performs a batched multi-actor update, so this path was
  exercised through the API rather than the interface.
- No console or page errors throughout.

Both fixes were run against a build without them, to confirm the tests catch what they
claim. The batch case left the actor gaining a pool at 0 of 5, because the other actor's
previous max was the one every post-hook read. The level-down case stranded 2 of 0.

## Checklist

- [x] Added or updated unit tests
- [x] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [x] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** yes
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues

References #640. Does not close it, since Pilfered Power needs the rest of the stack.


