### PR TITLE
fix(tests): join the live world through the v14.367 username field

### DIFF
--- a/tests/integration/pool.ts
+++ b/tests/integration/pool.ts
@@ -312,8 +312,11 @@ async function joinWorld(page: Page): Promise<void> {
 		throw new Error(`Expected to be on /join but got pathname ${pathname}`);
 	}
 
-	await page.selectOption('[name=userid]', { label: user });
-	await page.click('[name=join]');
+	// 14.367 replaced the userid <select> with a free-text username field, and the
+	// submit button's click handler does not fire for a synthetic click, so the
+	// form has to be submitted directly.
+	await page.fill('[name=username]', user);
+	await page.evaluate(() => document.querySelector<HTMLFormElement>('form')?.requestSubmit());
 	await page.waitForURL('**/game');
 	await page.waitForFunction(() => typeof game !== 'undefined' && game.ready);
 


### PR DESCRIPTION
## Problem

The live integration suite cannot connect to Foundry **14.367** at all. `joinWorld` does:

```ts
await page.selectOption('[name=userid]', { label: user });
await page.click('[name=join]');
```

14.367 replaced the userid `<select>` with a free-text `username` input, so the selector never
resolves and every run dies during browser setup:

```
page.selectOption: Timeout 30000ms exceeded.
  - waiting for locator('[name=userid]')
...
Caused by: Error: No Vite URL! The browser setup did not complete.
```

Filling the username alone is not enough either — a synthetic click on the submit button does
not trigger the join, so the form has to be submitted directly.

## Fix

Fill `[name=username]` and call `form.requestSubmit()`.

## Verification

Before: `pnpm test:integration` fails in `_setupBrowser` with the timeout above — no tests run.

After, against a live 14.367 world:

```
Using Foundry running at FOUNDRY_URL = http://localhost:30001.
Nimble | No migration needed: world schema version 45 is up to date
Joined world "nimble-test" as "Gamemaster".

 Test Files  1 passed (1)
      Tests  3 passed (3)
```

`pnpm check` is green: 245 test files, 3784 tests passed.

## Context

Found while diagnosing a reported double-application of ancestry bonuses on the 0.9.0 beta.
That bug needs no code change — it is `ready.ts` calling a bare `actor.prepareData()` combined
with a `prepareData()` that has no re-entry guard, both already fixed on `feature/v14` by
f6898dba1 (#902) but landing *after* the `0.9.0-beta.3` tag; it just needs a beta re-cut.
This harness is the gate that would have caught it, so it is worth having working.

Note this fix is needed on `feature/v14` too, which carries the same `pool.ts`.
