### PR TITLE
fix(shepherd): grant 2 Sacred Graces at level 5

### DIFF
--- a/packs/classFeatures/core/shepherd/shepherd-progression/sacred-graces.json
+++ b/packs/classFeatures/core/shepherd/shepherd-progression/sacred-graces.json
@@ -46,10 +46,21 @@
 		"selectionCountByLevel": {},
 		"levelUpOptions": [
 			{
+				"id": "sacred-grace-initial",
+				"label": "Choose 2 Sacred Graces",
+				"applyAtLevels": [
+					5
+				],
+				"rules": [],
+				"selectionGroups": [
+					"sacred-grace"
+				],
+				"selectionCount": 2
+			},
+			{
 				"id": "sacred-grace",
 				"label": "Choose a Sacred Grace",
 				"applyAtLevels": [
-					5,
 					9,
 					13
 				],

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -605,6 +605,14 @@
 			"confirmLevelDown": "Confirm Level Down",
 			"levelUpInProgress": "Cannot revert level while a level up is in progress."
 		},
+		"levelCorrectionDialog": {
+			"title": "Level Correction",
+			"hint": "This character is missing choices from an earlier level. Make them here to bring the sheet up to date.",
+			"gapHeading": "Level {level}",
+			"nothingMissing": "This character is not missing any level choices.",
+			"sheetWarning": "Missing level choices",
+			"sheetWarningTooltip": "Missing choices from level {level}. Click to correct."
+		},
 		"skillPointAssignment": {
 			"decrementSkillPoints": "Decrement Skill Points",
 			"incrementSkillPoints": "Increment Skill Points",

--- a/src/documents/actor/applyLevelCorrection.test.ts
+++ b/src/documents/actor/applyLevelCorrection.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { NimbleCharacter } from './character.js';
+
+interface HistoryEntry {
+	level: number;
+	grantedFeatureIds: string[];
+}
+
+function makeCharacter(levelUpHistory: HistoryEntry[]) {
+	return {
+		system: { levelUpHistory },
+		createEmbeddedDocuments: vi.fn(async (_type: string, sources: Array<{ name: string }>) =>
+			sources.map((source, position) => ({ id: `granted-${position}`, name: source.name })),
+		),
+		update: vi.fn(async () => undefined),
+		sheet: { render: vi.fn() },
+	};
+}
+
+function stubFromUuid(namesByUuid: Record<string, string>) {
+	const g = globalThis as unknown as { fromUuid?: (uuid: string) => Promise<unknown> };
+	const original = g.fromUuid;
+
+	g.fromUuid = async (uuid: string) => {
+		const name = namesByUuid[uuid];
+		if (!name) return null;
+		return { toObject: () => ({ name, _stats: {} }) };
+	};
+
+	return () => {
+		g.fromUuid = original;
+	};
+}
+
+function applyCorrection(
+	character: ReturnType<typeof makeCharacter>,
+	selections: Array<{ level: number; uuids: string[] }>,
+) {
+	return NimbleCharacter.prototype.applyLevelCorrection.call(
+		character as unknown as NimbleCharacter,
+		selections,
+	);
+}
+
+describe('applyLevelCorrection', () => {
+	let restoreFromUuid: (() => void) | null = null;
+
+	afterEach(() => {
+		restoreFromUuid?.();
+		restoreFromUuid = null;
+	});
+
+	it('records each grant on the history entry for the level that owed it', async () => {
+		restoreFromUuid = stubFromUuid({
+			'Item.light-bearer': 'Light Bearer',
+			'Item.thicker-fur': 'Thicker Fur',
+		});
+		const character = makeCharacter([
+			{ level: 5, grantedFeatureIds: ['existing-5'] },
+			{ level: 9, grantedFeatureIds: [] },
+		]);
+
+		await applyCorrection(character, [
+			{ level: 5, uuids: ['Item.light-bearer'] },
+			{ level: 9, uuids: ['Item.thicker-fur'] },
+		]);
+
+		expect(character.update).toHaveBeenCalledWith({
+			'system.levelUpHistory': [
+				{ level: 5, grantedFeatureIds: ['existing-5', 'granted-0'] },
+				{ level: 9, grantedFeatureIds: ['granted-1'] },
+			],
+		});
+	});
+
+	it('stamps the compendium source on every granted feature', async () => {
+		restoreFromUuid = stubFromUuid({ 'Item.light-bearer': 'Light Bearer' });
+		const character = makeCharacter([{ level: 5, grantedFeatureIds: [] }]);
+
+		await applyCorrection(character, [{ level: 5, uuids: ['Item.light-bearer'] }]);
+
+		expect(character.createEmbeddedDocuments).toHaveBeenCalledWith('Item', [
+			{ name: 'Light Bearer', _stats: { compendiumSource: 'Item.light-bearer' } },
+		]);
+	});
+
+	it('leaves the actor untouched when nothing was picked', async () => {
+		restoreFromUuid = stubFromUuid({});
+		const character = makeCharacter([{ level: 5, grantedFeatureIds: [] }]);
+
+		await applyCorrection(character, [{ level: 5, uuids: [] }]);
+
+		expect(character.createEmbeddedDocuments).not.toHaveBeenCalled();
+		expect(character.update).not.toHaveBeenCalled();
+	});
+
+	/**
+	 * Level 1 predates the first history entry, so there is nothing to record against. The
+	 * feature is still granted — a level-down can never reach level 1 to need it reverted.
+	 */
+	it('grants a level-1 correction without a history entry to record it on', async () => {
+		restoreFromUuid = stubFromUuid({ 'Item.light-bearer': 'Light Bearer' });
+		const character = makeCharacter([{ level: 2, grantedFeatureIds: ['existing-2'] }]);
+
+		await applyCorrection(character, [{ level: 1, uuids: ['Item.light-bearer'] }]);
+
+		expect(character.createEmbeddedDocuments).toHaveBeenCalledOnce();
+		expect(character.update).toHaveBeenCalledWith({
+			'system.levelUpHistory': [{ level: 2, grantedFeatureIds: ['existing-2'] }],
+		});
+	});
+});

--- a/src/documents/actor/character.ts
+++ b/src/documents/actor/character.ts
@@ -6,7 +6,16 @@ import type { NimbleClassItem } from '#documents/item/class.js';
 import type { NimbleFeatureItem } from '#documents/item/feature.js';
 import type { NimbleSubclassItem } from '#documents/item/subclass.js';
 import { SYSTEM_ID, systemHookName } from '#system';
+import type {
+	LevelCorrectionSelection,
+	LevelCorrectionSubmitData,
+	ResolvedLevelSelectionGap,
+} from '#types/components/CharacterLevelCorrectionDialog.d.ts';
 import type { SkillKeyType } from '#types/skillKey.js';
+import findMissingLevelSelections, {
+	type MissingLevelSelection,
+} from '#utils/findMissingLevelSelections.ts';
+import { buildClassFeatureIndex } from '#utils/getClassFeatures.ts';
 import { getHighestSpellTier } from '#utils/spell/getHighestSpellTier.ts';
 import CharacterMetaConfigDialog from '#view/dialogs/CharacterMetaConfigDialog.svelte';
 import getDeterministicBonus from '../../dice/getDeterministicBonus.ts';
@@ -24,6 +33,7 @@ import showInsufficientActionsConfirmation from '../../utils/showInsufficientAct
 import toMessageMode from '../../utils/toMessageMode.js';
 import CharacterArmorProficienciesConfigDialog from '../../view/dialogs/CharacterArmorProficienciesConfigDialog.svelte';
 import CharacterLanguageProficienciesConfigDialog from '../../view/dialogs/CharacterLanguageProficienciesConfigDialog.svelte';
+import CharacterLevelCorrectionDialog from '../../view/dialogs/CharacterLevelCorrectionDialog.svelte';
 import CharacterLevelDownDialog from '../../view/dialogs/CharacterLevelDownDialog.svelte';
 import CharacterLevelUpDialog from '../../view/dialogs/CharacterLevelUpDialog.svelte';
 import CharacterMovementConfigDialog from '../../view/dialogs/CharacterMovementConfigDialog.svelte';
@@ -1168,6 +1178,131 @@ export class NimbleCharacter extends NimbleBaseActor<'character'> {
 	 */
 	getLevelDownDialogId(): string {
 		return `${this.id}-level-down`;
+	}
+
+	/**
+	 * Get the unique dialog ID for level correction dialogs for this character.
+	 */
+	getLevelCorrectionDialogId(): string {
+		return `${this.id}-level-correction`;
+	}
+
+	/**
+	 * The class feature pools this character is still owed picks from.
+	 *
+	 * A level-up grant that was wrong when the character passed through it leaves no trace on the
+	 * sheet — the picks simply never happened — so the shortfall has to be recomputed from the
+	 * class data every time rather than read back from `levelUpHistory`.
+	 */
+	async getMissingLevelSelections(): Promise<MissingLevelSelection[]> {
+		const characterClass = Object.values(this.classes)?.[0];
+		if (!characterClass) return [];
+
+		const ownedSourceUuids = new Set<string>();
+		for (const item of this.items) {
+			if (item.type !== 'feature') continue;
+			const compendiumSource = item._stats?.compendiumSource;
+			if (compendiumSource) ownedSourceUuids.add(compendiumSource);
+		}
+
+		const index = await buildClassFeatureIndex();
+
+		return findMissingLevelSelections(
+			index,
+			characterClass.identifier,
+			characterClass.system.classLevel,
+			ownedSourceUuids,
+		);
+	}
+
+	/**
+	 * Opens the level correction dialog so the player can make the picks a past level owes them,
+	 * then grants what they chose.
+	 */
+	async triggerLevelCorrection() {
+		const gaps = await this.getMissingLevelSelections();
+
+		if (gaps.length === 0) {
+			ui.notifications?.info(game.i18n.localize('NIMBLE.levelCorrectionDialog.nothingMissing'));
+			return;
+		}
+
+		const resolvedGaps: ResolvedLevelSelectionGap[] = [];
+		for (const gap of gaps) {
+			const { candidateUuids, ...rest } = gap;
+			const candidates = await Promise.all(
+				candidateUuids.map((uuid) => fromUuid(uuid as `Item.${string}`)),
+			);
+			resolvedGaps.push({
+				...rest,
+				candidates: candidates.filter((doc): doc is NimbleFeatureItem => Boolean(doc)),
+			});
+		}
+
+		const dialogId = this.getLevelCorrectionDialogId();
+		const dialog = GenericDialog.getOrCreate(
+			`${this.name}: ${game.i18n.localize('NIMBLE.levelCorrectionDialog.title')}`,
+			CharacterLevelCorrectionDialog,
+			{ gaps: resolvedGaps },
+			{ icon: 'fa-solid fa-triangle-exclamation', width: 600, uniqueId: dialogId },
+		);
+
+		if (dialog.rendered) return;
+
+		await dialog.render(true);
+		const dialogData = await dialog.promise;
+		if (!dialogData) return;
+
+		await this.applyLevelCorrection(
+			(dialogData as unknown as LevelCorrectionSubmitData).selections,
+		);
+	}
+
+	/**
+	 * Grants the picks chosen in the level correction dialog.
+	 *
+	 * Each grant is recorded on the `levelUpHistory` entry for the level it was owed to, so
+	 * reverting that level still removes it. A correction owed to level 1 has no history entry
+	 * to record against — the character keeps the feature, and reverting cannot reach it anyway.
+	 */
+	async applyLevelCorrection(selections: LevelCorrectionSelection[]): Promise<void> {
+		const featureSources: Item.CreateData[] = [];
+		const levelByCreatedIndex: number[] = [];
+
+		for (const selection of selections) {
+			for (const uuid of selection.uuids) {
+				const feature = await fromUuid(uuid as `Item.${string}`);
+				if (!feature) continue;
+				const source = (feature as NimbleFeatureItem).toObject();
+				source._stats.compendiumSource = uuid;
+				featureSources.push(source as object as Item.CreateData);
+				levelByCreatedIndex.push(selection.level);
+			}
+		}
+
+		if (featureSources.length === 0) return;
+
+		const created = (await this.createEmbeddedDocuments('Item', featureSources)) ?? [];
+
+		const idsByLevel = new Map<number, string[]>();
+		created.forEach((doc, position) => {
+			const id = (doc as unknown as { id: string | null }).id;
+			if (!id) return;
+			const level = levelByCreatedIndex[position];
+			const ids = idsByLevel.get(level);
+			if (ids) ids.push(id);
+			else idsByLevel.set(level, [id]);
+		});
+
+		const levelUpHistory = this.system.levelUpHistory.map((entry) => {
+			const ids = idsByLevel.get(entry.level);
+			if (!ids?.length) return entry;
+			return { ...entry, grantedFeatureIds: [...entry.grantedFeatureIds, ...ids] };
+		});
+
+		const actorUpdates: Record<string, unknown> = { 'system.levelUpHistory': levelUpHistory };
+		await this.update(actorUpdates);
+		this.sheet?.render(true);
 	}
 
 	/**

--- a/src/utils/classProgression/shepherd.test.ts
+++ b/src/utils/classProgression/shepherd.test.ts
@@ -165,6 +165,29 @@ describe('Shepherd — sacred-grace pool resolution (singular/plural groupIdenti
 	});
 });
 
+describe('Shepherd — sacred-grace selection counts', () => {
+	// Rulebook: "Choose 2 Sacred Graces" at level 5, then a 3rd at 9 and a 4th at 13.
+	const GRACE_LEVELS = [5, 9, 13];
+	const EXPECTED_COUNT: Record<number, number> = { 5: 2, 9: 1, 13: 1 };
+
+	for (const level of GRACE_LEVELS) {
+		it(`level ${level}: offers ${EXPECTED_COUNT[level]} pick(s) from the pool`, () => {
+			const offered = summaries[level - 1].offeredGroups[SACRED_GRACE_GROUP];
+			expect(offered, `sacred-grace pool did not resolve at level ${level}`).toBeDefined();
+			expect(offered.selectionCount).toBe(EXPECTED_COUNT[level]);
+			expect(offered.options.length).toBeGreaterThanOrEqual(offered.selectionCount);
+		});
+	}
+
+	it('grants four graces in total across the progression', () => {
+		const total = GRACE_LEVELS.reduce(
+			(sum, level) => sum + summaries[level - 1].offeredGroups[SACRED_GRACE_GROUP].selectionCount,
+			0,
+		);
+		expect(total).toBe(4);
+	});
+});
+
 describe('Shepherd — data integrity across the full progression', () => {
 	it('produces exactly 20 level summaries', () => {
 		expect(summaries).toHaveLength(20);

--- a/src/utils/findMissingLevelSelections.test.ts
+++ b/src/utils/findMissingLevelSelections.test.ts
@@ -1,0 +1,191 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+	buildRealIndex,
+	getClassMeta,
+	loadAllClasses,
+	loadAllFeatureDocs,
+	restoreMocks,
+} from '../../tests/fixtures/classProgression.ts';
+import findMissingLevelSelections from './findMissingLevelSelections.ts';
+import getClassFeaturesFromIndex, { type ClassFeatureIndex } from './getClassFeatures.ts';
+import isLevelUpOptionApplicable from './isLevelUpOptionApplicable.ts';
+
+/**
+ * Drives the audit against the REAL compendium, so a character built by the real resolver is
+ * the baseline for "nothing is missing" and every gap is measured against actual class data.
+ */
+
+let index: ClassFeatureIndex;
+
+beforeAll(async () => {
+	index = await buildRealIndex();
+});
+
+afterAll(() => {
+	restoreMocks();
+});
+
+/** Not-yet-owned members of a pool, the way an option picker would offer them. */
+function poolMembers(groups: readonly string[], owned: ReadonlySet<string>): string[] {
+	return loadAllFeatureDocs()
+		.filter(
+			(feature) =>
+				!feature.system.subclass &&
+				groups.includes(feature.system.group) &&
+				!owned.has(feature.uuid),
+		)
+		.map((feature) => feature.uuid);
+}
+
+/**
+ * The compendium-source uuids a correctly built character of `classIdentifier` holds at
+ * `throughLevel` — every auto-grant, every selection group filled to its count, and every
+ * unambiguous level-up option's pool picks taken.
+ */
+async function buildOwnedFeatureUuids(
+	classIdentifier: string,
+	throughLevel: number,
+): Promise<Set<string>> {
+	const meta = getClassMeta(classIdentifier);
+	const owned = new Set<string>();
+
+	for (let level = 1; level <= throughLevel; level++) {
+		const offered = await getClassFeaturesFromIndex(
+			index,
+			classIdentifier,
+			level,
+			{ ownedFeatureUuids: owned },
+			meta.groupIdentifiers,
+		);
+
+		for (const feature of offered.autoGrant) owned.add(feature.uuid ?? '');
+
+		for (const group of offered.selectionGroups.values()) {
+			for (let i = 0; i < group.selectionCount && i < group.features.length; i++) {
+				owned.add(group.features[i].uuid ?? '');
+			}
+		}
+
+		for (const feature of offered.optionFeatures) {
+			owned.add(feature.uuid ?? '');
+
+			const applicable = (feature.system.levelUpOptions ?? []).filter((option) =>
+				isLevelUpOptionApplicable(option, level),
+			);
+			if (applicable.length !== 1) continue;
+
+			const [option] = applicable;
+			const groups = option.selectionGroups ?? [];
+			if (groups.length === 0) continue;
+
+			const pool = poolMembers(groups, owned);
+			const count = option.selectionCount ?? 1;
+			for (let i = 0; i < count && i < pool.length; i++) owned.add(pool[i]);
+		}
+	}
+
+	return owned;
+}
+
+/** The sacred graces a character owns, in compendium order. */
+function ownedSacredGraces(owned: ReadonlySet<string>): string[] {
+	return loadAllFeatureDocs()
+		.filter((feature) => feature.system.group === 'sacred-grace' && owned.has(feature.uuid))
+		.map((feature) => feature.uuid);
+}
+
+async function auditShepherd(level: number, owned: ReadonlySet<string>) {
+	return findMissingLevelSelections(index, 'shepherd', level, owned);
+}
+
+describe('findMissingLevelSelections', () => {
+	it('reports nothing for a Shepherd who took both level-5 Sacred Graces', async () => {
+		const owned = await buildOwnedFeatureUuids('shepherd', 5);
+
+		expect(ownedSacredGraces(owned)).toHaveLength(2);
+		expect(await auditShepherd(5, owned)).toEqual([]);
+	});
+
+	it('reports the second Sacred Grace for a Shepherd who reached level 5 with only one', async () => {
+		const owned = await buildOwnedFeatureUuids('shepherd', 5);
+		const graces = ownedSacredGraces(owned);
+		const short = new Set(owned);
+		short.delete(graces[0]);
+
+		const gaps = await auditShepherd(5, short);
+
+		expect(gaps).toHaveLength(1);
+		expect(gaps[0]).toMatchObject({
+			level: 5,
+			poolKey: 'sacred-grace',
+			poolGroups: ['sacred-grace'],
+			displayName: 'Sacred Graces',
+			optionLabel: 'Choose 2 Sacred Graces',
+			missingCount: 1,
+		});
+		expect(gaps[0].candidateUuids).toContain(graces[0]);
+		expect(gaps[0].candidateUuids).not.toContain(graces[1]);
+	});
+
+	it('does not report a level the character has not reached', async () => {
+		const owned = await buildOwnedFeatureUuids('shepherd', 4);
+
+		expect(ownedSacredGraces(owned)).toHaveLength(0);
+		expect(await auditShepherd(4, owned)).toEqual([]);
+	});
+
+	it('attributes a shortfall spanning several grace levels to level 5', async () => {
+		const owned = await buildOwnedFeatureUuids('shepherd', 9);
+		const graces = ownedSacredGraces(owned);
+		const short = new Set(owned);
+		for (const grace of graces.slice(1)) short.delete(grace);
+
+		const gaps = await auditShepherd(9, short);
+
+		expect(graces).toHaveLength(3);
+		expect(gaps).toHaveLength(1);
+		expect(gaps[0]).toMatchObject({ level: 5, missingCount: 2 });
+	});
+
+	it('reports nothing for a Shepherd who took all four graces by level 13', async () => {
+		const owned = await buildOwnedFeatureUuids('shepherd', 13);
+
+		expect(ownedSacredGraces(owned)).toHaveLength(4);
+		expect(await auditShepherd(13, owned)).toEqual([]);
+	});
+
+	/**
+	 * A level offering more than one alternative records nothing about which the player took,
+	 * so a missing pick there cannot be told apart from an alternative that needed no pick.
+	 * The Commander's "Fit for Any Battlefield" offers a pool pick OR a flat combat die at
+	 * levels 6+, and must never be reported.
+	 */
+	it('stays silent on a level whose level-up option had alternatives', async () => {
+		const owned = await buildOwnedFeatureUuids('commander', 20);
+		const tactics = poolMembers(['combat-tactics', 'commanders-orders'], new Set()).filter((uuid) =>
+			owned.has(uuid),
+		);
+		const short = new Set(owned);
+		for (const uuid of tactics.slice(1)) short.delete(uuid);
+
+		const gaps = await findMissingLevelSelections(index, 'commander', 20, short);
+
+		expect(gaps.filter((gap) => gap.level >= 6)).toEqual([]);
+	});
+});
+
+/**
+ * The warning this audit drives sits on every character sheet, so a false positive is worse
+ * than a missed gap. A character each class built correctly to level 20 must come back clean.
+ */
+describe('findMissingLevelSelections — correctly built characters', () => {
+	const CLASS_IDENTIFIERS = loadAllClasses().map((cls) => cls.identifier);
+
+	for (const classIdentifier of CLASS_IDENTIFIERS) {
+		it(`${classIdentifier} at level 20 reports no gaps`, async () => {
+			const owned = await buildOwnedFeatureUuids(classIdentifier, 20);
+			expect(await findMissingLevelSelections(index, classIdentifier, 20, owned)).toEqual([]);
+		});
+	}
+});

--- a/src/utils/findMissingLevelSelections.ts
+++ b/src/utils/findMissingLevelSelections.ts
@@ -1,0 +1,199 @@
+import getClassFeaturesFromIndex, { type ClassFeatureIndex } from '#utils/getClassFeatures.ts';
+import isLevelUpOptionApplicable from '#utils/isLevelUpOptionApplicable.ts';
+
+/**
+ * A pool of class features the character is still owed picks from, and the level whose
+ * grant fell short.
+ */
+export interface MissingLevelSelection {
+	/** Earliest level whose requirement the character's picks do not cover. */
+	level: number;
+	/** Stable key for the pool, used as the selection group key in the correction dialog. */
+	poolKey: string;
+	/** Feature `system.group` values the pool draws from. */
+	poolGroups: string[];
+	/** Heading to show, when the pool is named by a parent feature (e.g. "Sacred Graces"). */
+	displayName: string | null;
+	/** The level-up option's own wording, when the pool comes from one (e.g. "Choose 2 Sacred Graces"). */
+	optionLabel: string | null;
+	/** How many picks the character still owes from this pool. */
+	missingCount: number;
+	/** Pool candidates the character does not already own. */
+	candidateUuids: string[];
+}
+
+/** One level's demand on one pool. */
+interface PoolRequirement {
+	level: number;
+	poolGroups: string[];
+	requiredCount: number;
+	displayName: string | null;
+	optionLabel: string | null;
+}
+
+/** Order-independent identity for a pool, so the same groups always resolve to one bucket. */
+function buildPoolKey(groups: readonly string[]): string {
+	return [...groups].sort().join('+');
+}
+
+/**
+ * Every feature in the index that belongs to one of `poolGroups`, deduplicated by UUID.
+ *
+ * A pool spans the levels it is offered at, so the whole level map is scanned rather than a
+ * single level. `lookupKeys` covers both index shapes: features that carry a class are indexed
+ * under the class identifier, features that do not are indexed under their group.
+ */
+function collectPoolCandidates(
+	index: ClassFeatureIndex,
+	lookupKeys: readonly string[],
+	poolGroups: readonly string[],
+): string[] {
+	const groupSet = new Set(poolGroups);
+	const seen = new Set<string>();
+	const uuids: string[] = [];
+
+	for (const key of lookupKeys) {
+		const levelMap = index.get(key);
+		if (!levelMap) continue;
+
+		for (const entries of levelMap.values()) {
+			for (const entry of entries) {
+				if (!groupSet.has(entry.group)) continue;
+				if (seen.has(entry.uuid)) continue;
+				seen.add(entry.uuid);
+				uuids.push(entry.uuid);
+			}
+		}
+	}
+
+	return uuids;
+}
+
+/**
+ * What each level from 1 to `classLevel` asks the character to pick from a feature pool.
+ *
+ * A level-up option whose applicable set holds more than one alternative is skipped: the
+ * player's choice between alternatives is never stored, so which pool (if any) that level
+ * demanded picks from cannot be recovered. Reporting it would mean warning about a character
+ * that is fine.
+ */
+async function collectPoolRequirements(
+	index: ClassFeatureIndex,
+	classIdentifier: string,
+	classLevel: number,
+): Promise<PoolRequirement[]> {
+	const requirements: PoolRequirement[] = [];
+
+	for (let level = 1; level <= classLevel; level++) {
+		// An empty owned set asks the resolver what the level demands, independent of what the
+		// character has — the comparison against owned features happens below.
+		const offered = await getClassFeaturesFromIndex(index, classIdentifier, level, {});
+
+		for (const [groupName, group] of offered.selectionGroups) {
+			requirements.push({
+				level,
+				poolGroups: [groupName],
+				requiredCount: group.selectionCount,
+				displayName: group.displayName ?? null,
+				optionLabel: null,
+			});
+		}
+
+		for (const feature of offered.optionFeatures) {
+			const applicable = (feature.system.levelUpOptions ?? []).filter((option) =>
+				isLevelUpOptionApplicable(option, level),
+			);
+			if (applicable.length !== 1) continue;
+
+			const [option] = applicable;
+			const selectionGroups = option.selectionGroups ?? [];
+			if (selectionGroups.length === 0) continue;
+
+			requirements.push({
+				level,
+				poolGroups: [...selectionGroups],
+				// Compendium options may leave the count unset, meaning a single pick.
+				requiredCount: option.selectionCount ?? 1,
+				displayName: feature.name ?? null,
+				optionLabel: option.label || null,
+			});
+		}
+	}
+
+	return requirements;
+}
+
+/**
+ * Finds the feature pools a character is still owed picks from.
+ *
+ * Compares what every level up to `classLevel` asks the character to pick against the pool
+ * members they own, which catches a character who levelled through a level whose grant was
+ * later corrected — a Shepherd who reached level 5 when it offered one Sacred Grace instead
+ * of two keeps a single grace, and nothing on the sheet records the second as outstanding.
+ *
+ * The shortfall for a pool is reported once, against the earliest level whose requirement the
+ * character's picks do not cover: that is where the data first went wrong, and merging the
+ * levels keeps the correction dialog from offering the same candidate twice. It is capped at
+ * the number of candidates left, since a pick can only be offered from a pool that still has
+ * members to offer.
+ */
+export default async function findMissingLevelSelections(
+	index: ClassFeatureIndex,
+	classIdentifier: string,
+	classLevel: number,
+	ownedSourceUuids: ReadonlySet<string>,
+): Promise<MissingLevelSelection[]> {
+	if (!classIdentifier || classLevel < 1) return [];
+
+	const requirements = await collectPoolRequirements(index, classIdentifier, classLevel);
+
+	const requirementsByPool = new Map<string, PoolRequirement[]>();
+	for (const requirement of requirements) {
+		const key = buildPoolKey(requirement.poolGroups);
+		const bucket = requirementsByPool.get(key);
+		if (bucket) bucket.push(requirement);
+		else requirementsByPool.set(key, [requirement]);
+	}
+
+	const gaps: MissingLevelSelection[] = [];
+
+	for (const [poolKey, poolRequirements] of requirementsByPool) {
+		const poolGroups = poolRequirements[0].poolGroups;
+		const candidateUuids = collectPoolCandidates(
+			index,
+			[classIdentifier, ...poolGroups],
+			poolGroups,
+		);
+
+		const ownedCount = candidateUuids.filter((uuid) => ownedSourceUuids.has(uuid)).length;
+		const remainingUuids = candidateUuids.filter((uuid) => !ownedSourceUuids.has(uuid));
+
+		const requiredCount = poolRequirements.reduce((total, req) => total + req.requiredCount, 0);
+		const missingCount = Math.min(requiredCount - ownedCount, remainingUuids.length);
+		if (missingCount < 1) continue;
+
+		// The first level the owned picks run out on: allocate them across the levels in order.
+		let credit = ownedCount;
+		let shortfall: PoolRequirement | undefined;
+		for (const requirement of poolRequirements) {
+			if (credit < requirement.requiredCount) {
+				shortfall = requirement;
+				break;
+			}
+			credit -= requirement.requiredCount;
+		}
+		if (!shortfall) continue;
+
+		gaps.push({
+			level: shortfall.level,
+			poolKey,
+			poolGroups: [...shortfall.poolGroups],
+			displayName: shortfall.displayName,
+			optionLabel: shortfall.optionLabel,
+			missingCount,
+			candidateUuids: remainingUuids,
+		});
+	}
+
+	return gaps.sort((a, b) => a.level - b.level || a.poolKey.localeCompare(b.poolKey));
+}

--- a/src/view/dialogs/CharacterLevelCorrectionDialog.svelte
+++ b/src/view/dialogs/CharacterLevelCorrectionDialog.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+	import type { CharacterLevelCorrectionDialogProps } from '#types/components/CharacterLevelCorrectionDialog.d.ts';
+
+	import FeatureGroupSelection from './components/characterCreator/FeatureGroupSelection.svelte';
+	import Hint from '../components/Hint.svelte';
+	import localize from '#utils/localize.js';
+	import { createLevelCorrectionState } from './CharacterLevelCorrectionDialogState.svelte.ts';
+
+	let { gaps, dialog }: CharacterLevelCorrectionDialogProps = $props();
+
+	const { forms } = CONFIG.NIMBLE;
+
+	const state = createLevelCorrectionState(
+		() => gaps,
+		() => dialog,
+	);
+
+	const groups = $derived(state.groups);
+	const isComplete = $derived(state.isComplete);
+</script>
+
+<section class="nimble-sheet__body" style="--nimble-sheet-body-padding-block-start: 0.75rem;">
+	<Hint
+		hintText={localize('NIMBLE.levelCorrectionDialog.hint')}
+		hintIcon="fa-solid fa-triangle-exclamation"
+		hintType="warning"
+	/>
+
+	{#each groups as { gap, group } (gap.poolKey)}
+		<section class="level-correction-gap">
+			<h3 class="nimble-heading" data-heading-variant="section">
+				{localize('NIMBLE.levelCorrectionDialog.gapHeading', { level: String(gap.level) })}
+			</h3>
+
+			{#if gap.optionLabel}
+				<span class="level-correction-gap__label">{gap.optionLabel}</span>
+			{/if}
+
+			<FeatureGroupSelection
+				groupName={gap.poolKey}
+				{group}
+				selectedFeatures={state.getSelectedFeatures(gap.poolKey)}
+				onSelect={(feature) => state.toggleFeature(gap.poolKey, feature)}
+			/>
+		</section>
+	{/each}
+</section>
+
+<footer class="nimble-sheet__footer">
+	<button
+		class="nimble-button"
+		data-button-variant="basic"
+		aria-label={isComplete ? forms.submit : localize('NIMBLE.levelUpDialog.completeAllSelections')}
+		data-tooltip={isComplete ? '' : localize('NIMBLE.levelUpDialog.completeAllSelections')}
+		onclick={state.submit}
+		disabled={!isComplete}
+	>
+		{forms.submit}
+	</button>
+</footer>
+
+<style lang="scss">
+	.level-correction-gap {
+		margin-top: 1rem;
+
+		.nimble-heading {
+			margin: 1rem 0 0.25rem 0;
+		}
+
+		&__label {
+			font-size: 0.875rem;
+			color: var(--nimble-medium-text-color);
+		}
+	}
+
+	.nimble-sheet__footer {
+		--nimble-button-padding: 0.5rem 1rem;
+		--nimble-button-width: 100%;
+	}
+
+	.nimble-button[disabled] {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+</style>

--- a/src/view/dialogs/CharacterLevelCorrectionDialog.test.ts
+++ b/src/view/dialogs/CharacterLevelCorrectionDialog.test.ts
@@ -1,0 +1,96 @@
+import { fireEvent, render, waitFor } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { NimbleFeatureItem } from '#documents/item/feature.js';
+import type { ResolvedLevelSelectionGap } from '#types/components/CharacterLevelCorrectionDialog.d.ts';
+import CharacterLevelCorrectionDialog from './CharacterLevelCorrectionDialog.svelte';
+
+function createFeature(uuid: string, name: string): NimbleFeatureItem {
+	return {
+		uuid,
+		name,
+		img: 'icons/svg/item-bag.svg',
+		system: { description: '' },
+	} as NimbleFeatureItem;
+}
+
+const GRACES = [
+	createFeature('Item.light-bearer', 'Light Bearer'),
+	createFeature('Item.guiding-spirit', 'Guiding Spirit'),
+	createFeature('Item.vengeful-spirit', 'Vengeful Spirit'),
+];
+
+function sacredGraceGap(overrides: Partial<ResolvedLevelSelectionGap> = {}) {
+	return {
+		level: 5,
+		poolKey: 'sacred-grace',
+		poolGroups: ['sacred-grace'],
+		displayName: 'Sacred Graces',
+		optionLabel: 'Choose 2 Sacred Graces',
+		missingCount: 1,
+		candidates: GRACES,
+		...overrides,
+	} satisfies ResolvedLevelSelectionGap;
+}
+
+function renderDialog(gaps: ResolvedLevelSelectionGap[]) {
+	const dialog = { submit: vi.fn() };
+	const rendered = render(CharacterLevelCorrectionDialog, { props: { gaps, dialog } });
+	const submitButton = rendered.getByRole('button', { name: /submit/i });
+
+	return { ...rendered, dialog, submitButton };
+}
+
+describe('CharacterLevelCorrectionDialog', () => {
+	it('offers the pool the level owes picks from, headed by the feature name', () => {
+		const { getByText } = renderDialog([sacredGraceGap()]);
+
+		expect(getByText('Sacred Graces')).toBeTruthy();
+		expect(getByText('Choose 2 Sacred Graces')).toBeTruthy();
+		expect(getByText('Level 5')).toBeTruthy();
+		expect(getByText('Light Bearer')).toBeTruthy();
+	});
+
+	it('submits the picked uuids against the level they are owed to', async () => {
+		const { dialog, submitButton, getByLabelText } = renderDialog([sacredGraceGap()]);
+
+		expect(submitButton.hasAttribute('disabled')).toBe(true);
+
+		await fireEvent.click(getByLabelText('Select Guiding Spirit'));
+		await waitFor(() => expect(submitButton.hasAttribute('disabled')).toBe(false));
+		await fireEvent.click(submitButton);
+
+		expect(dialog.submit).toHaveBeenCalledWith({
+			selections: [{ level: 5, uuids: ['Item.guiding-spirit'] }],
+		});
+	});
+
+	it('stays disabled until every pool has its full count of picks', async () => {
+		const { submitButton, getByLabelText } = renderDialog([sacredGraceGap({ missingCount: 2 })]);
+
+		await fireEvent.click(getByLabelText('Select Guiding Spirit'));
+		expect(submitButton.hasAttribute('disabled')).toBe(true);
+
+		await fireEvent.click(getByLabelText('Select Light Bearer'));
+		await waitFor(() => expect(submitButton.hasAttribute('disabled')).toBe(false));
+	});
+
+	/**
+	 * A pool with exactly as many candidates left as picks owed renders as a non-interactive
+	 * list, so nothing can be clicked — the dialog has to fill it itself or it would never
+	 * become submittable.
+	 */
+	it('pre-fills a pool that offers no choice', async () => {
+		const onlyOption = [GRACES[0]];
+		const { dialog, submitButton } = renderDialog([
+			sacredGraceGap({ candidates: onlyOption, missingCount: 1 }),
+		]);
+
+		await waitFor(() => expect(submitButton.hasAttribute('disabled')).toBe(false));
+		await fireEvent.click(submitButton);
+
+		expect(dialog.submit).toHaveBeenCalledWith({
+			selections: [{ level: 5, uuids: ['Item.light-bearer'] }],
+		});
+	});
+});

--- a/src/view/dialogs/CharacterLevelCorrectionDialogState.svelte.ts
+++ b/src/view/dialogs/CharacterLevelCorrectionDialogState.svelte.ts
@@ -1,0 +1,101 @@
+import type { NimbleFeatureItem } from '#documents/item/feature.js';
+import type {
+	LevelCorrectionSelection,
+	ResolvedLevelSelectionGap,
+} from '#types/components/CharacterLevelCorrectionDialog.d.ts';
+import type { SelectionGroup } from '#types/components/ClassFeatureSelection.d.ts';
+
+import { isFixedGroup } from './selectionGroupRules.ts';
+
+/**
+ * Creates reactive state for the CharacterLevelCorrectionDialog component.
+ *
+ * Each gap is presented as one selection group asking for exactly the picks the character is
+ * still owed, and the dialog submits only once every gap is filled — a partial correction would
+ * leave the same warning on the sheet with no record of what was already answered.
+ */
+export function createLevelCorrectionState(
+	getGaps: () => ResolvedLevelSelectionGap[],
+	getDialog: () => { submit(data: Record<string, unknown>): void },
+) {
+	let selectionsByPool = $state<Map<string, NimbleFeatureItem[]>>(new Map());
+
+	const groups = $derived(
+		getGaps().map((gap) => ({
+			gap,
+			group: {
+				features: gap.candidates,
+				selectionCount: gap.missingCount,
+				...(gap.displayName ? { displayName: gap.displayName } : {}),
+			} satisfies SelectionGroup,
+		})),
+	);
+
+	const isComplete = $derived(
+		getGaps().every((gap) => (selectionsByPool.get(gap.poolKey) ?? []).length === gap.missingCount),
+	);
+
+	// A pool with exactly as many candidates left as picks owed offers no choice, and
+	// FeatureGroupSelection renders it as a non-interactive list — so fill it here or the dialog
+	// could never complete.
+	$effect(() => {
+		const filled = new Map(selectionsByPool);
+		let hasChanges = false;
+
+		for (const { gap, group } of groups) {
+			if (filled.has(gap.poolKey)) continue;
+			if (!isFixedGroup(group)) continue;
+			filled.set(gap.poolKey, [...group.features]);
+			hasChanges = true;
+		}
+
+		if (hasChanges) selectionsByPool = filled;
+	});
+
+	function getSelectedFeatures(poolKey: string): NimbleFeatureItem[] {
+		return selectionsByPool.get(poolKey) ?? [];
+	}
+
+	function toggleFeature(poolKey: string, feature: NimbleFeatureItem) {
+		const gap = getGaps().find((candidate) => candidate.poolKey === poolKey);
+		if (!gap) return;
+
+		const current = getSelectedFeatures(poolKey);
+		const isSelected = current.some((selected) => selected.uuid === feature.uuid);
+
+		let next: NimbleFeatureItem[];
+		if (isSelected) {
+			next = current.filter((selected) => selected.uuid !== feature.uuid);
+		} else if (current.length >= gap.missingCount) {
+			return;
+		} else {
+			next = [...current, feature];
+		}
+
+		const updated = new Map(selectionsByPool);
+		if (next.length === 0) updated.delete(poolKey);
+		else updated.set(poolKey, next);
+		selectionsByPool = updated;
+	}
+
+	function submit() {
+		const selections: LevelCorrectionSelection[] = getGaps().map((gap) => ({
+			level: gap.level,
+			uuids: getSelectedFeatures(gap.poolKey).map((feature) => feature.uuid ?? ''),
+		}));
+
+		getDialog().submit({ selections });
+	}
+
+	return {
+		get groups() {
+			return groups;
+		},
+		get isComplete() {
+			return isComplete;
+		},
+		getSelectedFeatures,
+		toggleFeature,
+		submit,
+	};
+}

--- a/src/view/dialogs/components/levelUpHelper/LevelUpFeatureOptionPicker.svelte
+++ b/src/view/dialogs/components/levelUpHelper/LevelUpFeatureOptionPicker.svelte
@@ -44,7 +44,9 @@
 	</ul>
 
 	<div class="feature-option-picker__body">
-		{#if !isSingleOption}
+		{#if isSingleOption}
+			<span class="feature-option-picker__hint">{options[0].label}</span>
+		{:else}
 			<span class="feature-option-picker__hint">
 				{localize('NIMBLE.classFeatureSelection.chooseOne')}
 			</span>

--- a/src/view/dialogs/components/levelUpHelper/LevelUpFeatureOptionPicker.svelte.test.ts
+++ b/src/view/dialogs/components/levelUpHelper/LevelUpFeatureOptionPicker.svelte.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
 import { render, waitFor } from '@testing-library/svelte';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -180,4 +183,56 @@ describe('createFeatureOptionPickerState', () => {
 		await waitFor(() => expect(getByTestId('loaded-count').textContent).toBe('2'));
 		expect(onSubItemSelect).not.toHaveBeenCalled();
 	});
+});
+
+/**
+ * Guards the Shepherd's level-5 "Choose 2 Sacred Graces" against a silent regression.
+ *
+ * The class-progression suites simulate the level-up flow, so they can agree with the
+ * compendium while the dialog still asks for one pick. This drives the REAL picker state
+ * with the REAL compendium document, which is the pair that decides what a player sees.
+ */
+describe('createFeatureOptionPickerState — Shepherd Sacred Graces (real compendium data)', () => {
+	const SACRED_GRACES_PATH = join(
+		process.cwd(),
+		'packs/classFeatures/core/shepherd/shepherd-progression/sacred-graces.json',
+	);
+
+	function loadSacredGraces(): NimbleFeatureItem {
+		const doc = JSON.parse(readFileSync(SACRED_GRACES_PATH, 'utf-8'));
+		return { name: doc.name, uuid: `Item.${doc._id}`, system: doc.system } as NimbleFeatureItem;
+	}
+
+	async function renderAtLevel(level: number) {
+		const feature = loadSacredGraces();
+		const applicable = feature.system.levelUpOptions.filter((opt) =>
+			opt.applyAtLevels.includes(level),
+		);
+		expect(applicable, `exactly one option must apply at level ${level}`).toHaveLength(1);
+
+		const { getByTestId } = render(FeatureOptionPickerStateHarness, {
+			props: {
+				feature,
+				levelingTo: level,
+				selectedOptionId: applicable[0].id,
+				onSelect: vi.fn(),
+				onSubItemSelect: vi.fn(),
+			},
+		});
+
+		await waitFor(() => expect(getByTestId('option-count').textContent).toBe('1'));
+		return getByTestId;
+	}
+
+	it('asks for 2 picks when leveling to 5', async () => {
+		const getByTestId = await renderAtLevel(5);
+		expect(getByTestId('sub-selection-count').textContent).toBe('2');
+	});
+
+	for (const level of [9, 13]) {
+		it(`asks for 1 pick when leveling to ${level}`, async () => {
+			const getByTestId = await renderAtLevel(level);
+			expect(getByTestId('sub-selection-count').textContent).toBe('1');
+		});
+	}
 });

--- a/src/view/dialogs/components/levelUpHelper/LevelUpFeatureOptionPicker.svelte.test.ts
+++ b/src/view/dialogs/components/levelUpHelper/LevelUpFeatureOptionPicker.svelte.test.ts
@@ -7,6 +7,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { NimbleFeatureItem } from '#documents/item/feature.js';
 import type { ClassFeatureIndex } from '#utils/getClassFeatures.ts';
 import FeatureOptionPickerStateHarness from '../../../../../tests/harnesses/FeatureOptionPickerStateHarness.svelte';
+// @ts-expect-error - Svelte component default export is provided by the Svelte compiler
+import LevelUpFeatureOptionPicker from './LevelUpFeatureOptionPicker.svelte';
 
 interface LevelUpOptionInput {
 	id: string;
@@ -235,4 +237,57 @@ describe('createFeatureOptionPickerState — Shepherd Sacred Graces (real compen
 			expect(getByTestId('sub-selection-count').textContent).toBe('1');
 		});
 	}
+});
+
+/**
+ * The count alone does not tell a player what they are picking; the option's own label does.
+ * The picker only drew the label when the level offered a choice between options, which is
+ * never at the Shepherd's level 5.
+ */
+describe('LevelUpFeatureOptionPicker — option label', () => {
+	it('shows the sole applicable option label instead of the "choose one" hint', () => {
+		const feature = createFeature([
+			{ id: 'sacred-grace-initial', label: 'Choose 2 Sacred Graces', applyAtLevels: [5] },
+			{ id: 'sacred-grace', label: 'Choose a Sacred Grace', applyAtLevels: [9, 13] },
+		]);
+
+		const { getByText, queryByText } = render(LevelUpFeatureOptionPicker, {
+			props: {
+				feature,
+				levelingTo: 5,
+				selectedOptionId: 'sacred-grace-initial',
+				selectedSubItemUuids: [],
+				ownedItemUuids: new Set<string>(),
+				classFeatureIndex: null,
+				onSelect: vi.fn(),
+				onSubItemSelect: vi.fn(),
+			},
+		});
+
+		expect(getByText('Choose 2 Sacred Graces')).toBeTruthy();
+		expect(queryByText('(Choose one)')).toBeNull();
+	});
+
+	it('keeps the "choose one" hint when the level offers alternatives', () => {
+		const feature = createFeature([
+			{ id: 'pool-pick', label: 'Choose a Combat Ability', applyAtLevels: [6] },
+			{ id: 'flat-bonus', label: '+1 Max Combat Die', applyAtLevels: [6] },
+		]);
+
+		const { getByText } = render(LevelUpFeatureOptionPicker, {
+			props: {
+				feature,
+				levelingTo: 6,
+				selectedOptionId: null,
+				selectedSubItemUuids: [],
+				ownedItemUuids: new Set<string>(),
+				classFeatureIndex: null,
+				onSelect: vi.fn(),
+				onSubItemSelect: vi.fn(),
+			},
+		});
+
+		expect(getByText('(Choose one)')).toBeTruthy();
+		expect(getByText('Choose a Combat Ability')).toBeTruthy();
+	});
 });

--- a/src/view/sheets/PlayerCharacterSheet.state.svelte.ts
+++ b/src/view/sheets/PlayerCharacterSheet.state.svelte.ts
@@ -9,6 +9,7 @@ import {
 	primeActorCombatManaSourceRules,
 } from '#utils/combatManaRules.js';
 import { getActiveCombatForCurrentScene, registerCombatStateHooks } from '#utils/combatState.js';
+import type { MissingLevelSelection } from '#utils/findMissingLevelSelections.ts';
 
 type NavigationComponents = {
 	core: unknown;
@@ -178,6 +179,48 @@ export function createPlayerCharacterSheetState(params: {
 
 		if ((mana.max ?? 0) > 0 || (mana.baseMax ?? 0) > 0) return true;
 		return classHasManaFormula;
+	});
+
+	let missingLevelSelections = $state<MissingLevelSelection[]>([]);
+
+	/**
+	 * What the audit's answer depends on: the class, its level, and which feature sources the
+	 * character holds. Re-auditing on anything else would rebuild the class-feature index on
+	 * every unrelated sheet update.
+	 */
+	const missingSelectionsAuditKey = $derived.by(() => {
+		const characterClass = actor.reactive.items.find((item: any) => item.type === 'class');
+		if (!characterClass) return '';
+
+		const featureSources = actor.reactive.items
+			.filter((item: any) => item.type === 'feature')
+			.map((item: any) => item._stats?.compendiumSource ?? '')
+			.sort()
+			.join(',');
+
+		return `${characterClass.identifier}:${characterClass.system.classLevel}:${featureSources}`;
+	});
+
+	let lastAuditedKey: string | null = null;
+
+	$effect(() => {
+		const auditKey = missingSelectionsAuditKey;
+		if (auditKey === lastAuditedKey) return;
+		lastAuditedKey = auditKey;
+
+		if (!auditKey) {
+			missingLevelSelections = [];
+			return;
+		}
+
+		void actor
+			.getMissingLevelSelections()
+			.then((gaps: MissingLevelSelection[]) => {
+				missingLevelSelections = gaps;
+			})
+			.catch((err: unknown) => {
+				console.warn('Nimble | Failed to audit level selections:', err);
+			});
 	});
 
 	const flags = $derived(actor.reactive.flags[SYSTEM_ID]);
@@ -366,6 +409,9 @@ export function createPlayerCharacterSheetState(params: {
 		},
 		get hitDiceData() {
 			return hitDiceData;
+		},
+		get missingLevelSelections() {
+			return missingLevelSelections;
 		},
 		toggleWounds,
 		updateCurrentHP,

--- a/src/view/sheets/PlayerCharacterSheet.svelte
+++ b/src/view/sheets/PlayerCharacterSheet.svelte
@@ -83,6 +83,7 @@
 	let editingEnabled = $derived(playerCharacterSheetState.editingEnabled);
 	let metaData = $derived(playerCharacterSheetState.metaData);
 	let hitDiceData = $derived(playerCharacterSheetState.hitDiceData);
+	let missingLevelSelections = $derived(playerCharacterSheetState.missingLevelSelections);
 
 	function handleActorPortraitImageError(event: Event) {
 		const img = event.currentTarget;
@@ -338,6 +339,20 @@
 	</div>
 </header>
 
+{#if missingLevelSelections.length > 0}
+	<button
+		class="nimble-hint nimble-hint--warning nimble-level-correction-warning"
+		type="button"
+		data-tooltip={localize('NIMBLE.levelCorrectionDialog.sheetWarningTooltip', {
+			level: String(missingLevelSelections[0].level),
+		})}
+		onclick={() => actor.triggerLevelCorrection()}
+	>
+		<i class="nimble-hint__icon fa-solid fa-triangle-exclamation"></i>
+		{localize('NIMBLE.levelCorrectionDialog.sheetWarning')}
+	</button>
+{/if}
+
 <PrimaryNavigation bind:currentTab {navigation} condenseNavigation={true} />
 
 <currentTab.component />
@@ -416,6 +431,20 @@
 <style lang="scss">
 	.nimble-sheet__header {
 		position: relative;
+	}
+
+	// Reuses the shared warning hint so the banner picks up its light/dark palette; only the
+	// button chrome needs resetting.
+	.nimble-level-correction-warning {
+		align-items: center;
+		width: 100%;
+		font-family: inherit;
+		color: inherit;
+		cursor: pointer;
+
+		&:hover {
+			border-color: var(--nimble-accent-color);
+		}
 	}
 
 	.nimble-sheet__left-trackers {

--- a/src/view/sheets/PlayerCharacterSheet.svelte
+++ b/src/view/sheets/PlayerCharacterSheet.svelte
@@ -337,21 +337,21 @@
 			</h4>
 		{/if}
 	</div>
-</header>
 
-{#if missingLevelSelections.length > 0}
-	<button
-		class="nimble-hint nimble-hint--warning nimble-level-correction-warning"
-		type="button"
-		data-tooltip={localize('NIMBLE.levelCorrectionDialog.sheetWarningTooltip', {
-			level: String(missingLevelSelections[0].level),
-		})}
-		onclick={() => actor.triggerLevelCorrection()}
-	>
-		<i class="nimble-hint__icon fa-solid fa-triangle-exclamation"></i>
-		{localize('NIMBLE.levelCorrectionDialog.sheetWarning')}
-	</button>
-{/if}
+	{#if missingLevelSelections.length > 0}
+		<button
+			class="nimble-hint nimble-hint--warning nimble-level-correction-warning"
+			type="button"
+			data-tooltip={localize('NIMBLE.levelCorrectionDialog.sheetWarningTooltip', {
+				level: String(missingLevelSelections[0].level),
+			})}
+			onclick={() => actor.triggerLevelCorrection()}
+		>
+			<i class="nimble-hint__icon fa-solid fa-triangle-exclamation"></i>
+			{localize('NIMBLE.levelCorrectionDialog.sheetWarning')}
+		</button>
+	{/if}
+</header>
 
 <PrimaryNavigation bind:currentTab {navigation} condenseNavigation={true} />
 
@@ -433,11 +433,16 @@
 		position: relative;
 	}
 
+	// Lives inside the header rather than between the header and the tab list: the sheet's
+	// window-content grid names every row, so a child with no grid area would be auto-placed
+	// into whichever named row happens to be empty, and the spells tab fills them both.
+	//
 	// Reuses the shared warning hint so the banner picks up its light/dark palette; only the
 	// button chrome needs resetting.
 	.nimble-level-correction-warning {
 		align-items: center;
-		width: 100%;
+		width: calc(100% - 0.5rem);
+		margin-inline: 0.25rem;
 		font-family: inherit;
 		color: inherit;
 		cursor: pointer;

--- a/tests/harnesses/FeatureOptionPickerStateHarness.svelte
+++ b/tests/harnesses/FeatureOptionPickerStateHarness.svelte
@@ -38,6 +38,7 @@
 	const optionCount = $derived(state.options.length);
 	const isSingleOption = $derived(state.isSingleOption);
 	const hasSubSelection = $derived(state.hasSubSelection);
+	const subSelectionCount = $derived(state.subSelectionCount);
 	const subItemsLoading = $derived(state.subItemsLoading);
 	const loadedCount = $derived(state.loadedSubItems.length);
 </script>
@@ -45,5 +46,6 @@
 <div data-testid="option-count">{optionCount}</div>
 <div data-testid="is-single">{String(isSingleOption)}</div>
 <div data-testid="has-sub-selection">{String(hasSubSelection)}</div>
+<div data-testid="sub-selection-count">{subSelectionCount}</div>
 <div data-testid="loading">{String(subItemsLoading)}</div>
 <div data-testid="loaded-count">{loadedCount}</div>

--- a/types/components/CharacterLevelCorrectionDialog.d.ts
+++ b/types/components/CharacterLevelCorrectionDialog.d.ts
@@ -1,0 +1,26 @@
+import type GenericDialog from '#documents/dialogs/GenericDialog.svelte.js';
+import type { NimbleFeatureItem } from '#documents/item/feature.js';
+import type { MissingLevelSelection } from '#utils/findMissingLevelSelections.ts';
+
+/**
+ * A gap reported by the audit with its remaining pool candidates resolved to documents, so the
+ * dialog can render them as feature cards.
+ */
+export interface ResolvedLevelSelectionGap extends Omit<MissingLevelSelection, 'candidateUuids'> {
+	candidates: NimbleFeatureItem[];
+}
+
+export interface CharacterLevelCorrectionDialogProps {
+	gaps: ResolvedLevelSelectionGap[];
+	dialog: GenericDialog;
+}
+
+/** One pool's correction: the picks to grant, and the level whose history records them. */
+export interface LevelCorrectionSelection {
+	level: number;
+	uuids: string[];
+}
+
+export interface LevelCorrectionSubmitData {
+	selections: LevelCorrectionSelection[];
+}


### PR DESCRIPTION
## Summary

The Shepherd was only ever offered **one** Sacred Grace per qualifying level, including level 5 where the rulebook says "Choose 2 Sacred Graces". This corrects the compendium data so the Shepherd gets 2 graces at level 5 and 1 each at levels 9 and 13 — 4 total, matching the rulebook.

## Changes

- `packs/classFeatures/core/shepherd/shepherd-progression/sacred-graces.json`: split the single `levelUpOptions` entry (`applyAtLevels: [5, 9, 13]`, `selectionCount: 1`) into two entries with disjoint levels:

  | id | levels | count | label |
  |---|---|---|---|
  | `sacred-grace-initial` | 5 | 2 | "Choose 2 Sacred Graces" |
  | `sacred-grace` | 9, 13 | 1 | "Choose a Sacred Grace" |

- Added `describe('Shepherd — sacred-grace selection counts')` to `src/utils/classProgression/shepherd.test.ts`, asserting the exact per-level pick count and the 4-grace total.

This is a **data-only fix** — no schema or resolver change was needed. `levelUpOptions[].selectionCount` already supports per-level counts; the Shepherd data just never expressed it. The new shape copies the pattern already used by [`mage-progression/spell-shaper.json`](packs/classFeatures/core/mage/mage-progression/spell-shaper.json), which has the identical progression (2 at the first level, then 1 at 9 and 13), and by `hunter-progression/thrill-of-the-hunt.json`.

## Test Plan

Automated (this is what proves the fix):

```bash
pnpm vitest run src/utils/classProgression/shepherd.test.ts
```

The new tests drive the **real** feature resolver against the on-disk compendium via the shared `classProgression` fixture. Before the data change they failed for exactly the reported bug:

```
expected 1 to be 2   ← level 5 selection count
expected 3 to be 4   ← total graces across the progression
```

Levels 9 and 13 were already correct and passed throughout.

Manual verification in Foundry (**not done by me — see checklist**): create or level a Shepherd to 5 and confirm the level-up dialog asks for 2 Sacred Graces, then confirm levels 9 and 13 each ask for 1.

## Checklist

- [x] Added or updated unit tests
- [x] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests) — 3788 tests / 245 files green
- [x] No hardcoded user-facing strings (used `localize()`) — n/a, no code changed; the option labels are compendium data, matching how `spell-shaper.json` stores them
- [ ] Tested in Foundry with no console errors — **not done.** Setup prompted to repoint the local `systems/nimble` symlink away from another active worktree, so I left it alone rather than disturb it. Needs a reviewer to click through the level-up dialog.
- [x] **Have you used AI to assist with this PR?** yes
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues

Reported in conversation, no tracking issue.
