### PR TITLE
fix(ui): make checkboxes square, legible in dark mode, and centred

### DIFF
--- a/src/scss/base/_theme.scss
+++ b/src/scss/base/_theme.scss
@@ -7,6 +7,12 @@
 	--nimble-combat-tracker-mystery-man-filter: none;
 
 	/** INPUT FIELDS **/
+	// Light mode fills a checked box with a dark colour and draws a pale
+	// checkmark on it. Dark mode is the inversion, so the fill has to be the pale
+	// one: the shared default is a bar background that goes near-black here,
+	// leaving a checked box indistinguishable from the card behind it.
+	--nimble-checkbox-checked-color: var(--nimble-dark-text-color);
+	--nimble-checkbox-checkmark-color: var(--nimble-light-text-color);
 	--nimble-input-background-color: hsla(0, 0%, 0%, 0.3);
 	--nimble-input-border-color: hsl(293, 10%, 40%);
 	--nimble-select-option-background-color: color-mix(in srgb, var(--nimble-input-background-color) 10%, #000);

--- a/src/scss/vendor/foundry/_input.scss
+++ b/src/scss/vendor/foundry/_input.scss
@@ -19,6 +19,15 @@
   input[type="checkbox"] {
     --checkbox-checked-color: var(--nimble-checkbox-checked-color);
 
+    // Foundry declares width and height on these pseudo-elements but never sets
+    // display, so they stay inline and the dimensions are ignored: the control
+    // renders as the square glyph's advance width by its line box (19.5x22
+    // rather than 22x22), leaving dead space to the right and below it.
+    &::before,
+    &::after {
+      display: block;
+    }
+
     &:checked::before {
       --checkbox-checkmark-color: var(--nimble-checkbox-checkmark-color);
     }

--- a/src/scss/vendor/foundry/_input.scss
+++ b/src/scss/vendor/foundry/_input.scss
@@ -23,9 +23,14 @@
     // display, so they stay inline and the dimensions are ignored: the control
     // renders as the square glyph's advance width by its line box (19.5x22
     // rather than 22x22), leaving dead space to the right and below it.
+    //
+    // Sizing the boxes then leaves the glyph itself off centre: Foundry sizes
+    // them to --checkbox-size, but the Font Awesome square only advances
+    // 0.875em, so at the default alignment it hugs the left edge of its box.
     &::before,
     &::after {
       display: block;
+      text-align: center;
     }
 
     &:checked::before {


### PR DESCRIPTION
Three defects, all visible on every checkbox in the system.

### 1. The control was not square

Foundry declares `width` and `height` on `input[type="checkbox"]::before` and `::after` but never sets `display`, so the pseudo-elements stay inline and those dimensions are ignored. The control rendered as the square glyph's advance width by its line box (19.5x22 rather than 22x22), leaving dead space to the right of and below the glyph. Blockifying the pseudo-elements lets Foundry's own dimensions apply.

### 2. A checked box was invisible in dark mode

The checked fill came from `--nimble-hp-bar-background`, which is near-black under `.theme-dark`, so a checked box was indistinguishable from the card behind it. Dark mode now inverts light mode's pairing: a pale fill with a dark checkmark. Both tokens are re-declared inside `.theme-dark` because the `:root` definitions resolve `var(--nimble-light-text-color)` against `:root`, which is not themed, so they would otherwise keep the light palette's values.

### 3. The glyph sat off centre inside its own outline

Fixing (1) gave the pseudo-elements Foundry's declared `--checkbox-size` of 20px, which exposed a further problem: the Font Awesome square glyph only advances 0.875em (FA's 448/512 viewBox), so at the default text alignment it painted hard against the left edge of its box. Measured on the 22x22 control, the 17.5px glyph sat 1.0px from the left border and 3.5px from the right, reading as a checkbox floating off centre inside its outline. Centring the glyph balances it at 2.25px on both sides.

## Verification

Measured in headless Chromium against the real Foundry stylesheet, Font Awesome webfonts, and the built `nimble.css`, by detecting the border box and the glyph ink bounds in a 4x screenshot:

| | glyph | inset L | inset R | imbalance |
|---|---|---|---|---|
| before | 17.5x17.5 | 1.00px | 3.50px | 2.50px |
| after | 17.5x17.5 | 2.25px | 2.25px | **0.00px** |

Checked, unchecked, indeterminate, and disabled states were each rendered in both `.theme-dark` and `.theme-light` and confirmed centred.

One residual note, left unfixed deliberately: the glyph sits ~0.5px high (1.75px top vs 2.75px bottom). That offset comes from the font's own baseline metrics within the line box rather than from alignment, so correcting it would mean hard-coding a `line-height` nudge tuned to Font Awesome's specific metrics. It is sub-pixel and not visible at normal zoom.