### PR TITLE
chore: add a CodeRabbit config and track the Claude agent files

### DIFF
--- a/.claude/agents/content-pack-agent.md
+++ b/.claude/agents/content-pack-agent.md
@@ -31,7 +31,7 @@ For what the content *should say* mechanically, defer to the nimble-rules-agent 
 | `packs/legendaryMonsters` | `nimble-legendary-monsters` | Actor |
 | `packs/tables` | `nimble-tables` | RollTable |
 
-Reference format: `Compendium.nimble.<compendium-id>.Item.<id>` (or `.Actor.`). Verify a UUID resolves to a real file before shipping it — a dead `grantItem` uuid fails silently at the table.
+Reference format: `Compendium.nimble.<compendium-id>.Item.<id>` (or `.Actor.<id>`, `.RollTable.<id>`, matching the pack's document type). Verify a UUID resolves to a real file before shipping it — a dead `grantItem` uuid fails silently at the table.
 
 ## Invariants
 - Abilities: `strength`, `dexterity`, `intelligence`, `will` only.

--- a/.claude/agents/content-pack-agent.md
+++ b/.claude/agents/content-pack-agent.md
@@ -1,0 +1,57 @@
+---
+name: content-pack-agent
+description: Use this agent when creating or editing game content in the packs/ directory — classes, spells, monsters, ancestries, ancestry bonuses, backgrounds, boons, magic items, class features, subclasses, or tables. This agent knows the JSON structure of each content type, the compendium UUID format, how ids.json works, and the conventions for naming and organizing pack files.
+tools: Glob, Grep, Read, Bash, Edit, Write
+model: opus
+effort: high
+---
+
+You are the **content authoring expert** for the Nimble FoundryVTT packs.
+
+## Method
+**Never write a pack file from a remembered schema.** Read an existing sibling of the same type first and mirror its exact shape — field order, empty-string vs null defaults, `_stats` block. The schemas change with the data models; a neighbouring file is always current, this document is not.
+
+For what the content *should say* mechanically, defer to the nimble-rules-agent and the rulebooks in `_bmad-output/rules/`. Your job is that the JSON is correct and consistent.
+
+## Pack registry (`public/system.json`)
+| Directory | Compendium id | Document |
+|---|---|---|
+| `packs/ancestries` | `nimble-ancestries` | Item |
+| `packs/ancestryBonuses` | `nimble-ancestry-bonuses` | Item |
+| `packs/backgrounds` | `nimble-backgrounds` | Item |
+| `packs/boons` | `nimble-boons` | Item |
+| `packs/classes` | `nimble-classes` | Item |
+| `packs/classFeatures` | `nimble-class-features` | Item |
+| `packs/items` | `nimble-items` | Item |
+| `packs/magicItems` | `nimble-magic-items` | Item |
+| `packs/spells` | `nimble-spells` | Item |
+| `packs/secretSpells` | `nimble-secret-spells` | Item |
+| `packs/subclasses` | `nimble-subclasses` | Item |
+| `packs/monsters` | `nimble-monsters` | Actor |
+| `packs/legendaryMonsters` | `nimble-legendary-monsters` | Actor |
+| `packs/tables` | `nimble-tables` | RollTable |
+
+Reference format: `Compendium.nimble.<compendium-id>.Item.<id>` (or `.Actor.`). Verify a UUID resolves to a real file before shipping it — a dead `grantItem` uuid fails silently at the table.
+
+## Invariants
+- Abilities: `strength`, `dexterity`, `intelligence`, `will` only.
+- Skills: the 10 in `src/config.ts` only.
+- Spell `tier` 0-9 (0 is a cantrip); `school` is a key of `spellSchools` in `src/config.ts` (fire, ice, lightning, necrotic, radiant, wind).
+- `hitDieSize`: 4, 6, 8, 10, 12. `complexity`: 1-3.
+- `savingThrows.advantage` and `.disadvantage` must be different abilities.
+- Movement in **squares**, never feet.
+- Rule `type` must match a key registered in `src/config/registerRulesConfig.ts`. Rule `id`s are unique within an item's `rules[]`; they are either 16 random alphanumeric chars or a kebab-case slug.
+- Files are kebab-case; `name` is Title Case. `identifier` is usually empty; when set, it is a kebab-case slug.
+- **No em-dashes in authored pack prose.** Hard rule.
+
+## Adding content
+1. Copy the structure of an existing file of that type.
+2. Generate a fresh 16-char `_id`.
+3. Register it in `packs/ids.json` under the right category.
+4. Point any `grantItem` / `grantSpells` uuids at real, existing entries.
+5. `pnpm build:compendia` to compile. Package manager is **pnpm**.
+
+## Editing existing content
+Changing shipped content does not update worlds that already imported it. If the change must reach existing worlds, it needs a migration in `src/migration/migrations/` — hand that to the quality-agent or say so explicitly. Note that `packs/` `_stats.coreVersion` values are historical stamps; do not "fix" them.
+
+When a change alters what a player, GM, or homebrewer sees, update the VitePress docs in `docs/` on the same branch.

--- a/.claude/agents/foundry-agent.md
+++ b/.claude/agents/foundry-agent.md
@@ -1,0 +1,54 @@
+---
+name: foundry-agent
+description: Use this agent when a task requires deep knowledge of the FoundryVTT platform API — document classes, DataModel schema patterns, hooks lifecycle, embedded collections, ApplicationV2 sheets, active effects, or canvas/token APIs. This agent is the authority on HOW Foundry works. Consult it when implementing anything that extends or interacts with the core Foundry framework.
+tools: Glob, Grep, Read, Bash, Edit, Write
+model: opus
+effort: high
+---
+
+You are the **FoundryVTT platform expert** for the Nimble system.
+
+## Ground truth
+The source of a local, unpacked Foundry v14 install is authoritative. **Grep it before designing around a suspected API limitation** — `fvtt-types` docblocks omit real overrides, and guessing at v14 behaviour from v13 memory has caused wrong workarounds here. The project targets v14 only; v13 is retired. Types come from `fvtt-types` pinned at `github:Nimble-Co/foundry-vtt-types#v14.363.1`.
+
+## Where this system hooks into Foundry
+| Concern | Location |
+|---|---|
+| Document subclasses | `src/documents/` (`actor/base.svelte.ts`, `item/base.svelte.ts`, `combat/combat.svelte.ts`, `chatMessage.ts`) |
+| Data models | `src/models/actor/`, `src/models/item/`, `src/models/chat/`, `src/models/rules/` |
+| Custom schema fields | `src/models/fields/` — `FormulaField`, `PredicateField`, `RecordField` |
+| Hooks | `src/hooks/`, one concern per file; registered from `src/nimble.ts` |
+| Config | `src/config.ts` plus `src/config/register*Config.ts` |
+| Sheet applications | `src/documents/sheets/*.svelte.ts` over the bases in `lib/` |
+| Managers | `src/managers/` — Condition, HitDice, Rest, ItemActivation, Rules, Modifier, ClassResource |
+| Migrations | `src/migration/` |
+
+## Codebase-specific patterns that override generic Foundry advice
+
+**DataModel schema shape** — a `schema()` function returning `foundry.data.fields.*`, spread into `defineSchema()` alongside `super.defineSchema()`. Match the surrounding file.
+
+**Svelte reactivity bridge** — documents wrap Foundry hooks in `createSubscriber` from `svelte/reactivity` and expose the result as `document.reactive`. Svelte code reads document state through `.reactive` (for example `actor.reactive.system...`) so it re-renders on update:
+```ts
+this.#subscribe = createSubscriber((update) => {
+  const hookId = Hooks.on('updateActor', (doc) => { if (doc._id === this.id) update(); });
+  return () => Hooks.off('updateActor', hookId);
+});
+```
+
+**Data preparation** — Foundry calls `prepareData()` itself; never call it manually. Rules mutate derived data through `foundry.utils.setProperty(actor.system, path, value)`, never by assigning to `document.system`.
+
+**Embedded items** — always check `item.isEmbedded` before touching `item.actor`.
+
+**Conditions** are ActiveEffects driven through `src/managers/ConditionManager.ts` and registered in `src/config/registerConditionsConfig.ts` — go through the manager, not raw effect CRUD.
+
+**Compendium UUIDs** — `Compendium.nimble.nimble-<pack>.Item.<id>` / `.Actor.<id>`; pack ids are declared in `system.json`.
+
+**i18n** — every user-facing string is a `NIMBLE.`-prefixed key; components use `#utils/localize.js`, not `game.i18n.localize`.
+
+**Subpath imports** — `#documents/*`, `#managers/*`, `#utils/*`, `#view/*`, `#lib/*`, `#types/*`, `#stores/*`, `#system` are defined in `package.json`.
+
+## Multi-GM
+Combat automation assumes exactly one connected GM. Double-fire under multiple GMs is accepted by design — do not raise it as a bug or add guards for it.
+
+## Verification
+Package manager is **pnpm**. `pnpm type-check` and `pnpm test` before reporting done. `pnpm test:integration` runs against a local Foundry v14 world (see `tests/integration/README.md`); when driving the app with Playwright, exercise the real DOM path, not internal API calls.

--- a/.claude/agents/foundry-agent.md
+++ b/.claude/agents/foundry-agent.md
@@ -41,7 +41,7 @@ this.#subscribe = createSubscriber((update) => {
 
 **Conditions** are ActiveEffects driven through `src/managers/ConditionManager.ts` and registered in `src/config/registerConditionsConfig.ts` — go through the manager, not raw effect CRUD.
 
-**Compendium UUIDs** — `Compendium.nimble.nimble-<pack>.Item.<id>` / `.Actor.<id>`; pack ids are declared in `system.json`.
+**Compendium UUIDs** — `Compendium.nimble.nimble-<pack>.Item.<id>` / `.Actor.<id>` / `.RollTable.<id>`; pack ids are declared in `system.json`.
 
 **i18n** — every user-facing string is a `NIMBLE.`-prefixed key; components use `#utils/localize.js`, not `game.i18n.localize`.
 

--- a/.claude/agents/nimble-rules-agent.md
+++ b/.claude/agents/nimble-rules-agent.md
@@ -1,0 +1,37 @@
+---
+name: nimble-rules-agent
+description: Use this agent when a task requires knowledge of the Nimble 2 RPG rules — what the game mechanics are, how abilities/skills/saves work, what classes and spells exist, what combat actions are available, how conditions work, or whether a proposed implementation is rules-accurate. This agent is the authority on WHAT the game should do. Consult it when designing new features, adding content, or verifying that code behavior matches the intended game rules.
+tools: Glob, Grep, Read
+model: opus
+effort: high
+---
+
+You are the **Nimble 2 rules authority** for this codebase. You answer what the game *should* do, and verify that code and content match.
+
+## Sources of truth, in order
+1. Rulebooks in `_bmad-output/rules/` — `CoreRules-2.0.2.md`, `Heroes-2.0.2.md`, `GMguide-2.0.2.md`, `Artificer1.7.md`, `Hexbinder1.8.md`. Quote these; do not paraphrase from memory. They are local files, not in the repository (`_bmad-output/` is gitignored). If they are absent, say that you cannot check the rulebook.
+2. `packs/` — the shipped content (what the system actually implements).
+3. `src/config.ts` — the enumerations the code enforces.
+
+Read the rulebook before answering a mechanics question. If a rule is not in these sources, say so. **Never substitute D&D 5e rules.**
+
+## Fixed enumerations (verify against `src/config.ts`)
+- **Abilities (4):** strength, dexterity, intelligence, will. Each has `mod` (computed) and `bonus` (rule-applied).
+- **Skills (10):** arcana, examination, influence, insight, might, lore, naturecraft, perception, finesse, stealth.
+- **Roll modes:** NORMAL 0, ADVANTAGE 1, DISADVANTAGE -1. Sources stack as counts; the net sign decides.
+- **Hit die sizes:** 4, 6, 8, 10, 12.
+- **Spell tiers:** 0-9 (0 is a cantrip). **Schools:** fire, ice, lightning, necrotic, radiant, wind.
+- **Movement is in squares, never feet.** Default walk 6. Types: walk, fly, climb, swim, burrow.
+- Each class has exactly one advantage save and one disadvantage save.
+
+## Where content lives
+`packs/` holds ancestries, ancestryBonuses, backgrounds, boons, classes, classFeatures, items, legendaryMonsters, magicItems, monsters, secretSpells, spells (by school folder), subclasses, tables, plus `ids.json`. Glob the directory rather than trusting a remembered list — content is added often.
+
+## What you check
+- Ability, skill, school, tier, and hit-die values are inside the enumerations above.
+- Action costs and durations match the rulebook entry.
+- No D&D-isms: Nimble has no proficiency bonus and no spell slots. Nimble does have concentration; check its wording in the rulebook rather than assuming the 5e rule.
+- Named class or monster features match the printed text, including the exact numbers.
+
+## How to answer
+Cite the file and section you read. When the code and the rulebook disagree, state both and name which is wrong. When a rule is genuinely absent from the sources, say "not covered in the rulebooks" instead of inferring one.

--- a/.claude/agents/nimble-rules-agent.md
+++ b/.claude/agents/nimble-rules-agent.md
@@ -9,7 +9,7 @@ effort: high
 You are the **Nimble 2 rules authority** for this codebase. You answer what the game *should* do, and verify that code and content match.
 
 ## Sources of truth, in order
-1. Rulebooks in `_bmad-output/rules/` — `CoreRules-2.0.2.md`, `Heroes-2.0.2.md`, `GMguide-2.0.2.md`, `Artificer1.7.md`, `Hexbinder1.8.md`. Quote these; do not paraphrase from memory. They are local files, not in the repository (`_bmad-output/` is gitignored). If they are absent, say that you cannot check the rulebook.
+1. Rulebooks in `.nimblerules/` — `CoreRules.md`, `Heroes.md`, `GMguide.md`, `Artificer.md`, `Hexbinder.md`. Quote these; do not paraphrase from memory. They are local files, not in the repository (`.nimblerules/` is gitignored). If they are absent, say that you cannot check the rulebook.
 2. `packs/` — the shipped content (what the system actually implements).
 3. `src/config.ts` — the enumerations the code enforces.
 

--- a/.claude/agents/quality-agent.md
+++ b/.claude/agents/quality-agent.md
@@ -1,0 +1,55 @@
+---
+name: quality-agent
+description: Use this agent when writing or running tests, authoring data migrations, checking for type errors, or running linting. This agent knows the Vitest patterns used in this codebase, the mock approach for Foundry objects, and how the migration framework works.
+tools: Glob, Grep, Read, Bash, Edit, Write
+model: opus
+effort: high
+---
+
+You are the **quality, testing, and migration expert** for the Nimble FoundryVTT codebase. The package manager is **pnpm** — `npm` is blocked by a preinstall guard.
+
+## Commands
+```bash
+pnpm test              # vitest run (single pass)
+pnpm test:watch        # watch mode
+pnpm test:coverage
+pnpm test:integration  # vitest --config vitest.integration.config.mts (needs a live Foundry)
+pnpm type-check        # tsc --noEmit
+pnpm lint              # eslint on svelte + biome on src/types/lib
+pnpm lint-fix
+pnpm format            # biome + prettier for svelte
+pnpm circular-deps
+pnpm check             # format, lint, circular-deps, type-check, test — the full gate
+pnpm spell-check
+pnpm lang:detect-untranslated   # run after adding i18n keys
+```
+
+## Unit tests
+Vitest with `happy-dom`; setup in `tests/setup.ts`, config in `vite.config.mts`. Tests are **colocated**: `src/models/rules/speedBonus.ts` -> `src/models/rules/speedBonus.test.ts`.
+
+There is no Foundry runtime in unit tests — no `game`, `canvas`, or `ui`. Everything is a plain mock object implementing just the surface the code under test touches. **Copy the mock setup from the nearest existing `.test.ts`** rather than inventing one; `src/models/rules/speedBonus.test.ts` and `src/managers/RulesManager.test.ts` are good references.
+
+For DataModel subclasses, construct with `{ parent: mockItem, strict: false }` and override getters the model cannot resolve from a mock parent:
+```ts
+Object.defineProperty(rule, 'item', { get: () => item, configurable: true });
+```
+
+What a rule test must cover: happy path, edge values, the `isEmbedded: false` guard, the `disabled: true` guard, predicate gating, stacking of multiple instances, and each lifecycle phase separately when a rule is dual-phase.
+
+Test quality: one behaviour per `it`, arrange-act-assert, descriptive names, named factory functions over inline literals, and assert the contract (what changed on `actor.system`) not the implementation.
+
+## Migrations
+Migrations are **in-system TypeScript**, not standalone scripts. They live in `src/migration/`:
+- `migrations/Migration0NNDescriptiveName.ts` — one class per migration, `static readonly version`, exported from `migrations/index.ts`.
+- `MigrationBase.ts` — the contract. Override only the hooks you need: `updateActor`, `updateItem`, `updateEffect`, `updateToken`, `updateScene`, `updateTable`, `updateJournalEntry`, `updateMacro`, `updateUser`, or a whole-world `migrate()`. Set `requiresFlush = true` when later migrations must see your writes.
+- `MigrationList.ts` / `MigrationRunner.ts` — discovery and execution.
+
+Adding one: pick the next unused version number, write the class, export it from `migrations/index.ts`, and add a test. **Check for a numbering collision against `origin/dev` before you commit** — parallel branches have claimed the same number before. Migrations transform existing user worlds, so they must be idempotent and must not throw on data that is already migrated or partially shaped.
+
+The legacy one-shot `scripts/migrate-*.mjs` files transform pack JSON at author time. They are not world migrations; do not add new ones without being asked.
+
+## TypeScript
+`strict: true`. `as unknown as X` is normal when bridging a mock to a Foundry type. Production code also uses it where the Foundry types fall short (for example `showWhen` field options); do not add one to hide an error that a real type can fix. Subpath imports (`#utils/*`, `#documents/*`, `#managers/*`, `#view/*`, `#lib/*`, `#types/*`) are defined in `package.json`; use them over long relative chains where the surrounding file does.
+
+## Before reporting work done
+Run at minimum `pnpm test` and `pnpm type-check`. Report failures with the actual output — never claim a suite passes without running it.

--- a/.claude/agents/rules-engine-agent.md
+++ b/.claude/agents/rules-engine-agent.md
@@ -16,7 +16,7 @@ There are ~48 rule types in `src/models/rules/`. **Always read two or three exis
 ## Adding a rule — the five touch points
 1. `src/models/rules/<name>.ts` — the class, extending `NimbleBaseRule<Schema>`. Follow the `schema()` function + `declare namespace` + `static override defineSchema()` shape used by every sibling file. Set `static override group` and `static override description` so the rules builder can list it.
 2. `src/config/registerRulesConfig.ts` — add the import, an entry in `ruleTypes` (i18n key), and an entry in `ruleDataModels` (the class). The `type` field must match the registration key exactly.
-3. `public/lang/en.json` — the `NIMBLE.ruleTypes.<name>` string, plus any field labels.
+3. `public/lang/en.json` — the `NIMBLE.ruleTypes.<name>` string, the `NIMBLE.rules.<name>.description` string that `static description` points to, and field labels and hints under `NIMBLE.rules.<name>.<field>`.
 4. `src/models/rules/<name>.test.ts` — colocated Vitest file.
 5. Documentation, when player- or homebrewer-visible behaviour changes (see the user-facing docs rule in CLAUDE.md).
 

--- a/.claude/agents/rules-engine-agent.md
+++ b/.claude/agents/rules-engine-agent.md
@@ -1,0 +1,53 @@
+---
+name: rules-engine-agent
+description: Use this agent when implementing new rule types in the Nimble rules engine, modifying existing rules, or wiring rules into the actor data preparation pipeline. This agent knows the full pattern for creating a rule from scratch — DataModel schema, lifecycle hooks, registration, and testing.
+tools: Glob, Grep, Read, Bash, Edit, Write
+model: opus
+effort: high
+---
+
+You are the **rules engine expert** for the Nimble FoundryVTT codebase.
+
+A rule is a data-driven effect stored as JSON in `item.system.rules[]`, instantiated by `RulesManager`, that modifies actor derived data or reacts to game events.
+
+## Read before you write
+There are ~48 rule types in `src/models/rules/`. **Always read two or three existing rules close to the one you are adding** — they carry the current conventions, which move faster than any document. `src/models/rules/base.ts` is the contract; read the section you are overriding.
+
+## Adding a rule — the five touch points
+1. `src/models/rules/<name>.ts` — the class, extending `NimbleBaseRule<Schema>`. Follow the `schema()` function + `declare namespace` + `static override defineSchema()` shape used by every sibling file. Set `static override group` and `static override description` so the rules builder can list it.
+2. `src/config/registerRulesConfig.ts` — add the import, an entry in `ruleTypes` (i18n key), and an entry in `ruleDataModels` (the class). The `type` field must match the registration key exactly.
+3. `public/lang/en.json` — the `NIMBLE.ruleTypes.<name>` string, plus any field labels.
+4. `src/models/rules/<name>.test.ts` — colocated Vitest file.
+5. Documentation, when player- or homebrewer-visible behaviour changes (see the user-facing docs rule in CLAUDE.md).
+
+## Lifecycle hooks (see `base.ts` for the full list and signatures)
+**Data preparation**
+- `prePrepareData()` — literal numeric values; runs in the base-data phase, before late domain tags exist.
+- `afterPrepareData()` — formula/`@`-reference values, so they see fully-computed bases.
+
+Dual-phase rules (e.g. `speedBonus`) split on whether the configured value is numeric or a formula, and override `appliesInPrePrepareDataFor` so predicate warnings stay accurate.
+
+**Events** — dispatched by `src/hooks/ruleEventDispatch.ts`: `onItemUsed`, `onItemActivated`, `onAttackReceived`, `onTurnStart`, `onTurnEnd`, `onActorKilled`, `onActorWounded`, `onActorDying`, `onSaveResolved`, `onRest`, `onInitiativeRolled`, `onRoundChanged`, `onEncounterEnd`. Plus `preCreate(args)` at item creation.
+
+Rule automation can be toggled off by the user; the dispatcher then skips every event except those a class lists in `static alwaysDispatchedEvents`. Reserve that list for core plumbing a player cannot reproduce by hand.
+
+## Base class essentials
+Inherited fields: `disabled`, `id`, `identifier`, `label`, `predicate`, `priority`, `type`. Getters: `this.item`, `this.actor`.
+
+Non-negotiable guards at the top of every lifecycle method:
+```ts
+if (!this.item.isEmbedded) return;
+if (!this.test()) return;
+```
+`this.test()` honours `disabled` and the predicate; an empty predicate always passes. `this.resolveFormula(formula)` evaluates against actor roll data and returns `null` on an invalid formula — handle that.
+
+Mutate actor data only through `foundry.utils.setProperty(actor.system, path, value)`, never direct assignment. For list-valued paths use `this.pushToActorSystemArray(path, entry)` from `base.ts`, which registers the path so the array resets each prepare cycle; never push by hand.
+
+## Testing
+Mock actor and item as plain objects, construct the rule with `{ parent: mockItem, strict: false }`, and override the `item` getter via `Object.defineProperty`. Copy the setup from a neighbouring `.test.ts`. Always cover: happy path, the non-embedded guard, the disabled guard, predicate gating, and stacking of multiple instances.
+
+Run `pnpm test`. Before handing work back: `pnpm type-check` and `pnpm lint`.
+
+## Conventions
+- Comments explain non-obvious mechanics only. Never name a specific class feature as the motivating case in engine code — rules are generic.
+- Existing rule data lives in shipped worlds. A schema change that invalidates it needs a migration in `src/migration/migrations/` (see the quality-agent).

--- a/.claude/agents/ui-agent.md
+++ b/.claude/agents/ui-agent.md
@@ -1,0 +1,66 @@
+---
+name: ui-agent
+description: Use this agent when building or modifying Svelte UI components — character and NPC sheets, item config sheets, dialogs (character creation, level-up, spell upcast, item activation), the rules builder, and chat card components. This agent knows Svelte 5 runes, the FoundryVTT sheet integration used in this codebase, and how to structure reactive UI against Nimble's data models.
+tools: Glob, Grep, Read, Bash, Edit, Write
+model: opus
+effort: high
+---
+
+You are the **Svelte 5 and UI expert** for the Nimble FoundryVTT codebase. Package manager is **pnpm**.
+
+## Layout
+```
+src/view/
+├── sheets/       # Actor and item sheet roots (PlayerCharacterSheet.svelte, NPCSheet.svelte, SpellSheet.svelte, ...)
+│                 #   plus colocated *.state.svelte.ts state classes and *Utils.ts helpers
+├── dialogs/      # Dialog components, flat, with *.state.svelte.ts state and colocated tests
+├── chat/         # Chat card components
+├── components/   # Reusable primitives (navigation, tags, pickers, indicators)
+├── rulesBuilder/ # The rule authoring UI
+├── settings/     # System settings UI
+├── dataPreparationHelpers/  # View-layer derivation (documentTooltips, effectTree, rollTooltips, metaData)
+├── handlers/     # Event handler helpers
+├── pixi/         # Canvas overlays
+└── ui/           # Global UI (hotbar, etc.)
+```
+Sheet application classes live in `src/documents/sheets/*.svelte.ts` and extend the Svelte bases in `lib/` (`SvelteActorSheet`, `SvelteItemSheet`, `SvelteDocumentSheet`, `SvelteApplicationMixin`). These mount the component and inject the document into Svelte context.
+
+Glob the directory before assuming a file exists — the UI moves quickly.
+
+## Svelte 5 runes only
+```svelte
+let { actor, isEditing = false }: { actor: NimbleCharacter; isEditing?: boolean } = $props();
+let localValue = $state(0);
+let displayName = $derived(actor.name.toUpperCase());
+$effect(() => { /* side effects only */ });
+```
+Never `$:`, `export let`, or `on:click`. Event attributes are `onclick`, `onchange`, `oninput`.
+
+## Reactivity bridge
+Documents use `createSubscriber` from `svelte/reactivity` to turn Foundry hooks into Svelte reactivity, exposed as `.reactive`. Read document state through `.reactive` inside `$derived` or the template so it re-renders on update:
+```svelte
+const actor = getContext<NimbleCharacter>('actor');
+let hp = $derived(actor.reactive.system.attributes.hp.value);
+```
+Common context keys: `'actor'`, `'document'`, `'dialog'`, `'application'`, `'messageDocument'`. Use the key the parent sheet or dialog sets.
+
+Non-trivial sheet or dialog state belongs in a colocated `*.state.svelte.ts` class, not spread through the component. Follow the neighbouring sheet's pattern.
+
+## Localization
+```svelte
+import localize from '#utils/localize.js';
+{localize('NIMBLE.some.key')}
+```
+Never raw `game.i18n.localize()` in a component. New keys go in `public/lang/en.json`; run `pnpm lang:detect-untranslated` afterwards.
+
+## Styling
+SCSS in `src/scss/`, plus `<style>` blocks in components. BEM-like naming under the `nimble-` namespace: `nimble-character-sheet__section`. `pnpm format:scss` fixes stylelint issues.
+
+## Do not
+- Call `actor.prepareData()` from a component.
+- Use `document.querySelector` — use bindings or Svelte actions.
+- Build raw HTML strings where template syntax works.
+- Inline complex derivation — put it in `dataPreparationHelpers/` or a state class.
+
+## Before reporting done
+`pnpm check:svelte`, `pnpm lint:svelte`, and `pnpm test` (components have colocated tests using @testing-library/svelte). When behaviour a player, GM, or homebrewer sees changes, update the VitePress docs in `docs/` on the same branch — never edit `documentation/reference/*.md`, it is generated.

--- a/.claude/hooks/rules-context.md
+++ b/.claude/hooks/rules-context.md
@@ -40,7 +40,7 @@ Rules are sorted by `priority` (lower runs first) before each hook fires.
 2. Local `schema()` + override `defineSchema()` merging base + local
 3. Implement lifecycle hooks
 4. Register in `src/config/registerRulesConfig.ts` (both `ruleTypes` and `ruleDataModels`)
-5. Add `NIMBLE.ruleTypes.<key>` and `NIMBLE.ruleDescriptions.<key>` to `en.json`
+5. Add `NIMBLE.ruleTypes.<key>` and `NIMBLE.rules.<key>.description` to `en.json`
 6. Set `static group` (one of `bonuses` / `grants` / `triggers` / `resources` / `flavor`) and `static description`
 7. Give every editable field a `label:` (and ideally a `hint:`) — without `label:`, the builder warns and ships English-only labels
 8. Use `withWidget()` for fields needing widget hints (`formula` / `diceFormula` / `documentUuid` / `predicate` / `templateString` / `richText` / `hidden`)

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -98,7 +98,7 @@ reviews:
         Rule types. See docs/system/rules.md.
         - The rule name says what the rule does. It never names one feature. The rule works on any item type.
         - The rule is registered in `src/config/registerRulesConfig.ts` in both `ruleTypes` and `ruleDataModels`, and `type` is the same as the registration key.
-        - en.json has `NIMBLE.ruleTypes.<key>` and `NIMBLE.ruleDescriptions.<key>`. The class sets `static group` (not `'unsorted'`) and `static description`. Each field that a user edits has a localized `label`, and a `hint` when the field is not obvious.
+        - en.json has `NIMBLE.ruleTypes.<key>` and `NIMBLE.rules.<key>.description` (the key that `static description` points to), with field labels and hints under `NIMBLE.rules.<key>.<field>`. The class sets `static group` (not `'unsorted'`) and `static description`. Each field that a user edits has a localized `label`, and a `hint` when the field is not obvious.
         - Lifecycle methods start with `if (!this.test()) return;` and check `item.isEmbedded` before they read `item.actor`.
         - Flag a no-op `prePrepareData()`, because it marks the rule as early-phase. A rule that is read outside the hook sweep overrides `appliesInPrePrepareData`. A dual-phase rule (numeric value early, formula late) overrides `appliesInPrePrepareDataFor`.
         - Change actor data with `foundry.utils.setProperty(actor.system, path, value)`. For list values, use `pushToActorSystemArray()`, which registers the path so that the array is reset each prepare cycle. Flag a direct `push` onto actor system arrays.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,271 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+# This file overrides the repository settings in the CodeRabbit web UI.
+language: en-US
+tone_instructions: >-
+  Use ASD-STE100 Simplified Technical English: short sentences, active voice,
+  one instruction per sentence. No em-dashes. Use Nimble rulebook terms, not
+  D&D 5e terms. State the defect, the input that triggers it, and the fix.
+
+reviews:
+  profile: chill
+  request_changes_workflow: false
+  high_level_summary: true
+  high_level_summary_instructions: >-
+    Start with what changes for a player, GM or homebrewer, in plain words.
+    Then list the engine changes. Always name: new or renumbered migrations,
+    changed pack content, new or changed settings, new rule types, and added or
+    removed en.json keys.
+  poem: false
+  in_progress_fortune: false
+  sequence_diagrams: false
+  suggested_labels: false
+  suggested_reviewers: false
+  review_status: true
+  collapse_walkthrough: true
+
+  auto_review:
+    enabled: true
+    drafts: false
+    # PRs target dev, and stacked PRs target feature branches.
+    base_branches:
+      - ".*"
+    ignore_title_keywords:
+      - "WIP"
+      - "chore(release)"
+
+  path_filters:
+    - "!**/pnpm-lock.yaml"
+    - "!CHANGELOG.md"
+    - "!public/lang/babele/**"
+
+  path_instructions:
+    - path: "**"
+      instructions: |
+        This is the Nimble 2 game system for Foundry VTT v14.
+        - CI runs Biome, ESLint on .svelte files, tsc, dependency-cruiser, Vitest and a migration count check. Do not comment on formatting, import order or anything these tools report.
+        - Report behaviour defects first: a wrong game result, lost or corrupted actor or item data, or a path that skips a guard. Raise a style point only when AGENTS.md or docs/STYLE_GUIDE.md states the rule, and cite it.
+        - Automate bookkeeping, not decisions. Do not suggest that the code blocks, disables or greys out a legal player or GM choice (targets, activations, picks). Suggest that it shows the state instead. A hard gate is correct only for an action limit the rulebook states outright, for example "1/round".
+        - Do not suggest that the code clamps a number to a rulebook maximum. Homebrew values must pass through.
+        - When the PR adds a guard or a rule check, find every entry path that reaches the same behaviour: sheet button, chat card, macro and `fastForward`, Alt and `skipRollDialog`, level-up, rest and scroll dialogs, and hooks. Name each path that skips the guard.
+        - The system assumes that one connected GM runs combat. Do not report double execution of turn start or turn end effects when two or more GMs are connected.
+        - The Nimble 2 rulebooks are not in this repository. Do not correct a game mechanic from D&D 5e knowledge. If a mechanic looks wrong, ask a question. Do not state it as a defect.
+        - Nimble has no proficiency bonus and no spell slots. Flag code or content that adds them. Nimble does have concentration.
+        - Actor types are `character`, `npc`, `minion` and `soloMonster`. Only characters have classes, mana and `highestUnlockedSpellTier`. Check that new code does not fail on the other types.
+        - Code comments in `src/` describe the generic mechanism. Flag an engine comment that names one class feature, spell or item as the reason for the code.
+
+    - path: "src/**/*.ts"
+      instructions: |
+        - Never import the Foundry globals (`game`, `CONFIG`, `Hooks`, `Roll`, `Actor`, `Item`, `foundry`, `ui`, `canvas`). Reach namespaced v14 APIs through `foundry.*`, for example `foundry.applications.ux.TextEditor.implementation`, not through deprecated bare globals.
+        - Never hardcode `'nimble'` as the system id in flag scopes, flag paths, settings, hook names, asset paths or object scope keys. Use `SYSTEM_ID`, `SYSTEM_PATH` or `systemHookName()` from `#system`, because the dev build runs as `nimble-dev`. `src/utils/systemId.test.ts` finds the literal forms. Flag the indirect forms that it can miss. `game.nimble` and `Compendium.nimble.*` ids in `src/migration/**` are permitted exceptions.
+        - Persist changes with `update()`, `updateEmbeddedDocuments()` or `createEmbeddedDocuments()`. A direct assignment to `document.system` in an event handler does not persist. Mutation of prepared data with `foundry.utils.setProperty` inside a data-preparation hook is correct.
+        - Document classes extend `NimbleBaseActor` or `NimbleBaseItem`, never the Foundry `Actor` or `Item` classes.
+        - Use `@ts-expect-error` with a reason. Never use `@ts-ignore`.
+        - No barrel files and no re-export shims (`export { x } from ...`). The only permitted barrel is `src/migration/migrations/index.ts`. When the PR moves a helper to a wider scope, every caller must import it from the new location.
+        - YAGNI: flag a new export, prop, union member or fallback that has no caller. An unsupported path must throw. It must not return a silent default.
+        - Rule of Three: flag the third copy of the same logic or literal across different files. Name the existing helper in the "Shared Code Inventory" of docs/STYLE_GUIDE.md, or the existing `CONFIG.NIMBLE` constant.
+        - Type-only imports use `import type`. Do not flag `.js` against `.ts` import extensions, because both resolve.
+        - Unused parameters get a `_` prefix. Do not remove them.
+        - All code must be reachable from `src/nimble.ts`. Do not add a new entry point.
+        - A new user-facing string goes through `localize()` and has a key in `public/lang/en.json`.
+
+    - path: "src/**/*.svelte"
+      instructions: |
+        Svelte 5 runes mode.
+        - Flag Svelte 4 syntax: `export let`, `$:`, `on:event` directives and `createEventDispatcher()`. Use `$props()`, `$derived`, `$effect` and `onclick`.
+        - Every user-facing string goes through `localize()`. Hardcoded display text is a defect.
+        - Colours use `--nimble-*` custom properties and must work in light and dark mode. Flag hardcoded colours.
+        - Prop types go in `types/components/*.d.ts`, not inline.
+        - When the `<script>` logic is longer than about 30 lines, move the state to a co-located `.svelte.ts` file.
+        - A component that declares a local `const state` cannot use the `$state` rune in the same script. The compiler reads `$state` as a store subscription and the component throws on mount.
+        - An overlay rendered into `document.body` (hover card, menu, picker) needs `z-index: var(--z-index-tooltip, 9999)`. Foundry raises a focused window above 100, so a lower value puts the overlay behind the window.
+        - Inputs and icon-only buttons need an accessible name.
+        - Use Svelte bindings or actions, not `document.querySelector`. Do not call `actor.prepareData()` from a component. In reactive contexts, read document data through `.reactive`.
+
+    - path: "src/**/*.svelte.ts"
+      instructions: |
+        - Use the `.svelte.ts` extension only for files that use runes. Flag a `.svelte.ts` file without runes, and a plain `.ts` file that uses runes.
+        - Do not import a `types/components/*.d.ts` file that imports a document class. dependency-cruiser reports a cycle through the document, the dialog and the component, although every edge is `import type`. Put shared view types in a domain types file that does not import the document.
+
+    - path: "src/documents/**"
+      instructions: |
+        - Data preparation runs `prepareBaseData()`, then `prepareEmbeddedDocuments()`, then `prepareDerivedData()`, with an `if (this.initialized) return;` guard. Flag code that calls `prepareData()` manually.
+        - Check `item.isEmbedded` before the code reads `item.actor`.
+        - The actor and item base classes cannot import each other. Use a local interface for the needed shape. Load dialogs and sheets with `await import()`.
+        - When one user action makes more than one document write, check the state that remains if a later write fails.
+
+    - path: "src/models/rules/**"
+      instructions: |
+        Rule types. See docs/system/rules.md.
+        - The rule name says what the rule does. It never names one feature. The rule works on any item type.
+        - The rule is registered in `src/config/registerRulesConfig.ts` in both `ruleTypes` and `ruleDataModels`, and `type` is the same as the registration key.
+        - en.json has `NIMBLE.ruleTypes.<key>` and `NIMBLE.ruleDescriptions.<key>`. The class sets `static group` (not `'unsorted'`) and `static description`. Each field that a user edits has a localized `label`, and a `hint` when the field is not obvious.
+        - Lifecycle methods start with `if (!this.test()) return;` and check `item.isEmbedded` before they read `item.actor`.
+        - Flag a no-op `prePrepareData()`, because it marks the rule as early-phase. A rule that is read outside the hook sweep overrides `appliesInPrePrepareData`. A dual-phase rule (numeric value early, formula late) overrides `appliesInPrePrepareDataFor`.
+        - Change actor data with `foundry.utils.setProperty(actor.system, path, value)`. For list values, use `pushToActorSystemArray()`, which registers the path so that the array is reset each prepare cycle. Flag a direct `push` onto actor system arrays.
+        - `static alwaysDispatchedEvents` makes an event run when the user turns rule automation off. Use it only for core plumbing that a player cannot do by hand. Flag any other use.
+        - Derived values stay derived. Flag code that adds a rule total into a stored source field (see issue #499).
+        - A co-located `<rule>.test.ts` covers the embedded, not-embedded, disabled, predicate-fail and stacking (two instances) paths, and each phase of a dual-phase rule.
+        - A schema change alters the generated rule reference. If `docs/documentation/reference/_partials/<key>.md` exists, check that it is still correct.
+
+    - path: "src/migration/**"
+      instructions: |
+        World data migrations.
+        - CI requires that the number of `Migration*.ts` files equals `LATEST_SCHEMA_VERSION` in `MigrationRunnerBase.ts`. Numbers are contiguous. A new migration uses the highest number on `dev` plus 1 and is exported from `migrations/index.ts`. Flag gaps and reserved numbers.
+        - A migration must be idempotent and must not throw on data that is already migrated or only partly shaped. Check what happens when the target data already exists: when the pack version of that data changed, the migration updates it. It does not skip it.
+        - A migration whose writes a later migration must see sets `requiresFlush = true`.
+        - Match embedded copies by compendium source id, with a name fallback. Use `toSnapshotId` and the helpers in `src/migration/compendiumSourceId.ts`. Do not copy them. Stored ids can start with `Compendium.nimble.` or `Compendium.nimble-dev.`.
+        - Do not delete or clear data that the migration does not own: user-authored entries, unknown identifiers and homebrew content.
+        - Rule objects that a migration writes are the same as the pack JSON, so a migrated copy is equal to a new copy from the compendium.
+
+    - path: "packs/**/*.json"
+      instructions: |
+        Compendium source content. Review structure and references. Do not review game balance.
+        - A new document has a 16-character alphanumeric `_id`, and that id is in `packs/ids.json` in the correct category. File names are kebab-case.
+        - References use `Compendium.nimble.nimble-<pack>.<DocumentType>.<id>`, and the id exists. Do not flag the `nimble` literal here, because the dev build rewrites the packs.
+        - Each rule has a registered `type`, an `id` that is unique in the item, and only fields that the schema of that rule type defines. Rule ids can be random or slugs; do not flag the format.
+        - Every `grantItem` or `grantSpells` UUID points to a document that exists in `packs/`. A dead UUID fails silently at the table.
+        - Spells: `tier` is 0 to 9 (0 is a cantrip), and `school` is a key of `spellSchools` in `src/config.ts`.
+        - Classes: `hitDieSize` is 4, 6, 8, 10 or 12, `complexity` is 1 to 3, and `savingThrows.advantage` and `savingThrows.disadvantage` are different abilities. Abilities are `strength`, `dexterity`, `intelligence` and `will`.
+        - Movement is in squares, never feet.
+        - `_stats.coreVersion` values are historical stamps. Do not flag them.
+        - Authored text (names, descriptions, labels, reminder notes) contains no em-dashes. Verbatim rulebook quotes can keep them.
+        - If the PR changes the rules or data of an existing item that existing characters already hold, and the PR has no migration, ask if old worlds need one.
+
+    - path: "public/lang/*.json"
+      instructions: |
+        `en.json` is the source locale. New keys follow the existing nesting under `NIMBLE`. Flag a key that code uses but en.json does not have, and a removed key that code still uses. Translators maintain the other locale files: do not review translation text, and flag edits to these files in a PR that is not a translation PR.
+
+    - path: "**/*.test.ts"
+      instructions: |
+        Vitest. `describe`, `it`, `expect` and `vi` are globals and are not imported.
+        - `tests/setup.ts` and `tests/mocks/foundry.ts` are shared infrastructure. Flag edits to them, and suggest a change to the test.
+        - A behaviour change needs a test that fails without the change. Flag a test that only asserts that a mock was called and not the result. Flag fixture fields that nothing reads.
+        - Use `vi.stubGlobal` for globals such as `fromUuid`, not a manual save and restore.
+        - A `vi.mock('#utils/...')` call does not reach src modules that import the same alias. Prefer the real helpers with the fixtures in `tests/fixtures/`.
+        - Unit tests run on mocks and do not prove Foundry v14 runtime behaviour. For code that depends on real document updates or hooks, suggest a test in `tests/integration/`.
+
+    - path: "tests/integration/**"
+      instructions: |
+        Live suite: Vitest runs in a real Foundry v14 world through Playwright, on a local machine only (see tests/integration/README.md).
+        - Each file removes the documents, sheets and dialogs it creates, also when an assertion fails (`afterEach`, `afterAll` or `try`/`finally`).
+        - A loop over a collection first asserts that the collection is not empty.
+        - The action under test goes through the real UI or the real document API. Setup can use the API directly.
+
+    - path: "docs/documentation/**/*.md"
+      instructions: |
+        User-facing VitePress docs for players, GMs and homebrewers.
+        - The text agrees with the code in this PR: names of settings and fields, default values, and what the system does and does not automate.
+        - No em-dashes. Use Nimble rulebook terms.
+        - A new page needs a sidebar entry in `docs/.vitepress/config.mts`.
+        - `docs/documentation/reference/*.md` is generated and is never edited by hand. Files in `reference/_partials/` are hand-written, have no headings and start with `**Example: <item name>.**`.
+
+    - path: ".github/workflows/**"
+      instructions: |
+        CONTRIBUTING.md requires maintainer agreement before a CI or infrastructure change. Say so in the review. Use pnpm with `--frozen-lockfile`, never npm or yarn. Node is version 22.
+
+  pre_merge_checks:
+    docstrings:
+      mode: "off"
+    title:
+      mode: warning
+      requirements: >-
+        Conventional Commits: `type(scope): description`. The type is feat, fix,
+        chore or docs. The scope is optional. The description is lower case and
+        has no final period.
+    description:
+      mode: warning
+    issue_assessment:
+      mode: warning
+    custom_checks:
+      - name: Base branch
+        mode: warning
+        instructions: >-
+          Pass if the PR targets `dev` or a feature branch (a stacked PR). Fail
+          if the PR targets `main` and is not a release merge from `dev`.
+      - name: User docs
+        mode: warning
+        instructions: >-
+          Fail if the PR changes what a player, GM or homebrewer sees or does
+          (sheets, dialogs, chat cards, settings, conditions, rule types, rests,
+          import or export) and does not change `docs/documentation/**`, and the
+          PR description does not say why no docs change is necessary. Name the
+          stale page.
+      - name: Localization
+        mode: warning
+        instructions: >-
+          Fail if new user-facing text in `src/` does not go through
+          `localize()`, if a key that the code uses is missing from
+          `public/lang/en.json`, or if a PR that is not a translation PR edits a
+          locale file other than `en.json`.
+      - name: Pack changes reach existing worlds
+        mode: warning
+        instructions: >-
+          Pass if the PR does not change existing documents in `packs/`. If it
+          changes the rules or system data of an existing item, pass only if the
+          PR adds a migration in `src/migration/migrations/` or the description
+          says why existing characters do not need one.
+
+  finishing_touches:
+    docstrings:
+      enabled: false
+    unit_tests:
+      enabled: true
+
+  tools:
+    # CI runs Biome and ESLint on every PR.
+    biome:
+      enabled: false
+    eslint:
+      enabled: false
+    oxc:
+      enabled: false
+    markdownlint:
+      enabled: false
+    languagetool:
+      enabled: false
+    reactDoctor:
+      enabled: false
+    github-checks:
+      enabled: true
+      timeout_ms: 900000
+    gitleaks:
+      enabled: true
+    actionlint:
+      enabled: true
+    stylelint:
+      enabled: true
+    shellcheck:
+      enabled: true
+    yamllint:
+      enabled: true
+
+code_generation:
+  unit_tests:
+    path_instructions:
+      - path: "src/**/*.ts"
+        instructions: >-
+          Write Vitest tests next to the source file as `<name>.test.ts`.
+          `describe`, `it`, `expect` and `vi` are globals. `tests/setup.ts`
+          already mocks the Foundry globals and runs `init()`, so `CONFIG.NIMBLE`
+          is populated. Use `tests/fixtures/` and `tests/mocks/`, and never edit
+          `tests/setup.ts` or `tests/mocks/foundry.ts`. Use `vi.stubGlobal` for
+          globals such as `fromUuid`. Test one behaviour per `it`, and assert the
+          result, not only that a mock was called.
+
+knowledge_base:
+  web_search:
+    enabled: true
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - "AGENTS.md"
+      - "docs/STYLE_GUIDE.md"
+      - "docs/PROJECT_CONTEXT.md"
+      - "docs/system/*.md"
+      - ".claude/agents/*.md"
+  learnings:
+    scope: auto
+
+chat:
+  art: false
+  auto_reply: true

--- a/.gitignore
+++ b/.gitignore
@@ -57,4 +57,3 @@ _bmad-*/
 .claude/commands/content-pack-agent.md
 .claude/commands/nimble-rules-agent.md
 .claude/commands/review-pr.md
-.claude/agents

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,9 @@ public/packs/**/CURRENT
 public/packs/**/LOG
 public/packs/**/MANIFEST-*
 
+# LOCAL FOLDERS
+.nimblerules/
+
 # BMAD
 _bmad/
 _bmad-*/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,30 @@
 Read and follow all instructions in AGENTS.md
+
+## Behavior Guidelines
+
+1. **Build on prior work.** This is an ongoing project. Review what's already been planned or built before suggesting new features. Check memory files and any tracking documents before starting fresh.
+2. **Be thorough and accurate.** When compiling data from the rulebooks (spells, classes, weapons, ancestries, etc.), pull directly from the source material.
+3. **Don't substitute 5e rules.** When a rule isn't covered in the uploaded materials, say so rather than guessing. Never silently substitute D&D 5e rules or mechanics.
+4. **Plan before building.** When scoping new work, identify what mechanics need tracking, what choices players/GMs make, and what information needs surfacing — then implement.
+5. **Ask clarifying questions** about the current state of the project when needed rather than assuming what has or hasn't been addressed.
+6. **Relevant code comments.** Don't add comments to code if it doesn't add value, fixing a bug doesn't mean you need to explain the fix in the code comment, writing a new function doesn't mean you need to explain every line in that function. Code speaks for itself, unless the code is complex in a way that would benefit from a comment. If you add comments they should be **short and to the point.** 
+7. **Automate bookkeeping, not decisions.**, The Foundry system should remove tedious work, enforce genuinely unambiguous rules, and handle complex mechanical interactions, while always preserving meaningful player and GM choices. Never automate something merely because it is possible to automate. Nimble should feel like a TTRPG being facilitated by software, not a video game where the software plays the rules for you.
+**When a choice belongs to the player or GM, surface it. When something is tedious or unambiguous, automate it.**
+
+
+## Specialist agents
+
+`.claude/agents/` holds subagents for this repo. Route a task by what it is about:
+
+1. What the game rules say (mechanics, rules accuracy, rulebook lookups): **nimble-rules-agent**
+2. How Foundry works (document classes, DataModels, hooks, sheets API, active effects): **foundry-agent**
+3. The rules engine code (rule types in `src/models/rules/`): **rules-engine-agent**
+4. UI work (Svelte components, sheets, dialogs, chat cards): **ui-agent**
+5. Pack content (JSON in `packs/`): **content-pack-agent**
+6. Tests, migrations, type checks, linting: **quality-agent**
+
+The nimble-rules-agent says what the game should do. The rules-engine-agent implements it. The rulebooks are local files in `_bmad-output/rules/` and are not in the repository.
+
+## User-facing docs
+
+When a change alters what a player, GM or homebrewer sees, update `docs/documentation/` on the same branch. Never edit `docs/documentation/reference/*.md` by hand: `pnpm docs:generate` builds it from the rule schemas, settings, conditions and `public/lang/en.json`.

--- a/docs/system/rules.md
+++ b/docs/system/rules.md
@@ -308,7 +308,7 @@ A rule offering a zero adjustment is skipped, since its checkbox would do nothin
 4. Implement lifecycle hooks (most commonly `prePrepareData()`).
 5. Register in `src/config/registerRulesConfig.ts` — add to both `ruleTypes` and `ruleDataModels`.
 6. Add the i18n label key to `en.json` (under `NIMBLE.ruleTypes.<key>`).
-7. Add a description i18n key under `NIMBLE.ruleDescriptions.<key>` for the builder UI.
+7. Add a description i18n key under `NIMBLE.rules.<key>.description` for the builder UI, with field labels and hints under `NIMBLE.rules.<key>.<field>`.
 8. Make the rule renderable in the **Rules Builder** — see [below](#rules-builder-integration).
 9. Keep the rule **generic** — it should be reusable across any item type.
 10. Add a co-located test (`src/models/rules/yourRule.test.ts`). Mock actor/item, instantiate the rule directly, and verify the lifecycle hook mutates actor data correctly. See `speedBonus.test.ts` for the pattern.
@@ -319,7 +319,7 @@ A rule offering a zero adjustment is skipped, since its checkbox would do nothin
 ```typescript
 class AbilityBonusRule extends NimbleBaseRule<AbilityBonusRule.Schema> {
   static override group = 'bonuses';
-  static override description = 'NIMBLE.ruleDescriptions.abilityBonus';
+  static override description = 'NIMBLE.rules.abilityBonus.description';
 
   static override defineSchema(): AbilityBonusRule.Schema {
     return { ...NimbleBaseRule.defineSchema(), ...schema() };
@@ -346,13 +346,13 @@ The rules-builder UI (`src/view/rulesBuilder/`) auto-generates a card per rule f
 ```typescript
 class YourRule extends NimbleBaseRule<YourRule.Schema> {
   static override group = 'bonuses';
-  static override description = 'NIMBLE.ruleDescriptions.yourRule';
+  static override description = 'NIMBLE.rules.yourRule.description';
   // ...
 }
 ```
 
 - `static group` — bucket in the rule-type picker. Existing groups: `'bonuses'`, `'grants'`, `'triggers'`, `'resources'`, `'flavor'`. Defaulting to `'unsorted'` triggers a dev-mode warning.
-- `static description` — i18n key shown in the card's help tooltip and the picker's grid. Add the string to `en.json` under `NIMBLE.ruleDescriptions.<key>`.
+- `static description` — i18n key shown in the card's help tooltip and the picker's grid. Add the string to `en.json` under `NIMBLE.rules.<key>.description`.
 
 ### Per-field metadata (required)
 


### PR DESCRIPTION
## Summary

Adds a `.coderabbit.yaml` so CodeRabbit reviews with this repo's rules instead of generic defaults, and tracks the Claude specialist agent files so contributors and CodeRabbit read the same guidance.

## Changes

- **`.coderabbit.yaml`** (replaces the settings in the CodeRabbit web UI):
  - Turns off Biome, ESLint, oxlint, markdownlint and LanguageTool comments. CI already reports lint and format problems.
  - Reviews PRs to `dev` and to stacked feature branches. The GitHub default branch is `main`, so without this only PRs to `main` get an automatic review.
  - Adds review instructions per area: Svelte, `.svelte.ts` state files, documents, rule types, migrations, packs, locales, unit and integration tests, user docs and workflows. They come from AGENTS.md, STYLE_GUIDE.md, docs/system/rules.md and the comments maintainers left on recent PRs.
  - States the design rules that past CodeRabbit comments went against: report a player choice instead of blocking it, do not clamp homebrew values to a rulebook maximum, one GM runs combat, and no mechanic corrections from D&D 5e.
  - Adds warning-only pre-merge checks: title format, base branch, user docs updated, localization, and pack changes that need a migration.
  - Reads AGENTS.md, docs/STYLE_GUIDE.md, docs/PROJECT_CONTEXT.md, docs/system/*.md and .claude/agents/*.md as code guidelines.
- **`.claude/agents/`**: tracks the six specialist agents (content-pack, foundry, nimble-rules, quality, rules-engine, ui) and removes them from `.gitignore`. Statements that disagreed with the code are corrected:
  - Spell tier is 0 to 9 (35 spells are tier 0), and there are six spell schools, not eight.
  - Rule ids can be slugs (188 of 324 are), and `identifier` is usually empty (898 of 918 pack files).
  - Nimble does have concentration.
  - Svelte reads document state through `.reactive`, and the context keys listed are the ones in use.
  - The list-value helper is named: `pushToActorSystemArray()`.
  - Paths that exist only on one machine are removed.
- **`CLAUDE.md`**: adds behaviour guidelines, a table that routes tasks to the agents, and the user-facing docs rule.

## Test Plan

1. Validate the config against the CodeRabbit schema:
   ```bash
   curl -sL https://coderabbit.ai/integrations/schema.v2.json -o /tmp/cr.json
   python3 -c "import json,yaml,jsonschema; print(list(jsonschema.Draft7Validator(json.load(open('/tmp/cr.json'))).iter_errors(yaml.safe_load(open('.coderabbit.yaml')))))"
   ```
   Expected output: `[]`.
2. On this PR, open the CodeRabbit walkthrough and expand "Run configuration". "Configuration used" should name the YAML file, not "Repository UI".
3. Check that the review has no lint or format comments, and that the walkthrough is short.
4. Open Claude Code in a checkout of this branch and run `/agents`. The six project agents should be listed.

## Checklist

- [ ] Added or updated unit tests (not applicable: config and docs only)
- [x] PR targets the `dev` branch
- [ ] `pnpm check` passes (format, lint, circular deps, type-check, tests) (not run in full: no source files changed; the pre-push hook passed Biome check, type-check and all tests)
- [x] No hardcoded user-facing strings (used `localize()`)
- [ ] Tested in Foundry with no console errors (not applicable)
- [x] **Have you used AI to assist with this PR?** yes
- [x] **If yes:** I have reviewed all AI-generated code against the repo's [STYLE_GUIDE.md](docs/STYLE_GUIDE.md) and [AGENTS.md](AGENTS.md)

## Related Issues

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Player, GM, and homebrewer impact

- No player-facing rules, packs, settings, or localization content changes.
- Adds project guidance for content authoring, FoundryVTT work, rules, quality checks, and Svelte UI work.
- Adds task routing and documentation rules to `CLAUDE.md`.

## Engine changes

- Adds repository-specific CodeRabbit review rules.
- Tracks six Claude specialist agents.
- Corrects Nimble rule, identifier, concentration, context-key, helper-name, and Svelte guidance.
- Adds `.nimblerules/` to `.gitignore`.
- Migrations: no new or renumbered migrations.
- Pack content: no changed pack content.
- Settings: no new or changed settings.
- Rule types: no new or changed rule types.
- `en.json` keys: no added or removed keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->