### PR TITLE
feat(spells): derive unlocked spell tier from a class's own spell grants

### DIFF
--- a/docs/documentation/characters/character-sheet.md
+++ b/docs/documentation/characters/character-sheet.md
@@ -62,6 +62,8 @@ Your class features, subclass features, ancestry, background, and boons, grouped
 
 Your known spells. When you know spells from two or more schools, a school filter appears. Click a spell's icon to cast it. Spells that can be upcast open a window asking how much mana to spend, with a preview of what the extra mana buys.
 
+Dropping a spell from a compendium onto the sheet asks whether to add it to your spell list or to add it as a single-use spell scroll. If the spell's tier is above your highest unlocked spell tier, the spell list option shows a warning: the spell would be added to your list, but you would not be able to cast it.
+
 ![The spells tab with the school filter and a spell card visible](/images/documentation/character-sheet-spells-tab.png)
 
 ### Bio
@@ -71,6 +73,8 @@ Freeform character details: age, height, weight, gender, and notes.
 ### Settings
 
 Per-character sheet options: portrait positioning and scale, whether item macros run when you use an item, whether item images are shown, and inventory slot tracking.
+
+This tab also shows your **Highest Unlocked Spell Tier**. The sheet works this out from the spell grants on your class, subclass, and features, so it normally needs no attention. If your table plays it differently, enable editing and use the plus and minus buttons to set the tier by hand. A tier you set stays until you click **Reset spell tier**, which hands the value back to the sheet.
 
 ## Dice pools and charges
 

--- a/docs/documentation/characters/creation.md
+++ b/docs/documentation/characters/creation.md
@@ -54,7 +54,7 @@ Open the new sheet and give it a quick once-over:
 
 - **Hit Points**: your maximum HP comes from your class. Make sure the HP bar looks right.
 - **Hit dice**: you should have one hit die of your class's size at level 1.
-- **Mana**: if you play a spellcasting class, the mana bar appears in the sheet header. No mana bar means the sheet doesn't think you're a caster.
+- **Mana**: if your class has a mana formula, the mana bar appears in the sheet header. The mana bar does not decide whether you can cast. That comes from the spell grants on your class: the Settings tab shows your **Highest Unlocked Spell Tier**, and a 0 there means your class grants no tiered spells.
 - **Known spells**: check the Spells tab against what you picked in the creator.
 - **Equipment**: if you chose starting equipment, it should already be equipped on the Inventory tab; if you chose gold, you should have 50 gp.
 

--- a/docs/documentation/homebrew/character-options.md
+++ b/docs/documentation/homebrew/character-options.md
@@ -56,7 +56,7 @@ A class is the most involved item in the system, split across a **Description** 
 - **Key Stats**: the class's key ability scores; the highest of them backs the `@key` reference in formulas.
 - **Saving throw advantage / disadvantage**: which save the class is naturally good and bad at.
 - **Hit Die Size**: d4 through d12. This also determines starting HP when the class is dropped on a character.
-- **Mana Formula** and **Mana Recovery**: leave the formula empty for non-casters; a formula (it can reference things like `@level` and ability modifiers) makes the class a caster, and the recovery setting says when the pool refills.
+- **Mana Formula** and **Mana Recovery**: leave the formula empty for classes without mana; a formula (it can reference things like `@level` and ability modifiers) gives the class a mana pool, and the recovery setting says when the pool refills. Mana alone does not let a character cast tiered spells; see [Spell grants unlock spell tiers](#spell-grants-unlock-spell-tiers).
 - **Armor Proficiencies** and **Weapon Proficiencies**: what the class can use. Weapon proficiency names matter for crits: a weapon whose type is not in the wielder's list cannot critically hit.
 - **Feature Groups**: extra group names whose features this class can draw from, used to share feature pools between classes.
 
@@ -80,6 +80,10 @@ When a player levels up, the level-up window automatically grants the features r
 ::: tip Start from a copy, not from blank
 Strongly recommended: import an existing class from the **Classes** compendium and study or adapt it rather than starting empty. One important subtlety: because the progression is looked up by **identifier**, a duplicated class with the same identifier shows the *original* class's features. That is often exactly what you want ("the Berserker, but with my extra feature at level 3"): keep the identifier, and use the Progression tab's add buttons to layer your own world features on top of the compendium ones. If you want a genuinely new class, give it a new identifier and build its feature list fresh.
 :::
+
+### Spell grants unlock spell tiers
+
+A **Grant Spells** rule on a class, subclass, or class feature also decides which spell tiers the character can cast. Give the rule a level condition (`level` is at least `5`, for example) and it unlocks the tiers it lists once the character reaches that level. The character's highest unlocked tier is the highest tier across all such rules they meet. A grant with no level condition still hands out its spells, but it does not unlock a tier. A class with no such rule leaves the character unable to cast tiered spells, whatever its mana formula says.
 
 ### Features can do things too
 

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -3479,7 +3479,7 @@
 				"addToSpellListHintCantrip": "Learn it. Cantrips are free to cast.",
 				"addAsScroll": "Add as a spell scroll",
 				"addAsScrollHint": "Single use. No mana, no magical ability needed.",
-				"noManaWarning": "{name} has no mana, so this spell would sit on the list uncastable.",
+				"notACasterWarning": "{name} cannot cast spells of this tier, so it would sit on the list uncastable.",
 				"labelTier": "Tier",
 				"labelValue": "Value",
 				"labelCasting": "Casting",

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -3479,7 +3479,7 @@
 				"addToSpellListHintCantrip": "Learn it. Cantrips are free to cast.",
 				"addAsScroll": "Add as a spell scroll",
 				"addAsScrollHint": "Single use. No mana, no magical ability needed.",
-				"notACasterWarning": "{name} cannot cast spells of this tier, so it would sit on the list uncastable.",
+				"tierLockedWarning": "{name} cannot cast spells of this tier. It would be added to their spell list, but they would not be able to use it.",
 				"labelTier": "Tier",
 				"labelValue": "Value",
 				"labelCasting": "Casting",

--- a/src/documents/actor/character.ts
+++ b/src/documents/actor/character.ts
@@ -271,9 +271,15 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 		actorData.resources.mana.value = actorData.resources.mana.current;
 		actorData.resources.mana.max = this._prepareMaxMana(actorData);
 
-		// Prepare highest unlocked spell tier (only if not manually set)
-		actorData.resources.highestUnlockedSpellTier ??=
-			this._prepareHighestUnlockedSpellTier(actorData);
+		// Prepare highest unlocked spell tier. A stored number is a manual
+		// override; a stored null means derive. Reading the override from the
+		// source keeps the derivation live — assigning onto the prepared value
+		// and re-checking it would freeze the first computed number in place.
+		const spellTierOverride = (
+			this.system._source as { resources?: { highestUnlockedSpellTier?: number | null } }
+		).resources?.highestUnlockedSpellTier;
+		actorData.resources.highestUnlockedSpellTier =
+			spellTierOverride ?? this._prepareHighestUnlockedSpellTier(actorData);
 
 		// Prepare Inventory Slots
 		const baseInventorySlots = 10 + actorData.abilities.strength.mod;
@@ -525,14 +531,10 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 		return maxMana;
 	}
 
-	_prepareHighestUnlockedSpellTier(_: NimbleCharacterData): number | null {
-		const classes = Object.values(this.classes ?? {});
-		if (classes.length === 0) return 0;
-		// Check if there are any spellcasting classes - if not, return null
-		const isSpellCaster = this.system.resources.mana.max > 0;
-
-		if (!isSpellCaster) return null;
-		// Only update if value is null e.g not migrated
+	// Derived from the spell grants on the character's class, subclass, and
+	// feature items. A character with no eligible tiered grant — whatever
+	// resource they hold — has no unlocked tier and is not a caster.
+	_prepareHighestUnlockedSpellTier(_: NimbleCharacterData): number {
 		return getHighestSpellTier(this);
 	}
 

--- a/src/documents/actor/character.ts
+++ b/src/documents/actor/character.ts
@@ -273,7 +273,7 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 
 		// Prepare highest unlocked spell tier. A stored number is a manual
 		// override; a stored null means derive. Reading the override from the
-		// source keeps the derivation live — assigning onto the prepared value
+		// source keeps the derivation live. Assigning onto the prepared value
 		// and re-checking it would freeze the first computed number in place.
 		const spellTierOverride = (
 			this.system._source as { resources?: { highestUnlockedSpellTier?: number | null } }
@@ -532,8 +532,8 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 	}
 
 	// Derived from the spell grants on the character's class, subclass, and
-	// feature items. A character with no eligible tiered grant — whatever
-	// resource they hold — has no unlocked tier and is not a caster.
+	// feature items. A character with no eligible tiered grant, whatever
+	// resource they hold, has no unlocked tier and is not a caster.
 	_prepareHighestUnlockedSpellTier(_: NimbleCharacterData): number {
 		return getHighestSpellTier(this);
 	}

--- a/src/documents/actor/prepareHighestUnlockedSpellTier.test.ts
+++ b/src/documents/actor/prepareHighestUnlockedSpellTier.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from 'vitest';
+import { NimbleCharacter } from './character.js';
+
+interface GrantItem {
+	type: string;
+	rules: Map<string, unknown>;
+}
+
+interface ActorStub {
+	system: {
+		_source: { resources: { highestUnlockedSpellTier: number | null } };
+		resources: { highestUnlockedSpellTier: number | null; mana: Record<string, number> };
+		[key: string]: unknown;
+	};
+	items: { contents: GrantItem[] };
+	[key: string]: unknown;
+}
+
+/** A class item with one level-gated spell grant that the rules engine accepts. */
+function makeGrantItem(tier: number): GrantItem {
+	const rule = {
+		type: 'grantSpells',
+		disabled: false,
+		tiers: [tier],
+		predicate: { level: { min: 1 } },
+		appliesTo: () => true,
+	};
+
+	return { type: 'class', rules: new Map([['0', rule]]) };
+}
+
+/**
+ * Only the fields `prepareDerivedData` touches. Sibling derivations that do not
+ * feed the spell tier are stubbed out so the test isolates the override logic.
+ */
+function makeStub(storedTier: number | null, items: GrantItem[]): ActorStub {
+	return {
+		system: {
+			_source: { resources: { highestUnlockedSpellTier: storedTier } },
+			abilities: { strength: { mod: 0 }, dexterity: { mod: 0 } },
+			attributes: {
+				armor: { components: [] },
+				initiative: { defaultRollMode: 0, mod: 0 },
+				wounds: { bonus: 0, max: 0 },
+				hitDice: {},
+			},
+			// Prepared data starts as a copy of the source, so the prepared value
+			// begins equal to the stored one, just as it does on a real actor.
+			resources: { mana: { current: 0, value: 0, max: 0 }, highestUnlockedSpellTier: storedTier },
+			inventory: { bonusSlots: 0, totalSlots: 0, usedSlots: 0 },
+		},
+		items: { contents: items },
+		classes: {},
+		rules: [],
+		tags: new Set<string>(),
+		_prepareEarlyDerivedData: vi.fn(),
+		_populateDerivedTags: vi.fn(),
+		_prepareAbilitySaveAndSkillModifiers: vi.fn(),
+		prepareClassData: vi.fn(),
+		_prepareMaxMana: vi.fn(() => 0),
+		getUsedInventorySlots: vi.fn(() => 0),
+		_prepareHighestUnlockedSpellTier: NimbleCharacter.prototype._prepareHighestUnlockedSpellTier,
+	};
+}
+
+function runPrepareDerivedData(stub: ActorStub): number | null {
+	NimbleCharacter.prototype.prepareDerivedData.call(stub as unknown as NimbleCharacter);
+	return stub.system.resources.highestUnlockedSpellTier;
+}
+
+describe('prepareDerivedData: highest unlocked spell tier', () => {
+	it('uses a stored number as a manual override instead of deriving', () => {
+		const stub = makeStub(4, [makeGrantItem(2)]);
+
+		expect(runPrepareDerivedData(stub)).toBe(4);
+	});
+
+	it('treats a stored zero as an override, not as a request to derive', () => {
+		const stub = makeStub(0, [makeGrantItem(2)]);
+
+		expect(runPrepareDerivedData(stub)).toBe(0);
+	});
+
+	it('derives the tier from spell grants when the stored value is null', () => {
+		const stub = makeStub(null, [makeGrantItem(2)]);
+
+		expect(runPrepareDerivedData(stub)).toBe(2);
+	});
+
+	it('re-derives on a later prepare cycle when the grants have changed', () => {
+		const stub = makeStub(null, [makeGrantItem(2)]);
+		expect(runPrepareDerivedData(stub)).toBe(2);
+
+		// Same system object as the first cycle: a derivation that read its own
+		// prepared value back would keep the 2 here.
+		stub.items.contents = [makeGrantItem(3)];
+		expect(runPrepareDerivedData(stub)).toBe(3);
+
+		stub.items.contents = [];
+		expect(runPrepareDerivedData(stub)).toBe(0);
+	});
+});

--- a/src/models/rules/grantSpells.ts
+++ b/src/models/rules/grantSpells.ts
@@ -18,7 +18,7 @@ function schema() {
 				label: 'NIMBLE.rules.grantSpells.schools.label',
 			},
 		),
-		tiers: new fields.ArrayField(new fields.NumberField({ integer: true, min: 0 }), {
+		tiers: new fields.ArrayField(new fields.NumberField({ integer: true, min: 0, max: 9 }), {
 			required: false,
 			nullable: false,
 			initial: [0],

--- a/src/utils/spell/getHighestSpellTier.packs.test.ts
+++ b/src/utils/spell/getHighestSpellTier.packs.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import type { NimbleCharacter } from '#documents/actor/character.js';
+import { loadAllFeatureDocs } from '../../../tests/fixtures/classProgression.js';
+import { getHighestSpellTier } from './getHighestSpellTier.js';
+
+type RawRule = { type?: string; [key: string]: unknown };
+
+function createActorFromPackFeatures(
+	classIdentifier: string,
+	level: number,
+	{ subclass }: { subclass?: string } = {},
+): NimbleCharacter {
+	const items = loadAllFeatureDocs()
+		.filter((feature) => feature.system.class === classIdentifier)
+		.filter((feature) => {
+			if (!feature.system.subclass) return true;
+			return subclass !== undefined && feature.system.group === subclass;
+		})
+		.map((feature) => ({
+			type: 'feature',
+			rules: new Map(
+				((feature.system.rules ?? []) as RawRule[]).map((rule, index) => [String(index), rule]),
+			),
+		}));
+
+	return {
+		levels: { character: level, classes: {} },
+		items: { contents: items },
+	} as unknown as NimbleCharacter;
+}
+
+// The authored class ladders these assert against are the source of truth the
+// deleted global level table contradicted, including at the first rung: every
+// caster's first tiered grant arrives at level 2 or later, never level 1.
+describe('getHighestSpellTier against authored pack ladders', () => {
+	it.each([
+		[1, 0],
+		[2, 1],
+		[3, 1],
+		[4, 2],
+		[6, 3],
+		[8, 4],
+		[10, 5],
+		[12, 6],
+		[14, 7],
+		[16, 8],
+		[18, 9],
+		[20, 9],
+	])('unlocks tier %2$i for a level %1$i Mage', (level, expectedTier) => {
+		expect(getHighestSpellTier(createActorFromPackFeatures('mage', level))).toBe(expectedTier);
+	});
+
+	it.each([
+		[1, 0],
+		[2, 1],
+		[4, 1],
+		[5, 2],
+		[7, 3],
+		[9, 3],
+		[10, 4],
+		[13, 5],
+		[16, 6],
+		[19, 7],
+		[20, 7],
+	])('unlocks tier %2$i for a level %1$i Shadowmancer', (level, expectedTier) => {
+		expect(getHighestSpellTier(createActorFromPackFeatures('shadowmancer', level))).toBe(
+			expectedTier,
+		);
+	});
+
+	it('derives the same Shadowmancer ladder with a subclass attached', () => {
+		const actor = createActorFromPackFeatures('shadowmancer', 13, {
+			subclass: 'pact-of-the-red-dragon',
+		});
+		expect(getHighestSpellTier(actor)).toBe(5);
+	});
+
+	it('treats a Berserker as having no unlocked tier at any level', () => {
+		for (const level of [1, 5, 10, 15, 20]) {
+			expect(getHighestSpellTier(createActorFromPackFeatures('berserker', level))).toBe(0);
+		}
+	});
+});

--- a/src/utils/spell/getHighestSpellTier.packs.test.ts
+++ b/src/utils/spell/getHighestSpellTier.packs.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { NimbleCharacter } from '#documents/actor/character.js';
 import { loadAllFeatureDocs } from '../../../tests/fixtures/classProgression.js';
+import { Predicate, type RawPredicate } from '../../etc/Predicate.js';
 import { getHighestSpellTier } from './getHighestSpellTier.js';
 
 type RawRule = { type?: string; [key: string]: unknown };
@@ -10,6 +11,7 @@ function createActorFromPackFeatures(
 	level: number,
 	{ subclass }: { subclass?: string } = {},
 ): NimbleCharacter {
+	const domain = new Set([`level:${level}`]);
 	const items = loadAllFeatureDocs()
 		.filter((feature) => feature.system.class === classIdentifier)
 		.filter((feature) => {
@@ -19,7 +21,17 @@ function createActorFromPackFeatures(
 		.map((feature) => ({
 			type: 'feature',
 			rules: new Map(
-				((feature.system.rules ?? []) as RawRule[]).map((rule, index) => [String(index), rule]),
+				((feature.system.rules ?? []) as RawRule[]).map((rule, index) => {
+					// Rule preparation binds `appliesTo` to the authored predicate,
+					// evaluated against the actor's domain. Bind the same thing here so
+					// the pack ladders are read through the real predicate engine.
+					const raw = (rule.predicate ?? {}) as RawPredicate;
+					const prepared = {
+						...rule,
+						appliesTo: () => new Predicate(raw).test(domain),
+					};
+					return [String(index), prepared] as const;
+				}),
 			),
 		}));
 

--- a/src/utils/spell/getHighestSpellTier.packs.test.ts
+++ b/src/utils/spell/getHighestSpellTier.packs.test.ts
@@ -70,6 +70,7 @@ describe('getHighestSpellTier against authored pack ladders', () => {
 		[7, 3],
 		[9, 3],
 		[10, 4],
+		[12, 4],
 		[13, 5],
 		[16, 6],
 		[19, 7],

--- a/src/utils/spell/getHighestSpellTier.test.ts
+++ b/src/utils/spell/getHighestSpellTier.test.ts
@@ -2,35 +2,154 @@ import { describe, expect, it } from 'vitest';
 import type { NimbleCharacter } from '#documents/actor/character.js';
 import { getHighestSpellTier } from './getHighestSpellTier.js';
 
-function createActor(level: number): NimbleCharacter {
+type GrantRuleOptions = {
+	tiers: number[];
+	minLevel?: number;
+	disabled?: boolean;
+	type?: string;
+	predicate?: unknown;
+};
+
+function createGrantRule({
+	tiers,
+	minLevel,
+	disabled = false,
+	type = 'grantSpells',
+	predicate,
+}: GrantRuleOptions) {
+	return {
+		type,
+		tiers,
+		disabled,
+		predicate: predicate ?? (minLevel === undefined ? {} : { level: { min: minLevel } }),
+	};
+}
+
+function createItem(rules: ReturnType<typeof createGrantRule>[], itemType = 'feature') {
+	return {
+		type: itemType,
+		rules: new Map(rules.map((rule, index) => [String(index), rule])),
+	};
+}
+
+function createActor(level: number, items: ReturnType<typeof createItem>[]): NimbleCharacter {
 	return {
 		levels: { character: level, classes: {} },
+		items: { contents: items },
 	} as unknown as NimbleCharacter;
 }
 
+const MAGE_LADDER = [1, 2, 3, 4, 5, 6, 7, 8, 9].map((tier) =>
+	createGrantRule({ tiers: [tier], minLevel: tier * 2 }),
+);
+
+const SHADOWMANCER_LADDER = [
+	createGrantRule({ tiers: [0], minLevel: 2 }),
+	createGrantRule({ tiers: [1], minLevel: 2 }),
+	createGrantRule({ tiers: [2], minLevel: 5 }),
+	createGrantRule({ tiers: [3], minLevel: 7 }),
+	createGrantRule({ tiers: [4], minLevel: 10 }),
+	createGrantRule({ tiers: [5], minLevel: 13 }),
+	createGrantRule({ tiers: [6], minLevel: 16 }),
+	createGrantRule({ tiers: [7], minLevel: 19 }),
+];
+
 describe('getHighestSpellTier', () => {
+	it('returns 0 for a character with no items', () => {
+		expect(getHighestSpellTier(createActor(10, []))).toBe(0);
+	});
+
 	it.each([
-		[0, 0],
-		[1, 1],
+		[1, 0],
+		[2, 1],
 		[3, 1],
 		[4, 2],
-		[5, 2],
-		[6, 3],
-		[7, 3],
-		[8, 4],
-		[9, 4],
 		[10, 5],
-		[11, 5],
-		[12, 6],
-		[13, 6],
-		[14, 7],
-		[15, 7],
-		[16, 8],
-		[17, 8],
 		[18, 9],
 		[20, 9],
-	])('returns tier %i for level %i', (level, expectedTier) => {
-		const actor = createActor(level);
+	])('derives tier %2$i at level %1$i from an evenly spaced ladder', (level, expectedTier) => {
+		const actor = createActor(level, [createItem(MAGE_LADDER)]);
 		expect(getHighestSpellTier(actor)).toBe(expectedTier);
+	});
+
+	it.each([
+		[1, 0],
+		[2, 1],
+		[4, 1],
+		[5, 2],
+		[7, 3],
+		[10, 4],
+		[13, 5],
+		[16, 6],
+		[19, 7],
+		[20, 7],
+	])('derives tier %2$i at level %1$i from an uneven ladder', (level, expectedTier) => {
+		const actor = createActor(level, [createItem(SHADOWMANCER_LADDER)]);
+		expect(getHighestSpellTier(actor)).toBe(expectedTier);
+	});
+
+	it('takes the highest tier across class and subclass grants that disagree', () => {
+		const classFeature = createItem([createGrantRule({ tiers: [2], minLevel: 5 })]);
+		const subclassFeature = createItem([createGrantRule({ tiers: [3], minLevel: 5 })]);
+
+		expect(getHighestSpellTier(createActor(5, [classFeature, subclassFeature]))).toBe(3);
+	});
+
+	it('ignores grants that have no level threshold', () => {
+		const feature = createItem([createGrantRule({ tiers: [3] })]);
+
+		expect(getHighestSpellTier(createActor(20, [feature]))).toBe(0);
+	});
+
+	it('ignores disabled grants', () => {
+		const feature = createItem([createGrantRule({ tiers: [3], minLevel: 2, disabled: true })]);
+
+		expect(getHighestSpellTier(createActor(10, [feature]))).toBe(0);
+	});
+
+	it('ignores rules that are not spell grants', () => {
+		const feature = createItem([createGrantRule({ tiers: [3], minLevel: 2, type: 'grantItem' })]);
+
+		expect(getHighestSpellTier(createActor(10, [feature]))).toBe(0);
+	});
+
+	it('treats a character with only cantrip grants as having no unlocked tier', () => {
+		const feature = createItem([createGrantRule({ tiers: [0], minLevel: 2 })]);
+
+		expect(getHighestSpellTier(createActor(10, [feature]))).toBe(0);
+	});
+
+	it('ignores grants on items that are not class, subclass, or feature items', () => {
+		const wand = createItem([createGrantRule({ tiers: [3], minLevel: 1 })], 'object');
+		const background = createItem([createGrantRule({ tiers: [2], minLevel: 1 })], 'background');
+
+		expect(getHighestSpellTier(createActor(10, [wand, background]))).toBe(0);
+	});
+
+	it('reads grants on class and subclass items themselves', () => {
+		const classItem = createItem([createGrantRule({ tiers: [1], minLevel: 2 })], 'class');
+		const subclassItem = createItem([createGrantRule({ tiers: [2], minLevel: 3 })], 'subclass');
+
+		expect(getHighestSpellTier(createActor(3, [classItem, subclassItem]))).toBe(2);
+	});
+
+	it('uses the highest value in a grant with multiple tiers', () => {
+		const feature = createItem([createGrantRule({ tiers: [0, 1, 2], minLevel: 4 })]);
+
+		expect(getHighestSpellTier(createActor(4, [feature]))).toBe(2);
+	});
+
+	it('reads the raw predicate from a prepared Predicate instance', () => {
+		const feature = createItem([
+			createGrantRule({ tiers: [1], predicate: { _source: { level: { min: 2 } } } }),
+		]);
+
+		expect(getHighestSpellTier(createActor(2, [feature]))).toBe(1);
+	});
+
+	it('skips items with no prepared rules', () => {
+		const bareItem = { type: 'feature' } as unknown as ReturnType<typeof createItem>;
+
+		expect(getHighestSpellTier(createActor(10, [bareItem]))).toBe(0);
 	});
 });

--- a/src/utils/spell/getHighestSpellTier.test.ts
+++ b/src/utils/spell/getHighestSpellTier.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { NimbleCharacter } from '#documents/actor/character.js';
+import { Predicate, type RawPredicate } from '../../etc/Predicate.js';
 import { getHighestSpellTier } from './getHighestSpellTier.js';
 
 type GrantRuleOptions = {
@@ -32,7 +33,29 @@ function createItem(rules: ReturnType<typeof createGrantRule>[], itemType = 'fea
 	};
 }
 
+/**
+ * Binds each rule's `appliesTo` the way rule preparation does: the authored
+ * predicate, evaluated against a domain carrying the character's level tag.
+ * Building it here rather than stubbing a boolean keeps the tests honest about
+ * which predicates the real engine would accept.
+ */
 function createActor(level: number, items: ReturnType<typeof createItem>[]): NimbleCharacter {
+	const domain = new Set([`level:${level}`]);
+
+	for (const item of items) {
+		for (const rule of item.rules?.values() ?? []) {
+			const authored = (rule as { predicate?: unknown }).predicate;
+			// A prepared rule holds a Predicate instance, whose raw data sits on
+			// `_source`; unwrap it so the fixture evaluates what was authored.
+			const raw = (
+				authored && typeof authored === 'object' && '_source' in authored
+					? (authored as { _source: unknown })._source
+					: authored
+			) as RawPredicate;
+			(rule as { appliesTo?: () => boolean }).appliesTo = () => new Predicate(raw).test(domain);
+		}
+	}
+
 	return {
 		levels: { character: level, classes: {} },
 		items: { contents: items },
@@ -145,6 +168,17 @@ describe('getHighestSpellTier', () => {
 		]);
 
 		expect(getHighestSpellTier(createActor(2, [feature]))).toBe(1);
+	});
+
+	it('honours every part of the predicate, not only its minimum level', () => {
+		// The minimum is met but the maximum is not, so the grant does not apply.
+		// A derivation that read `level.min` alone would hand out the tier.
+		const feature = createItem([
+			createGrantRule({ tiers: [3], predicate: { level: { min: 2, max: 4 } } }),
+		]);
+
+		expect(getHighestSpellTier(createActor(10, [feature]))).toBe(0);
+		expect(getHighestSpellTier(createActor(3, [feature]))).toBe(3);
 	});
 
 	it('skips items with no prepared rules', () => {

--- a/src/utils/spell/getHighestSpellTier.test.ts
+++ b/src/utils/spell/getHighestSpellTier.test.ts
@@ -162,6 +162,12 @@ describe('getHighestSpellTier', () => {
 		expect(getHighestSpellTier(createActor(4, [feature]))).toBe(2);
 	});
 
+	it('ignores a tier outside the 0 to 9 range instead of unlocking it', () => {
+		const feature = createItem([createGrantRule({ tiers: [3, 10], minLevel: 4 })]);
+
+		expect(getHighestSpellTier(createActor(4, [feature]))).toBe(3);
+	});
+
 	it('reads the raw predicate from a prepared Predicate instance', () => {
 		const feature = createItem([
 			createGrantRule({ tiers: [1], predicate: { _source: { level: { min: 2 } } } }),

--- a/src/utils/spell/getHighestSpellTier.test.ts
+++ b/src/utils/spell/getHighestSpellTier.test.ts
@@ -187,6 +187,41 @@ describe('getHighestSpellTier', () => {
 		expect(getHighestSpellTier(createActor(3, [feature]))).toBe(3);
 	});
 
+	it('finds a level threshold nested inside an $and branch', () => {
+		const feature = createItem([
+			createGrantRule({
+				tiers: [3],
+				predicate: { $and: [{ level: { min: 5 } }, { level: { max: 10 } }] },
+			}),
+		]);
+
+		expect(getHighestSpellTier(createActor(5, [feature]))).toBe(3);
+		expect(getHighestSpellTier(createActor(4, [feature]))).toBe(0);
+	});
+
+	it('finds a level threshold nested inside an $or branch', () => {
+		const feature = createItem([
+			createGrantRule({
+				tiers: [3],
+				predicate: { $or: ['class:mage', { level: { min: 5 } }] },
+			}),
+		]);
+
+		expect(getHighestSpellTier(createActor(5, [feature]))).toBe(3);
+		expect(getHighestSpellTier(createActor(4, [feature]))).toBe(0);
+	});
+
+	it('finds a level threshold nested two operators deep', () => {
+		const feature = createItem([
+			createGrantRule({
+				tiers: [2],
+				predicate: { $and: ['level:6', { $or: [{ level: { min: 6 } }] }] },
+			}),
+		]);
+
+		expect(getHighestSpellTier(createActor(6, [feature]))).toBe(2);
+	});
+
 	it('skips items with no prepared rules', () => {
 		const bareItem = { type: 'feature' } as unknown as ReturnType<typeof createItem>;
 

--- a/src/utils/spell/getHighestSpellTier.ts
+++ b/src/utils/spell/getHighestSpellTier.ts
@@ -1,20 +1,76 @@
-/** Minimal interface for actors that have character levels */
-interface ActorWithLevels {
-	levels: { character: number };
+/**
+ * Item types whose spell grants can unlock cast tiers. Spells granted by
+ * other item types (wands, scrolls, backgrounds) do not make a character a
+ * caster and do not raise their unlocked tier.
+ */
+const TIER_GRANTING_ITEM_TYPES = new Set(['class', 'subclass', 'feature']);
+
+interface GrantRuleLike {
+	type?: string;
+	disabled?: boolean;
+	tiers?: unknown;
+	predicate?: unknown;
+}
+
+interface RuleBackedItemLike {
+	type?: string;
+	rules?: Map<string, GrantRuleLike>;
+}
+
+interface SpellTierActorLike {
+	levels?: { character?: number };
+	items?: { contents?: RuleBackedItemLike[] };
 }
 
 /**
- * Calculate the highest spell tier a character can access based on their level.
- * @param actor - An actor with character level information
- * @returns The highest spell tier (1-9) the character can access, or 0 if below level 1
+ * A prepared rule holds a Predicate instance whose raw data sits on
+ * `_source`; raw pack data and test fixtures hold the plain object directly.
  */
-export function getHighestSpellTier(actor: ActorWithLevels): number {
-	const level = actor.levels.character;
-	const tiers = [1, 4, 6, 8, 10, 12, 14, 16, 18];
+function getRuleMinLevel(rule: GrantRuleLike): number | null {
+	const predicate = rule.predicate;
+	if (!predicate || typeof predicate !== 'object') return null;
 
-	for (let index = tiers.length - 1; index >= 0; index -= 1) {
-		if (level >= tiers[index]) return index + 1;
+	const source =
+		'_source' in predicate && predicate._source && typeof predicate._source === 'object'
+			? predicate._source
+			: predicate;
+
+	const level = (source as { level?: { min?: unknown } }).level;
+	const min = level?.min;
+	return typeof min === 'number' ? min : null;
+}
+
+/**
+ * Derives the highest spell tier a character has unlocked from the spell
+ * grants authored on their class, subclass, and feature items: the highest
+ * granted tier whose level threshold the character has reached.
+ *
+ * Grants without a level threshold are ignored — they attach spells to a
+ * character without anchoring a tier unlock to a level.
+ *
+ * @returns The highest unlocked tier (1-9), or 0 for a character with no
+ *          eligible tiered spell grants.
+ */
+export function getHighestSpellTier(actor: SpellTierActorLike): number {
+	const characterLevel = actor.levels?.character ?? 0;
+	let highestTier = 0;
+
+	for (const item of actor.items?.contents ?? []) {
+		if (!item.type || !TIER_GRANTING_ITEM_TYPES.has(item.type)) continue;
+		if (!item.rules) continue;
+
+		for (const rule of item.rules.values()) {
+			if (rule.type !== 'grantSpells' || rule.disabled) continue;
+
+			const minLevel = getRuleMinLevel(rule);
+			if (minLevel === null || characterLevel < minLevel) continue;
+
+			const tiers = Array.isArray(rule.tiers) ? rule.tiers : [];
+			for (const tier of tiers) {
+				if (typeof tier === 'number' && tier > highestTier) highestTier = tier;
+			}
+		}
 	}
 
-	return 0;
+	return highestTier;
 }

--- a/src/utils/spell/getHighestSpellTier.ts
+++ b/src/utils/spell/getHighestSpellTier.ts
@@ -10,6 +10,8 @@ interface GrantRuleLike {
 	disabled?: boolean;
 	tiers?: unknown;
 	predicate?: unknown;
+	/** Optional because plain objects satisfy this structural type in tests. */
+	appliesTo?: () => boolean;
 }
 
 interface RuleBackedItemLike {
@@ -18,17 +20,22 @@ interface RuleBackedItemLike {
 }
 
 interface SpellTierActorLike {
-	levels?: { character?: number };
 	items?: { contents?: RuleBackedItemLike[] };
 }
 
 /**
- * A prepared rule holds a Predicate instance whose raw data sits on
- * `_source`; raw pack data and test fixtures hold the plain object directly.
+ * Whether the grant anchors its tiers to a character level.
+ *
+ * This asks only whether a threshold was authored, never whether it is met:
+ * the rules engine decides that. A grant with no threshold cannot be placed on
+ * the tier ladder at all, so it is skipped rather than read as level zero.
+ *
+ * A prepared rule holds a Predicate instance whose raw data sits on `_source`;
+ * raw pack data and test fixtures hold the plain object directly.
  */
-function getRuleMinLevel(rule: GrantRuleLike): number | null {
+function hasLevelThreshold(rule: GrantRuleLike): boolean {
 	const predicate = rule.predicate;
-	if (!predicate || typeof predicate !== 'object') return null;
+	if (!predicate || typeof predicate !== 'object') return false;
 
 	const source =
 		'_source' in predicate && predicate._source && typeof predicate._source === 'object'
@@ -36,8 +43,7 @@ function getRuleMinLevel(rule: GrantRuleLike): number | null {
 			: predicate;
 
 	const level = (source as { level?: { min?: unknown } }).level;
-	const min = level?.min;
-	return typeof min === 'number' ? min : null;
+	return typeof level?.min === 'number';
 }
 
 /**
@@ -45,14 +51,17 @@ function getRuleMinLevel(rule: GrantRuleLike): number | null {
  * grants authored on their class, subclass, and feature items: the highest
  * granted tier whose level threshold the character has reached.
  *
- * Grants without a level threshold are ignored — they attach spells to a
+ * Grants without a level threshold are ignored: they attach spells to a
  * character without anchoring a tier unlock to a level.
+ *
+ * Whether a threshold is met is decided by the rule's own predicate, through
+ * the rules engine, so a grant gated on more than a level is honoured in full
+ * rather than in part.
  *
  * @returns The highest unlocked tier (1-9), or 0 for a character with no
  *          eligible tiered spell grants.
  */
 export function getHighestSpellTier(actor: SpellTierActorLike): number {
-	const characterLevel = actor.levels?.character ?? 0;
 	let highestTier = 0;
 
 	for (const item of actor.items?.contents ?? []) {
@@ -62,8 +71,8 @@ export function getHighestSpellTier(actor: SpellTierActorLike): number {
 		for (const rule of item.rules.values()) {
 			if (rule.type !== 'grantSpells' || rule.disabled) continue;
 
-			const minLevel = getRuleMinLevel(rule);
-			if (minLevel === null || characterLevel < minLevel) continue;
+			if (!hasLevelThreshold(rule)) continue;
+			if (rule.appliesTo && !rule.appliesTo()) continue;
 
 			const tiers = Array.isArray(rule.tiers) ? rule.tiers : [];
 			for (const tier of tiers) {

--- a/src/utils/spell/getHighestSpellTier.ts
+++ b/src/utils/spell/getHighestSpellTier.ts
@@ -76,7 +76,9 @@ export function getHighestSpellTier(actor: SpellTierActorLike): number {
 
 			const tiers = Array.isArray(rule.tiers) ? rule.tiers : [];
 			for (const tier of tiers) {
-				if (typeof tier === 'number' && tier > highestTier) highestTier = tier;
+				// Spell tiers run 0 to 9; anything else is bad authoring, not a tier.
+				if (!Number.isInteger(tier) || tier < 0 || tier > 9) continue;
+				if (tier > highestTier) highestTier = tier;
 			}
 		}
 	}

--- a/src/utils/spell/getHighestSpellTier.ts
+++ b/src/utils/spell/getHighestSpellTier.ts
@@ -1,3 +1,6 @@
+import { Predicate } from '../../etc/Predicate.js';
+import { isPlainObject } from '../isPlainObject.js';
+
 /**
  * Item types whose spell grants can unlock cast tiers. Spells granted by
  * other item types (wands, scrolls, backgrounds) do not make a character a
@@ -30,6 +33,10 @@ interface SpellTierActorLike {
  * the rules engine decides that. A grant with no threshold cannot be placed on
  * the tier ladder at all, so it is skipped rather than read as level zero.
  *
+ * The threshold may sit at the top level or inside any `$and` / `$or` branch,
+ * the only logical operators the predicate schema defines. Whether the branch
+ * that holds it is the one that applies is again left to the rules engine.
+ *
  * A prepared rule holds a Predicate instance whose raw data sits on `_source`;
  * raw pack data and test fixtures hold the plain object directly.
  */
@@ -42,8 +49,19 @@ function hasLevelThreshold(rule: GrantRuleLike): boolean {
 			? predicate._source
 			: predicate;
 
-	const level = (source as { level?: { min?: unknown } }).level;
-	return typeof level?.min === 'number';
+	return containsLevelMin(source);
+}
+
+function containsLevelMin(raw: object): boolean {
+	const level = (raw as { level?: { min?: unknown } }).level;
+	if (typeof level?.min === 'number') return true;
+
+	for (const [key, value] of Object.entries(raw)) {
+		if (!Predicate.isLogicalKey(key) || !Array.isArray(value)) continue;
+		if (value.some((item) => isPlainObject(item) && containsLevelMin(item))) return true;
+	}
+
+	return false;
 }
 
 /**

--- a/src/view/dialogs/SpellScrollDialog.state.svelte.test.ts
+++ b/src/view/dialogs/SpellScrollDialog.state.svelte.test.ts
@@ -22,6 +22,7 @@ interface Snapshot {
 	submitIcon: string;
 	manaCostLabel: string;
 	upcastLabel: string;
+	showTierWarning: boolean;
 	arcanaLabel: string;
 }
 
@@ -372,6 +373,38 @@ describe('createSpellScrollDialogState', () => {
 				.upcastLabel;
 
 			expect(label).not.toContain('5');
+		});
+
+		it('warns when the scroll is above the tier the actor has unlocked', async () => {
+			const { showTierWarning } = setup({
+				mode: 'chooser',
+				tier: 3,
+				highestUnlockedSpellTier: 1,
+			}).read();
+
+			expect(showTierWarning).toBe(true);
+		});
+
+		it('warns an actor with no spellcasting about any tiered scroll', async () => {
+			const { showTierWarning } = setup({ mode: 'chooser', tier: 1 }).read();
+
+			expect(showTierWarning).toBe(true);
+		});
+
+		it('does not warn when the actor has unlocked the tier', async () => {
+			const { showTierWarning } = setup({
+				mode: 'chooser',
+				tier: 3,
+				highestUnlockedSpellTier: 3,
+			}).read();
+
+			expect(showTierWarning).toBe(false);
+		});
+
+		it('never warns about a cantrip', async () => {
+			const { showTierWarning } = setup({ mode: 'chooser', tier: 0 }).read();
+
+			expect(showTierWarning).toBe(false);
 		});
 
 		it('asks for an Arcana check when the actor knows nothing of the school', async () => {

--- a/src/view/dialogs/SpellScrollDialog.state.svelte.ts
+++ b/src/view/dialogs/SpellScrollDialog.state.svelte.ts
@@ -80,6 +80,13 @@ export function createSpellScrollDialogState(getProps: () => SpellScrollDialogPr
 			: localize('NIMBLE.spellScroll.dialog.upcastNone');
 	});
 
+	// The scroll's spell is castable only up to the tier the actor has unlocked;
+	// an actor with no spellcasting has unlocked nothing, so this covers them too.
+	const showTierWarning = $derived.by(() => {
+		const { tier = 0, highestUnlockedSpellTier = 0 } = getProps();
+		return tier > 0 && tier > highestUnlockedSpellTier;
+	});
+
 	const arcanaLabel = $derived.by(() => {
 		const { school = '', knowsSchool = false, actorName } = getProps();
 		return knowsSchool
@@ -142,6 +149,9 @@ export function createSpellScrollDialogState(getProps: () => SpellScrollDialogPr
 		},
 		get upcastLabel() {
 			return upcastLabel;
+		},
+		get showTierWarning() {
+			return showTierWarning;
 		},
 		get arcanaLabel() {
 			return arcanaLabel;

--- a/src/view/dialogs/SpellScrollDialog.svelte
+++ b/src/view/dialogs/SpellScrollDialog.svelte
@@ -18,7 +18,7 @@
 		school = '',
 		activationSummary = '',
 		scrollPrice = 0,
-		hasMana = false,
+		isSpellcaster = false,
 		candidates = [],
 		tierLabel = '',
 	} = $derived(props);
@@ -48,11 +48,11 @@
 				<dd>{state.upcastLabel}</dd>
 			</dl>
 
-			{#if !hasMana && tier > 0}
+			{#if !isSpellcaster && tier > 0}
 				<Hint
 					hintType="warning"
 					hintIcon="fa-solid fa-circle-exclamation"
-					hintText={localize('NIMBLE.spellScroll.dialog.noManaWarning', { name: actorName })}
+					hintText={localize('NIMBLE.spellScroll.dialog.notACasterWarning', { name: actorName })}
 				/>
 			{/if}
 		</SpellScrollChoiceCard>

--- a/src/view/dialogs/SpellScrollDialog.svelte
+++ b/src/view/dialogs/SpellScrollDialog.svelte
@@ -50,7 +50,7 @@
 				<Hint
 					hintType="warning"
 					hintIcon="fa-solid fa-circle-exclamation"
-					hintText={localize('NIMBLE.spellScroll.dialog.notACasterWarning', { name: actorName })}
+					hintText={localize('NIMBLE.spellScroll.dialog.tierLockedWarning', { name: actorName })}
 				/>
 			{/if}
 		</SpellScrollChoiceCard>

--- a/src/view/dialogs/SpellScrollDialog.svelte
+++ b/src/view/dialogs/SpellScrollDialog.svelte
@@ -14,11 +14,9 @@
 	let {
 		mode,
 		actorName,
-		tier = 0,
 		school = '',
 		activationSummary = '',
 		scrollPrice = 0,
-		isSpellcaster = false,
 		candidates = [],
 		tierLabel = '',
 	} = $derived(props);
@@ -48,7 +46,7 @@
 				<dd>{state.upcastLabel}</dd>
 			</dl>
 
-			{#if !isSpellcaster && tier > 0}
+			{#if state.showTierWarning}
 				<Hint
 					hintType="warning"
 					hintIcon="fa-solid fa-circle-exclamation"

--- a/src/view/dialogs/openSpellScrollDialog.ts
+++ b/src/view/dialogs/openSpellScrollDialog.ts
@@ -22,7 +22,6 @@ export interface ScrollDialogActor {
 	items: Iterable<{ type: string; system?: unknown }>;
 	system?: {
 		resources?: {
-			mana?: { max?: number };
 			highestUnlockedSpellTier?: number;
 		};
 	};
@@ -61,8 +60,14 @@ function highestUnlockedSpellTier(actor: ScrollDialogActor): number {
 	return actor.system?.resources?.highestUnlockedSpellTier ?? 0;
 }
 
-function hasMana(actor: ScrollDialogActor): boolean {
-	return (actor.system?.resources?.mana?.max ?? 0) > 0;
+/**
+ * Whether the actor can cast tiered spells at all. Holding mana is not the
+ * test: a class may pay for its spells from a pool instead, and would hold
+ * none. An unlocked tier above zero means a class or subclass granted them
+ * tiered spells, which is what makes a spell on the list castable.
+ */
+function isSpellcaster(actor: ScrollDialogActor): boolean {
+	return highestUnlockedSpellTier(actor) > 0;
 }
 
 /**
@@ -126,7 +131,7 @@ export default async function openSpellScrollDialog(
 						SPELL_SCROLL_PRICE_BY_TIER[options.spell.system?.tier ?? 0] ??
 						SPELL_SCROLL_PRICE_BY_TIER[0],
 					highestUnlockedSpellTier: highestUnlockedSpellTier(options.actor),
-					hasMana: hasMana(options.actor),
+					isSpellcaster: isSpellcaster(options.actor),
 					knowsSchool: knowsSpellSchool(options.actor, options.spell.system?.school ?? ''),
 				}
 			: {

--- a/src/view/dialogs/openSpellScrollDialog.ts
+++ b/src/view/dialogs/openSpellScrollDialog.ts
@@ -61,16 +61,6 @@ function highestUnlockedSpellTier(actor: ScrollDialogActor): number {
 }
 
 /**
- * Whether the actor can cast tiered spells at all. Holding mana is not the
- * test: a class may pay for its spells from a pool instead, and would hold
- * none. An unlocked tier above zero means a class or subclass granted them
- * tiered spells, which is what makes a spell on the list castable.
- */
-function isSpellcaster(actor: ScrollDialogActor): boolean {
-	return highestUnlockedSpellTier(actor) > 0;
-}
-
-/**
  * The spells of `tier` that may be inscribed, built from the pack indexes alone.
  *
  * A collapsed row needs the name, image, school and action cost, all of which the
@@ -131,7 +121,6 @@ export default async function openSpellScrollDialog(
 						SPELL_SCROLL_PRICE_BY_TIER[options.spell.system?.tier ?? 0] ??
 						SPELL_SCROLL_PRICE_BY_TIER[0],
 					highestUnlockedSpellTier: highestUnlockedSpellTier(options.actor),
-					isSpellcaster: isSpellcaster(options.actor),
 					knowsSchool: knowsSpellSchool(options.actor, options.spell.system?.school ?? ''),
 				}
 			: {

--- a/src/view/sheets/pages/PlayerCharacterSettingsTab.svelte
+++ b/src/view/sheets/pages/PlayerCharacterSettingsTab.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { getContext } from 'svelte';
 	import { SYSTEM_ID } from '#system';
-	import { getHighestSpellTier } from '#utils/spell/getHighestSpellTier.ts';
 	import localize from '#utils/localize.ts';
 	import CharacterJsonExportButton from '#view/sheets/components/CharacterJsonExportButton.svelte';
 	import CharacterPdfExportButton from '#view/sheets/character/pdfExport/CharacterPdfExportButton.svelte';
@@ -14,7 +13,11 @@
 		() => actor,
 		() => $editingEnabledStore ?? true,
 	);
-	const { updateBonusInventorySlots, updateHighestUnlockedSpellTier } = state;
+	const {
+		updateBonusInventorySlots,
+		updateHighestUnlockedSpellTier,
+		resetHighestUnlockedSpellTier,
+	} = state;
 </script>
 
 <section class="nimble-sheet__body nimble-sheet__body--player-character">
@@ -229,7 +232,7 @@
 				type="button"
 				disabled={!state.editingEnabled}
 				aria-label="Reset Highest Unlocked Spell Tier"
-				onclick={() => updateHighestUnlockedSpellTier(getHighestSpellTier(actor))}
+				onclick={() => resetHighestUnlockedSpellTier()}
 			>
 				Reset spell tier
 			</button>

--- a/src/view/sheets/pages/PlayerCharacterSettingsTabState.svelte.test.ts
+++ b/src/view/sheets/pages/PlayerCharacterSettingsTabState.svelte.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest';
+import { SYSTEM_ID } from '#system';
+import { createPlayerCharacterSettingsTabState } from './PlayerCharacterSettingsTabState.svelte.js';
+
+function createActor() {
+	return {
+		update: vi.fn().mockResolvedValue(undefined),
+		reactive: {
+			flags: { [SYSTEM_ID]: {} },
+			system: { inventory: { bonusSlots: 0 }, resources: { highestUnlockedSpellTier: 3 } },
+		},
+	};
+}
+
+describe('createPlayerCharacterSettingsTabState', () => {
+	describe('resetHighestUnlockedSpellTier', () => {
+		it('stores null so the tier is derived from spell grants again', async () => {
+			const actor = createActor();
+			const state = createPlayerCharacterSettingsTabState(
+				() => actor,
+				() => true,
+			);
+
+			await state.resetHighestUnlockedSpellTier();
+
+			expect(actor.update).toHaveBeenCalledTimes(1);
+			expect(actor.update).toHaveBeenCalledWith({
+				'system.resources.highestUnlockedSpellTier': null,
+			});
+		});
+	});
+});

--- a/src/view/sheets/pages/PlayerCharacterSettingsTabState.svelte.ts
+++ b/src/view/sheets/pages/PlayerCharacterSettingsTabState.svelte.ts
@@ -33,6 +33,12 @@ export function createPlayerCharacterSettingsTabState(
 		await getActor().update({ 'system.resources.highestUnlockedSpellTier': newValue });
 	}
 
+	// A stored null means "derive from spell grants", so resetting clears the
+	// override instead of persisting the currently computed number.
+	async function resetHighestUnlockedSpellTier() {
+		await getActor().update({ 'system.resources.highestUnlockedSpellTier': null });
+	}
+
 	return {
 		get editingEnabled() {
 			return editingEnabled;
@@ -72,5 +78,6 @@ export function createPlayerCharacterSettingsTabState(
 		},
 		updateBonusInventorySlots,
 		updateHighestUnlockedSpellTier,
+		resetHighestUnlockedSpellTier,
 	};
 }

--- a/tests/harnesses/SpellScrollDialogStateHarness.svelte
+++ b/tests/harnesses/SpellScrollDialogStateHarness.svelte
@@ -33,6 +33,7 @@
 			submitIcon: state.submitIcon,
 			manaCostLabel: state.manaCostLabel,
 			upcastLabel: state.upcastLabel,
+			showTierWarning: state.showTierWarning,
 			arcanaLabel: state.arcanaLabel,
 		}),
 	);

--- a/types/components/SpellScrollDialog.d.ts
+++ b/types/components/SpellScrollDialog.d.ts
@@ -51,7 +51,7 @@ export interface SpellScrollDialogProps {
 	scrollPrice?: number;
 	/** 0 when the actor has no spellcasting. */
 	highestUnlockedSpellTier?: number;
-	hasMana?: boolean;
+	isSpellcaster?: boolean;
 	knowsSchool?: boolean;
 	/** Picker mode: the spells of the blank's tier that may be inscribed. */
 	candidates?: SpellScrollCandidate[];

--- a/types/components/SpellScrollDialog.d.ts
+++ b/types/components/SpellScrollDialog.d.ts
@@ -51,7 +51,6 @@ export interface SpellScrollDialogProps {
 	scrollPrice?: number;
 	/** 0 when the actor has no spellcasting. */
 	highestUnlockedSpellTier?: number;
-	isSpellcaster?: boolean;
 	knowsSchool?: boolean;
 	/** Picker mode: the spells of the blank's tier that may be inscribed. */
 	candidates?: SpellScrollCandidate[];


### PR DESCRIPTION
## Summary

One global level table decided which spell tiers every character had
unlocked, and it disagreed with every class in the system, including at the first
rung. It granted tier 1 at level 1 where every class grants it at level 2 or 3.
The table is deleted and the tier now comes from each class's own authored grants.

**This changes which tiers an existing character can reach at some levels.** Please
check a caster of a class you know before approving.

## Changes

- Delete the global spell tier table. The unlocked tier is the highest tier granted
  by a class or subclass feature whose level threshold the character has reached.
- A grant with no level threshold is skipped rather than read as level zero. Two
  features in the packs are affected.
- Whether a threshold is met is decided by the rule's own predicate through the
  rules engine, so a grant gated on more than a level is honoured in full.
- Spellcaster status no longer means holding mana. The spell scroll dialog used to
  warn that a character "has no mana, so this spell would sit on the list
  uncastable", which is wrong for a class that pays another way.
- The manual tier override on the sheet used to freeze at the first computed value.
  Clearing it now returns to derivation.

## Test Plan

1. Open a Mage at level 4, 6, 8 and 10. The unlocked tier should follow the class's
   printed ladder, not the old table.
2. Do the same for a Shadowmancer and a Stormshifter. Subclass grants should count.
3. On a character sheet, set the unlocked tier by hand in Settings. It should hold.
   Clear it. It should go back to deriving.
4. Drop a spell scroll on a caster. No "no mana" warning.
5. Drop a spell scroll on a Berserker. It should still warn, because they cannot
   cast tiered spells.

## Known limits, recorded rather than hidden

- Commander Spellblade unlocks tiers on a schedule independent of what it is granted,
  so derivation is wrong for it. Spellblade spellcasting is not implemented today, so
  this is not a regression, but it is not solved either.
- The Shadowmancer pack grants tier 3 at level 7. Issue #640's table says level 8.
  Both come from the same damaged text extract. Someone with the printed book should
  settle it. It is a one line content fix either way.

## Checklist

- [x] Added or updated unit tests
- [ ] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [x] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** yes
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues

References #640. Does not close it, since Pilfered Power needs the rest of the stack.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Players and GMs now receive spell tiers from authored spell grants on class, subclass, and feature items. A numeric Highest Unlocked Spell Tier override remains active. A null override resumes automatic derivation. Scrolls now warn when their tier exceeds the character’s unlocked tier, including for casters without mana. Non-casters also receive the warning.

Homebrewers can define spell-tier progression with Grant Spells rules and level thresholds. Mana formulas now create mana pools without making a character a caster. Documentation explains spell grants, tier overrides, reset behavior, and scroll warnings.

Engine changes:
- `getHighestSpellTier` evaluates enabled, applicable grant rules through the predicate engine.
- Thresholdless, invalid, out-of-range, and non-integer tier grants are ignored.
- Nested `$and` and `$or` predicates support level-threshold checks.
- Highest tier selection is limited to integer tiers from 0 through 9.
- Spellcaster status no longer depends on mana ownership.
- Resetting the tier stores `null` and enables re-derivation during later preparation cycles.
- Scroll warning state uses `showTierWarning` and the `tierLockedWarning` localization key.
- Added unit, integration, actor preparation, settings, and scroll warning tests.
- No migrations were added or renumbered.
- No compendium pack content changed. Tests use authored feature-pack grants.
- No new settings were added or changed.
- No new rule types were added. Existing Grant Spells rules now unlock tiers from authored thresholds.
- The `noManaWarning` key was replaced by the `tierLockedWarning` key in `public/lang/en.json`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->