### PR TITLE
fix(charges): keep a variable spend and its deduction one number

### DIFF
--- a/docs/documentation/reference/_partials/chargeConsumer.md
+++ b/docs/documentation/reference/_partials/chargeConsumer.md
@@ -5,14 +5,19 @@
 - **Cost mode** → `fixed`
 - **Cost** → `1`
 
-The consumer sits on the item that spends the charges, which need not be the item that declares the pool: point it at the identifier of a Charge Pool rule anywhere on the actor and it spends from there. A use with too few charges left is blocked, and the chat card reports what the use cost.
+The consumer goes on the item that spends the charges. It does not have to be the item that holds the pool: point **Pool** at any Charge Pool rule on the character. If too few charges are left, the item cannot be used. The chat card reports what the use cost.
 
-**Example: a pool you spend any amount of.** Set **Cost mode** to `variable` and the activation asks how much to spend instead of taking a fixed amount. **Cost** becomes the smallest legal spend and **Maximum cost** the largest, with a blank maximum meaning whatever the pool has left. The amount the player picks is available to the item's own damage and healing formulas as `@spent`, so a healing effect of `@spent` restores exactly what was spent. This is how Lay on Hands works: a pool of `5 * @level` that refills on a safe rest, and a variable consumer that heals what it spends.
+**Example: a pool you spend any amount of.** Set **Cost mode** to `variable` and the item asks the player how many charges to spend. **Cost** is the smallest amount they can pick, **Maximum cost** the largest. Leave **Maximum cost** blank to let them spend whatever the pool has.
 
-Because the amount is player input, an item with a variable consumer always opens its roll window, whatever its skip setting says.
+The item's own damage and healing formulas read that amount as `@spent`, so a healing effect of `@spent` heals what was spent. Lay on Hands works this way: a pool of `5 * @level` that refills on a safe rest, and a variable consumer that heals what it spends.
 
-One variable consumer per pool, per item. The activation asks for one amount per pool, so a second variable consumer pointing at the same pool has no amount of its own: the system refuses to use the item rather than guess which spend you meant. Give each one its own pool, or make all but one a fixed cost.
+An item with a variable consumer always opens its roll window, even when it is set to skip it.
 
-An item may pair a fixed consumer with a variable one on the same pool. The fixed cost is reserved first, so the amount offered for the variable spend is what is left after it. A pool of 10 with a fixed cost of 3 offers a variable spend of up to 7, and the item is refused outright if the pool cannot cover both.
+An item can have a fixed cost and a variable one on the same pool. The fixed cost comes out first and the player picks from what is left, so a pool of 10 with a fixed cost of 3 offers up to 7. If the pool cannot cover both, the item cannot be used.
 
-A variable spend the activation could never ask about is refused the same way, naming the pool: a hidden pool has no prompt to show, a maximum cost below the minimum leaves no legal amount, and a spell is routed to the upcast window, which asks about tier rather than charges. Put a variable consumer on a feature or an item, not on a spell.
+A variable consumer will not work in these cases. The item cannot be used, and the message names the pool.
+
+- **Two variable consumers on one pool.** The item asks once per pool, so the second has no answer of its own. Give it another pool, or make it a fixed cost.
+- **Maximum cost below Cost.** Nothing is left to pick.
+- **A hidden pool.** It has no control on the sheet, so there is nowhere to enter an amount.
+- **A variable consumer on a spell.** Casting opens the upcast window, which asks for a tier. Put it on a feature or an item instead.

--- a/docs/documentation/reference/_partials/chargeConsumer.md
+++ b/docs/documentation/reference/_partials/chargeConsumer.md
@@ -14,3 +14,5 @@ Because the amount is player input, an item with a variable consumer always open
 One variable consumer per pool, per item. The activation asks for one amount per pool, so a second variable consumer pointing at the same pool has no amount of its own: the system refuses to use the item rather than guess which spend you meant. Give each one its own pool, or make all but one a fixed cost.
 
 An item may pair a fixed consumer with a variable one on the same pool. The fixed cost is reserved first, so the amount offered for the variable spend is what is left after it. A pool of 10 with a fixed cost of 3 offers a variable spend of up to 7, and the item is refused outright if the pool cannot cover both.
+
+A variable spend the activation could never ask about is refused the same way, naming the pool: a hidden pool has no prompt to show, a maximum cost below the minimum leaves no legal amount, and a spell is routed to the upcast window, which asks about tier rather than charges. Put a variable consumer on a feature or an item, not on a spell.

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -1544,7 +1544,8 @@
 			"notifications": {
 				"poolMissing": "{item} requires the charge pool \"{pool}\", but it is not available.",
 				"insufficient": "{item} needs {required} charge(s) from \"{pool}\", but only {available} are available.",
-				"conflictingConsumers": "{item} asks for more than one player-chosen spend from the charge pool \"{pool}\". Give each variable consumer its own pool, or make all but one a fixed cost."
+				"conflictingConsumers": "{item} asks for more than one player-chosen spend from the charge pool \"{pool}\". Give each variable consumer its own pool, or make all but one a fixed cost.",
+				"unofferableSpend": "{item} cannot ask how much to spend from the charge pool \"{pool}\". A hidden pool has no prompt to show, a maximum cost below the minimum leaves no legal amount, and a spell asks about tier instead."
 			}
 		},
 		"dicePoolTracker": {

--- a/src/hooks/chargeSystem.ts
+++ b/src/hooks/chargeSystem.ts
@@ -78,6 +78,16 @@ function notifyChargeFailure(itemName: string, failure: ChargeValidationFailure)
 		return;
 	}
 
+	if (failure.code === 'unofferableSpend') {
+		ui.notifications?.error(
+			localize('NIMBLE.charges.notifications.unofferableSpend', {
+				item: itemName,
+				pool: failure.poolLabel,
+			}),
+		);
+		return;
+	}
+
 	if (failure.code === 'poolMissing') {
 		ui.notifications?.error(
 			localize('NIMBLE.charges.notifications.poolMissing', {

--- a/src/managers/ItemActivationManager.test.ts
+++ b/src/managers/ItemActivationManager.test.ts
@@ -1396,6 +1396,22 @@ describe('ItemActivationManager.getData (rolls)', () => {
 			return roll;
 		}
 
+		/**
+		 * stubRolls answers every formula with one total, which would make a pool's
+		 * max indistinguishable from a consumer's cost. Resolve each numeric formula
+		 * to itself instead.
+		 */
+		function stubRollsByFormula() {
+			MockRoll.mockImplementation((formula: unknown) => {
+				const total = Number.parseInt(String(formula), 10);
+				return {
+					evaluate: vi.fn().mockResolvedValue(undefined),
+					evaluateSync: vi.fn(() => ({ total })),
+					toJSON: vi.fn().mockReturnValue({ total }),
+				} as never;
+			});
+		}
+
 		/** Gives the mock item a pool and a consumer that spends a chosen amount of it. */
 		function makeItemSpendVariableCharges() {
 			mockItem.id = 'item-1';
@@ -1456,13 +1472,15 @@ describe('ItemActivationManager.getData (rolls)', () => {
 			return pools?.fury?.faces;
 		}
 
-		/** Current charges of the item-scoped `focus` pool, read back off the fixture. */
-		function readFocusCharges(): number | undefined {
+		/** Current charges of an item-scoped charge pool, read back off the fixture. */
+		function readChargePool(identifier: string): number | undefined {
 			const pools = foundry.utils.getProperty(mockItem, ChargePoolRuleConfig.flagPath) as
 				| Record<string, { current?: number }>
 				| undefined;
-			return pools?.focus?.current;
+			return pools?.[identifier]?.current;
 		}
+
+		const readFocusCharges = () => readChargePool('focus');
 
 		it('should skip the config dialog and complete activation when skipRollDialog is set', async () => {
 			manager = new ItemActivationManager(
@@ -1524,7 +1542,10 @@ describe('ItemActivationManager.getData (rolls)', () => {
 		});
 
 		it('should pass the charges spent in the dialog to effect formulas as @spent', async () => {
-			dialogState.result = { rollMode: 0, spentCharges: 8 };
+			dialogState.result = {
+				rollMode: 0,
+				consumedVariableCharges: [{ poolId: 'focus', count: 8 }],
+			};
 			makeItemSpendVariableCharges();
 			manager = new ItemActivationManager(
 				mockItem as unknown as ConstructorParameters<typeof ItemActivationManager>[0],
@@ -1559,8 +1580,7 @@ describe('ItemActivationManager.getData (rolls)', () => {
 			// no card, so the deduction waits for applyDeferredPoolNodes().
 			dialogState.result = {
 				rollMode: 0,
-				spentCharges: 10,
-				consumedChargePools: [{ poolId: 'focus', count: 10 }],
+				consumedVariableCharges: [{ poolId: 'focus', count: 10 }],
 			};
 			makeItemSpendVariableCharges();
 			manager = new ItemActivationManager(
@@ -1596,7 +1616,10 @@ describe('ItemActivationManager.getData (rolls)', () => {
 		it('should cap @spent at what the pool actually holds', async () => {
 			// The dialog clamps against a snapshot from when it opened, so a pool that
 			// moved underneath it could otherwise heal for more than it can pay.
-			dialogState.result = { rollMode: 0, spentCharges: 40 };
+			dialogState.result = {
+				rollMode: 0,
+				consumedVariableCharges: [{ poolId: 'focus', count: 40 }],
+			};
 			makeItemSpendVariableCharges();
 			manager = new ItemActivationManager(
 				mockItem as unknown as ConstructorParameters<typeof ItemActivationManager>[0],
@@ -1628,7 +1651,10 @@ describe('ItemActivationManager.getData (rolls)', () => {
 		it('should cap @spent at what a same-pool fixed cost leaves behind', async () => {
 			// The fixed cost is taken after the variable spend, so a spend sized
 			// against the whole pool would empty it and leave that cost unpaid.
-			dialogState.result = { rollMode: 0, spentCharges: 10 };
+			dialogState.result = {
+				rollMode: 0,
+				consumedVariableCharges: [{ poolId: 'focus', count: 10 }],
+			};
 			makeItemSpendVariableCharges();
 			mockItem.rules!.set('2', {
 				type: 'chargeConsumer',
@@ -1653,17 +1679,7 @@ describe('ItemActivationManager.getData (rolls)', () => {
 
 			manager.activationData = { effects: [healingNode] };
 			mockReconstructEffectsTree.mockReturnValue([healingNode]);
-			// stubRolls answers every formula with the same total, which would make
-			// the pool max and the fixed cost indistinguishable. Resolve each numeric
-			// formula to itself instead.
-			MockRoll.mockImplementation((formula: unknown) => {
-				const total = Number.parseInt(String(formula), 10);
-				return {
-					evaluate: vi.fn().mockResolvedValue(undefined),
-					evaluateSync: vi.fn(() => ({ total })),
-					toJSON: vi.fn().mockReturnValue({ total }),
-				} as never;
-			});
+			stubRollsByFormula();
 
 			await manager.getData();
 
@@ -1672,6 +1688,171 @@ describe('ItemActivationManager.getData (rolls)', () => {
 				{ level: 1, strength: 10, spent: 6 },
 				undefined,
 			);
+		});
+
+		it('should deduct the same number of charges that @spent resolved to', async () => {
+			// A pool that moved underneath the open dialog would otherwise be charged
+			// the player's choice while the effect resolved for what the pool could
+			// still pay.
+			dialogState.result = {
+				rollMode: 0,
+				consumedVariableCharges: [{ poolId: 'focus', count: 6 }],
+			};
+			makeItemSpendVariableCharges();
+			mockItem.rules!.set('0', {
+				type: 'chargePool',
+				id: 'pool-rule',
+				identifier: 'focus',
+				scope: 'item',
+				max: '5',
+				initial: 'max',
+			});
+			mockItem.rules!.set('2', {
+				type: 'chargeConsumer',
+				id: 'fixed-consumer-rule',
+				poolIdentifier: 'focus',
+				poolScope: 'item',
+				costMode: 'fixed',
+				cost: '4',
+			});
+			manager = new ItemActivationManager(
+				mockItem as unknown as ConstructorParameters<typeof ItemActivationManager>[0],
+				{},
+			);
+			const healingNode: EffectNode = {
+				id: 'healing-1',
+				type: 'healing',
+				healingType: 'healing',
+				formula: '@spent',
+				parentContext: null,
+				parentNode: null,
+			} as EffectNode;
+
+			manager.activationData = { effects: [healingNode] };
+			mockReconstructEffectsTree.mockReturnValue([healingNode]);
+			stubRollsByFormula();
+
+			await manager.getData();
+			await manager.applyDeferredPoolNodes();
+
+			// 5 charges less the fixed cost of 4 leaves 1 to spend, not the 6 asked for.
+			expect(MockRoll).toHaveBeenCalledWith(
+				'@spent',
+				{ level: 1, strength: 10, spent: 1 },
+				undefined,
+			);
+			expect(readFocusCharges()).toBe(4);
+		});
+
+		it("should cap @spent per pool, not against the pools' combined headroom", async () => {
+			// Two variable consumers on two pools: spare charges in one must not pay
+			// for an overspend in the other.
+			dialogState.result = {
+				rollMode: 0,
+				consumedVariableCharges: [
+					{ poolId: 'focus', count: 6 },
+					{ poolId: 'vigor', count: 8 },
+				],
+			};
+			makeItemSpendVariableCharges();
+			mockItem.rules!.set('0', {
+				type: 'chargePool',
+				id: 'pool-rule',
+				identifier: 'focus',
+				scope: 'item',
+				max: '3',
+				initial: 'max',
+			});
+			mockItem.rules!.set('2', {
+				type: 'chargePool',
+				id: 'vigor-pool-rule',
+				identifier: 'vigor',
+				scope: 'item',
+				max: '10',
+				initial: 'max',
+			});
+			mockItem.rules!.set('3', {
+				type: 'chargeConsumer',
+				id: 'vigor-consumer-rule',
+				poolIdentifier: 'vigor',
+				poolScope: 'item',
+				costMode: 'variable',
+				cost: '1',
+				maxCost: '',
+			});
+			manager = new ItemActivationManager(
+				mockItem as unknown as ConstructorParameters<typeof ItemActivationManager>[0],
+				{},
+			);
+			const healingNode: EffectNode = {
+				id: 'healing-1',
+				type: 'healing',
+				healingType: 'healing',
+				formula: '@spent',
+				parentContext: null,
+				parentNode: null,
+			} as EffectNode;
+
+			manager.activationData = { effects: [healingNode] };
+			mockReconstructEffectsTree.mockReturnValue([healingNode]);
+			stubRollsByFormula();
+
+			await manager.getData();
+			await manager.applyDeferredPoolNodes();
+
+			// 3 from focus and 8 from vigor, not the 14 the dialog named.
+			expect(MockRoll).toHaveBeenCalledWith(
+				'@spent',
+				{ level: 1, strength: 10, spent: 11 },
+				undefined,
+			);
+			expect(readFocusCharges()).toBe(0);
+			expect(readChargePool('vigor')).toBe(2);
+		});
+
+		it('should reserve a rollable charge spend taken from the same pool', async () => {
+			// Both come out of one pool in the same activation, so the variable
+			// spend can only have what the rollable one leaves.
+			dialogState.result = {
+				rollMode: 0,
+				consumedChargePools: [{ poolId: 'focus', count: 2 }],
+				consumedVariableCharges: [{ poolId: 'focus', count: 10 }],
+			};
+			makeItemSpendVariableCharges();
+			mockItem.rules!.set('0', {
+				type: 'chargePool',
+				id: 'pool-rule',
+				identifier: 'focus',
+				scope: 'item',
+				max: '5',
+				initial: 'max',
+			});
+			manager = new ItemActivationManager(
+				mockItem as unknown as ConstructorParameters<typeof ItemActivationManager>[0],
+				{},
+			);
+			const healingNode: EffectNode = {
+				id: 'healing-1',
+				type: 'healing',
+				healingType: 'healing',
+				formula: '@spent',
+				parentContext: null,
+				parentNode: null,
+			} as EffectNode;
+
+			manager.activationData = { effects: [healingNode] };
+			mockReconstructEffectsTree.mockReturnValue([healingNode]);
+			stubRollsByFormula();
+
+			await manager.getData();
+			await manager.applyDeferredPoolNodes();
+
+			expect(MockRoll).toHaveBeenCalledWith(
+				'@spent',
+				{ level: 1, strength: 10, spent: 3 },
+				undefined,
+			);
+			expect(readFocusCharges()).toBe(0);
 		});
 
 		it('should hold spent pool dice until the caller clears the preUseItem gate', async () => {
@@ -1699,7 +1880,7 @@ describe('ItemActivationManager.getData (rolls)', () => {
 			});
 			dialogState.result = {
 				rollMode: 0,
-				spentCharges: 1,
+				consumedVariableCharges: [{ poolId: 'focus', count: 1 }],
 				consumedPoolDice: [{ poolId: 'fury', faceIndex: 1 }],
 			};
 			manager = new ItemActivationManager(
@@ -1747,6 +1928,32 @@ describe('ItemActivationManager.getData (rolls)', () => {
 			expect(readFocusCharges()).toBeUndefined();
 		});
 
+		it('should refuse the use when the variable spend cannot be offered', async () => {
+			// A hidden pool renders no stepper, so the dialog would ask nothing and
+			// the activation would resolve `@spent` as 0. Refused before it opens.
+			makeItemSpendVariableCharges();
+			mockItem.rules!.set('0', {
+				type: 'chargePool',
+				id: 'pool-rule',
+				identifier: 'focus',
+				scope: 'item',
+				max: '10',
+				initial: 'max',
+				hidden: true,
+			});
+			manager = new ItemActivationManager(
+				mockItem as unknown as ConstructorParameters<typeof ItemActivationManager>[0],
+				{},
+			);
+			manager.activationData = { effects: [] };
+			mockReconstructEffectsTree.mockReturnValue([]);
+
+			const result = await manager.getData();
+
+			expect(result).toEqual({ activation: null, rolls: null });
+			expect(MockItemActivationConfigDialog).not.toHaveBeenCalled();
+		});
+
 		it('should leave the pool to the table when spending automation is off', async () => {
 			// The prompt still runs: the amount feeds the item's own effect formulas,
 			// so suppressing it would heal for nothing rather than hand the GM a count.
@@ -1759,8 +1966,7 @@ describe('ItemActivationManager.getData (rolls)', () => {
 			try {
 				dialogState.result = {
 					rollMode: 0,
-					spentCharges: 4,
-					consumedChargePools: [{ poolId: 'focus', count: 4 }],
+					consumedVariableCharges: [{ poolId: 'focus', count: 4 }],
 				};
 				makeItemSpendVariableCharges();
 				manager = new ItemActivationManager(

--- a/src/managers/ItemActivationManager.ts
+++ b/src/managers/ItemActivationManager.ts
@@ -670,7 +670,9 @@ class ItemActivationManager {
 		for (const entry of entries as Array<{ poolId?: unknown; count?: unknown }>) {
 			if (!entry || typeof entry.poolId !== 'string') continue;
 			const count = Math.max(0, Math.floor(Number(entry.count) || 0));
-			const allowed = Math.min(count, ceilings.get(entry.poolId) ?? count);
+			const ceiling = ceilings.get(entry.poolId);
+			if (ceiling === undefined) continue;
+			const allowed = Math.min(count, ceiling);
 			if (allowed < 1) continue;
 			clamped.push({ poolId: entry.poolId, count: allowed });
 		}

--- a/src/managers/ItemActivationManager.ts
+++ b/src/managers/ItemActivationManager.ts
@@ -4,6 +4,7 @@ import { adjustPool } from '#utils/chargePool/chargePoolRecover.js';
 import { getPools as getChargePools } from '#utils/chargePool/chargePoolSync.js';
 import {
 	findConflictingVariablePools,
+	findUnofferableVariableSpends,
 	getChargeConsumers,
 	getFixedChargeCostsByPool,
 } from '#utils/chargePool/helpers.js';
@@ -105,6 +106,8 @@ class ItemActivationManager {
 	 * fail its own validation and lose the charges with no card.
 	 */
 	#deferredChargeSpends: Array<{ poolId: string; count: number }> = [];
+
+	#deferredVariableSpends: Array<{ poolId: string; count: number }> = [];
 
 	/**
 	 * Dice-pool faces named in the dialog, held for the same reason: the gate
@@ -218,12 +221,14 @@ class ItemActivationManager {
 			{ delivery: this.#getAttackDelivery() },
 		);
 
+		// Hold what the dialog spent until the caller clears the preUseItem gate.
+		// The dialog already included the dice faces in rollFormula above. Settled
+		// before the rolls so the spend and the `@spent` the formulas resolve
+		// against are capped by one reading of the pools.
+		this.#deferPoolSpends(dialogData);
+
 		let rolls: (Roll | DamageRoll)[] = [];
 		rolls = await this.#getRolls(dialogData, targetDomain, incomingAttackPlan);
-
-		// Hold what the dialog spent until the caller clears the preUseItem gate.
-		// The dialog already included the dice faces in rollFormula above.
-		this.#deferPoolSpends(dialogData);
 
 		return {
 			rolls,
@@ -277,7 +282,7 @@ class ItemActivationManager {
 		// which keeps a formula referencing it from failing to parse.
 		const activationRollData = {
 			...(this.actor?.getRollData() ?? {}),
-			spent: this.#resolveSpentCharges(dialogData),
+			spent: this.#resolveSpentCharges(),
 		};
 		let foundDamageRoll = false;
 		// The primary damage node and its incoming-attack plan, resolved after the
@@ -596,19 +601,20 @@ class ItemActivationManager {
 	}
 
 	/**
-	 * What the item's own formulas read as `@spent`.
+	 * The most each of this item's variable consumers can spend right now, keyed
+	 * by pool id.
 	 *
-	 * The dialog clamps the player's choice, but against a snapshot taken when it
-	 * opened. Capping the formula input at what the variable consumers' pools
-	 * actually hold keeps the healing from outrunning the charges if the pool
-	 * moved underneath the open dialog.
+	 * Two claims come off the same pool later in the activation and are reserved
+	 * rather than spent twice over: the item's own fixed charge costs, and any
+	 * rollable charges the player also chose to spend from that pool.
 	 */
-	#resolveSpentCharges(dialogData: ItemActivationManager.DialogData): number {
-		const named = Math.max(0, Math.floor(Number(dialogData.spentCharges) || 0));
-		if (named < 1) return 0;
+	#getVariableChargeCeilings(
+		rollableSpends: Array<{ poolId: string; count: number }> = [],
+	): Map<string, number> {
+		const ceilings = new Map<string, number>();
 
 		const actor = this.actor;
-		if (actor?.type !== 'character') return named;
+		if (actor?.type !== 'character') return ceilings;
 
 		const variablePoolIds = new Set(
 			getChargeConsumers(
@@ -619,22 +625,57 @@ class ItemActivationManager {
 				.filter((consumer) => consumer.variable)
 				.map((consumer) => consumer.poolId),
 		);
-		if (variablePoolIds.size < 1) return named;
+		if (variablePoolIds.size < 1) return ceilings;
 
-		// The item's own fixed costs come out of the same pools later in the
-		// activation, so they are reserved here rather than spent twice over.
 		const fixedCosts = getFixedChargeCostsByPool(
 			actor as unknown as CharacterActorLike,
 			this.#item as unknown as RuleBackedItem,
 		);
 		const pools = getChargePools(actor as unknown as Actor.Implementation);
-		let ceiling = 0;
 		for (const poolId of variablePoolIds) {
 			const current = pools.find((candidate) => candidate.id === poolId)?.current ?? 0;
-			ceiling += Math.max(0, current - (fixedCosts.get(poolId) ?? 0));
+			const rollable = rollableSpends
+				.filter((entry) => entry?.poolId === poolId)
+				.reduce((total, entry) => total + Math.max(0, Math.floor(Number(entry.count) || 0)), 0);
+			ceilings.set(poolId, Math.max(0, current - (fixedCosts.get(poolId) ?? 0) - rollable));
 		}
 
-		return Math.min(named, ceiling);
+		return ceilings;
+	}
+
+	/**
+	 * What the item's own formulas read as `@spent`: the variable spends the
+	 * dialog submitted, after `#deferPoolSpends` capped them at what their pools
+	 * can pay. Reading the deducted numbers rather than a separate total from the
+	 * dialog is what keeps the effect and the pool in step when a pool moved
+	 * underneath the open dialog.
+	 */
+	#resolveSpentCharges(): number {
+		return this.#deferredVariableSpends.reduce((total, entry) => total + entry.count, 0);
+	}
+
+	/**
+	 * The dialog's variable spends, each capped at what its pool can still pay.
+	 * The dialog bounded the player's choice against a snapshot taken when it
+	 * opened, which the pool may have moved out from under.
+	 */
+	#clampVariableSpends(
+		entries: unknown,
+		rollableSpends: Array<{ poolId: string; count: number }>,
+	): Array<{ poolId: string; count: number }> {
+		if (!Array.isArray(entries)) return [];
+
+		const ceilings = this.#getVariableChargeCeilings(rollableSpends);
+		const clamped: Array<{ poolId: string; count: number }> = [];
+		for (const entry of entries as Array<{ poolId?: unknown; count?: unknown }>) {
+			if (!entry || typeof entry.poolId !== 'string') continue;
+			const count = Math.max(0, Math.floor(Number(entry.count) || 0));
+			const allowed = Math.min(count, ceilings.get(entry.poolId) ?? count);
+			if (allowed < 1) continue;
+			clamped.push({ poolId: entry.poolId, count: allowed });
+		}
+
+		return clamped;
 	}
 
 	/**
@@ -648,6 +689,10 @@ class ItemActivationManager {
 
 		const charges = dialogData.consumedChargePools;
 		this.#deferredChargeSpends = Array.isArray(charges) ? [...charges] : [];
+		this.#deferredVariableSpends = this.#clampVariableSpends(
+			dialogData.consumedVariableCharges,
+			this.#deferredChargeSpends,
+		);
 
 		const dice = dialogData.consumedPoolDice;
 		this.#deferredPoolDice = Array.isArray(dice) ? [...dice] : [];
@@ -665,8 +710,9 @@ class ItemActivationManager {
 	 * hand the count back to the GM.
 	 */
 	async #consumeChargePools(): Promise<void> {
-		const consumed = this.#deferredChargeSpends;
+		const consumed = [...this.#deferredChargeSpends, ...this.#deferredVariableSpends];
 		this.#deferredChargeSpends = [];
+		this.#deferredVariableSpends = [];
 		if (consumed.length < 1) return;
 		if (!isResourceSpendingAutomationEnabled()) return;
 
@@ -970,6 +1016,20 @@ class ItemActivationManager {
 			return null;
 		}
 
+		// Same reason: the dialog would render no prompt for a spend it cannot
+		// offer, so the player would fill in a blank window and roll before the
+		// gate refused the use.
+		const unofferable = this.#findUnofferableVariableSpend();
+		if (unofferable) {
+			ui.notifications?.error(
+				game.i18n.format('NIMBLE.charges.notifications.unofferableSpend', {
+					item: this.#item.name ?? '',
+					pool: unofferable,
+				}),
+			);
+			return null;
+		}
+
 		// A variable charge spend has no sensible default — the amount is the
 		// player's input — so an item that asks for one always gets the dialog.
 		const hasVariableChargeSpend = this.#hasVariableChargeSpend();
@@ -1022,6 +1082,18 @@ class ItemActivationManager {
 			this.#item as unknown as RuleBackedItem,
 		);
 		return conflict?.poolIdentifier ?? null;
+	}
+
+	/** The first pool whose player-chosen spend cannot be offered, if any. */
+	#findUnofferableVariableSpend(): string | null {
+		const actor = this.actor;
+		if (actor?.type !== 'character') return null;
+
+		const [unofferable] = findUnofferableVariableSpends(
+			actor as unknown as CharacterActorLike,
+			this.#item as unknown as RuleBackedItem,
+		);
+		return unofferable?.poolLabel ?? null;
 	}
 
 	/** Whether this item spends a player-chosen number of charges. */
@@ -1178,11 +1250,12 @@ namespace ItemActivationManager {
 		 */
 		consumedChargePools?: Array<{ poolId: string; count: number }>;
 		/**
-		 * Charges spent by this item's variable charge consumers. Exposed to the
-		 * item's own effect formulas as `@spent`, which is how an activation whose
-		 * effect *is* the amount spent gets at the player's choice.
+		 * Charges spent by this item's variable charge consumers, per pool. Their
+		 * total is what the item's own effect formulas read as `@spent`, which is
+		 * how an activation whose effect *is* the amount spent gets at the
+		 * player's choice.
 		 */
-		spentCharges?: number;
+		consumedVariableCharges?: Array<{ poolId: string; count: number }>;
 		/**
 		 * Typed damage from conditional-bonus choices (e.g. a marked-target rule that
 		 * grants a specific damage type). Each becomes its own damage effect so the

--- a/src/utils/chargePool/chargePoolConsume.ts
+++ b/src/utils/chargePool/chargePoolConsume.ts
@@ -5,6 +5,7 @@ import {
 	buildEffectiveChargePoolMap,
 	clampCurrentToMax,
 	findConflictingVariablePools,
+	findUnofferableVariableSpends,
 	getApplicableUsageTriggers,
 	getChargeConsumers,
 	isCharacterActor,
@@ -80,6 +81,22 @@ function validateItemChargeConsumption(item: Item | null | undefined): ChargeVal
 				identifier: consumer.poolIdentifier,
 				required: minimum,
 			});
+	}
+
+	// See findUnofferableVariableSpends: an amount the activation could never ask
+	// about is an authoring mistake, not a spend of nothing.
+	const [unofferable] = findUnofferableVariableSpends(actor, ruleBackedItem);
+	if (unofferable) {
+		return {
+			ok: false,
+			failure: {
+				code: 'unofferableSpend',
+				poolIdentifier: unofferable.poolIdentifier,
+				poolLabel: unofferable.poolLabel,
+				required: unofferable.minimum,
+				available: unofferable.available,
+			},
+		};
 	}
 
 	for (const [poolId, tally] of requiredByPoolId) {

--- a/src/utils/chargePool/helpers.ts
+++ b/src/utils/chargePool/helpers.ts
@@ -521,6 +521,50 @@ function findConflictingVariablePools(
 	return [...conflicting.values()];
 }
 
+/**
+ * Variable consumers on this item whose amount could never be asked for.
+ *
+ * A hidden pool is an internal gate rather than a resource the player manages,
+ * so it renders no stepper to prompt with; a maximum below the minimum leaves
+ * no legal amount; and a spell is routed to the upcast window, which asks about
+ * tier rather than charges. Each would post a card that resolved `@spent` as 0
+ * and moved neither the pool nor the target, so the use is refused instead.
+ */
+function findUnofferableVariableSpends(
+	actor: CharacterActorLike,
+	item: RuleBackedItem,
+): Array<{ poolIdentifier: string; poolLabel: string; minimum: number; available: number }> {
+	const pools = buildEffectiveChargePoolMap(actor);
+	const unofferable: Array<{
+		poolIdentifier: string;
+		poolLabel: string;
+		minimum: number;
+		available: number;
+	}> = [];
+
+	for (const consumer of getChargeConsumers(actor, item, { includeVariable: true })) {
+		if (!consumer.variable) continue;
+		const pool = pools[consumer.poolId];
+		if (!pool) continue;
+
+		const minimum = Math.max(1, consumer.cost);
+		const offerable =
+			!pool.hidden &&
+			item.type !== 'spell' &&
+			(consumer.maxCost === null || consumer.maxCost >= minimum);
+		if (offerable) continue;
+
+		unofferable.push({
+			poolIdentifier: consumer.poolIdentifier,
+			poolLabel: pool.label,
+			minimum,
+			available: toFiniteNonNegativeInteger(pool.current),
+		});
+	}
+
+	return unofferable;
+}
+
 function getApplicableUsageTriggers(context: {
 	isMiss?: boolean;
 	isCritical?: boolean;
@@ -771,6 +815,7 @@ export {
 	getChargeConsumers,
 	getFixedChargeCostsByPool,
 	findConflictingVariablePools,
+	findUnofferableVariableSpends,
 	getApplicableUsageTriggers,
 	applyRecoveryTriggersToPools,
 	resolveRecoveryTrigger,

--- a/src/utils/chargePool/types.ts
+++ b/src/utils/chargePool/types.ts
@@ -126,7 +126,12 @@ type ChargeContext = {
 };
 
 type ChargeValidationFailure = {
-	code: 'poolMissing' | 'insufficientCharges' | 'consumptionBlocked' | 'conflictingConsumers';
+	code:
+		| 'poolMissing'
+		| 'insufficientCharges'
+		| 'consumptionBlocked'
+		| 'conflictingConsumers'
+		| 'unofferableSpend';
 	poolIdentifier: string;
 	poolLabel: string;
 	required: number;

--- a/src/utils/chargePoolService.test.ts
+++ b/src/utils/chargePoolService.test.ts
@@ -243,6 +243,87 @@ describe('ChargePoolService', () => {
 		expect(validation.failure?.required).toBe(3);
 	});
 
+	function itemWithVariableConsumer(
+		poolOverrides: Partial<MockRule>,
+		consumerOverrides: Partial<MockRule>,
+	) {
+		const actor = createMockActor({
+			items: [
+				{
+					id: 'item-1',
+					name: 'Wand',
+					rules: [
+						{
+							type: 'chargePool',
+							id: 'pool-rule',
+							identifier: 'wand',
+							scope: 'item',
+							max: '5',
+							initial: 'max',
+							...poolOverrides,
+						},
+						{
+							type: 'chargeConsumer',
+							id: 'variable-rule',
+							poolIdentifier: 'wand',
+							poolScope: 'item',
+							costMode: 'variable',
+							cost: '1',
+							...consumerOverrides,
+						},
+					],
+					itemFlags: {
+						nimble: {
+							chargePools: {
+								wand: { current: 5, max: 5, recoveries: [] },
+							},
+						},
+					},
+				},
+			],
+		});
+
+		return actor.items.contents[0] as unknown as Item.Implementation;
+	}
+
+	it('blocks activation when a variable consumer sits on a hidden pool', () => {
+		// A hidden pool has no stepper to prompt with, so the spend could never be
+		// asked for: the item would post a card that spent nothing.
+		const validation = validateItemChargeConsumption(
+			itemWithVariableConsumer({ hidden: true }, {}),
+		);
+
+		expect(validation.ok).toBe(false);
+		expect(validation.failure?.code).toBe('unofferableSpend');
+		expect(validation.failure?.poolIdentifier).toBe('wand');
+	});
+
+	it('blocks activation when a variable maximum falls below its minimum', () => {
+		const validation = validateItemChargeConsumption(
+			itemWithVariableConsumer({}, { cost: '3', maxCost: '2' }),
+		);
+
+		expect(validation.ok).toBe(false);
+		expect(validation.failure?.code).toBe('unofferableSpend');
+		expect(validation.failure?.required).toBe(3);
+	});
+
+	it('blocks activation when a variable consumer sits on a spell', () => {
+		// A spell is routed to the upcast window, which asks about tier and has no
+		// stepper to prompt for an amount.
+		const item = itemWithVariableConsumer({}, {});
+		(item as unknown as { type: string }).type = 'spell';
+
+		const validation = validateItemChargeConsumption(item);
+
+		expect(validation.ok).toBe(false);
+		expect(validation.failure?.code).toBe('unofferableSpend');
+	});
+
+	it('allows a variable consumer with a blank maximum on a visible pool', () => {
+		expect(validateItemChargeConsumption(itemWithVariableConsumer({}, {})).ok).toBe(true);
+	});
+
 	it('blocks activation when the fixed and variable costs together exceed the pool', () => {
 		// Each consumer fits on its own, so only the per-pool total catches this.
 		const actor = createMockActor({

--- a/src/view/dialogs/ItemActivationConfigDialog.svelte
+++ b/src/view/dialogs/ItemActivationConfigDialog.svelte
@@ -40,12 +40,9 @@
 			const [poolId, indexStr] = key.split(':');
 			return { poolId, faceIndex: Number(indexStr) };
 		});
-		const consumedChargePools = [
-			...Object.entries(state.chargeSpendCounts)
-				.filter(([, count]) => count > 0)
-				.map(([poolId, count]) => ({ poolId, count })),
-			...state.consumedVariableCharges,
-		];
+		const consumedChargePools = Object.entries(state.chargeSpendCounts)
+			.filter(([, count]) => count > 0)
+			.map(([poolId, count]) => ({ poolId, count }));
 		dialog.submitActivation({
 			// Fold any "advantage" conditional-bonus choices into the roll mode; "damage"
 			// choices are already baked into the modified formula below. Clamp the sum to
@@ -58,7 +55,7 @@
 			rollHidden: state.shouldRollBeHidden,
 			consumedPoolDice,
 			consumedChargePools,
-			spentCharges: state.spentCharges,
+			consumedVariableCharges: state.consumedVariableCharges,
 			// Typed conditional-bonus damage rolls as its own damage effect so the
 			// chosen type applies; untyped choices are already folded into rollFormula.
 			conditionalDamages: state.conditionalTypedDamages,

--- a/src/view/dialogs/itemActivationConfigDialogState.svelte.ts
+++ b/src/view/dialogs/itemActivationConfigDialogState.svelte.ts
@@ -187,16 +187,6 @@ export function createItemActivationConfigDialogState(
 		spendablePools.length > 0 || spendableChargePools.length > 0 || autoBonusPools.length > 0,
 	);
 
-	// What the item's own effect formulas read as `@spent`. Summed across
-	// consumers so an item with two variable spends reports one budget, which is
-	// what a formula referring to "the amount spent" means.
-	const spentCharges = $derived(
-		variableChargeSpends.reduce(
-			(total, spend) => total + (variableSpendCounts[spend.poolId] ?? 0),
-			0,
-		),
-	);
-
 	// The variable spends in the shape the manager deducts from.
 	const consumedVariableCharges = $derived(
 		variableChargeSpends
@@ -341,9 +331,6 @@ export function createItemActivationConfigDialogState(
 		},
 		get variableSpendCounts() {
 			return variableSpendCounts;
-		},
-		get spentCharges() {
-			return spentCharges;
 		},
 		get consumedVariableCharges() {
 			return consumedVariableCharges;

--- a/tests/integration/liveHelpers.ts
+++ b/tests/integration/liveHelpers.ts
@@ -216,14 +216,6 @@ async function createCombatWith(
 const RULE_AUTOMATION_SETTING = 'automation.applyRuleEffects';
 
 /**
- * The rule-automation world setting, read/written through the same casts the
- * system uses (see isRuleAutomationEnabled) — it is not in fvtt-types'
- * registered settings map. This is the toggle that gates ruleEventDispatch, so
- * suites that depend on rule lifecycle events firing (or not) must snapshot and
- * restore it. Note that the health-state sync (bloodied/dying status mirroring)
- * has its own toggle and is NOT gated by this setting.
- */
-/**
  * Any `automation.*` world toggle, read and written through the casts the
  * system uses: none of them are in fvtt-types' registered settings map. Suites
  * that depend on a toggle must snapshot and restore it.
@@ -236,6 +228,13 @@ async function setAutomationToggle(key: string, value: boolean): Promise<void> {
 	await game.settings.set(game.system.id as 'core', key as 'rollMode', value as never);
 }
 
+/**
+ * The rule-automation world setting. This is the toggle that gates
+ * ruleEventDispatch, so suites that depend on rule lifecycle events firing (or
+ * not) must snapshot and restore it. Note that the health-state sync
+ * (bloodied/dying status mirroring) has its own toggle and is NOT gated by
+ * this setting.
+ */
 function getRuleAutomationEnabled(): boolean {
 	return getAutomationToggle(RULE_AUTOMATION_SETTING);
 }

--- a/types/components/ItemActivationConfigDialog.d.ts
+++ b/types/components/ItemActivationConfigDialog.d.ts
@@ -68,9 +68,13 @@ export interface ItemActivationConfigDialogSubmitData {
 	consumedChargePools: ConsumedChargePool[];
 	/**
 	 * Charges spent by variable consumers, which effect formulas read as `@spent`.
+	 * Kept apart from `consumedChargePools` because the two are bounded
+	 * differently: a variable spend is the amount the activation resolves
+	 * against, a rollable charge spend is a rider on it.
+	 *
 	 * Optional: the upcast dialog submits the same shape without it.
 	 */
-	spentCharges?: number;
+	consumedVariableCharges?: ConsumedChargePool[];
 }
 
 export interface ItemActivationConfigDialogInstance {


### PR DESCRIPTION
## Summary

Non-blocking follow-ups from @trevlar's review on #933, plus the two correctness gaps that surfaced while fixing them.

## Changes

- **A variable spend and its deduction are one number now.** The dialog reported the player's choice twice: once as a per-pool list to deduct from, once as a single total (`spentCharges`) for the item's formulas to read as `@spent`. The two were bounded differently, so a pool that moved underneath an open dialog was charged the choice while the effect resolved for what the pool could still pay. Variable spends now travel only as `consumedVariableCharges`, capped per pool, and `@spent` is their sum.
- **The cap reserves everything else coming out of the same pool.** Not just the item's own fixed charge costs, but any rollable charges the player also chose to spend from that pool in the same dialog. A single total also let headroom in one pool pay for an overspend in another; the cap is per pool.
- **A variable spend the activation could never ask about is refused, naming the pool.** A hidden pool renders no stepper, a maximum cost below the minimum leaves no legal amount, and a spell is routed to the upcast window, which asks about tier. Each used to post a card that healed 0 and moved nothing. The refusal fires before the dialog opens, as the two-consumers-on-one-pool refusal already did.
- `#deferPoolSpends` settles before the rolls, so the spend and the `@spent` the formulas resolve against come from one reading of the pools.
- Moves a doc comment in `liveHelpers.ts` back onto the function it describes, and adds the missing trailing newline to the `chargeConsumer` docs partial.

### One review note taken a different way

The review asked for the spell card's flags to carry `chargeConsumption` the way `base.svelte.ts` does. That flag would have stayed empty: `manager.chargeConsumption` is fed only by the activation dialog, and a spell is routed to `SpellUpcastDialog`, which never collects a charge spend. Refusing a variable consumer on a spell removes the situation instead of half-supporting it. A spell with a *fixed* consumer is unaffected, and its card already reports the spend through the `useItem` hook.

## Test Plan

Automated: `pnpm check` passes (4091 unit tests). New coverage for each fix, and I confirmed the two clamp tests fail without their fix rather than passing vacuously:

- `@spent` is capped per pool, not against the pools' combined headroom.
- A rollable charge spend from the same pool is reserved before the variable one.
- The use is refused before the dialog opens when the spend cannot be offered.
- `validateItemChargeConsumption` refuses a hidden pool, a maximum below the minimum, and a spell.

By hand, on a level 1 Oathsworn, Lay on Hands should behave exactly as it does on `dev`: pill at 5/5, spend prompt bounded 1 to 5, the card reports the spend, Apply Healing lands it, Safe Rest refills. Nothing in this PR changes the single-variable-consumer path that ships.

To see a fix bite, put a `chargeConsumer` in `variable` mode on a pool that is also `hidden`, or set its maximum cost below its cost. The use should be refused with the pool named, instead of posting a card that heals 0.

## Known limitation

The variable stepper's upper bound is still taken when the dialog opens, so on a pool that is both rollable (`dieSize` set) and variable-consumed, the stepper can offer more than the rollable spend chosen alongside it leaves. The manager clamps the spend safely, so nothing is over-drawn, but the stepper is optimistic. No pack content pairs a `dieSize` pool with a variable consumer.

## Checklist

- [x] Added or updated unit tests
- [x] PR targets the `dev` branch
- [x] `pnpm check` passes (format, lint, circular deps, type-check, tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [ ] Tested in Foundry with no console errors
- [x] **Have you used AI to assist with this PR?** yes
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues

Follow-up to #933


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Variable charge spending now supports multiple pools, with amounts limited to available balances.
  * Fixed and variable charges can share a pool, with fixed costs reserved first.
  * Activation dialogs identify variable charge usage by pool.

* **Bug Fixes**
  * Unofferable variable charges are blocked before activation with localized explanations.
  * Improved handling for hidden pools, invalid cost ranges, and spell-related restrictions.

* **Documentation**
  * Clarified charge-pool sharing rules, variable spending prompts, and `@spent` formula usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->